### PR TITLE
Add persistent history for file transcriptions

### DIFF
--- a/Sources/Fluid/Persistence/FileTranscriptionHistoryStore.swift
+++ b/Sources/Fluid/Persistence/FileTranscriptionHistoryStore.swift
@@ -119,7 +119,7 @@ final class FileTranscriptionHistoryStore: ObservableObject {
         let entry = FileTranscriptionEntry(from: result)
         self.entries.insert(entry, at: 0)
 
-        if self.entries.count > maxEntries {
+        if self.entries.count > self.maxEntries {
             self.entries.removeLast()
         }
 

--- a/Sources/Fluid/Services/MeetingTranscriptionService.swift
+++ b/Sources/Fluid/Services/MeetingTranscriptionService.swift
@@ -48,12 +48,12 @@ struct TranscriptionResult: Identifiable, Sendable, Codable {
 
     func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
-        try c.encode(text, forKey: .text)
-        try c.encode(confidence, forKey: .confidence)
-        try c.encode(duration, forKey: .duration)
-        try c.encode(processingTime, forKey: .processingTime)
-        try c.encode(fileName, forKey: .fileName)
-        try c.encode(timestamp, forKey: .timestamp)
+        try c.encode(self.text, forKey: .text)
+        try c.encode(self.confidence, forKey: .confidence)
+        try c.encode(self.duration, forKey: .duration)
+        try c.encode(self.processingTime, forKey: .processingTime)
+        try c.encode(self.fileName, forKey: .fileName)
+        try c.encode(self.timestamp, forKey: .timestamp)
     }
 }
 
@@ -67,7 +67,7 @@ final class MeetingTranscriptionService: ObservableObject {
     @Published var error: String?
     @Published var result: TranscriptionResult?
 
-    // Share the ASR service instance to avoid loading models twice
+    /// Share the ASR service instance to avoid loading models twice
     private let asrService: ASRService
 
     init(asrService: ASRService) {

--- a/Sources/Fluid/UI/MeetingTranscriptionView.swift
+++ b/Sources/Fluid/UI/MeetingTranscriptionView.swift
@@ -201,9 +201,11 @@ struct MeetingTranscriptionView: View {
                                 .stroke(self.theme.palette.cardBorder.opacity(0.45), lineWidth: 1)
                         )
                 )
-                .overlay(RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [8]))
-                    .foregroundColor(Color.fluidGreen.opacity(0.3)))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [8]))
+                        .foregroundColor(Color.fluidGreen.opacity(0.3))
+                )
             }
         }
         .fileImporter(
@@ -543,7 +545,9 @@ struct MeetingTranscriptionView: View {
 // MARK: - Document for Export
 
 struct TranscriptionDocument: FileDocument {
-    static var readableContentTypes: [UTType] { [.plainText, .json] }
+    static var readableContentTypes: [UTType] {
+        [.plainText, .json]
+    }
 
     let result: TranscriptionResult
     let format: MeetingTranscriptionView.ExportFormat


### PR DESCRIPTION
## Description
- Add `FileTranscriptionHistoryStore` and `FileTranscriptionEntry` so completed file transcriptions are saved to UserDefaults (cap 50, newest first).
- After a successful `transcribeFile()`, append the result to the store so it survives navigation away from the Meeting Transcription tab.
- In Meeting Transcription UI: add a "Recent transcriptions" section below the result/error cards with a selectable list; tapping an entry shows a detail card (copy, export, delete). Reuse existing export/copy flow via `FileTranscriptionEntry.toTranscriptionResult()`.
- Give `TranscriptionResult` an explicit initializer and custom Codable (id not encoded) so history entries can be turned into `TranscriptionResult` for export and so decoding stays backward compatible.

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
Relates #141 

## Testing
- [ ] Tested on Intel/Apple Silicon Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS Tahoe 26.4
- [x] Ran linter locally: `brew install swiftlint && swiftlint --strict --config .swiftlint.yml`
- [x] Ran formatter locally: `brew install swiftformat && swiftformat --config .swiftformat Sources`

## Screenshots / Video 

https://github.com/user-attachments/assets/1ab6e7ad-86d9-4c7d-8f3d-4a21d668a5ea

