### PR TITLE
Fix file transcription upload UX: full-area tap and drag-and-drop

### DIFF
--- a/Sources/Fluid/UI/MeetingTranscriptionView.swift
+++ b/Sources/Fluid/UI/MeetingTranscriptionView.swift
@@ -182,9 +182,11 @@ struct MeetingTranscriptionView: View {
                                 .stroke(self.theme.palette.cardBorder.opacity(0.45), lineWidth: 1)
                         )
                 )
-                .overlay(RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [8]))
-                    .foregroundColor(Color.fluidGreen.opacity(self.isDropTargeted ? 0.7 : 0.3)))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [8]))
+                        .foregroundColor(Color.fluidGreen.opacity(self.isDropTargeted ? 0.7 : 0.3))
+                )
                 .onDrop(of: [.fileURL], isTargeted: self.$isDropTargeted) { providers in
                     self.handleDrop(providers: providers)
                 }
@@ -459,7 +461,9 @@ struct MeetingTranscriptionView: View {
 // MARK: - Document for Export
 
 struct TranscriptionDocument: FileDocument {
-    static var readableContentTypes: [UTType] { [.plainText, .json] }
+    static var readableContentTypes: [UTType] {
+        [.plainText, .json]
+    }
 
     let result: TranscriptionResult
     let format: MeetingTranscriptionView.ExportFormat


### PR DESCRIPTION
## Description

Make the whole upload card tappable by adding `contentShape(Rectangle())` so the button responds to taps anywhere on the card, not only the label.

Add `onDrop(of: .fileURL)` so supported audio/video files can be dropped onto the upload zone; highlight the dashed border while dragging over.

Reject unsupported file types and show an error card: "Accepted file types: `WAV`, `MP3`, `M4A`, `MP4`, `MOV`, and more." with Dismiss and auto-clear after 3 seconds.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
None

## Testing
- [ ] Tested on Intel/Apple Silicon Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS Tahoe 26.4
- [x] Ran linter locally: `brew install swiftlint && swiftlint --strict --config .swiftlint.yml`
- [x] Ran formatter locally: `brew install swiftformat && swiftformat --config .swiftformat Sources`

## Screenshots / Video 

https://github.com/user-attachments/assets/2bbc7a03-f764-48ea-8d6f-3dda1235fe95