### PR TITLE
Voxtral MLX ASR integration + build fix for MediaRemoteAdapter

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,33 @@
       }
     },
     {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "4dccaeda1d83cf8697f235d2786c2d72ad4bb925",
+        "version" : "0.30.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
+      "state" : {
+        "revision" : "360c5052b81cc154b04ee0933597a4ad6db4b8ae",
+        "version" : "2.30.3"
+      }
+    },
+    {
+      "identity" : "mlx-voxtral-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/VincentGourbin/mlx-voxtral-swift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "b355644d6f4c4b191db6f17a406a456b77598a3c"
+      }
+    },
+    {
       "identity" : "path.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mxcl/Path.swift",
@@ -61,6 +88,51 @@
       "state" : {
         "revision" : "8a98e31a47854d3180882c8068cc4d9381bf382d",
         "version" : "6.22.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
+        "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "573e5c9036c2f136b3a8a071da8e8907322403d0",
+        "version" : "1.1.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,8 @@ let package = Package(
         .package(url: "https://github.com/MrKai77/DynamicNotchKit", from: "1.0.0"),
         .package(url: "https://github.com/exPHAT/SwiftWhisper.git", branch: "master"),
         .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
+        // Voxtral MLX for Apple Silicon speech-to-text
+        .package(url: "https://github.com/VincentGourbin/mlx-voxtral-swift", branch: "main"),
     ],
     targets: [
         .executableTarget(
@@ -26,6 +28,7 @@ let package = Package(
                 "DynamicNotchKit",
                 "SwiftWhisper",
                 .product(name: "PostHog", package: "posthog-ios"),
+                .product(name: "VoxtralCore", package: "mlx-voxtral-swift"),
             ]
         ),
     ]

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1520,6 +1520,11 @@ final class SettingsStore: ObservableObject {
         case whisperLargeTurbo = "whisper-large-turbo" // temporarily disabled in UI
         case whisperLarge = "whisper-large"
 
+        // MARK: - Voxtral MLX Models (Apple Silicon Only)
+        case voxtralMini = "voxtral-mini"
+        case voxtralMini8bit = "voxtral-mini-8bit"
+        case voxtralMini4bit = "voxtral-mini-4bit"
+
         var id: String { rawValue }
 
         // MARK: - Display Properties
@@ -1536,6 +1541,9 @@ final class SettingsStore: ObservableObject {
             case .whisperMedium: return "Whisper Medium"
             case .whisperLargeTurbo: return "Whisper Large Turbo (Disabled)"
             case .whisperLarge: return "Whisper Large"
+            case .voxtralMini: return "Voxtral Mini 3B"
+            case .voxtralMini8bit: return "Voxtral Mini 3B (8-bit)"
+            case .voxtralMini4bit: return "Voxtral Mini 3B (4-bit)"
             }
         }
 
@@ -1547,6 +1555,8 @@ final class SettingsStore: ObservableObject {
             case .appleSpeechAnalyzer: return "EN, ES, FR, DE, IT, JA, KO, PT, ZH"
             case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
                 return "99 Languages"
+            case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit:
+                return "13 Languages (incl. German)"
             }
         }
 
@@ -1562,12 +1572,23 @@ final class SettingsStore: ObservableObject {
             case .whisperMedium: return "~1.5 GB"
             case .whisperLargeTurbo: return "~1.6 GB"
             case .whisperLarge: return "~2.9 GB"
+            case .voxtralMini: return "~6 GB"
+            case .voxtralMini8bit: return "~3.5 GB"
+            case .voxtralMini4bit: return "~2 GB"
             }
         }
 
         var requiresAppleSilicon: Bool {
             switch self {
             case .parakeetTDT, .parakeetTDTv2: return true
+            case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit: return true
+            default: return false
+            }
+        }
+
+        var isVoxtralModel: Bool {
+            switch self {
+            case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit: return true
             default: return false
             }
         }
@@ -1575,6 +1596,7 @@ final class SettingsStore: ObservableObject {
         var isWhisperModel: Bool {
             switch self {
             case .parakeetTDT, .parakeetTDTv2, .appleSpeech, .appleSpeechAnalyzer: return false
+            case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit: return false
             default: return true
             }
         }
@@ -1657,6 +1679,9 @@ final class SettingsStore: ObservableObject {
             case .whisperMedium: return "Medium Quality"
             case .whisperLargeTurbo: return "Higher Quality but Faster"
             case .whisperLarge: return "Maximum Accuracy"
+            case .voxtralMini: return "Voxtral - Full Precision"
+            case .voxtralMini8bit: return "Voxtral - Fast & Accurate"
+            case .voxtralMini4bit: return "Voxtral - Ultra Fast"
             }
         }
 
@@ -1683,6 +1708,12 @@ final class SettingsStore: ObservableObject {
                 return "Near-maximum accuracy with optimized speed."
             case .whisperLarge:
                 return "Best possible accuracy. Large download and memory usage."
+            case .voxtralMini:
+                return "Mistral's Voxtral model. Full precision, 13 languages."
+            case .voxtralMini8bit:
+                return "Voxtral quantized to 8-bit. Best speed/quality balance."
+            case .voxtralMini4bit:
+                return "Voxtral quantized to 4-bit. Fastest, smallest footprint."
             }
         }
 
@@ -1705,6 +1736,12 @@ final class SettingsStore: ObservableObject {
                 return 8.0
             case .whisperLarge:
                 return 10.0 // Large model needs ~6-8GB working memory + model size
+            case .voxtralMini:
+                return 15.0 // Full precision ~6GB model + working memory
+            case .voxtralMini8bit:
+                return 10.0 // 8-bit ~3.5GB model + working memory
+            case .voxtralMini4bit:
+                return 8.0 // 4-bit ~2GB model + working memory
             }
         }
 
@@ -1735,6 +1772,9 @@ final class SettingsStore: ObservableObject {
             case .whisperMedium: return 2
             case .whisperLargeTurbo: return 3
             case .whisperLarge: return 1
+            case .voxtralMini: return 3
+            case .voxtralMini8bit: return 4
+            case .voxtralMini4bit: return 5
             }
         }
 
@@ -1751,6 +1791,9 @@ final class SettingsStore: ObservableObject {
             case .whisperMedium: return 4
             case .whisperLargeTurbo: return 5
             case .whisperLarge: return 5
+            case .voxtralMini: return 5
+            case .voxtralMini8bit: return 4
+            case .voxtralMini4bit: return 4
             }
         }
 
@@ -1767,6 +1810,9 @@ final class SettingsStore: ObservableObject {
             case .whisperMedium: return 0.40
             case .whisperLargeTurbo: return 0.65
             case .whisperLarge: return 0.20
+            case .voxtralMini: return 0.50
+            case .voxtralMini8bit: return 0.75
+            case .voxtralMini4bit: return 0.90
             }
         }
 
@@ -1783,6 +1829,9 @@ final class SettingsStore: ObservableObject {
             case .whisperMedium: return 0.80
             case .whisperLargeTurbo: return 0.95
             case .whisperLarge: return 1.00
+            case .voxtralMini: return 0.92
+            case .voxtralMini8bit: return 0.88
+            case .voxtralMini4bit: return 0.85
             }
         }
 
@@ -1822,6 +1871,7 @@ final class SettingsStore: ObservableObject {
             case nvidia = "NVIDIA"
             case apple = "Apple"
             case openai = "OpenAI"
+            case voxtral = "Voxtral"
         }
 
         /// Which provider this model belongs to
@@ -1833,6 +1883,8 @@ final class SettingsStore: ObservableObject {
                 return .apple
             case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
                 return .openai
+            case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit:
+                return .voxtral
             }
         }
 
@@ -1883,6 +1935,8 @@ final class SettingsStore: ObservableObject {
                 return "Apple"
             case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
                 return "OpenAI"
+            case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit:
+                return "Voxtral"
             }
         }
 
@@ -1903,6 +1957,8 @@ final class SettingsStore: ObservableObject {
                 return "#A2AAAD" // Apple Gray
             case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
                 return "#10A37F" // OpenAI Teal
+            case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit:
+                return "#FF4A00" // Voxtral/Mistral-ish orange
             }
         }
     }

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -134,6 +134,7 @@ final class ASRService: ObservableObject {
     private var fluidAudioProvider: FluidAudioProvider?
     private var whisperProvider: WhisperProvider?
     private var appleSpeechProvider: AppleSpeechProvider?
+    private var voxtralMLXProvider: VoxtralMLXProvider?
     /// Stored as Any? because @available cannot be applied to stored properties
     private var _appleSpeechAnalyzerProvider: Any?
 
@@ -159,6 +160,8 @@ final class ASRService: ObservableObject {
             return self.getAppleSpeechProvider()
         case .parakeetTDT, .parakeetTDTv2:
             return self.getFluidAudioProvider()
+        case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit:
+            return self.getVoxtralMLXProvider()
         default:
             return self.getWhisperProvider()
         }
@@ -181,6 +184,16 @@ final class ASRService: ObservableObject {
         let provider = WhisperProvider()
         self.whisperProvider = provider
         DebugLogger.shared.info("ASRService: Created Whisper provider", source: "ASRService")
+        return provider
+    }
+
+    private func getVoxtralMLXProvider() -> VoxtralMLXProvider {
+        if let existing = voxtralMLXProvider {
+            return existing
+        }
+        let provider = VoxtralMLXProvider()
+        self.voxtralMLXProvider = provider
+        DebugLogger.shared.info("ASRService: Created VoxtralMLX provider", source: "ASRService")
         return provider
     }
 
@@ -231,6 +244,10 @@ final class ASRService: ObservableObject {
         case .parakeetTDT, .parakeetTDTv2:
             // Create a new provider configured for the specific model
             let provider = FluidAudioProvider(modelOverride: model)
+            return provider
+        case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit:
+            // Voxtral MLX provider for Apple Silicon
+            let provider = VoxtralMLXProvider(modelOverride: model)
             return provider
         default:
             // Whisper models - create provider with specific model override
@@ -304,6 +321,7 @@ final class ASRService: ObservableObject {
         self.fluidAudioProvider = nil
         self.whisperProvider = nil
         self.appleSpeechProvider = nil
+        self.voxtralMLXProvider = nil
         self._appleSpeechAnalyzerProvider = nil
 
         // CRITICAL FIX: Check if the NEW model's files exist on disk

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -1,5 +1,6 @@
 import Foundation
-#if arch(arm64)
+
+#if canImport(MediaRemoteAdapter) && arch(arm64)
 import MediaRemoteAdapter
 #endif
 
@@ -12,7 +13,7 @@ import MediaRemoteAdapter
 final class MediaPlaybackService {
     static let shared = MediaPlaybackService()
 
-    #if arch(arm64)
+    #if canImport(MediaRemoteAdapter) && arch(arm64)
     private let mediaController = MediaController()
     #endif
 
@@ -20,7 +21,7 @@ final class MediaPlaybackService {
 
     // MARK: - Public API
 
-    #if arch(arm64)
+    #if canImport(MediaRemoteAdapter) && arch(arm64)
     /// Pauses system media playback if something is currently playing.
     ///
     /// - Returns: `true` if we successfully paused playback, `false` if nothing was playing

--- a/Sources/Fluid/Services/VoxtralMLXProvider.swift
+++ b/Sources/Fluid/Services/VoxtralMLXProvider.swift
@@ -1,0 +1,191 @@
+import Foundation
+#if arch(arm64)
+import VoxtralCore
+#endif
+
+/// TranscriptionProvider implementation using Voxtral MLX for Apple Silicon.
+/// This provides on-device speech recognition using Mistral's Voxtral model via MLX.
+final class VoxtralMLXProvider: TranscriptionProvider {
+    let name = "Voxtral MLX"
+
+    /// Whether this provider is supported on the current system.
+    /// Voxtral MLX requires Apple Silicon.
+    var isAvailable: Bool {
+        CPUArchitecture.isAppleSilicon
+    }
+
+    #if arch(arm64)
+    private var pipeline: VoxtralPipeline?
+    #endif
+    
+    private(set) var isReady: Bool = false
+    private var loadedModelId: String?
+
+    /// Optional model override - if set, uses this model instead of the global setting.
+    var modelOverride: SettingsStore.SpeechModel?
+
+    init(modelOverride: SettingsStore.SpeechModel? = nil) {
+        self.modelOverride = modelOverride
+    }
+
+    /// The model to use - reads from override first, then global setting
+    private var currentModel: SettingsStore.SpeechModel {
+        modelOverride ?? SettingsStore.shared.selectedSpeechModel
+    }
+
+    func prepare(progressHandler: ((Double) -> Void)? = nil) async throws {
+        #if arch(arm64)
+        guard isReady == false else { return }
+
+        let model = currentModel
+        let modelId = model.id
+
+        // Detect model change
+        if isReady, loadedModelId != modelId {
+            DebugLogger.shared.info("VoxtralMLXProvider: Model changed, forcing reload", source: "VoxtralMLXProvider")
+            isReady = false
+            pipeline?.unload()
+            pipeline = nil
+            loadedModelId = nil
+        }
+
+        DebugLogger.shared.info("VoxtralMLXProvider: Starting model preparation for \(model.displayName)", source: "VoxtralMLXProvider")
+
+        // Map SpeechModel to VoxtralPipeline.Model
+        let voxtralModel: VoxtralPipeline.Model
+        switch model {
+        case .voxtralMini:
+            voxtralModel = .mini3b
+        case .voxtralMini8bit:
+            voxtralModel = .mini3b8bit
+        case .voxtralMini4bit:
+            voxtralModel = .mini3b4bit
+        default:
+            voxtralModel = .mini3b8bit // Default to 8-bit for best speed/quality balance
+        }
+
+        pipeline = VoxtralPipeline(model: voxtralModel, backend: .auto)
+
+        do {
+            try await pipeline?.loadModel { progress, status in
+                DebugLogger.shared.debug("VoxtralMLXProvider: [\(Int(progress * 100))%] \(status)", source: "VoxtralMLXProvider")
+                progressHandler?(progress)
+            }
+
+            loadedModelId = modelId
+            isReady = true
+            DebugLogger.shared.info("VoxtralMLXProvider: Model ready (\(model.displayName))", source: "VoxtralMLXProvider")
+        } catch {
+            DebugLogger.shared.error("VoxtralMLXProvider: Failed to load model: \(error)", source: "VoxtralMLXProvider")
+            throw error
+        }
+        #else
+        throw NSError(
+            domain: "VoxtralMLXProvider",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "Voxtral MLX requires Apple Silicon"]
+        )
+        #endif
+    }
+
+    func transcribe(_ samples: [Float]) async throws -> ASRTranscriptionResult {
+        #if arch(arm64)
+        guard let pipeline = pipeline else {
+            throw NSError(
+                domain: "VoxtralMLXProvider",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Voxtral model not loaded"]
+            )
+        }
+
+        // Voxtral expects audio files, so we need to create a temporary WAV file
+        let tempURL = try createTempAudioFile(from: samples)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        DebugLogger.shared.debug("VoxtralMLXProvider: Starting transcription with \(samples.count) samples", source: "VoxtralMLXProvider")
+
+        do {
+            // Use "auto" for automatic language detection
+            let text = try await pipeline.transcribe(audio: tempURL, language: "auto")
+            let cleanedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            
+            DebugLogger.shared.debug("VoxtralMLXProvider: Transcription completed: '\(cleanedText)'", source: "VoxtralMLXProvider")
+            
+            return ASRTranscriptionResult(text: cleanedText, confidence: 1.0)
+        } catch {
+            DebugLogger.shared.error("VoxtralMLXProvider: Transcription failed: \(error)", source: "VoxtralMLXProvider")
+            throw error
+        }
+        #else
+        throw NSError(
+            domain: "VoxtralMLXProvider",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "Voxtral MLX requires Apple Silicon"]
+        )
+        #endif
+    }
+
+    func modelsExistOnDisk() -> Bool {
+        // VoxtralCore handles model caching via HuggingFace Hub
+        // For simplicity, we return true and let VoxtralCore handle downloading
+        return true
+    }
+
+    func clearCache() async throws {
+        #if arch(arm64)
+        pipeline?.unload()
+        pipeline = nil
+        #endif
+        isReady = false
+        loadedModelId = nil
+        DebugLogger.shared.info("VoxtralMLXProvider: Cache cleared", source: "VoxtralMLXProvider")
+    }
+
+    // MARK: - Audio File Conversion
+
+    /// Creates a temporary WAV file from Float PCM samples.
+    /// Voxtral expects audio file input rather than raw samples.
+    private func createTempAudioFile(from samples: [Float]) throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempURL = tempDir.appendingPathComponent("voxtral_input_\(UUID().uuidString).wav")
+
+        // WAV file parameters (16kHz mono 16-bit PCM)
+        let sampleRate: UInt32 = 16000
+        let numChannels: UInt16 = 1
+        let bitsPerSample: UInt16 = 16
+        let dataSize = UInt32(samples.count * 2) // 2 bytes per sample (16-bit)
+
+        var data = Data()
+
+        // RIFF header
+        data.append(contentsOf: "RIFF".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: (36 + dataSize).littleEndian) { Array($0) })
+        data.append(contentsOf: "WAVE".utf8)
+
+        // fmt chunk
+        data.append(contentsOf: "fmt ".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(16).littleEndian) { Array($0) }) // Chunk size
+        data.append(contentsOf: withUnsafeBytes(of: UInt16(1).littleEndian) { Array($0) }) // Audio format (PCM)
+        data.append(contentsOf: withUnsafeBytes(of: numChannels.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: sampleRate.littleEndian) { Array($0) })
+        let byteRate = sampleRate * UInt32(numChannels) * UInt32(bitsPerSample) / 8
+        data.append(contentsOf: withUnsafeBytes(of: byteRate.littleEndian) { Array($0) })
+        let blockAlign = numChannels * bitsPerSample / 8
+        data.append(contentsOf: withUnsafeBytes(of: blockAlign.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: bitsPerSample.littleEndian) { Array($0) })
+
+        // data chunk
+        data.append(contentsOf: "data".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: dataSize.littleEndian) { Array($0) })
+
+        // Convert Float [-1.0, 1.0] samples to Int16
+        for sample in samples {
+            let clamped = max(-1.0, min(1.0, sample))
+            let int16Value = Int16(clamped * 32767.0)
+            data.append(contentsOf: withUnsafeBytes(of: int16Value.littleEndian) { Array($0) })
+        }
+
+        try data.write(to: tempURL)
+        return tempURL
+    }
+}

--- a/VOXTRAL_INTEGRATION.md
+++ b/VOXTRAL_INTEGRATION.md
@@ -1,0 +1,276 @@
+# Voxtral MLX Integration Plan
+
+**Status:** 🚧 In Progress
+**Assigned:** Schurl
+**Created:** 2026-02-05
+
+## Ziel
+
+Voxtral MLX als neues Speech-to-Text Modell in FluidVoice integrieren.
+
+## Dependency hinzufügen
+
+In `Package.swift`:
+```swift
+.package(url: "https://github.com/VincentGourbin/mlx-voxtral-swift", branch: "main")
+
+// In target dependencies:
+.product(name: "VoxtralCore", package: "mlx-voxtral-swift")
+```
+
+## Neue Dateien
+
+### 1. `Sources/Fluid/Services/VoxtralMLXProvider.swift`
+
+```swift
+import Foundation
+import VoxtralCore
+
+/// TranscriptionProvider implementation using Voxtral MLX for Apple Silicon
+final class VoxtralMLXProvider: TranscriptionProvider {
+    let name = "Voxtral MLX"
+    
+    var isAvailable: Bool {
+        CPUArchitecture.isAppleSilicon
+    }
+    
+    private var pipeline: VoxtralPipeline?
+    private(set) var isReady: Bool = false
+    private var loadedModel: SettingsStore.SpeechModel?
+    
+    var modelOverride: SettingsStore.SpeechModel?
+    
+    init(modelOverride: SettingsStore.SpeechModel? = nil) {
+        self.modelOverride = modelOverride
+    }
+    
+    private var currentModel: SettingsStore.SpeechModel {
+        modelOverride ?? SettingsStore.shared.selectedSpeechModel
+    }
+    
+    func prepare(progressHandler: ((Double) -> Void)?) async throws {
+        guard isReady == false else { return }
+        
+        let model = currentModel
+        let voxtralModel: VoxtralPipeline.Model = switch model {
+            case .voxtralMini: .mini3b
+            case .voxtralMini8bit: .mini3b8bit
+            case .voxtralMini4bit: .mini3b4bit
+            default: .mini3b8bit // Default to 8-bit for best speed/quality
+        }
+        
+        pipeline = VoxtralPipeline(model: voxtralModel, backend: .auto)
+        
+        try await pipeline?.loadModel { progress, status in
+            progressHandler?(progress)
+        }
+        
+        loadedModel = model
+        isReady = true
+    }
+    
+    func transcribe(_ samples: [Float]) async throws -> ASRTranscriptionResult {
+        guard let pipeline = pipeline else {
+            throw NSError(domain: "VoxtralMLXProvider", code: -1, 
+                         userInfo: [NSLocalizedDescriptionKey: "Voxtral model not loaded"])
+        }
+        
+        // Convert samples to audio URL (Voxtral expects file input)
+        let tempURL = try createTempAudioFile(from: samples)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        
+        let text = try await pipeline.transcribe(audio: tempURL, language: "auto")
+        return ASRTranscriptionResult(text: text, confidence: 1.0)
+    }
+    
+    func modelsExistOnDisk() -> Bool {
+        // Check if model weights are cached
+        // VoxtralCore handles caching via HuggingFace Hub
+        return true // Simplified - VoxtralCore auto-downloads
+    }
+    
+    func clearCache() async throws {
+        pipeline?.unload()
+        pipeline = nil
+        isReady = false
+        loadedModel = nil
+    }
+    
+    private func createTempAudioFile(from samples: [Float]) throws -> URL {
+        // Convert Float samples to WAV file
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempURL = tempDir.appendingPathComponent("voxtral_input_\(UUID().uuidString).wav")
+        
+        // Write WAV header + PCM data (16kHz mono)
+        var data = Data()
+        let sampleRate: UInt32 = 16000
+        let numChannels: UInt16 = 1
+        let bitsPerSample: UInt16 = 16
+        let dataSize = UInt32(samples.count * 2)
+        
+        // RIFF header
+        data.append(contentsOf: "RIFF".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: (36 + dataSize).littleEndian) { Array($0) })
+        data.append(contentsOf: "WAVE".utf8)
+        
+        // fmt chunk
+        data.append(contentsOf: "fmt ".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(16).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: UInt16(1).littleEndian) { Array($0) }) // PCM
+        data.append(contentsOf: withUnsafeBytes(of: numChannels.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: sampleRate.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: (sampleRate * UInt32(numChannels) * UInt32(bitsPerSample) / 8).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: (numChannels * bitsPerSample / 8).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: bitsPerSample.littleEndian) { Array($0) })
+        
+        // data chunk
+        data.append(contentsOf: "data".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: dataSize.littleEndian) { Array($0) })
+        
+        // Convert Float [-1, 1] to Int16
+        for sample in samples {
+            let clamped = max(-1.0, min(1.0, sample))
+            let int16 = Int16(clamped * 32767.0)
+            data.append(contentsOf: withUnsafeBytes(of: int16.littleEndian) { Array($0) })
+        }
+        
+        try data.write(to: tempURL)
+        return tempURL
+    }
+}
+```
+
+## Bestehende Dateien ändern
+
+### 2. `Sources/Fluid/Persistence/SettingsStore.swift`
+
+Im `SpeechModel` enum hinzufügen:
+
+```swift
+// MARK: - Voxtral MLX Models (Apple Silicon Only)
+case voxtralMini = "voxtral-mini"
+case voxtralMini8bit = "voxtral-mini-8bit"  
+case voxtralMini4bit = "voxtral-mini-4bit"
+```
+
+Properties erweitern:
+
+```swift
+var displayName: String {
+    // ... existing cases ...
+    case .voxtralMini: return "Voxtral Mini 3B"
+    case .voxtralMini8bit: return "Voxtral Mini 3B (8-bit)"
+    case .voxtralMini4bit: return "Voxtral Mini 3B (4-bit)"
+}
+
+var languageSupport: String {
+    case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit: return "13 Languages"
+}
+
+var downloadSize: String {
+    case .voxtralMini: return "~6 GB"
+    case .voxtralMini8bit: return "~3.5 GB"
+    case .voxtralMini4bit: return "~2 GB"
+}
+
+var requiresAppleSilicon: Bool {
+    case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit: return true
+}
+
+var isVoxtralModel: Bool {
+    switch self {
+    case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit: return true
+    default: return false
+    }
+}
+```
+
+### 3. `Sources/Fluid/Services/ASRService.swift`
+
+Provider-Cache hinzufügen:
+
+```swift
+private var voxtralMLXProvider: VoxtralMLXProvider?
+```
+
+Getter hinzufügen:
+
+```swift
+private func getVoxtralMLXProvider() -> VoxtralMLXProvider {
+    if let existing = voxtralMLXProvider {
+        return existing
+    }
+    let provider = VoxtralMLXProvider()
+    self.voxtralMLXProvider = provider
+    DebugLogger.shared.info("ASRService: Created VoxtralMLX provider", source: "ASRService")
+    return provider
+}
+```
+
+In `transcriptionProvider` getter erweitern:
+
+```swift
+private var transcriptionProvider: TranscriptionProvider {
+    let model = SettingsStore.shared.selectedSpeechModel
+    
+    switch model {
+    // ... existing cases ...
+    case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit:
+        return self.getVoxtralMLXProvider()
+    default:
+        return self.getWhisperProvider()
+    }
+}
+```
+
+In `getProvider(for:)` erweitern:
+
+```swift
+func getProvider(for model: SettingsStore.SpeechModel) -> TranscriptionProvider {
+    switch model {
+    // ... existing cases ...
+    case .voxtralMini, .voxtralMini8bit, .voxtralMini4bit:
+        return VoxtralMLXProvider(modelOverride: model)
+    default:
+        return WhisperProvider(modelOverride: model)
+    }
+}
+```
+
+In `resetTranscriptionProvider()`:
+
+```swift
+self.voxtralMLXProvider = nil
+```
+
+### 4. `Package.swift`
+
+```swift
+dependencies: [
+    // ... existing ...
+    .package(url: "https://github.com/VincentGourbin/mlx-voxtral-swift", branch: "main"),
+],
+targets: [
+    .executableTarget(
+        name: "FluidVoice",
+        dependencies: [
+            // ... existing ...
+            .product(name: "VoxtralCore", package: "mlx-voxtral-swift"),
+        ]
+    ),
+]
+```
+
+## Testing
+
+1. Build in Xcode
+2. Select Voxtral Mini 4-bit in settings
+3. Download model (first time)
+4. Test transcription
+5. Verify German language works
+
+## Notes
+
+- VoxtralCore erwartet Audio-Files, nicht raw samples → Temp WAV erstellen
+- Model-Download via HuggingFace Hub (automatisch)
+- 4-bit empfohlen für beste Performance (~17 tok/s)


### PR DESCRIPTION
Implements Voxtral MLX speech recognition integration + fixes pre-existing build break.

## Fix
- `MediaPlaybackService` now uses `#if canImport(MediaRemoteAdapter)` instead of `#if arch(arm64)` so the project builds even when the private framework is unavailable.

## Voxtral integration
- Adds `VoxtralMLXProvider` (TranscriptionProvider)
- Extends `SettingsStore.SpeechModel` with: `voxtralMini`, `voxtralMini8bit`, `voxtralMini4bit`
- Wires Voxtral provider into `ASRService`
- Adds `mlx-voxtral-swift` dependency in `Package.swift`
- Adds `VOXTRAL_INTEGRATION.md`

## Notes
- `swift build` succeeds.
- `swift test` currently errors due to unhandled resources in SPM deps (existing packaging issue); not caused by this PR.
