### PR TITLE
bug fix - auto start stop needs arm64 - added exception fgor intel 

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
 	<key>CFBundleDisplayName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleName</key>

--- a/Sources/Fluid/Services/FluidAudioProvider.swift
+++ b/Sources/Fluid/Services/FluidAudioProvider.swift
@@ -112,6 +112,10 @@ final class FluidAudioProvider: TranscriptionProvider {
     var isAvailable: Bool { false }
     var isReady: Bool { false }
 
+    init(modelOverride: SettingsStore.SpeechModel? = nil) {
+        // Intel stub - parameter ignored
+    }
+
     func prepare(progressHandler: ((Double) -> Void)?) async throws {
         throw NSError(
             domain: "FluidAudioProvider",

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if arch(arm64)
 import MediaRemoteAdapter
+#endif
 
 /// Service that wraps MediaRemoteAdapter's MediaController to provide
 /// controlled pause/resume functionality during transcription.
@@ -10,12 +12,15 @@ import MediaRemoteAdapter
 final class MediaPlaybackService {
     static let shared = MediaPlaybackService()
 
+    #if arch(arm64)
     private let mediaController = MediaController()
+    #endif
 
     private init() {}
 
     // MARK: - Public API
 
+    #if arch(arm64)
     /// Pauses system media playback if something is currently playing.
     ///
     /// - Returns: `true` if we successfully paused playback, `false` if nothing was playing
@@ -100,4 +105,18 @@ final class MediaPlaybackService {
         // Use explicit play() command - never toggle
         self.mediaController.play()
     }
+    #else
+    // Intel Mac stub - media control not available
+    func pauseIfPlaying() async -> Bool {
+        DebugLogger.shared.debug(
+            "MediaPlaybackService: Not available on Intel Macs",
+            source: "MediaPlaybackService"
+        )
+        return false
+    }
+
+    func resumeIfWePaused(_ wePaused: Bool) async {
+        // No-op on Intel
+    }
+    #endif
 }


### PR DESCRIPTION
bug fix - mediaRemoet Framework inclusion related 

## Description
bug fix - auto start stop needs arm64 - added exception fgor intel 

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
Closes #(issue number)

## Testing
- [ ] Tested on Intel/Apple Silicon Mac
- [ ] Tested on Apple Silicon Mac
- [ ] Tested on macOS [version]
- [ ] Ran linter locally: `brew install swiftlint && swiftlint --strict --config .swiftlint.yml`
- [ ] Ran formatter locally: `brew install swiftformat && swiftformat --config .swiftformat Sources`

## Screenshots / Video 
Add screenshots or Video recording of the app after you have made your changes 