### PR TITLE
Fix integration with local Ollama models

### DIFF
--- a/Sources/Fluid/Services/LLMClient.swift
+++ b/Sources/Fluid/Services/LLMClient.swift
@@ -191,9 +191,7 @@ final class LLMClient {
         }
 
         // Add streaming flag
-        if config.streaming {
-            body["stream"] = true
-        }
+        body["stream"] = config.streaming
 
         // Add extra parameters in layers:
         // 1. Model-specific parameters (from ThinkingParserFactory)
@@ -262,9 +260,7 @@ final class LLMClient {
         DebugLogger.shared.debug("LLMClient: Non-streaming response received (\(data.count) bytes)", source: "LLMClient")
 
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = json["choices"] as? [[String: Any]],
-              let choice = choices.first,
-              let message = choice["message"] as? [String: Any]
+              let message = json["message"] as? [String: Any]
         else {
             throw LLMError.invalidResponse
         }
@@ -296,6 +292,9 @@ final class LLMClient {
         var contentBuffer: [String] = []
         var tagDetectionBuffer = ""
 
+        // Track if we've seen separate thinking fields (for runtime detection)
+        var hasSeenSeparateThinkingField = false
+
         // Tool call accumulation
         var toolCallId: String?
         var toolCallName: String?
@@ -304,21 +303,26 @@ final class LLMClient {
         // Process SSE lines
         for try await rawLine in bytes.lines {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard line.hasPrefix("data:") else { continue }
+            DebugLogger.shared.debug("LLMClient: Line: \(line)", source: "LLMClient")
+            var jsonString = ""
+            if line.hasPrefix("data:") {
+                jsonString = String(line.dropFirst(5))
+                if jsonString.hasPrefix(" ") {
+                    jsonString = String(jsonString.dropFirst(1))
+                }
 
-            var jsonString = String(line.dropFirst(5))
-            if jsonString.hasPrefix(" ") {
-                jsonString = String(jsonString.dropFirst(1))
+                if jsonString.trimmingCharacters(in: .whitespaces) == "[DONE]" {
+                    continue
+                }
             }
-
-            if jsonString.trimmingCharacters(in: .whitespaces) == "[DONE]" {
-                continue
+            // This means the data comes in different format i.e. local ollama
+            else {
+                jsonString = line
             }
 
             guard let jsonData = jsonString.data(using: .utf8),
                   let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-                  let choices = json["choices"] as? [[String: Any]],
-                  let delta = choices.first?["delta"] as? [String: Any]
+                  let delta = json["message"] as? [String: Any]
             else {
                 continue
             }
@@ -330,13 +334,16 @@ final class LLMClient {
                 DebugLogger.shared.debug("LLMClient: Full Delta: \(deltaString)", source: "LLMClient")
             }
 
-            // Handle separate reasoning fields (OpenAI 'reasoning', 'reasoning_content', DeepSeek, etc.)
+            // Handle separate reasoning fields (OpenAI 'reasoning', 'reasoning_content', DeepSeek, Qwen, etc.)
             let reasoningField = delta["reasoning_content"] as? String ??
                 delta["reasoning"] as? String ??
                 delta["thought"] as? String ??
                 delta["thinking"] as? String
 
             if let reasoning = reasoningField {
+                // Mark that this stream uses separate thinking fields
+                hasSeenSeparateThinkingField = true
+                
                 if state == .initial {
                     state = .inThinking
                     config.onThinkingStart?()
@@ -356,6 +363,16 @@ final class LLMClient {
                     // For safety with tag-based parsers, we let the parser decide unless it's a known separate-field model.
                 }
 
+                // CRITICAL FIX: For models using separate thinking fields (detected at runtime),
+                // if we were in thinking mode and now receive content WITHOUT a reasoning field,
+                // this signals the transition from thinking to content.
+                if hasSeenSeparateThinkingField && state == .inThinking && reasoningField == nil {
+                    // Transition from thinking to content for separate-field models
+                    state = .inContent
+                    config.onThinkingEnd?()
+                    DebugLogger.shared.debug("LLMClient: Detected field-based transition from thinking to content", source: "LLMClient")
+                }
+
                 // Debug: Log first few chunks and any chunk containing think tags
                 let containsThinkTag = content.contains("<think") || content.contains("</think") || content.contains("<thinking") || content.contains("</thinking")
                 if thinkingBuffer.count + contentBuffer.count < 8 || containsThinkTag {
@@ -364,12 +381,22 @@ final class LLMClient {
                     DebugLogger.shared.debug("LLMClient: Chunk '\(escaped)'\(marker)", source: "LLMClient")
                 }
 
+                // For separate-field models already in content state, bypass parser and route directly
                 let previousState = state
-                let (newState, thinkChunk, contentChunk) = parser.processChunk(
-                    content,
-                    currentState: state,
-                    tagBuffer: &tagDetectionBuffer
-                )
+                let (newState, thinkChunk, contentChunk): (ThinkingParserState, String, String)
+                
+                if hasSeenSeparateThinkingField && state == .inContent {
+                    // Direct routing for separate-field models in content phase
+                    newState = .inContent
+                    (_, thinkChunk, contentChunk) = ("", "", content)
+                } else {
+                    // Use parser for tag-based detection or hybrid models
+                    (newState, thinkChunk, contentChunk) = parser.processChunk(
+                        content,
+                        currentState: state,
+                        tagBuffer: &tagDetectionBuffer
+                    )
+                }
 
                 // Handle state transitions for callbacks
                 if previousState != .inThinking && newState == .inThinking {
@@ -428,6 +455,10 @@ final class LLMClient {
 
         // Use parser's finalize to get final clean thinking and content
         let (thinkingText, contentText) = parser.finalize(thinkingBuffer: thinkingBuffer, contentBuffer: contentBuffer, finalState: state)
+
+        // Debug logs of final strings:
+        // DebugLogger.shared.debug("LLMClient: THINKING: \(thinkingText)", source: "LLMClient")
+        // DebugLogger.shared.debug("LLMClient: CONTEXT: \(contentText)", source: "LLMClient")
 
         DebugLogger.shared.debug("LLMClient: Streaming complete. Thinking: \(thinkingText.count) chars, Content: \(contentText.count) chars", source: "LLMClient")
 


### PR DESCRIPTION
## Description

> **I want to open the discussion on the topic of running local Ollama models with FluidVoice.**

> Short story: I have installed latest Ollama and downloaded few models trying to hook them into this great app. I have faced few issues, thus this PR was made.

This PR fixes three issues:
1. Allow local Ollama's models to run by adjusting json parsing to current standards of API. (ref: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion)

2. Fix passing of `config.streaming` value -- Ollama models require `stream` value to be explicitly set to `false`, otherwise they default to `true`.

3. Problem with cases where streaming parser solution cannot accurately detect the switch between "think"/"content" switch:
    ```
    Stream: {"thinking": "reasoning...", "content": ":"} → {"thinking": "more...", "content": ":"} → {"content": "Subject:"}
    ```
    I have encountered this problem as all models (tested by me) use `StandardThinkingParser` as the default. I know it is already mentioned that `we let the parser decide unless it's a known separate-field model`. But this case is a little bit different, it includes both fields and only removes "thinking" later on. I have spotted this behaviour on Qwen-based models.

Also I am attaching the screenshot of my setting that I have used to test the solution (with Enable Streaming on and off). Additionally, I have used Apple Intelligence to verify correctness.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Testing
- [ ] Tested on Intel/Apple Silicon Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.2
- [ ] Ran linter locally: `brew install swiftlint && swiftlint --strict --config .swiftlint.yml`
- [ ] Ran formatter locally: `brew install swiftformat && swiftformat --config .swiftformat Sources`

## Screenshots / Video 
<img width="2436" height="1414" alt="Image 03-01-2026 at 23 33" src="https://github.com/user-attachments/assets/c9fb9e7b-7637-4f18-bf74-f39ae7fca38d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic runtime detection for AI models that use separate thinking and reasoning fields
  * Expanded support for diverse response formats from different AI service providers and local models

* **Bug Fixes**
  * Improved streaming response parsing to accommodate varied message data formats
  * Enhanced streaming request handling for more consistent and reliable operation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->