### PR TITLE
Add transcription sound volume control

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -47,6 +47,8 @@ final class SettingsStore: ObservableObject {
         static let accentColorOption = "AccentColorOption"
         static let enableTranscriptionSounds = "EnableTranscriptionSounds"
         static let transcriptionStartSound = "TranscriptionStartSound"
+        static let transcriptionSoundVolume = "TranscriptionSoundVolume"
+        static let transcriptionSoundIndependentVolume = "TranscriptionSoundIndependentVolume"
         static let pressAndHoldMode = "PressAndHoldMode"
         static let enableStreamingPreview = "EnableStreamingPreview"
         static let enableAIStreaming = "EnableAIStreaming"
@@ -791,6 +793,29 @@ final class SettingsStore: ObservableObject {
         set {
             objectWillChange.send()
             self.defaults.set(newValue, forKey: Keys.enableTranscriptionSounds)
+        }
+    }
+
+    var transcriptionSoundVolume: Float {
+        get {
+            let value = self.defaults.object(forKey: Keys.transcriptionSoundVolume)
+            return (value as? Float) ?? 1.0
+        }
+        set {
+            objectWillChange.send()
+            let clamped = max(0.0, min(1.0, newValue))
+            self.defaults.set(clamped, forKey: Keys.transcriptionSoundVolume)
+        }
+    }
+
+    var transcriptionSoundIndependentVolume: Bool {
+        get {
+            let value = self.defaults.object(forKey: Keys.transcriptionSoundIndependentVolume)
+            return value as? Bool ?? false
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.transcriptionSoundIndependentVolume)
         }
     }
 

--- a/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
+++ b/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreAudio
 import Foundation
 
 @MainActor
@@ -6,6 +7,7 @@ final class TranscriptionSoundPlayer {
     static let shared = TranscriptionSoundPlayer()
 
     private var players: [String: AVAudioPlayer] = [:]
+    private var savedSystemVolume: Float?
 
     private init() {}
 
@@ -14,10 +16,36 @@ final class TranscriptionSoundPlayer {
         self.play(soundName: selected.soundFileName)
     }
 
-    private func play(soundName: String) {
+    /// Preview a specific sound at the current volume setting (used in Settings UI).
+    func playPreview(sound: SettingsStore.TranscriptionStartSound) {
+        self.play(soundName: sound.soundFileName)
+    }
+
+    /// Preview current sound at a specific volume (used when slider is released).
+    func playPreviewAtVolume(_ volume: Float) {
+        let selected = SettingsStore.shared.transcriptionStartSound
+        self.play(soundName: selected.soundFileName, overrideVolume: volume)
+    }
+
+    private func play(soundName: String, overrideVolume: Float? = nil) {
         guard let url = Bundle.main.url(forResource: soundName, withExtension: "m4a") else {
             DebugLogger.shared.error("Missing sound resource: \(soundName).m4a", source: "TranscriptionSoundPlayer")
             return
+        }
+
+        let settings = SettingsStore.shared
+        let desiredVolume = overrideVolume ?? settings.transcriptionSoundVolume
+        let independent = settings.transcriptionSoundIndependentVolume
+
+        // If independent volume is on, temporarily adjust system volume
+        if independent {
+            let systemVol = Self.getSystemVolume()
+            // Respect mute: if system volume is 0, don't play
+            if systemVol <= 0.001 {
+                return
+            }
+            self.savedSystemVolume = systemVol
+            Self.setSystemVolume(desiredVolume)
         }
 
         do {
@@ -31,12 +59,72 @@ final class TranscriptionSoundPlayer {
             }
 
             player.currentTime = 0
+            player.volume = independent ? 1.0 : desiredVolume
             player.play()
+
+            // Restore system volume after the sound finishes
+            if independent, let savedVol = self.savedSystemVolume {
+                let duration = player.duration
+                let restoreVolume = savedVol
+                DispatchQueue.main.asyncAfter(deadline: .now() + duration + 0.05) {
+                    Self.setSystemVolume(restoreVolume)
+                    self.savedSystemVolume = nil
+                }
+            }
         } catch {
+            // Restore system volume on error
+            if independent, let savedVol = self.savedSystemVolume {
+                Self.setSystemVolume(savedVol)
+                self.savedSystemVolume = nil
+            }
             DebugLogger.shared.error(
                 "Failed to play sound \(soundName).m4a: \(error.localizedDescription)",
                 source: "TranscriptionSoundPlayer"
             )
         }
+    }
+
+    // MARK: - System Volume Control via CoreAudio
+
+    private static func getDefaultOutputDeviceID() -> AudioObjectID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioObjectID(0)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address, 0, nil, &size, &deviceID
+        )
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    static func getSystemVolume() -> Float {
+        guard let deviceID = getDefaultOutputDeviceID() else { return 1.0 }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var volume: Float32 = 1.0
+        var size = UInt32(MemoryLayout<Float32>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &volume)
+        guard status == noErr else { return 1.0 }
+        return volume
+    }
+
+    private static func setSystemVolume(_ volume: Float) {
+        guard let deviceID = getDefaultOutputDeviceID() else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var vol = max(0.0, min(1.0, volume))
+        let size = UInt32(MemoryLayout<Float32>.size)
+        AudioObjectSetPropertyData(deviceID, &address, 0, nil, size, &vol)
     }
 }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -203,7 +203,10 @@ struct SettingsView: View {
 
                                     Picker("", selection: Binding(
                                         get: { SettingsStore.shared.transcriptionStartSound },
-                                        set: { SettingsStore.shared.transcriptionStartSound = $0 }
+                                        set: { newValue in
+                                            SettingsStore.shared.transcriptionStartSound = newValue
+                                            TranscriptionSoundPlayer.shared.playPreview(sound: newValue)
+                                        }
                                     )) {
                                         ForEach(SettingsStore.TranscriptionStartSound.allCases) { option in
                                             Text(option.displayName).tag(option)
@@ -212,6 +215,43 @@ struct SettingsView: View {
                                     .pickerStyle(.menu)
                                     .frame(width: 170, alignment: .trailing)
                                 }
+
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text("Volume")
+                                            .font(.body)
+                                        Text("Adjust the notification sound volume.")
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                    }
+
+                                    Spacer()
+
+                                    Slider(
+                                        value: Binding(
+                                            get: { Double(SettingsStore.shared.transcriptionSoundVolume) },
+                                            set: { SettingsStore.shared.transcriptionSoundVolume = Float($0) }
+                                        ),
+                                        in: 0...1,
+                                        step: 0.05
+                                    ) { editing in
+                                        if !editing {
+                                            TranscriptionSoundPlayer.shared.playPreviewAtVolume(
+                                                SettingsStore.shared.transcriptionSoundVolume
+                                            )
+                                        }
+                                    }
+                                    .frame(width: 150)
+                                }
+
+                                self.settingsToggleRow(
+                                    title: "Independent Volume",
+                                    description: "Sound volume stays constant regardless of system volume. Mute is still respected.",
+                                    isOn: Binding(
+                                        get: { SettingsStore.shared.transcriptionSoundIndependentVolume },
+                                        set: { SettingsStore.shared.transcriptionSoundIndependentVolume = $0 }
+                                    )
+                                )
                             }
 
                             Divider().opacity(0.2)


### PR DESCRIPTION
## Summary
- **Volume slider** for transcription notification sounds (0–100%), shown in Settings when sounds are enabled
- **Independent Volume toggle** — keeps notification volume constant regardless of system volume level. Uses CoreAudio to temporarily set system volume for the duration of the sound, then restores it. Mute (system volume = 0) is respected
- **Sound preview on selection** — changing the sound in the picker immediately plays it so the user can hear it before use
- **Sound preview on slider release** — releasing the volume slider plays the current sound at the new level

## Changes
- `SettingsStore.swift` — added `transcriptionSoundVolume` (Float, default 1.0) and `transcriptionSoundIndependentVolume` (Bool, default false) properties with UserDefaults persistence
- `TranscriptionSoundPlayer.swift` — added CoreAudio system volume get/set, independent volume mode logic, and `playPreview`/`playPreviewAtVolume` public methods
- `SettingsView.swift` — added volume Slider, Independent Volume toggle row, and sound preview on picker change / slider release

## Test plan
- [ ] Enable transcription sounds, verify volume slider appears
- [ ] Adjust slider, release — sound plays at the set volume
- [ ] Change sound in picker — new sound plays immediately
- [ ] Toggle "Independent Volume" on, lower system volume, trigger recording — notification plays at the configured level
- [ ] With "Independent Volume" on, mute system — notification should not play
- [ ] Verify system volume is restored after notification sound finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)