### PR TITLE
fix(media): guard against double-resume crash in pauseIfPlaying

### DIFF
--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -3,39 +3,6 @@ import Foundation
 import MediaRemoteAdapter
 #endif
 
-/// Thread-safe guard that ensures a CheckedContinuation is resumed at most once.
-///
-/// MediaRemoteAdapter's `getTrackInfo` callback can fire multiple times under certain
-/// race conditions (e.g., rapid media state changes, system under load). Since
-/// `CheckedContinuation` must be resumed exactly once, a duplicate `resume` call
-/// triggers a fatal `SIGTRAP` (EXC_BREAKPOINT) crash.
-///
-/// This guard serializes access via `NSLock` and silently drops duplicate resumes.
-private final class ContinuationOnceGuard<T: Sendable>: @unchecked Sendable {
-    private var resumed = false
-    private let lock = NSLock()
-
-    /// Attempts to resume the continuation. Returns `true` if this was the first call
-    /// (continuation was actually resumed), `false` if a prior call already resumed it.
-    @discardableResult
-    func resume(_ continuation: CheckedContinuation<T, Never>, returning value: T) -> Bool {
-        lock.lock()
-        let alreadyResumed = resumed
-        if !alreadyResumed { resumed = true }
-        lock.unlock()
-
-        if alreadyResumed {
-            DebugLogger.shared.warning(
-                "ContinuationOnceGuard: Suppressed duplicate resume (MediaRemoteAdapter callback fired more than once)",
-                source: "MediaPlaybackService"
-            )
-            return false
-        }
-        continuation.resume(returning: value)
-        return true
-    }
-}
-
 /// Service that wraps MediaRemoteAdapter's MediaController to provide
 /// controlled pause/resume functionality during transcription.
 ///
@@ -59,19 +26,39 @@ final class MediaPlaybackService {
     /// - Returns: `true` if we successfully paused playback, `false` if nothing was playing
     ///   or if we couldn't determine playback state.
     ///
-    /// - Note: Uses `ContinuationOnceGuard` to protect against `MediaRemoteAdapter`
+    /// - Note: Uses a local one-shot gate to protect against `MediaRemoteAdapter`
     ///   firing the `getTrackInfo` callback more than once, which would otherwise
     ///   crash with `EXC_BREAKPOINT` (SIGTRAP) due to double-resume of a
     ///   `CheckedContinuation`.
     func pauseIfPlaying() async -> Bool {
         return await withCheckedContinuation { continuation in
-            // Guard against MediaRemoteAdapter firing the callback multiple times.
-            // A double-resume of CheckedContinuation is a fatal error (SIGTRAP).
-            let once = ContinuationOnceGuard<Bool>()
+            let resumeLock = NSLock()
+            var didResume = false
+
+            func resumeOnce(_ value: Bool) {
+                var shouldResume = false
+
+                resumeLock.lock()
+                if !didResume {
+                    didResume = true
+                    shouldResume = true
+                }
+                resumeLock.unlock()
+
+                guard shouldResume else {
+                    DebugLogger.shared.warning(
+                        "MediaPlaybackService: Suppressed duplicate resume (MediaRemoteAdapter callback fired more than once)",
+                        source: "MediaPlaybackService"
+                    )
+                    return
+                }
+
+                continuation.resume(returning: value)
+            }
 
             self.mediaController.getTrackInfo { [weak self] trackInfo in
                 guard let self = self else {
-                    once.resume(continuation, returning: false)
+                    resumeOnce(false)
                     return
                 }
 
@@ -81,7 +68,7 @@ final class MediaPlaybackService {
                         "MediaPlaybackService: No track info available, nothing to pause",
                         source: "MediaPlaybackService"
                     )
-                    once.resume(continuation, returning: false)
+                    resumeOnce(false)
                     return
                 }
 
@@ -115,13 +102,13 @@ final class MediaPlaybackService {
                         source: "MediaPlaybackService"
                     )
                     self.mediaController.pause()
-                    once.resume(continuation, returning: true)
+                    resumeOnce(true)
                 } else {
                     DebugLogger.shared.debug(
                         "MediaPlaybackService: Media is not playing, no action needed",
                         source: "MediaPlaybackService"
                     )
-                    once.resume(continuation, returning: false)
+                    resumeOnce(false)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Adds `ContinuationOnceGuard` — a thread-safe wrapper that ensures a `CheckedContinuation` is resumed exactly once
- Prevents `SIGTRAP` (EXC_BREAKPOINT) crash when `MediaRemoteAdapter`'s `getTrackInfo` callback fires multiple times under race conditions (rapid media state changes, system under load)
- Guard logs a warning on duplicate resume attempts for observability

## Root Cause

`MediaPlaybackService.pauseIfPlaying()` uses `withCheckedContinuation` to bridge `MediaRemoteAdapter`'s callback-based `getTrackInfo` API. Under certain conditions, the callback fires more than once, causing `CheckedContinuation.resume()` to be called twice — which is a fatal error.

## Changes

- **`MediaPlaybackService.swift`**: Added `ContinuationOnceGuard<T>` that serializes access via `NSLock` and silently drops duplicate resumes. All four `continuation.resume(returning:)` call sites now go through the guard.

## Testing

- Reproduced by triggering rapid pause/play cycling during transcription; crash no longer occurs
- Existing functionality (pause on record start, resume on record stop) works identically

Closes #188