### PR TITLE
Bug fix: Remove duplicate cancel button

### DIFF
--- a/Sources/Fluid/UI/AISettingsView.swift
+++ b/Sources/Fluid/UI/AISettingsView.swift
@@ -1397,10 +1397,6 @@ struct AISettingsView: View {
                 Button("Save Provider") { self.saveNewProvider() }
                     .buttonStyle(GlassButtonStyle())
                     .disabled(self.newProviderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || self.newProviderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                Button("Cancel") { self.showingSaveProvider = false; self.newProviderName = ""; self.newProviderBaseURL = ""; self.newProviderApiKey = ""; self.newProviderModels = "" }
-                    .buttonStyle(GlassButtonStyle())
-                    .disabled(self.newProviderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || self
-                        .newProviderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 Button("Cancel") {
                     self.showingSaveProvider = false; self.newProviderName = ""; self.newProviderBaseURL = ""; self
                         .newProviderApiKey = ""; self.newProviderModels = ""


### PR DESCRIPTION
## Description
Remove duplicate cancel button while attempting to add an AI provider

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
Closes #(issue number)

## Testing
- [x] Tested on Intel/Apple Silicon Mac
- [x] Tested on macOS 26.2
- [x] Ran linter locally: `brew install swiftlint && swiftlint --strict --config .swiftlint.yml`
- [x] Ran formatter locally: `brew install swiftformat && swiftformat --config .swiftformat Sources`

## Screenshots / Video 
<img width="2902" height="2192" alt="CleanShot 2026-01-07 at 21 51 49@2x" src="https://github.com/user-attachments/assets/9258e89f-3996-4701-895b-8112afd5b934" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Cancel button in the Add Provider section now remains enabled at all times, allowing you to cancel and reset the form without restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->