### PR TITLE
Store api keys in keychain

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		7C078D8F2E3B339200FB7CAC /* FluidVoice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = FluidVoice.app; path = "FluidVoice Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7C078D8F2E3B339200FB7CAC /* FluidVoice Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FluidVoice Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -50,7 +50,7 @@
 		7C078D902E3B339200FB7CAC /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				7C078D8F2E3B339200FB7CAC /* FluidVoice.app */,
+				7C078D8F2E3B339200FB7CAC /* FluidVoice Debug.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -81,7 +81,7 @@
 				7CE006BC2E80EBE600DDCCD6 /* AppUpdater */,
 			);
 			productName = FluidVoice;
-			productReference = 7C078D8F2E3B339200FB7CAC /* FluidVoice.app */;
+			productReference = 7C078D8F2E3B339200FB7CAC /* FluidVoice Debug.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -283,7 +283,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V4J43B279J;
+				DEVELOPMENT_TEAM = J67LH9U7BN;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_CODE_COVERAGE = NO;
 				ENABLE_FILE_ACCESS_DOWNLOADS_FOLDER = readwrite;
@@ -334,11 +334,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Fluid.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application: Barathwaj Anandan (V4J43B279J)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application: Barathwaj Anandan (V4J43B279J)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = V4J43B279J;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = J67LH9U7BN;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_CODE_COVERAGE = NO;
 				ENABLE_FILE_ACCESS_DOWNLOADS_FOLDER = readwrite;

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ https://github.com/user-attachments/assets/c57ef6d5-f0a1-4a3f-a121-637533442c24
 2. Move to Applications folder
 3. Grant microphone and accessibility permissions when prompted
 4. Set your preferred hotkey in settings
-5. Optionally add an AI provider API key for enhanced transcription
+5. Optionally add an AI provider API key for enhanced transcription (keys are stored securely in your macOS Keychain)
 
 ## Requirements
 

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -277,7 +277,6 @@ struct ContentView: View {
                 // Use models from saved provider
                 availableModels = saved.models
                 openAIBaseURL = saved.baseURL
-                providerAPIKeys[currentProvider] = saved.apiKey
             } else if let stored = availableModelsByProvider[currentProvider], !stored.isEmpty {
                 // Use provider-specific stored list if present
                 availableModels = stored
@@ -1288,8 +1287,6 @@ struct ContentView: View {
                                     if let provider = savedProviders.first(where: { $0.id == newValue }) {
                                         openAIBaseURL = provider.baseURL
                                         updateCurrentProvider()
-                                        providerAPIKeys[currentProvider] = provider.apiKey
-                                        saveProviderAPIKeys()
                                         let key = providerKey(for: newValue)
                                         availableModels = provider.models.isEmpty ? (availableModelsByProvider[key] ?? defaultModels(for: key)) : provider.models
                                         if let sel = selectedModelByProvider[key], availableModels.contains(sel) { selectedModel = sel }
@@ -1495,7 +1492,6 @@ struct ContentView: View {
                                             id: savedProviders[providerIndex].id,
                                             name: savedProviders[providerIndex].name,
                                             baseURL: savedProviders[providerIndex].baseURL,
-                                            apiKey: savedProviders[providerIndex].apiKey,
                                             models: list
                                         )
                                         savedProviders[providerIndex] = updatedProvider
@@ -1718,7 +1714,6 @@ struct ContentView: View {
                                         let newProvider = SettingsStore.SavedProvider(
                                             name: name,
                                             baseURL: base,
-                                            apiKey: api,
                                             models: models
                                         )
 
@@ -2745,7 +2740,6 @@ struct ContentView: View {
                 id: savedProviders[providerIndex].id,
                 name: savedProviders[providerIndex].name,
                 baseURL: savedProviders[providerIndex].baseURL,
-                apiKey: savedProviders[providerIndex].apiKey,
                 models: list
             )
             savedProviders[providerIndex] = updatedProvider
@@ -3305,7 +3299,6 @@ struct ContentView: View {
                 id: savedProviders[providerIndex].id,
                 name: savedProviders[providerIndex].name,
                 baseURL: savedProviders[providerIndex].baseURL,
-                apiKey: savedProviders[providerIndex].apiKey,
                 models: availableModels
             )
             savedProviders[providerIndex] = updatedProvider

--- a/Sources/Fluid/Persistence/KeychainService.swift
+++ b/Sources/Fluid/Persistence/KeychainService.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Security
+
+enum KeychainServiceError: Error, LocalizedError {
+    case invalidData
+    case unhandled(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidData:
+            return "Failed to convert key data."
+        case .unhandled(let status):
+            if let message = SecCopyErrorMessageString(status, nil) as String? {
+                return message
+            }
+            return "Unhandled Keychain status: \(status)"
+        }
+    }
+}
+
+/// Lightweight helper for storing provider API keys in the system Keychain.
+/// Keys are stored as generic passwords scoped to the FluidVoice service.
+final class KeychainService {
+    static let shared = KeychainService()
+
+    private let service = "com.fluidvoice.provider-api-keys"
+
+    private init() {}
+
+    func storeKey(_ key: String, for providerID: String) throws {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8) else {
+            throw KeychainServiceError.invalidData
+        }
+
+        var attributes = baseQuery(for: providerID)
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        attributes[kSecValueData as String] = data
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+
+        switch status {
+        case errSecSuccess:
+            return
+        case errSecDuplicateItem:
+            let updateStatus = SecItemUpdate(baseQuery(for: providerID) as CFDictionary,
+                                             [kSecValueData as String: data] as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw KeychainServiceError.unhandled(updateStatus)
+            }
+        default:
+            throw KeychainServiceError.unhandled(status)
+        }
+    }
+
+    func fetchKey(for providerID: String) throws -> String? {
+        var query = baseQuery(for: providerID)
+        query[kSecReturnData as String] = kCFBooleanTrue
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data,
+                  let key = String(data: data, encoding: .utf8) else {
+                throw KeychainServiceError.invalidData
+            }
+            return key
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainServiceError.unhandled(status)
+        }
+    }
+
+    func deleteKey(for providerID: String) throws {
+        let status = SecItemDelete(baseQuery(for: providerID) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainServiceError.unhandled(status)
+        }
+    }
+
+    func containsKey(for providerID: String) -> Bool {
+        var query = baseQuery(for: providerID)
+        query[kSecReturnData as String] = kCFBooleanFalse
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    func allProviderIDs() throws -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+
+        var items: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &items)
+
+        switch status {
+        case errSecSuccess:
+            guard let attributesArray = items as? [[String: Any]] else { return [] }
+            return attributesArray.compactMap { $0[kSecAttrAccount as String] as? String }
+        case errSecItemNotFound:
+            return []
+        default:
+            throw KeychainServiceError.unhandled(status)
+        }
+    }
+
+    private func baseQuery(for providerID: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: providerID
+        ]
+    }
+}
+


### PR DESCRIPTION
This change adds Apple keychain support to securely store the api keys. It is backward compatible so that users who already have added api keys, it is moved to keychain


Note: Before generating a release, update the team 