### PR TITLE
feat: support Globe/fn key as hotkey without triggering Emoji Picker

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -55,6 +55,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         DebugLogger.shared.info("Application will terminate", source: "AppDelegate")
+        // Restore Globe key system setting before quitting
+        GlobeKeyManager.shared.restoreSystemGlobeAction()
         // Clean up the update check timer
         self.updateCheckTimer?.invalidate()
         self.updateCheckTimer = nil

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -30,6 +30,8 @@ final class GlobalHotkeyManager: NSObject {
     private nonisolated(unsafe) var state = HotkeyState()
     private nonisolated(unsafe) var eventTap: CFMachPort?
     private nonisolated(unsafe) var runLoopSource: CFRunLoopSource?
+    private nonisolated(unsafe) var eventTapThread: Thread?
+    private nonisolated(unsafe) var eventTapRunLoop: CFRunLoop?
     private let asrService: ASRService
     private var shortcut: HotkeyShortcut
     private var commandModeShortcut: HotkeyShortcut
@@ -132,6 +134,14 @@ final class GlobalHotkeyManager: NSObject {
         self.isRewriteRecordingProvider = isRewriteRecordingProvider
         super.init()
 
+        // If any shortcut uses the Globe key, suppress the system action (Emoji Picker)
+        if GlobeKeyManager.isGlobeKey(shortcut)
+            || (commandModeShortcutEnabled && GlobeKeyManager.isGlobeKey(commandModeShortcut))
+            || (rewriteModeShortcutEnabled && GlobeKeyManager.isGlobeKey(rewriteModeShortcut))
+        {
+            GlobeKeyManager.shared.suppressSystemGlobeAction()
+        }
+
         self.initializeWithDelay()
     }
 
@@ -156,12 +166,16 @@ final class GlobalHotkeyManager: NSObject {
     }
 
     func updateShortcut(_ newShortcut: HotkeyShortcut) {
+        let oldShortcut = self.shortcut
         self.shortcut = newShortcut
+        self.updateGlobeKeyOverride(oldShortcut: oldShortcut, newShortcut: newShortcut)
         DebugLogger.shared.info("Updated transcription hotkey", source: "GlobalHotkeyManager")
     }
 
     func updateCommandModeShortcut(_ newShortcut: HotkeyShortcut) {
+        let oldShortcut = self.commandModeShortcut
         self.commandModeShortcut = newShortcut
+        self.updateGlobeKeyOverride(oldShortcut: oldShortcut, newShortcut: newShortcut)
         DebugLogger.shared.info("Updated command mode hotkey", source: "GlobalHotkeyManager")
     }
 
@@ -170,7 +184,9 @@ final class GlobalHotkeyManager: NSObject {
     }
 
     func updateRewriteModeShortcut(_ newShortcut: HotkeyShortcut) {
+        let oldShortcut = self.rewriteModeShortcut
         self.rewriteModeShortcut = newShortcut
+        self.updateGlobeKeyOverride(oldShortcut: oldShortcut, newShortcut: newShortcut)
         DebugLogger.shared.info("Updated rewrite mode hotkey", source: "GlobalHotkeyManager")
     }
 
@@ -264,8 +280,24 @@ final class GlobalHotkeyManager: NSObject {
             return false
         }
 
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
+        // Run the event tap on a dedicated high-priority thread so events are
+        // processed immediately, before macOS can trigger system actions (e.g.
+        // the Emoji Picker for the Globe key).
+        let tapReady = DispatchSemaphore(value: 0)
+        let thread = Thread { [weak self] in
+            guard let self else { tapReady.signal(); return }
+            let runLoop = CFRunLoopGetCurrent()
+            self.eventTapRunLoop = runLoop
+            CFRunLoopAddSource(runLoop, source, .commonModes)
+            CGEvent.tapEnable(tap: tap, enable: true)
+            tapReady.signal()
+            CFRunLoopRun()
+        }
+        thread.name = "com.fluidvoice.eventTap"
+        thread.qualityOfService = .userInteractive
+        thread.start()
+        self.eventTapThread = thread
+        tapReady.wait()
 
         if !self.isEventTapEnabled() {
             DebugLogger.shared.error("Event tap could not be enabled", source: "GlobalHotkeyManager")
@@ -273,7 +305,7 @@ final class GlobalHotkeyManager: NSObject {
             return false
         }
 
-        DebugLogger.shared.info("Event tap successfully created and enabled", source: "GlobalHotkeyManager")
+        DebugLogger.shared.info("Event tap successfully created and enabled on dedicated thread", source: "GlobalHotkeyManager")
         return true
     }
 
@@ -282,12 +314,15 @@ final class GlobalHotkeyManager: NSObject {
             CGEvent.tapEnable(tap: tap, enable: false)
         }
 
-        if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        if let runLoop = eventTapRunLoop, let source = runLoopSource {
+            CFRunLoopRemoveSource(runLoop, source, .commonModes)
+            CFRunLoopStop(runLoop)
         }
 
         self.eventTap = nil
         self.runLoopSource = nil
+        self.eventTapRunLoop = nil
+        self.eventTapThread = nil
     }
 
     private func handleKeyEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -323,6 +358,13 @@ final class GlobalHotkeyManager: NSObject {
         if flags.contains(.maskAlternate) { eventModifiers.insert(.option) }
         if flags.contains(.maskControl) { eventModifiers.insert(.control) }
         if flags.contains(.maskShift) { eventModifiers.insert(.shift) }
+
+        // macOS generates a synthetic keyDown/keyUp for the "Globe function key" after
+        // the Globe key's flagsChanged event. This is what triggers the Emoji Picker.
+        // Consume it when any shortcut uses the Globe key.
+        if keyCode == GlobeKeyManager.globeSyntheticKeyCode, self.anyShortcutUsesGlobeKey() {
+            return nil
+        }
 
         switch type {
         case .keyDown:
@@ -890,6 +932,27 @@ final class GlobalHotkeyManager: NSObject {
             await callback()
         } else {
             await self.asrService.stopWithoutTranscription()
+        }
+    }
+
+    // MARK: - Globe Key Override
+
+    /// Returns true if any active shortcut uses the Globe key.
+    private func anyShortcutUsesGlobeKey() -> Bool {
+        if GlobeKeyManager.isGlobeKey(self.shortcut) { return true }
+        if self.commandModeShortcutEnabled, GlobeKeyManager.isGlobeKey(self.commandModeShortcut) { return true }
+        if self.rewriteModeShortcutEnabled, GlobeKeyManager.isGlobeKey(self.rewriteModeShortcut) { return true }
+        return false
+    }
+
+    /// Called when a shortcut changes. Enables or disables the Globe key system override as needed.
+    private func updateGlobeKeyOverride(oldShortcut: HotkeyShortcut, newShortcut: HotkeyShortcut) {
+        let wasGlobe = GlobeKeyManager.isGlobeKey(oldShortcut)
+        let isGlobe = GlobeKeyManager.isGlobeKey(newShortcut)
+        if isGlobe, !wasGlobe {
+            GlobeKeyManager.shared.suppressSystemGlobeAction()
+        } else if wasGlobe, !isGlobe, !self.anyShortcutUsesGlobeKey() {
+            GlobeKeyManager.shared.restoreSystemGlobeAction()
         }
     }
 

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -195,6 +195,7 @@ final class GlobalHotkeyManager: NSObject {
         if !enabled {
             self.isCommandModeKeyPressed = false
         }
+        self.recomputeGlobeKeyOverride()
         DebugLogger.shared.info(
             "Command mode shortcut \(enabled ? "enabled" : "disabled")",
             source: "GlobalHotkeyManager"
@@ -206,6 +207,7 @@ final class GlobalHotkeyManager: NSObject {
         if !enabled {
             self.isRewriteKeyPressed = false
         }
+        self.recomputeGlobeKeyOverride()
         DebugLogger.shared.info(
             "Rewrite mode shortcut \(enabled ? "enabled" : "disabled")",
             source: "GlobalHotkeyManager"
@@ -952,6 +954,15 @@ final class GlobalHotkeyManager: NSObject {
         if isGlobe, !wasGlobe {
             GlobeKeyManager.shared.suppressSystemGlobeAction()
         } else if wasGlobe, !isGlobe, !self.anyShortcutUsesGlobeKey() {
+            GlobeKeyManager.shared.restoreSystemGlobeAction()
+        }
+    }
+
+    /// Re-evaluate whether the Globe key override should be active (e.g. after enabling/disabling a mode).
+    private func recomputeGlobeKeyOverride() {
+        if self.anyShortcutUsesGlobeKey() {
+            GlobeKeyManager.shared.suppressSystemGlobeAction()
+        } else {
             GlobeKeyManager.shared.restoreSystemGlobeAction()
         }
     }

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -64,7 +64,7 @@ final class GlobalHotkeyManager: NSObject {
         set { self.state.withLock { self.state.isRewriteKeyPressed = newValue } }
     }
 
-    // Modifier-only shortcut tracking: detect if another key was pressed during modifier hold
+    /// Modifier-only shortcut tracking: detect if another key was pressed during modifier hold
     private nonisolated var modifierOnlyKeyDown: Bool {
         get { self.state.withLock { self.state.modifierOnlyKeyDown } }
         set { self.state.withLock { self.state.modifierOnlyKeyDown = newValue } }
@@ -75,7 +75,7 @@ final class GlobalHotkeyManager: NSObject {
         set { self.state.withLock { self.state.otherKeyPressedDuringModifier = newValue } }
     }
 
-    // Reserved for future tap-vs-hold timing detection (e.g., quick tap to toggle vs long hold)
+    /// Reserved for future tap-vs-hold timing detection (e.g., quick tap to toggle vs long hold)
     private nonisolated var modifierPressStartTime: Date? {
         get { self.state.withLock { self.state.modifierPressStartTime } }
         set { self.state.withLock { self.state.modifierPressStartTime = newValue } }
@@ -86,13 +86,13 @@ final class GlobalHotkeyManager: NSObject {
         set { self.state.withLock { self.state.pendingHoldModeStart = newValue } }
     }
 
-    // Tracks which mode's pending start is active (for cancellation on key combos)
+    /// Tracks which mode's pending start is active (for cancellation on key combos)
     private nonisolated var pendingHoldModeType: HotkeyHoldModeType? {
         get { self.state.withLock { self.state.pendingHoldModeType } }
         set { self.state.withLock { self.state.pendingHoldModeType = newValue } }
     }
 
-    // Busy flag to prevent race conditions during stop processing
+    /// Busy flag to prevent race conditions during stop processing
     private var isProcessingStop = false
 
     private var isInitialized = false

--- a/Sources/Fluid/Services/GlobeKeyManager.swift
+++ b/Sources/Fluid/Services/GlobeKeyManager.swift
@@ -50,8 +50,11 @@ final class GlobeKeyManager {
 
         // Set to 0 = "Do Nothing"
         CFPreferencesSetValue(
-            self.key, 0 as CFNumber, self.domain,
-            kCFPreferencesCurrentUser, kCFPreferencesCurrentHost
+            self.key,
+            0 as CFNumber,
+            self.domain,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesCurrentHost
         )
         CFPreferencesSynchronize(self.domain, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost)
 
@@ -73,8 +76,11 @@ final class GlobeKeyManager {
         let originalValue = UserDefaults.standard.integer(forKey: self.savedOriginalKey)
 
         CFPreferencesSetValue(
-            self.key, originalValue as CFNumber, self.domain,
-            kCFPreferencesCurrentUser, kCFPreferencesCurrentHost
+            self.key,
+            originalValue as CFNumber,
+            self.domain,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesCurrentHost
         )
         CFPreferencesSynchronize(self.domain, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost)
 
@@ -101,6 +107,6 @@ final class GlobeKeyManager {
 
     /// Check whether the given shortcut is the Globe/fn key (keyCode 63 with no modifiers).
     nonisolated static func isGlobeKey(_ shortcut: HotkeyShortcut) -> Bool {
-        return shortcut.keyCode == Self.globeKeyCode && shortcut.modifierFlags.isEmpty
+        return shortcut.keyCode == self.globeKeyCode && shortcut.modifierFlags.isEmpty
     }
 }

--- a/Sources/Fluid/Services/GlobeKeyManager.swift
+++ b/Sources/Fluid/Services/GlobeKeyManager.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Manages the macOS system Globe/fn key behavior to prevent the Emoji Picker
+/// from appearing when the Globe key is used as a FluidVoice hotkey.
+///
+/// Uses `CFPreferencesSetValue` to set `AppleFnUsageType` in the
+/// `com.apple.HIToolbox` domain:
+///   0 = Do Nothing, 1 = Change Input Source, 2 = Show Emoji & Symbols, 3 = Start Dictation
+@MainActor
+final class GlobeKeyManager {
+    static let shared = GlobeKeyManager()
+    static let globeKeyCode: UInt16 = 63
+    /// Synthetic "Globe function" key that macOS generates alongside the fn flagsChanged event.
+    /// This keyDown/keyUp is what actually triggers the Emoji Picker.
+    static let globeSyntheticKeyCode: UInt16 = 179
+
+    private let domain = "com.apple.HIToolbox" as CFString
+    private let key = "AppleFnUsageType" as CFString
+
+    private let savedOriginalKey = "GlobeKeyOriginalFnUsageType"
+    private let overrideActiveKey = "GlobeKeyOverrideActive"
+
+    private init() {
+        // Crash recovery: if the app was killed while the override was active,
+        // restore the original setting before anything else runs.
+        if UserDefaults.standard.bool(forKey: self.overrideActiveKey) {
+            DebugLogger.shared.warning(
+                "Globe key override was still active from previous session - restoring",
+                source: "GlobeKeyManager"
+            )
+            self.restoreSystemGlobeAction()
+        }
+    }
+
+    /// Suppress the system Globe key action by setting `AppleFnUsageType` to 0 ("Do Nothing").
+    /// Saves the original value so it can be restored later.
+    func suppressSystemGlobeAction() {
+        let isAlreadyActive = UserDefaults.standard.bool(forKey: self.overrideActiveKey)
+
+        if !isAlreadyActive {
+            // Only save original value on first activation (not on re-suppress)
+            let currentValue = CFPreferencesCopyValue(
+                self.key, self.domain, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost
+            )
+            let originalValue = (currentValue as? Int) ?? 2 // Default is 2 (Emoji & Symbols)
+            UserDefaults.standard.set(originalValue, forKey: self.savedOriginalKey)
+        }
+
+        UserDefaults.standard.set(true, forKey: self.overrideActiveKey)
+
+        // Set to 0 = "Do Nothing"
+        CFPreferencesSetValue(
+            self.key, 0 as CFNumber, self.domain,
+            kCFPreferencesCurrentUser, kCFPreferencesCurrentHost
+        )
+        CFPreferencesSynchronize(self.domain, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost)
+
+        // Notify the system to re-read the preference (otherwise the cached value is used)
+        self.postFnUsageTypeChanged()
+
+        DebugLogger.shared.info(
+            "Suppressed system Globe key action (wasAlreadyActive: \(isAlreadyActive))",
+            source: "GlobeKeyManager"
+        )
+    }
+
+    /// Restore the original system Globe key action.
+    func restoreSystemGlobeAction() {
+        guard UserDefaults.standard.bool(forKey: self.overrideActiveKey) else {
+            return
+        }
+
+        let originalValue = UserDefaults.standard.integer(forKey: self.savedOriginalKey)
+
+        CFPreferencesSetValue(
+            self.key, originalValue as CFNumber, self.domain,
+            kCFPreferencesCurrentUser, kCFPreferencesCurrentHost
+        )
+        CFPreferencesSynchronize(self.domain, kCFPreferencesCurrentUser, kCFPreferencesCurrentHost)
+
+        UserDefaults.standard.removeObject(forKey: self.savedOriginalKey)
+        UserDefaults.standard.removeObject(forKey: self.overrideActiveKey)
+
+        self.postFnUsageTypeChanged()
+
+        DebugLogger.shared.info(
+            "Restored system Globe key action (value: \(originalValue))",
+            source: "GlobeKeyManager"
+        )
+    }
+
+    /// Notify the system that `AppleFnUsageType` changed so running processes pick up the new value.
+    private func postFnUsageTypeChanged() {
+        DistributedNotificationCenter.default().postNotificationName(
+            NSNotification.Name("com.apple.HIToolbox.AppleFnUsageTypeChangedNotification"),
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+    }
+
+    /// Check whether the given shortcut is the Globe/fn key (keyCode 63 with no modifiers).
+    nonisolated static func isGlobeKey(_ shortcut: HotkeyShortcut) -> Bool {
+        return shortcut.keyCode == Self.globeKeyCode && shortcut.modifierFlags.isEmpty
+    }
+}

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -11,7 +11,10 @@ import SwiftUI
 
 struct SettingsView: View {
     @EnvironmentObject var appServices: AppServices
-    private var asr: ASRService { self.appServices.asr }
+    private var asr: ASRService {
+        self.appServices.asr
+    }
+
     @Environment(\.theme) private var theme
     @ObservedObject private var settings = SettingsStore.shared
     @Binding var appear: Bool
@@ -449,11 +452,13 @@ struct SettingsView: View {
                                     .frame(width: 8, height: 8)
 
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text(self.asr.micStatus == .authorized ? "Microphone access granted" :
-                                        self.asr.micStatus == .denied ? "Microphone access denied" :
-                                        "Microphone access not determined")
-                                        .font(.body)
-                                        .foregroundStyle(self.asr.micStatus == .authorized ? .primary : self.theme.palette.warning)
+                                    Text(
+                                        self.asr.micStatus == .authorized ? "Microphone access granted" :
+                                            self.asr.micStatus == .denied ? "Microphone access denied" :
+                                            "Microphone access not determined"
+                                    )
+                                    .font(.body)
+                                    .foregroundStyle(self.asr.micStatus == .authorized ? .primary : self.theme.palette.warning)
 
                                     if self.asr.micStatus != .authorized {
                                         Text("Microphone access is required for voice recording")
@@ -1349,7 +1354,6 @@ struct SettingsView: View {
 
     // MARK: - Helper Views
 
-    @ViewBuilder
     private func settingsToggleRow(
         title: String,
         description: String,
@@ -1382,7 +1386,6 @@ struct SettingsView: View {
         }
     }
 
-    @ViewBuilder
     private func optionToggleRow(
         title: String,
         description: String,
@@ -1406,7 +1409,6 @@ struct SettingsView: View {
         }
     }
 
-    @ViewBuilder
     private func instructionsBox(
         title: String,
         steps: [String],
@@ -1502,17 +1504,23 @@ struct SettingsView: View {
                         .foregroundStyle(.orange)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(RoundedRectangle(cornerRadius: 5, style: .continuous)
-                            .fill(.orange.opacity(0.2)))
+                        .background(
+                            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                .fill(.orange.opacity(0.2))
+                        )
                 } else {
                     Text(shortcut.displayString)
                         .font(.caption.monospaced().weight(.medium))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(RoundedRectangle(cornerRadius: 5, style: .continuous)
-                            .fill(.quaternary.opacity(0.5))
-                            .overlay(RoundedRectangle(cornerRadius: 5, style: .continuous)
-                                .stroke(.primary.opacity(0.15), lineWidth: 1)))
+                        .background(
+                            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                .fill(.quaternary.opacity(0.5))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                        .stroke(.primary.opacity(0.15), lineWidth: 1)
+                                )
+                        )
                 }
 
                 Button("Change") {
@@ -1556,8 +1564,10 @@ struct FillerWordsEditor: View {
                     }
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(.quaternary))
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(.quaternary)
+                    )
                 }
             }
 

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -568,6 +568,7 @@ struct SettingsView: View {
                                             self.isRecordingShortcut = true
                                         }
                                     )
+                                    self.globeKeyHint(for: self.hotkeyShortcut)
                                     Divider().opacity(0.2).padding(.vertical, 4)
 
                                     self.shortcutRow(
@@ -583,6 +584,7 @@ struct SettingsView: View {
                                             self.isRecordingCommandModeShortcut = true
                                         }
                                     )
+                                    self.globeKeyHint(for: self.commandModeShortcut)
                                     Divider().opacity(0.2).padding(.vertical, 4)
 
                                     self.shortcutRow(
@@ -598,6 +600,7 @@ struct SettingsView: View {
                                             self.isRecordingRewriteShortcut = true
                                         }
                                     )
+                                    self.globeKeyHint(for: self.rewriteShortcut)
                                 }
                                 .padding(12)
                                 .background(
@@ -1439,6 +1442,16 @@ struct SettingsView: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill((warningStyle ? self.theme.palette.warning : self.theme.palette.accent).opacity(0.12))
         )
+    }
+
+    @ViewBuilder
+    private func globeKeyHint(for shortcut: HotkeyShortcut) -> some View {
+        if GlobeKeyManager.isGlobeKey(shortcut) {
+            Text("Globe key system action will be disabled while this shortcut is active.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.leading, 28)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- Move CGEvent tap to a dedicated high-priority thread so events are intercepted before macOS triggers system actions (like the Emoji Picker)
- Add `GlobeKeyManager` service that suppresses/restores the system Globe key action (`AppleFnUsageType`) via `CFPreferences` + `DistributedNotification`
- Consume synthetic keyCode 179 events (the actual trigger for the Emoji Picker)
- Crash recovery: if the app is force-quit while the override is active, the original Globe key setting is restored on next launch
- Show info text in Settings when a Globe key shortcut is active

## Context

Using the Globe/fn key (keyCode 63) as a dictation hotkey caused the macOS Emoji Picker to open alongside FluidVoice's dictation every time the key was pressed. Dictation itself worked fine (start/stop), but the Emoji Picker appearing in parallel was disruptive.

## Test plan

- [ ] Set Globe key as Transcribe Mode shortcut → Emoji Picker should NOT appear
- [ ] Globe key press → dictation starts
- [ ] Globe key press again → dictation stops
- [ ] Press and Hold mode: hold Globe → dictation starts, release → stops
- [ ] Change shortcut to something else → Emoji Picker works again
- [ ] Force-quit app while Globe key shortcut is active → on next launch, Globe key system setting is restored
- [ ] Other hotkeys (Ctrl, Cmd, etc.) continue to work correctly