### PR TITLE
Split GAAV mode into separate text formatting settings

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1523,7 +1523,7 @@ struct ContentView: View {
             }
 
             let result = await self.processTextWithAI(transcribedText, overrideSystemPrompt: promptTest.draftPromptText)
-            let finalText = ASRService.applyGAAVFormatting(result)
+            let finalText = ASRService.applyTranscriptionFormatting(result)
             promptTest.lastOutputText = finalText
             return
         }
@@ -1579,9 +1579,9 @@ struct ContentView: View {
             self.menuBarManager.setProcessing(false)
         }
 
-        // Apply GAAV formatting as the FINAL step (after AI post-processing)
-        // This ensures the user's preference for no capitalization/period is respected
-        finalText = ASRService.applyGAAVFormatting(finalText)
+        // Apply text formatting as the FINAL step (after AI post-processing)
+        // This ensures the user's formatting preferences are respected
+        finalText = ASRService.applyTranscriptionFormatting(finalText)
 
         DebugLogger.shared.info("Transcription finalized (chars: \(finalText.count))", source: "ContentView")
 

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -17,6 +17,7 @@ final class SettingsStore: ObservableObject {
         self.migrateProviderAPIKeysIfNeeded()
         self.scrubSavedProviderAPIKeys()
         self.migrateDictationPromptProfilesIfNeeded()
+        self.migrateGAAVModeIfNeeded()
     }
 
     // Keys
@@ -82,7 +83,13 @@ final class SettingsStore: ObservableObject {
         static let removeFillerWordsEnabled = "RemoveFillerWordsEnabled"
 
         // GAAV Mode (removes capitalization and trailing punctuation)
+        // Legacy key - kept for migration purposes
         static let gaavModeEnabled = "GAAVModeEnabled"
+
+        // Text Formatting Options (replaces GAAV Mode)
+        static let uppercaseFirstLetter = "UppercaseFirstLetter"
+        static let keepTrailingPeriod = "KeepTrailingPeriod"
+        static let insertTrailingSpace = "InsertTrailingSpace"
 
         // Custom Dictionary
         static let customDictionaryEntries = "CustomDictionaryEntries"
@@ -1253,6 +1260,26 @@ final class SettingsStore: ObservableObject {
         DebugLogger.shared.info("Migrated legacy custom dictation prompt to a prompt profile", source: "SettingsStore")
     }
 
+    private func migrateGAAVModeIfNeeded() {
+        // Migration path from legacy GAAV mode to separate text formatting settings.
+        // If user had GAAV mode enabled, disable both uppercase and period (inverted logic).
+        guard let legacyValue = defaults.object(forKey: Keys.gaavModeEnabled) as? Bool,
+              legacyValue == true else {
+            // No migration needed - either never set or was false
+            return
+        }
+
+        // Migrate: GAAV enabled → disable uppercase and period (inverted from old behavior)
+        self.uppercaseFirstLetter = false
+        self.keepTrailingPeriod = false
+        // Note: insertTrailingSpace stays false (new feature, not part of original GAAV)
+
+        // Remove legacy key to prevent re-migration
+        defaults.removeObject(forKey: Keys.gaavModeEnabled)
+
+        DebugLogger.shared.info("Migrated GAAV mode to separate text formatting settings", source: "SettingsStore")
+    }
+
     private func scrubSavedProviderAPIKeys() {
         guard let data = defaults.data(forKey: Keys.savedProviders),
               var decoded = try? JSONDecoder().decode([SavedProvider].self, from: data) else { return }
@@ -1429,16 +1456,32 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    // MARK: - GAAV Mode
+    // MARK: - Text Formatting Options
 
-    /// GAAV Mode: Removes first letter capitalization and trailing period from transcriptions.
-    /// Useful for search queries, form fields, or casual text input where sentence formatting is unwanted.
-    /// Feature requested by maxgaav – thank you for the suggestion!
-    var gaavModeEnabled: Bool {
-        get { self.defaults.object(forKey: Keys.gaavModeEnabled) as? Bool ?? false }
+    /// Keep the first letter capitalized in transcriptions.
+    var uppercaseFirstLetter: Bool {
+        get { self.defaults.object(forKey: Keys.uppercaseFirstLetter) as? Bool ?? true }
         set {
             objectWillChange.send()
-            self.defaults.set(newValue, forKey: Keys.gaavModeEnabled)
+            self.defaults.set(newValue, forKey: Keys.uppercaseFirstLetter)
+        }
+    }
+
+    /// Keep the period at the end of transcriptions.
+    var keepTrailingPeriod: Bool {
+        get { self.defaults.object(forKey: Keys.keepTrailingPeriod) as? Bool ?? true }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.keepTrailingPeriod)
+        }
+    }
+
+    /// Insert a space after the transcription for easier continuation.
+    var insertTrailingSpace: Bool {
+        get { self.defaults.object(forKey: Keys.insertTrailingSpace) as? Bool ?? false }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.insertTrailingSpace)
         }
     }
 

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -2220,26 +2220,33 @@ final class ASRService: ObservableObject {
         return result
     }
 
-    // MARK: - GAAV Mode Formatting
+    // MARK: - Text Formatting
 
-    /// Applies GAAV mode formatting: removes first letter capitalization and trailing period.
-    /// This is useful for search queries, form fields, or casual text input.
-    ///
-    /// Feature requested by maxgaav – thank you for the suggestion!
-    static func applyGAAVFormatting(_ text: String) -> String {
-        guard SettingsStore.shared.gaavModeEnabled else { return text }
+    /// Applies user-configured text formatting options:
+    /// - Uppercase first letter: capitalizes the first character
+    /// - Keep trailing period: keeps or removes the period at the end
+    /// - Insert trailing space: adds a space after the transcription
+    static func applyTranscriptionFormatting(_ text: String) -> String {
         guard !text.isEmpty else { return text }
 
         var result = text
+        let settings = SettingsStore.shared
 
-        // Remove trailing period (if present)
-        if result.hasSuffix(".") {
+        // Lowercase the first character (if uppercase setting is disabled)
+        if !settings.uppercaseFirstLetter,
+           let first = result.first, first.isUppercase
+        {
+            result = first.lowercased() + result.dropFirst()
+        }
+
+        // Remove trailing period (if keep period setting is disabled and one exists)
+        if !settings.keepTrailingPeriod && result.hasSuffix(".") {
             result.removeLast()
         }
 
-        // Lowercase the first character (if it's uppercase)
-        if let first = result.first, first.isUppercase {
-            result = first.lowercased() + result.dropFirst()
+        // Add trailing space (if setting enabled, result is non-empty, and doesn't already end with space)
+        if settings.insertTrailingSpace && !result.isEmpty && !result.hasSuffix(" ") {
+            result += " "
         }
 
         return result

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -510,16 +510,6 @@ struct SettingsView: View {
                                     Divider().opacity(0.2)
 
                                     self.optionToggleRow(
-                                        title: "GAAV Mode",
-                                        description: "Remove first letter capitalization and trailing period. Useful for search queries, form fields, or casual text.\nFeature requested by MaxGaav.",
-                                        isOn: Binding(
-                                            get: { SettingsStore.shared.gaavModeEnabled },
-                                            set: { SettingsStore.shared.gaavModeEnabled = $0 }
-                                        )
-                                    )
-                                    Divider().opacity(0.2)
-
-                                    self.optionToggleRow(
                                         title: "Pause Media During Transcription",
                                         description: "Automatically pause currently playing audio/video when transcription starts. Resumes only if FluidVoice paused it.",
                                         isOn: Binding(
@@ -528,6 +518,48 @@ struct SettingsView: View {
                                         )
                                     )
                                     Divider().opacity(0.2)
+
+                                    // MARK: - Text Formatting Section
+
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("Text Formatting")
+                                            .font(.subheadline.weight(.medium))
+                                            .foregroundStyle(.secondary)
+                                            .padding(.bottom, 4)
+
+                                        self.optionToggleRow(
+                                            title: "Uppercase First Letter",
+                                            description: "Keep the first letter capitalized in transcriptions.",
+                                            isOn: Binding(
+                                                get: { SettingsStore.shared.uppercaseFirstLetter },
+                                                set: { SettingsStore.shared.uppercaseFirstLetter = $0 }
+                                            )
+                                        )
+                                        Divider().opacity(0.2)
+
+                                        self.optionToggleRow(
+                                            title: "Keep Trailing Period",
+                                            description: "Keep the period at the end of transcriptions.",
+                                            isOn: Binding(
+                                                get: { SettingsStore.shared.keepTrailingPeriod },
+                                                set: { SettingsStore.shared.keepTrailingPeriod = $0 }
+                                            )
+                                        )
+                                        Divider().opacity(0.2)
+
+                                        self.optionToggleRow(
+                                            title: "Add Trailing Space",
+                                            description: "Insert a space after the transcription for easier continuation.",
+                                            isOn: Binding(
+                                                get: { SettingsStore.shared.insertTrailingSpace },
+                                                set: { SettingsStore.shared.insertTrailingSpace = $0 }
+                                            )
+                                        )
+                                    }
+                                    .padding(.top, 4)
+
+                                    Divider().opacity(0.2)
+                                        .padding(.vertical, 8)
 
                                     self.optionToggleRow(
                                         title: "Share Anonymous Analytics",


### PR DESCRIPTION
## Description

- Replace single GAAV mode toggle with three independent settings:
  - Uppercase First Letter (default: on)
  - Keep Trailing Period (default: on)
  - Add Trailing Space (default: off, new feature)
- Use positive framing for all settings (on = apply formatting)
- Add automatic migration from legacy GAAV mode setting
- Preserve existing behavior for users with GAAV enabled
- Update UI to group settings under 'Text Formatting' section
- Rename applyGAAVFormatting to applyTranscriptionFormatting

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Testing
- [ ] Tested on Intel/Apple Silicon Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.2
- [ ] Ran linter locally: `brew install swiftlint && swiftlint --strict --config .swiftlint.yml`
- [ ] Ran formatter locally: `brew install swiftformat && swiftformat --config .swiftformat Sources`

I couldn't run swiftlint due to: `SourceKittenFramework/library_wrapper.swift:58: Fatal error: Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed`

And swiftformat generated lots of unrelated changes.

<img width="1163" height="846" alt="image" src="https://github.com/user-attachments/assets/9c2163b3-98a9-4d41-8a3f-99d33cc42d54" />

