### PR TITLE
Refactor FluidVoice for macOS Big Sur (11.0) compatibility

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -328,7 +328,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -388,7 +388,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -434,7 +434,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FluidApp.app;
 				PRODUCT_NAME = "FluidVoice Debug";
@@ -488,7 +488,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FluidApp.app;
 				PRODUCT_NAME = FluidVoice;
@@ -521,7 +521,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FluidApp.FluidDictationIntegrationTests;
 				PRODUCT_NAME = FluidDictationIntegrationTests;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
@@ -546,7 +546,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FluidApp.FluidDictationIntegrationTests;
 				PRODUCT_NAME = FluidDictationIntegrationTests;
 				SWIFT_VERSION = 5.0;

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "FluidVoice",
     platforms: [
-        .macOS(.v14),
+        .macOS(.v11),
     ],
     dependencies: [
         .package(url: "https://github.com/mxcl/AppUpdater.git", from: "1.0.0"),

--- a/README.md
+++ b/README.md
@@ -82,11 +82,15 @@ Universal support (runs on Intel & Apple Silicon). Supports 99 languages.
 
 ## Requirements
 
-- macOS 14.0 (Sonoma) or later
+- macOS 11.0 (Big Sur) or later
 - Apple Silicon Mac (M1, M2, M3, M4)
-- Intel Macs are supported from 1.5.1 builds using Whisper models!
+- Intel Macs are supported using Whisper models!
 - Microphone access
 - Accessibility permissions for typing
+
+> **Note**: This is a community fork targeting macOS Big Sur (11.7.x) compatibility.
+> Some features may have reduced visual fidelity on older macOS versions (e.g., no Material blur effects, no notch overlay on pre-notch Macs).
+> Streaming SSE responses are buffered on macOS 11 (true streaming requires macOS 12+).
 
 
 ## Join our small community to help us grow and give feedback :) ( Or just hang?!)   

--- a/Sources/Fluid/Analytics/AnalyticsService.swift
+++ b/Sources/Fluid/Analytics/AnalyticsService.swift
@@ -232,7 +232,7 @@ private actor AnalyticsCore {
         // Detached task ensures we never block the actor while URLSession does its work.
         Task.detached(priority: .background) {
             let session = URLSession.shared
-            _ = try? await session.data(for: request)
+            _ = try? await session.compatData(for: request)
         }
     }
 }

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -78,7 +78,7 @@ struct ContentView: View {
     @State private var pendingModifierFlags: NSEvent.ModifierFlags = []
     @State private var pendingModifierKeyCode: UInt16?
     @State private var pendingModifierOnly = false
-    @FocusState private var isTranscriptionFocused: Bool
+    @State private var isTranscriptionFocused: Bool = false
 
     @State private var selectedSidebarItem: SidebarItem?
     @State private var previousSidebarItem: SidebarItem? = nil // Track previous for mode transitions
@@ -138,22 +138,18 @@ struct ContentView: View {
 
     @State private var savedProviders: [SettingsStore.SavedProvider] = []
     @State private var selectedProviderID: String = SettingsStore.shared.selectedProviderID
-    @State private var columnVisibility: NavigationSplitViewVisibility = .all
-
     var body: some View {
         let layout = AnyView(
-            NavigationSplitView(columnVisibility: self.$columnVisibility) {
+            NavigationView {
                 self.sidebarView
-                    .navigationSplitViewColumnWidth(min: 220, ideal: 250, max: 300)
-            } detail: {
+                    .frame(minWidth: 220, idealWidth: 250, maxWidth: 300)
                 self.detailView
             }
-            .navigationSplitViewStyle(.balanced)
         )
 
         let tracked = layout.withMouseTracking(self.mouseTracker)
         let env = tracked.environmentObject(self.mouseTracker)
-        let nav = env.onChange(of: self.menuBarManager.requestedNavigationDestination) { _, destination in
+        let nav = env.onChange(of: self.menuBarManager.requestedNavigationDestination) { destination in
             self.handleMenuBarNavigation(destination)
         }
 
@@ -493,19 +489,19 @@ struct ContentView: View {
                 return event
             }
         }
-        .onChange(of: self.accessibilityEnabled) { _, enabled in
+        .onChange(of: self.accessibilityEnabled) { enabled in
             if enabled && self.hotkeyManager != nil && !self.hotkeyManagerInitialized {
                 DebugLogger.shared.debug("Accessibility enabled, reinitializing hotkey manager", source: "ContentView")
                 self.hotkeyManager?.reinitialize()
             }
         }
-        .onChange(of: self.selectedModel) { _, newValue in
+        .onChange(of: self.selectedModel) { newValue in
             if newValue != "__ADD_MODEL__" {
                 self.selectedModelByProvider[self.currentProvider] = newValue
                 SettingsStore.shared.selectedModelByProvider = self.selectedModelByProvider
             }
         }
-        .onChange(of: self.selectedProviderID) { _, newValue in
+        .onChange(of: self.selectedProviderID) { newValue in
             SettingsStore.shared.selectedProviderID = newValue
         }
         .onChange(of: self.isCommandModeShortcutEnabled) { newValue in
@@ -559,19 +555,18 @@ struct ContentView: View {
                 .accessibilityLabel("Report an issue")
             }
         }
-        .overlay(alignment: .center) {}
-        .alert(
-            self.asr.errorTitle,
-            isPresented: Binding(
-                get: { self.asr.showError },
-                set: { self.asr.showError = $0 }
+        .overlay(Group {}, alignment: .center)
+        .alert(isPresented: Binding(
+            get: { self.asr.showError },
+            set: { self.asr.showError = $0 }
+        )) {
+            Alert(
+                title: Text(self.asr.errorTitle),
+                message: Text(self.asr.errorMessage),
+                dismissButton: .default(Text("OK"))
             )
-        ) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(self.asr.errorMessage)
         }
-        .onChange(of: self.audioObserver.changeTick) { _, _ in
+        .onChange(of: self.audioObserver.changeTick) { _ in
             // Hardware change detected → refresh device lists
             self.refreshDevices()
 
@@ -623,7 +618,7 @@ struct ContentView: View {
             self.accessibilityPollingTask?.cancel()
             self.accessibilityPollingTask = nil
         }
-        .onChange(of: self.hotkeyShortcut) { _, newValue in
+        .onChange(of: self.hotkeyShortcut) { newValue in
             DebugLogger.shared.debug("Hotkey shortcut changed to \(newValue.displayString)", source: "ContentView")
             self.hotkeyManager?.updateShortcut(newValue)
 
@@ -636,7 +631,7 @@ struct ContentView: View {
                 )
             }
         }
-        .onChange(of: self.selectedSidebarItem) { _, newValue in
+        .onChange(of: self.selectedSidebarItem) { newValue in
             self.handleModeTransition(from: self.previousSidebarItem, to: newValue)
             self.previousSidebarItem = newValue
         }
@@ -773,7 +768,7 @@ struct ContentView: View {
                     Spacer()
                     Image(systemName: "chevron.right")
                         .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .rotationEffect(.degrees(self.aiSettingsExpanded ? 90 : 0))
                 }
                 .contentShape(Rectangle())
@@ -853,15 +848,15 @@ struct ContentView: View {
         .listStyle(.sidebar)
         .animation(nil, value: self.selectedSidebarItem)
         .navigationTitle("FluidVoice")
-        .scrollContentBackground(.hidden)
-        .background {
+        
+        .background(
             ZStack {
                 self.theme.palette.sidebarBackground
                 Rectangle().fill(self.theme.materials.sidebar)
             }
             .ignoresSafeArea()
-        }
-        .tint(self.theme.palette.accent)
+        )
+        .accentColor(self.theme.palette.accent)
     }
 
     private func sidebarRowBackground(for item: SidebarItem) -> some View {
@@ -946,12 +941,12 @@ struct ContentView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(self.labelFor(status: self.asr.micStatus))
                         .fontWeight(.medium)
-                        .foregroundStyle(self.asr.micStatus == .authorized ? self.theme.palette.primaryText : self.theme.palette.warning)
+                        .foregroundColor(self.asr.micStatus == .authorized ? self.theme.palette.primaryText : self.theme.palette.warning)
 
                     if self.asr.micStatus != .authorized {
                         Text("Microphone access is required for voice recording")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                 }
                 Spacer()
@@ -1000,12 +995,12 @@ struct ContentView: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
                 Image(systemName: "info.circle.fill")
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
                     .font(.caption)
                 Text("How to enable microphone access:")
                     .font(.caption)
                     .fontWeight(.medium)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -1029,12 +1024,12 @@ struct ContentView: View {
         HStack(spacing: 8) {
             Text(number + ".")
                 .font(.caption2)
-                .foregroundStyle(self.theme.palette.accent)
+                .foregroundColor(self.theme.palette.accent)
                 .fontWeight(.semibold)
                 .frame(width: 16)
             Text(text)
                 .font(.caption)
-                .foregroundStyle(.primary)
+                .foregroundColor(.primary)
         }
     }
 

--- a/Sources/Fluid/CustomAnimations.swift
+++ b/Sources/Fluid/CustomAnimations.swift
@@ -56,7 +56,7 @@ struct PulseAudioVisualizationView: View {
                 .frame(width: 12, height: 12)
         }
         .frame(width: 100, height: 100)
-        .onChange(of: self.data.audioLevel) { _, newLevel in
+        .onChange(of: self.data.audioLevel) { newLevel in
             // Only trigger animation update for significant changes to prevent cycles
             if abs(newLevel - (self.data.audioLevel)) > 0.1 {
                 self.animationId = UUID()
@@ -90,7 +90,7 @@ struct WaveAudioVisualizationView: View {
             }
         }
         .frame(width: 60, height: 40)
-        .onChange(of: self.data.audioLevel) { _, newLevel in
+        .onChange(of: self.data.audioLevel) { newLevel in
             // Only trigger animation update for significant changes to prevent cycles
             if abs(newLevel - (self.data.audioLevel)) > 0.1 {
                 self.animationId = UUID()

--- a/Sources/Fluid/Networking/AIProvider.swift
+++ b/Sources/Fluid/Networking/AIProvider.swift
@@ -120,7 +120,7 @@ final class OpenAICompatibleProvider: AIProvider {
         request.httpBody = jsonData
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.compatData(for: request)
 
             #if DEBUG
             DebugLogger.shared.debug("AI Request to: \(request.url?.absoluteString ?? "unknown")", source: "AIProvider")

--- a/Sources/Fluid/Networking/FunctionCallingProvider.swift
+++ b/Sources/Fluid/Networking/FunctionCallingProvider.swift
@@ -252,7 +252,7 @@ final class FunctionCallingProvider {
         request.httpBody = jsonData
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.compatData(for: request)
 
             // Log response
             if let responseString = String(data: data, encoding: .utf8) {
@@ -377,7 +377,7 @@ final class FunctionCallingProvider {
         request.httpBody = jsonData
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.compatData(for: request)
 
             if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
                 let errText = String(data: data, encoding: .utf8) ?? "Unknown error"

--- a/Sources/Fluid/Networking/ModelDownloader.swift
+++ b/Sources/Fluid/Networking/ModelDownloader.swift
@@ -233,7 +233,7 @@ final class HuggingFaceModelDownloader {
         let fileURL = self.baseResolveURL.appendingPathComponent(relativePath)
         var req = URLRequest(url: fileURL)
         req.httpMethod = "HEAD"
-        let (_, resp) = try await URLSession.shared.data(for: req)
+        let (_, resp) = try await URLSession.shared.compatData(for: req)
         guard let http = resp as? HTTPURLResponse, http.statusCode < 400 else {
             return 0
         }

--- a/Sources/Fluid/Services/LLMClient.swift
+++ b/Sources/Fluid/Services/LLMClient.swift
@@ -1,5 +1,129 @@
 import Foundation
 
+// MARK: - URLSession Compatibility for macOS 11
+
+/// Wraps URLSession's completion-handler APIs into async versions for macOS 11 compatibility.
+/// On macOS 12+, delegates to the native async APIs.
+extension URLSession {
+    func compatData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        if #available(macOS 12.0, *) {
+            return try await self.data(for: request)
+        } else {
+            return try await withCheckedThrowingContinuation { continuation in
+                let task = self.dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if let data = data, let response = response {
+                        continuation.resume(returning: (data, response))
+                    } else {
+                        continuation.resume(throwing: URLError(.unknown))
+                    }
+                }
+                task.resume()
+            }
+        }
+    }
+
+    /// Streams response data line-by-line for SSE processing. On macOS 12+, uses native bytes API.
+    /// On macOS 11, downloads full response then yields lines.
+    func compatStreamLines(for request: URLRequest) async throws -> (AsyncLineSequence, URLResponse) {
+        if #available(macOS 12.0, *) {
+            let (bytes, response) = try await self.bytes(for: request)
+            return (AsyncLineSequence(nativeLines: bytes.lines, nativeBytes: bytes), response)
+        } else {
+            let (data, response) = try await self.compatData(for: request)
+            let text = String(data: data, encoding: .utf8) ?? ""
+            let lines = text.components(separatedBy: "\n")
+            return (AsyncLineSequence(bufferedLines: lines), response)
+        }
+    }
+}
+
+/// A wrapper that provides async line iteration, compatible with macOS 11+.
+struct AsyncLineSequence: AsyncSequence {
+    typealias Element = String
+
+    private enum Source {
+        case buffered([String])
+        case native(Any, Any) // URLSession.AsyncBytes.AsyncLineSequence, URLSession.AsyncBytes
+    }
+
+    private let source: Source
+
+    init(bufferedLines: [String]) {
+        self.source = .buffered(bufferedLines)
+    }
+
+    @available(macOS 12.0, *)
+    init(nativeLines: URLSession.AsyncBytes.AsyncLineSequence, nativeBytes: URLSession.AsyncBytes) {
+        self.source = .native(nativeLines, nativeBytes)
+    }
+
+    /// Collect all bytes (used for error body reading)
+    func collectAllData() async throws -> Data {
+        if #available(macOS 12.0, *), case let .native(_, bytesAny) = source {
+            let bytes = bytesAny as! URLSession.AsyncBytes
+            var data = Data()
+            for try await byte in bytes {
+                data.append(byte)
+            }
+            return data
+        } else if case let .buffered(lines) = source {
+            return lines.joined(separator: "\n").data(using: .utf8) ?? Data()
+        }
+        return Data()
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+        switch source {
+        case let .buffered(lines):
+            return AsyncIterator(bufferedLines: lines)
+        case let .native(linesAny, _):
+            if #available(macOS 12.0, *) {
+                let lines = linesAny as! URLSession.AsyncBytes.AsyncLineSequence
+                return AsyncIterator(nativeLines: lines)
+            } else {
+                return AsyncIterator(bufferedLines: [])
+            }
+        }
+    }
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+        private enum IteratorSource {
+            case buffered(Array<String>.Iterator)
+            case native(Any) // URLSession.AsyncBytes.AsyncLineSequence.AsyncIterator
+        }
+
+        private var source: IteratorSource
+
+        init(bufferedLines: [String]) {
+            self.source = .buffered(bufferedLines.makeIterator())
+        }
+
+        @available(macOS 12.0, *)
+        init(nativeLines: URLSession.AsyncBytes.AsyncLineSequence) {
+            self.source = .native(nativeLines.makeAsyncIterator())
+        }
+
+        mutating func next() async throws -> String? {
+            switch source {
+            case var .buffered(iterator):
+                let result = iterator.next()
+                self.source = .buffered(iterator)
+                return result
+            case var .native(iteratorAny):
+                if #available(macOS 12.0, *) {
+                    var nativeIterator = iteratorAny as! URLSession.AsyncBytes.AsyncLineSequence.AsyncIterator
+                    let result = try await nativeIterator.next()
+                    self.source = .native(nativeIterator)
+                    return result
+                }
+                return nil
+            }
+        }
+    }
+}
+
 // MARK: - Error Types
 
 enum LLMError: Error, LocalizedError {
@@ -282,7 +406,7 @@ final class LLMClient {
     private func processNonStreaming(request: URLRequest) async throws -> Response {
         DebugLogger.shared.debug("LLMClient: Making non-streaming request to \(request.url?.absoluteString ?? "unknown")", source: "LLMClient")
 
-        let (data, response) = try await self.session.data(for: request)
+        let (data, response) = try await self.session.compatData(for: request)
 
         if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
             let errText = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -306,14 +430,11 @@ final class LLMClient {
     private func processStreaming(request: URLRequest, config: Config) async throws -> Response {
         DebugLogger.shared.debug("LLMClient: Starting streaming request to \(request.url?.absoluteString ?? "unknown")", source: "LLMClient")
 
-        let (bytes, response) = try await self.session.bytes(for: request)
+        let (lineSequence, response) = try await self.session.compatStreamLines(for: request)
 
         // Check for HTTP errors
         if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
-            var errorData = Data()
-            for try await byte in bytes {
-                errorData.append(byte)
-            }
+            let errorData = try await lineSequence.collectAllData()
             let errText = String(data: errorData, encoding: .utf8) ?? "Unknown error"
             throw LLMError.httpError(http.statusCode, errText)
         }
@@ -333,7 +454,7 @@ final class LLMClient {
         var toolCallArguments = ""
 
         // Process SSE lines
-        for try await rawLine in bytes.lines {
+        for try await rawLine in lineSequence {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             guard line.hasPrefix("data:") else { continue }
 

--- a/Sources/Fluid/Services/MeetingTranscriptionService.swift
+++ b/Sources/Fluid/Services/MeetingTranscriptionService.swift
@@ -290,7 +290,7 @@ final class MeetingTranscriptionService: ObservableObject {
     nonisolated func exportToText(_ result: TranscriptionResult, to destinationURL: URL) throws {
         let content = """
         Transcription: \(result.fileName)
-        Date: \(result.timestamp.formatted())
+        Date: \(DateFormatter.localizedString(from: result.timestamp, dateStyle: .medium, timeStyle: .short))
         Duration: \(String(format: "%.1f", result.duration))s
         Processing Time: \(String(format: "%.1f", result.processingTime))s
         Confidence: \(String(format: "%.1f%%", result.confidence * 100))

--- a/Sources/Fluid/Services/ModelRepository.swift
+++ b/Sources/Fluid/Services/ModelRepository.swift
@@ -264,7 +264,7 @@ final class ModelRepository {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await URLSession.shared.compatData(for: request)
         } catch {
             let errorDetails = self.detailedNetworkError(error)
             DebugLogger.shared.error(

--- a/Sources/Fluid/Services/SimpleUpdater.swift
+++ b/Sources/Fluid/Services/SimpleUpdater.swift
@@ -256,7 +256,24 @@ final class SimpleUpdater {
         let downloadURL = tempDir.appendingPathComponent(asset.browser_download_url.lastPathComponent)
 
         do {
-            let (tmpFile, _) = try await URLSession.shared.download(from: asset.browser_download_url)
+            let tmpFile: URL
+            if #available(macOS 12.0, *) {
+                let (file, _) = try await URLSession.shared.download(from: asset.browser_download_url)
+                tmpFile = file
+            } else {
+                tmpFile = try await withCheckedThrowingContinuation { continuation in
+                    let task = URLSession.shared.downloadTask(with: asset.browser_download_url) { url, _, error in
+                        if let error = error {
+                            continuation.resume(throwing: error)
+                        } else if let url = url {
+                            continuation.resume(returning: url)
+                        } else {
+                            continuation.resume(throwing: URLError(.unknown))
+                        }
+                    }
+                    task.resume()
+                }
+            }
             try FileManager.default.moveItem(at: tmpFile, to: downloadURL)
         } catch {
             throw SimpleUpdateError.downloadFailed

--- a/Sources/Fluid/Theme/AppTheme.swift
+++ b/Sources/Fluid/Theme/AppTheme.swift
@@ -72,11 +72,11 @@ struct AppTheme {
     }
 
     struct Materials {
-        let window: Material
-        let sidebar: Material
-        let card: Material
-        let elevatedCard: Material
-        let toolbar: Material
+        let window: Color
+        let sidebar: Color
+        let card: Color
+        let elevatedCard: Color
+        let toolbar: Color
     }
 
     let palette: Palette
@@ -110,11 +110,11 @@ struct AppTheme {
                 elevatedCardShadow: .subtle(color: .black, opacity: 0.80)
             ),
             materials: Materials(
-                window: .thinMaterial,
-                sidebar: .ultraThinMaterial,
-                card: .thinMaterial,
-                elevatedCard: .regularMaterial,
-                toolbar: .ultraThinMaterial
+                window: Color(white: 0.08, opacity: 0.85),
+                sidebar: Color(white: 0.06, opacity: 0.80),
+                card: Color(white: 0.10, opacity: 0.85),
+                elevatedCard: Color(white: 0.12, opacity: 0.90),
+                toolbar: Color(white: 0.06, opacity: 0.80)
             )
         )
     }

--- a/Sources/Fluid/Theme/Components/SetupComponents.swift
+++ b/Sources/Fluid/Theme/Components/SetupComponents.swift
@@ -43,27 +43,27 @@ struct SetupStepView: View {
 
                     if self.status == .completed {
                         Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(self.statusColor)
+                            .foregroundColor(self.statusColor)
                             .font(.body.weight(.semibold))
                     } else if self.status == .inProgress {
                         ProgressView()
-                            .controlSize(.small)
-                            .tint(self.statusColor)
+                            
+                            .accentColor(self.statusColor)
                     } else {
                         Text("\(self.step)")
                             .font(.caption.weight(.bold))
-                            .foregroundStyle(self.statusColor)
+                            .foregroundColor(self.statusColor)
                     }
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(self.title)
                         .font(.body.weight(.medium))
-                        .foregroundStyle(.primary)
+                        .foregroundColor(.primary)
 
                     Text(self.description)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .lineLimit(2)
                 }
 
@@ -73,10 +73,10 @@ struct SetupStepView: View {
                 if self.status == .completed {
                     Label("Done", systemImage: "checkmark")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(Color.fluidGreen, in: Capsule())
+                        .background(Capsule().fill(Color.fluidGreen))
                 } else if self.showActionButton {
                     HStack(spacing: 3) {
                         Text(self.actionButtonTitle)
@@ -84,10 +84,10 @@ struct SetupStepView: View {
                         Image(systemName: "arrow.right")
                             .font(.caption2.weight(.bold))
                     }
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(self.theme.palette.accent.opacity(0.12), in: Capsule())
+                    .background(Capsule().fill(self.theme.palette.accent.opacity(0.12)))
                 }
             }
             .padding(10)
@@ -138,7 +138,7 @@ struct InstructionStep: View {
 
                 Text("\(self.number)")
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
             }
 
             VStack(alignment: .leading, spacing: 1) {
@@ -147,7 +147,7 @@ struct InstructionStep: View {
 
                 Text(self.description)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                     .lineLimit(2)
             }
         }

--- a/Sources/Fluid/Theme/Components/ThemedCard.swift
+++ b/Sources/Fluid/Theme/Components/ThemedCard.swift
@@ -33,7 +33,7 @@ struct ThemedCard<Content: View>: View {
 
         self.content
             .padding(self.padding ?? 14)
-            .background(configuration.material, in: shape)
+            .background(shape.fill(configuration.material))
             .background(
                 shape
                     .fill(configuration.background)
@@ -72,7 +72,7 @@ private extension ThemedCard {
         let borderOpacity: Double
         let hoverBorderOpacity: Double
         let borderWidth: CGFloat
-        let material: Material
+        let material: Color
         let cornerRadius: CGFloat
         let shadow: AppTheme.Metrics.Shadow
         let hoverShadowBoost: Double

--- a/Sources/Fluid/Theme/Components/ThemedGroupBox.swift
+++ b/Sources/Fluid/Theme/Components/ThemedGroupBox.swift
@@ -25,7 +25,7 @@ struct ThemedGroupBox<Label: View, Content: View>: View {
             VStack(alignment: .leading, spacing: self.theme.metrics.spacing.md) {
                 self.label
                     .font(.headline)
-                    .foregroundStyle(self.theme.palette.secondaryText)
+                    .foregroundColor(self.theme.palette.secondaryText)
                     .padding(.top, self.theme.metrics.spacing.md)
                     .padding(.horizontal, self.theme.metrics.spacing.md)
 

--- a/Sources/Fluid/Theme/NativeButtonStyles.swift
+++ b/Sources/Fluid/Theme/NativeButtonStyles.swift
@@ -25,8 +25,8 @@ struct GlassButtonStyle: ButtonStyle {
                 .padding(.horizontal, self.theme.metrics.spacing.lg)
                 .padding(.vertical, self.theme.metrics.spacing.sm)
                 .frame(height: self.height ?? 36)
-                .foregroundStyle(self.theme.palette.primaryText)
-                .background(self.theme.materials.card, in: self.shape)
+                .foregroundColor(self.theme.palette.primaryText)
+                .background(self.shape.fill(self.theme.materials.card))
                 .background(
                     self.shape
                         .fill(self.theme.palette.cardBackground)
@@ -104,7 +104,7 @@ struct PremiumButtonStyle: ButtonStyle {
                 .fontWeight(.semibold)
                 .frame(maxWidth: .infinity)
                 .frame(height: self.height)
-                .foregroundStyle(self.isRecording ? Color.white : self.theme.palette.primaryText)
+                .foregroundColor(self.isRecording ? Color.white : self.theme.palette.primaryText)
                 .background(
                     self.shape
                         .fill(self.baseGradient)
@@ -151,8 +151,8 @@ struct SecondaryButtonStyle: ButtonStyle {
                 .fontWeight(.semibold)
                 .frame(maxWidth: .infinity)
                 .frame(height: 42)
-                .foregroundStyle(self.theme.palette.primaryText)
-                .background(self.theme.materials.card, in: self.shape)
+                .foregroundColor(self.theme.palette.primaryText)
+                .background(self.shape.fill(self.theme.materials.card))
                 .background(
                     self.shape
                         .fill(self.theme.palette.cardBackground)
@@ -213,8 +213,8 @@ struct CompactButtonStyle: ButtonStyle {
                 .fontWeight(.medium)
                 .padding(.horizontal, self.theme.metrics.spacing.md)
                 .frame(height: 34)
-                .foregroundStyle(foregroundColor)
-                .background(self.theme.materials.card, in: self.shape)
+                .foregroundColor(foregroundColor)
+                .background(self.shape.fill(self.theme.materials.card))
                 .background(
                     self.shape
                         .fill(self.theme.palette.cardBackground)
@@ -264,7 +264,7 @@ struct AccentButtonStyle: ButtonStyle {
                 .padding(.horizontal, self.compact ? 12 : self.theme.metrics.spacing.lg)
                 .padding(.vertical, self.compact ? 8 : self.theme.metrics.spacing.md)
                 .frame(minHeight: self.compact ? 32 : 36)
-                .foregroundStyle(Color.white)
+                .foregroundColor(Color.white)
                 .background(
                     self.shape
                         .fill(
@@ -318,7 +318,7 @@ struct InlineButtonStyle: ButtonStyle {
                 .fontWeight(.medium)
                 .padding(.horizontal, self.theme.metrics.spacing.md)
                 .padding(.vertical, self.theme.metrics.spacing.xs)
-                .foregroundStyle(Color.white)
+                .foregroundColor(Color.white)
                 .background(
                     self.shape
                         .fill(self.theme.palette.accent.opacity(self.isHovered ? 0.9 : 0.8))
@@ -351,13 +351,13 @@ struct GlassToggleStyle: ToggleStyle {
         var body: some View {
             HStack {
                 self.configuration.label
-                    .foregroundStyle(self.theme.palette.primaryText)
+                    .foregroundColor(self.theme.palette.primaryText)
 
                 Spacer()
 
                 Toggle("", isOn: self.configuration.$isOn)
                     .toggleStyle(.switch)
-                    .tint(self.theme.palette.accent)
+                    .accentColor(self.theme.palette.accent)
                     .labelsHidden()
             }
         }
@@ -372,7 +372,7 @@ struct FormRowStyle: ViewModifier {
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
             .background(RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(.ultraThinMaterial.opacity(0.5))
+                .fill(Color(white: 0.15, opacity: 0.5))
                 .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(.white.opacity(0.08), lineWidth: 1)))
     }

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsView.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsView.swift
@@ -22,24 +22,25 @@ struct AIEnhancementSettingsView: View {
                     self.expandedProviderID = self.viewModel.selectedProviderID
                 }
             }
-            .onChange(of: self.viewModel.showKeychainPermissionAlert) { _, isPresented in
+            .onChange(of: self.viewModel.showKeychainPermissionAlert) { isPresented in
                 guard isPresented else { return }
                 self.viewModel.presentKeychainAccessAlert(message: self.viewModel.keychainPermissionMessage)
                 self.viewModel.showKeychainPermissionAlert = false
             }
-            .alert("Delete Prompt?", isPresented: self.$viewModel.showingDeletePromptConfirm) {
-                Button("Delete", role: .destructive) {
-                    self.viewModel.deletePendingPrompt()
-                }
-                Button("Cancel", role: .cancel) {
-                    self.viewModel.clearPendingDeletePrompt()
-                }
-            } message: {
-                if self.viewModel.pendingDeletePromptName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    Text("This cannot be undone.")
-                } else {
-                    Text("Delete “\(self.viewModel.pendingDeletePromptName)”? This cannot be undone.")
-                }
+            .alert(isPresented: self.$viewModel.showingDeletePromptConfirm) {
+                let message = self.viewModel.pendingDeletePromptName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? “This cannot be undone.”
+                    : “Delete \”\(self.viewModel.pendingDeletePromptName)\”? This cannot be undone.”
+                return Alert(
+                    title: Text(“Delete Prompt?”),
+                    message: Text(message),
+                    primaryButton: .destructive(Text(“Delete”)) {
+                        self.viewModel.deletePendingPrompt()
+                    },
+                    secondaryButton: .cancel {
+                        self.viewModel.clearPendingDeletePrompt()
+                    }
+                )
             }
     }
 }

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -657,7 +657,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
         // Make the request
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.compatData(for: request)
 
             if let httpResponse = response as? HTTPURLResponse {
                 let statusCode = httpResponse.statusCode

--- a/Sources/Fluid/UI/AISettings/VoiceEngineSettingsView.swift
+++ b/Sources/Fluid/UI/AISettings/VoiceEngineSettingsView.swift
@@ -8,7 +8,7 @@ struct VoiceEngineSettingsView: View {
     var body: some View {
         self.speechRecognitionCard
             .onAppear { self.viewModel.onAppear() }
-            .onChange(of: self.settings.selectedSpeechModel) { _, newValue in
+            .onChange(of: self.settings.selectedSpeechModel) { newValue in
                 self.viewModel.handleSelectedSpeechModelChange(newValue)
             }
     }

--- a/Sources/Fluid/UI/AISettingsComponents.swift
+++ b/Sources/Fluid/UI/AISettingsComponents.swift
@@ -67,10 +67,10 @@ struct LiquidBar: View {
             HStack(spacing: 4) {
                 Image(systemName: self.icon)
                     .font(.system(size: 10))
-                    .foregroundStyle(self.color)
+                    .foregroundColor(self.color)
                 Text(self.label)
                     .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
 
             // Liquid Container (Capsule Glass)
@@ -137,14 +137,14 @@ struct LiquidBar: View {
             // Percentage (shows target, not animated)
             Text("\(Int(self.fillPercent * 100))%")
                 .font(.system(size: 11, weight: .bold, design: .rounded))
-                .foregroundStyle(self.fillPercent > 0 ? self.color : .secondary)
+                .foregroundColor(self.fillPercent > 0 ? self.color : .secondary)
                 .contentTransition(.numericText())
         }
         .onAppear {
             // Initialize to target on first appear
             self.animatedFill = self.fillPercent
         }
-        .onChange(of: self.fillPercent) { _, newValue in
+        .onChange(of: self.fillPercent) { newValue in
             // Animate liquid level change with a gentle "sloshing" feel
             withAnimation(.interpolatingSpring(stiffness: 140, damping: 18)) {
                 self.animatedFill = newValue

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -54,7 +54,7 @@ extension AIEnhancementSettingsView {
                         HStack(spacing: 10) {
                             Image(systemName: "brain")
                                 .font(.title3)
-                                .foregroundStyle(self.theme.palette.accent)
+                                .foregroundColor(self.theme.palette.accent)
                             Text("AI Enhancement")
                                 .font(.title3)
                                 .fontWeight(.semibold)
@@ -63,7 +63,7 @@ extension AIEnhancementSettingsView {
                         Toggle("", isOn: self.$viewModel.enableAIProcessing)
                             .toggleStyle(.switch)
                             .labelsHidden()
-                            .tint(self.theme.palette.accent)
+                            .accentColor(self.theme.palette.accent)
                     }
 
                     if self.viewModel.enableAIProcessing {
@@ -76,7 +76,7 @@ extension AIEnhancementSettingsView {
                                     .font(.system(size: 14, weight: .semibold))
                                 Text("Configure your AI provider")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                             }
 
                             Spacer()
@@ -89,7 +89,7 @@ extension AIEnhancementSettingsView {
                                         .font(.caption)
                                         .fontWeight(.medium)
                                 }
-                                .foregroundStyle(self.viewModel.showHelp ? self.theme.palette.accent : .secondary)
+                                .foregroundColor(self.viewModel.showHelp ? self.theme.palette.accent : .secondary)
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 6)
                                 .background(
@@ -124,11 +124,11 @@ extension AIEnhancementSettingsView {
     var apiKeyWarningView: some View {
         HStack(spacing: 10) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
+                .foregroundColor(.orange)
                 .font(.system(size: 16))
             Text("API key required for AI enhancement to work")
                 .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.orange)
+                .foregroundColor(.orange)
             Spacer()
         }
         .padding(12)
@@ -143,7 +143,7 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 8) {
                 Image(systemName: "lightbulb.fill")
                     .font(.system(size: 14))
-                    .foregroundStyle(.yellow)
+                    .foregroundColor(.yellow)
                 Text("Quick Start Guide")
                     .font(.system(size: 13, weight: .semibold))
             }
@@ -178,15 +178,15 @@ extension AIEnhancementSettingsView {
                     .frame(width: 22, height: 22)
                 Text(number)
                     .font(.system(size: 11, weight: .bold, design: .rounded))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
             }
             Image(systemName: icon)
                 .font(.system(size: 11))
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
                 .frame(width: 16)
             Text(text)
                 .font(.system(size: 12))
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
         }
     }
 
@@ -194,15 +194,15 @@ extension AIEnhancementSettingsView {
         HStack(spacing: 12) {
             Image(systemName: "sparkles")
                 .font(.system(size: 24))
-                .foregroundStyle(self.theme.palette.accent.opacity(0.5))
+                .foregroundColor(self.theme.palette.accent.opacity(0.5))
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("AI Enhancement Disabled")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 Text("Turn this on to enable AI-powered cleanup. We'll guide you through setup in a few short steps.")
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(.secondary)
                     .lineLimit(2)
             }
         }
@@ -244,19 +244,19 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 6) {
                 Image(systemName: "square.grid.2x2")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(self.theme.palette.secondaryText)
+                    .foregroundColor(self.theme.palette.secondaryText)
                 Text("All providers")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(self.theme.palette.secondaryText)
+                    .foregroundColor(self.theme.palette.secondaryText)
                 Text("(\(count))")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(self.theme.palette.tertiaryText)
+                    .foregroundColor(self.theme.palette.tertiaryText)
             }
 
             HStack(spacing: 8) {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 TextField("Search providers", text: self.$providerSearchText)
                     .textFieldStyle(.plain)
                     .font(.system(size: 12))
@@ -281,7 +281,7 @@ extension AIEnhancementSettingsView {
                         if filteredItems.isEmpty, !query.isEmpty {
                             Text("No providers match \"\(query)\"")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                                 .padding(.vertical, 12)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
@@ -317,27 +317,27 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 6) {
                 Image(systemName: "checkmark.seal.fill")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(Color.fluidGreen)
+                    .foregroundColor(Color.fluidGreen)
                 Text("Verified providers")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(self.theme.palette.secondaryText)
+                    .foregroundColor(self.theme.palette.secondaryText)
                 Text("(\(count))")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(self.theme.palette.tertiaryText)
+                    .foregroundColor(self.theme.palette.tertiaryText)
             }
 
             if verified.isEmpty {
                 HStack(spacing: 10) {
                     Image(systemName: "info.circle")
                         .font(.system(size: 14))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                     VStack(alignment: .leading, spacing: 2) {
                         Text("No verified providers yet")
                             .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                         Text("Set up a provider below and verify its connection")
                             .font(.caption)
-                            .foregroundStyle(.tertiary)
+                            .foregroundColor(.secondary)
                     }
                 }
                 .padding(14)
@@ -396,7 +396,7 @@ extension AIEnhancementSettingsView {
             Text(status.text)
         }
         .font(.caption2)
-        .foregroundStyle(status.color)
+        .foregroundColor(status.color)
 
         return VStack(alignment: .leading, spacing: 0) {
             Button(action: { if !isComingSoon { self.toggleProviderExpansion(item.id) } }) {
@@ -407,7 +407,7 @@ extension AIEnhancementSettingsView {
                     HStack(spacing: 8) {
                         Text(item.name)
                             .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(isComingSoon ? self.theme.palette.accent : self.theme.palette.primaryText)
+                            .foregroundColor(isComingSoon ? self.theme.palette.accent : self.theme.palette.primaryText)
 
                         if isFluidInterest {
                             statusView
@@ -431,7 +431,7 @@ extension AIEnhancementSettingsView {
                     if !isComingSoon {
                         Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
                             .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(.secondary.opacity(0.7))
+                            .foregroundColor(.secondary.opacity(0.7))
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -529,35 +529,35 @@ extension AIEnhancementSettingsView {
                 HStack(spacing: 8) {
                     Image(systemName: "checkmark.seal.fill")
                         .font(.system(size: 13))
-                        .foregroundStyle(self.theme.palette.accent)
+                        .foregroundColor(self.theme.palette.accent)
                     Text("Thank you — coming soon")
                         .font(.system(size: 13, weight: .semibold))
                 }
 
                 Text("We saved your interest in Fluid-1, our private on-device model. We'll notify you when it's ready.")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             } else {
                 HStack(spacing: 8) {
                     Image(systemName: "envelope.fill")
                         .font(.system(size: 13))
-                        .foregroundStyle(self.theme.palette.accent)
+                        .foregroundColor(self.theme.palette.accent)
                     Text("Join Fluid-1 early access")
                         .font(.system(size: 13, weight: .semibold))
                 }
 
                 Text("Share your email to get notified when our private on-device model is ready.")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Email")
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                     TextField("you@example.com", text: self.$fluid1InterestEmail)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(size: 13))
-                        .onChange(of: self.fluid1InterestEmail) { _, _ in
+                        .onChange(of: self.fluid1InterestEmail) { _ in
                             if !self.fluid1InterestErrorMessage.isEmpty {
                                 self.fluid1InterestErrorMessage = ""
                             }
@@ -569,7 +569,7 @@ extension AIEnhancementSettingsView {
                         HStack(spacing: 6) {
                             if self.fluid1InterestIsSubmitting {
                                 ProgressView()
-                                    .controlSize(.small)
+                                    
                             } else {
                                 Image(systemName: "paperplane.fill")
                                     .font(.system(size: 11))
@@ -585,7 +585,7 @@ extension AIEnhancementSettingsView {
                 if !self.fluid1InterestErrorMessage.isEmpty {
                     Text(self.fluid1InterestErrorMessage)
                         .font(.caption)
-                        .foregroundStyle(.red)
+                        .foregroundColor(.red)
                 }
             }
         }
@@ -648,7 +648,7 @@ extension AIEnhancementSettingsView {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await URLSession.shared.compatData(for: request)
             if let httpResponse = response as? HTTPURLResponse {
                 let success = (200...299).contains(httpResponse.statusCode)
                 if success {
@@ -701,10 +701,10 @@ extension AIEnhancementSettingsView {
                 HStack(spacing: 10) {
                     Image(systemName: "lock.slash")
                         .font(.system(size: 14))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                     Text("Apple Intelligence is unavailable on this device. Enable it in System Settings → Apple Intelligence & Siri.")
                         .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -752,10 +752,10 @@ extension AIEnhancementSettingsView {
                 HStack(spacing: 10) {
                     Image(systemName: "lock.shield.fill")
                         .font(.system(size: 14))
-                        .foregroundStyle(Color.fluidGreen)
+                        .foregroundColor(Color.fluidGreen)
                     Text("Apple Intelligence runs on-device and does not require an API key.")
                         .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -779,10 +779,10 @@ extension AIEnhancementSettingsView {
                         HStack(spacing: 6) {
                             Image(systemName: "textformat")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                             Text("Provider Name")
                                 .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                         }
                         TextField("Custom Provider", text: nameBinding)
                             .textFieldStyle(.roundedBorder)
@@ -793,10 +793,10 @@ extension AIEnhancementSettingsView {
                         HStack(spacing: 6) {
                             Image(systemName: "link")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                             Text("Base URL")
                                 .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                         }
                         TextField("https://api.yourprovider.com/v1", text: baseURLBinding)
                             .textFieldStyle(.roundedBorder)
@@ -807,7 +807,7 @@ extension AIEnhancementSettingsView {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("API Key")
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                     HStack(alignment: .center, spacing: 8) {
                         SecureField("Enter API key", text: apiKeyBinding)
                             .textFieldStyle(.roundedBorder)
@@ -829,7 +829,7 @@ extension AIEnhancementSettingsView {
                                     RoundedRectangle(cornerRadius: 6, style: .continuous)
                                         .fill(self.theme.palette.accent)
                                 )
-                                .foregroundStyle(.white)
+                                .foregroundColor(.white)
                             }
                             .buttonStyle(.plain)
                         }
@@ -839,7 +839,7 @@ extension AIEnhancementSettingsView {
                 HStack(spacing: 10) {
                     Text("Model")
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .frame(width: 50, alignment: .leading)
 
                     SearchableModelPicker(
@@ -870,7 +870,7 @@ extension AIEnhancementSettingsView {
                         Text(error)
                             .font(.caption)
                     }
-                    .foregroundStyle(.red)
+                    .foregroundColor(.red)
                     .padding(10)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(
@@ -887,7 +887,7 @@ extension AIEnhancementSettingsView {
                         HStack(spacing: 6) {
                             if self.viewModel.isTestingConnection {
                                 ProgressView()
-                                    .controlSize(.mini)
+                                    
                             } else {
                                 Image(systemName: "checkmark.shield")
                                     .font(.system(size: 12))
@@ -905,14 +905,14 @@ extension AIEnhancementSettingsView {
                         Text(hasModels ? "Select a model to enable verification" : "Refresh models to enable verification")
                             .font(.caption)
                     }
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 }
 
                 if isCustom {
                     Divider()
                         .background(self.theme.palette.separator.opacity(0.5))
 
-                    Button(role: .destructive) {
+                    Button {
                         self.viewModel.deleteCurrentProvider()
                         self.expandedProviderID = nil
                     } label: {
@@ -941,24 +941,24 @@ extension AIEnhancementSettingsView {
 
                     Image(systemName: "plus")
                         .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(self.theme.palette.accent)
+                        .foregroundColor(self.theme.palette.accent)
                 }
                 .frame(width: 40, height: 40)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Add Custom Provider")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(self.theme.palette.primaryText)
+                        .foregroundColor(self.theme.palette.primaryText)
                     Text("OpenAI-compatible endpoint")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
 
                 Spacer()
 
                 Image(systemName: "chevron.right")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary.opacity(0.7))
+                    .foregroundColor(.secondary.opacity(0.7))
             }
             .padding(14)
             .background(
@@ -1012,11 +1012,11 @@ extension AIEnhancementSettingsView {
                 HStack(spacing: 8) {
                     Text(item.name)
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(self.theme.palette.primaryText)
+                        .foregroundColor(self.theme.palette.primaryText)
 
                     Image(systemName: "checkmark.seal.fill")
                         .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(Color.fluidGreen)
+                        .foregroundColor(Color.fluidGreen)
 
                     if isSelected {
                         Text("Active")
@@ -1025,7 +1025,7 @@ extension AIEnhancementSettingsView {
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)
                             .background(Capsule().fill(Color.fluidGreen.opacity(0.2)))
-                            .foregroundStyle(Color.fluidGreen)
+                            .foregroundColor(Color.fluidGreen)
                     }
                 }
 
@@ -1130,7 +1130,7 @@ extension AIEnhancementSettingsView {
             } else {
                 Text(self.providerInitials(for: item))
                     .font(.system(size: 14, weight: .bold, design: .rounded))
-                    .foregroundStyle(self.theme.palette.primaryText)
+                    .foregroundColor(self.theme.palette.primaryText)
             }
         }
         .frame(width: 38, height: 38)
@@ -1278,13 +1278,13 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 8) {
                 Image(systemName: "text.bubble.fill")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
                 HStack(alignment: .firstTextBaseline, spacing: 0) {
                     Text("Prompts & Advanced")
                         .font(.system(size: 14, weight: .semibold))
                     Text(" - Choose how to process your speech — email, code, terminal, and more")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -1314,7 +1314,7 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 8) {
                 Image(systemName: "pencil.circle.fill")
                     .font(.system(size: 14))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
                 Text("Edit Provider")
                     .font(.system(size: 14, weight: .semibold))
                 Spacer()
@@ -1327,10 +1327,10 @@ extension AIEnhancementSettingsView {
                             HStack(spacing: 6) {
                                 Image(systemName: "textformat")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                 Text("Name")
                                     .font(.system(size: 12, weight: .medium))
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                             }
                             TextField("Provider name", text: self.$viewModel.editProviderName)
                                 .textFieldStyle(.roundedBorder)
@@ -1342,10 +1342,10 @@ extension AIEnhancementSettingsView {
                             HStack(spacing: 6) {
                                 Image(systemName: "link")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                 Text("Base URL")
                                     .font(.system(size: 12, weight: .medium))
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                             }
                             TextField("e.g., http://localhost:11434/v1", text: self.$viewModel.editProviderBaseURL)
                                 .textFieldStyle(.roundedBorder)
@@ -1358,10 +1358,10 @@ extension AIEnhancementSettingsView {
                     HStack(spacing: 6) {
                         Image(systemName: "key")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                         Text("API Key")
                             .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                     HStack(alignment: .center, spacing: 8) {
                         SecureField("Enter API key", text: apiKeyBinding)
@@ -1384,7 +1384,7 @@ extension AIEnhancementSettingsView {
                                     RoundedRectangle(cornerRadius: 6, style: .continuous)
                                         .fill(self.theme.palette.accent)
                                 )
-                                .foregroundStyle(.white)
+                                .foregroundColor(.white)
                             }
                             .buttonStyle(.plain)
                         }
@@ -1430,7 +1430,7 @@ extension AIEnhancementSettingsView {
                 }
 
                 if !isBuiltIn {
-                    Button(role: .destructive) {
+                    Button {
                         self.viewModel.deleteCurrentProvider()
                         self.viewModel.showingEditProvider = false
                         self.expandedProviderID = nil
@@ -1469,11 +1469,11 @@ extension AIEnhancementSettingsView {
         HStack(spacing: 8) {
             Image(systemName: "apple.logo").font(.system(size: 14))
             Text("On-Device").fontWeight(.medium)
-            Text("•").foregroundStyle(.secondary)
+            Text("•").foregroundColor(.secondary)
             Image(systemName: "lock.shield.fill").font(.system(size: 12))
             Text("Private").fontWeight(.medium)
         }
-        .font(.caption).foregroundStyle(Color.fluidGreen)
+        .font(.caption).foregroundColor(Color.fluidGreen)
         .padding(.horizontal, 12).padding(.vertical, 8)
         .background(RoundedRectangle(cornerRadius: 8).fill(Color.fluidGreen.opacity(0.15))
             .overlay(RoundedRectangle(cornerRadius: 8).stroke(
@@ -1485,7 +1485,7 @@ extension AIEnhancementSettingsView {
     var appleIntelligenceModelRow: some View {
         HStack(spacing: 12) {
             self.formLabel("Model:")
-            Text("System Language Model").foregroundStyle(.secondary).font(.system(.body))
+            Text("System Language Model").foregroundColor(.secondary).font(.system(.body))
             Spacer()
         }
     }
@@ -1544,10 +1544,6 @@ extension AIEnhancementSettingsView {
         HStack(spacing: 8) {
             TextField("Enter model name", text: self.$viewModel.newModelName)
                 .textFieldStyle(.roundedBorder)
-                .onSubmit {
-                    if !self.viewModel.newModelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        self.viewModel.addNewModel()
-                    }
                 }
             Button("Add") { self.viewModel.addNewModel() }
                 .buttonStyle(CompactButtonStyle(isReady: true))
@@ -1568,15 +1564,15 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 8) {
                 Image(systemName: "brain.head.profile")
                     .font(.system(size: 14))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
                 Text("Reasoning for \(self.viewModel.selectedModel)")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(self.theme.palette.primaryText)
+                    .foregroundColor(self.theme.palette.primaryText)
                 Spacer()
                 Button(action: { self.viewModel.showingReasoningConfig = false }) {
                     Image(systemName: "xmark")
                         .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
                 .help("Close")
@@ -1585,10 +1581,10 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 16) {
                 Toggle("", isOn: self.$viewModel.editingReasoningEnabled)
                     .toggleStyle(.switch)
-                    .controlSize(.small)
+                    
                 Text(self.viewModel.editingReasoningEnabled ? "Enabled" : "Disabled")
                     .font(.caption)
-                    .foregroundStyle(self.viewModel.editingReasoningEnabled ? self.theme.palette.accent : .secondary)
+                    .foregroundColor(self.viewModel.editingReasoningEnabled ? self.theme.palette.accent : .secondary)
             }
 
             if self.viewModel.editingReasoningEnabled {
@@ -1597,7 +1593,7 @@ extension AIEnhancementSettingsView {
                     HStack(spacing: 12) {
                         Text("Parameter")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                             .frame(width: 70, alignment: .trailing)
 
                         Picker("", selection: Binding(
@@ -1644,7 +1640,7 @@ extension AIEnhancementSettingsView {
                         HStack(spacing: 12) {
                             Text("Name")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                                 .frame(width: 70, alignment: .trailing)
                             TextField("e.g., thinking_budget", text: self.$viewModel.editingReasoningParamName)
                                 .textFieldStyle(.roundedBorder)
@@ -1657,7 +1653,7 @@ extension AIEnhancementSettingsView {
                     HStack(spacing: 12) {
                         Text("Value")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                             .frame(width: 70, alignment: .trailing)
 
                         if self.viewModel.editingReasoningParamName == "reasoning_effort" {
@@ -1739,18 +1735,18 @@ extension AIEnhancementSettingsView {
             // Connection Status Display
             if self.viewModel.connectionStatus == .success {
                 HStack(spacing: 8) {
-                    Image(systemName: "checkmark.circle.fill").foregroundStyle(Color.fluidGreen).font(.caption)
-                    Text("Connection verified").font(.caption).foregroundStyle(Color.fluidGreen)
+                    Image(systemName: "checkmark.circle.fill").foregroundColor(Color.fluidGreen).font(.caption)
+                    Text("Connection verified").font(.caption).foregroundColor(Color.fluidGreen)
                 }
             } else if self.viewModel.connectionStatus == .failed {
                 HStack(spacing: 8) {
-                    Image(systemName: "exclamationmark.circle.fill").foregroundStyle(.red).font(.caption)
+                    Image(systemName: "exclamationmark.circle.fill").foregroundColor(.red).font(.caption)
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Connection failed").font(.caption).foregroundStyle(.red)
+                        Text("Connection failed").font(.caption).foregroundColor(.red)
                         if !self.viewModel.connectionErrorMessage.isEmpty {
                             Text(self.viewModel.connectionErrorMessage)
                                 .font(.caption2)
-                                .foregroundStyle(.red.opacity(0.8))
+                                .foregroundColor(.red.opacity(0.8))
                                 .lineLimit(1)
                         }
                     }
@@ -1758,7 +1754,7 @@ extension AIEnhancementSettingsView {
             } else if self.viewModel.connectionStatus == .testing {
                 HStack(spacing: 8) {
                     ProgressView().frame(width: 16, height: 16)
-                    Text("Verifying...").font(.caption).foregroundStyle(self.theme.palette.accent)
+                    Text("Verifying...").font(.caption).foregroundColor(self.theme.palette.accent)
                 }
             }
 
@@ -1827,7 +1823,7 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 8) {
                 Image(systemName: "plus.circle.fill")
                     .font(.system(size: 14))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
                 Text("Add Custom Provider")
                     .font(.system(size: 14, weight: .semibold))
             }
@@ -1837,10 +1833,10 @@ extension AIEnhancementSettingsView {
                     HStack(spacing: 6) {
                         Image(systemName: "link")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                         Text("OpenAI-compatible base URL")
                             .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                     TextField("https://api.yourprovider.com/v1", text: self.$viewModel.newProviderBaseURL)
                         .textFieldStyle(.roundedBorder)
@@ -1851,10 +1847,10 @@ extension AIEnhancementSettingsView {
                     HStack(spacing: 6) {
                         Image(systemName: "key")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                         Text("API Key (optional for local endpoints)")
                             .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                     SecureField("Enter API key", text: self.$viewModel.newProviderApiKey)
                         .textFieldStyle(.roundedBorder)

--- a/Sources/Fluid/UI/AISettingsView+AdvancedSettings.swift
+++ b/Sources/Fluid/UI/AISettingsView+AdvancedSettings.swift
@@ -19,10 +19,10 @@ extension AIEnhancementSettingsView {
                         HStack(alignment: .firstTextBaseline, spacing: 0) {
                             Text("Prompt Profiles")
                                 .font(.system(size: 15, weight: .semibold))
-                                .foregroundStyle(self.theme.palette.primaryText)
+                                .foregroundColor(self.theme.palette.primaryText)
                             Text(" - Pick one prompt for Dictate and one for Edit Text.")
                                 .font(.system(size: 13))
-                                .foregroundStyle(self.theme.palette.secondaryText)
+                                .foregroundColor(self.theme.palette.secondaryText)
                         }
                         .lineLimit(1)
                         .truncationMode(.tail)
@@ -83,7 +83,7 @@ extension AIEnhancementSettingsView {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Text(title)
                             .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(self.theme.palette.primaryText)
+                            .foregroundColor(self.theme.palette.primaryText)
                         if mode.normalized == .edit {
                             Text("Context: Auto")
                                 .font(.caption2)
@@ -93,12 +93,12 @@ extension AIEnhancementSettingsView {
                                     RoundedRectangle(cornerRadius: 5, style: .continuous)
                                         .fill(tone.opacity(0.12))
                                 )
-                                .foregroundStyle(tone)
+                                .foregroundColor(tone)
                         }
                     }
                     Text(subtitle)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .multilineTextAlignment(.leading)
@@ -113,7 +113,7 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 10) {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(isSelected ? tone : self.theme.palette.secondaryText.opacity(0.35))
+                    .foregroundColor(isSelected ? tone : self.theme.palette.secondaryText.opacity(0.35))
                     .frame(width: 18, height: 18)
 
                 Menu {
@@ -124,12 +124,12 @@ extension AIEnhancementSettingsView {
                     }
                     if let onDelete {
                         Divider()
-                        Button(role: .destructive, action: { onDelete() }) {
+                        Button( action: { onDelete() }) {
                             Label("Delete Prompt", systemImage: "trash")
                         }
                     } else if let onResetDefault {
                         Divider()
-                        Button("Reset to Built-in Default", role: .destructive) { onResetDefault() }
+                        Button("Reset to Built-in Default")  { onResetDefault() }
                             .disabled(!canResetDefault)
                     }
                 } label: {
@@ -138,7 +138,7 @@ extension AIEnhancementSettingsView {
                         .frame(width: AISettingsLayout.controlHeight, height: AISettingsLayout.controlHeight)
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(self.theme.palette.secondaryText)
+                .foregroundColor(self.theme.palette.secondaryText)
             }
         }
         .padding(12)
@@ -174,16 +174,16 @@ extension AIEnhancementSettingsView {
             HStack(spacing: 8) {
                 Image(systemName: self.modeSymbol(mode))
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.95))
+                    .foregroundColor(.white.opacity(0.95))
                     .frame(width: 20, height: 20)
                     .background(Circle().fill(tone.opacity(mode.normalized == .dictate ? 0.85 : 0.65)))
                 HStack(alignment: .firstTextBaseline, spacing: 0) {
                     Text(mode.normalized == .dictate ? "Dictate Mode" : "Edit Text Mode")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(self.theme.palette.primaryText)
+                        .foregroundColor(self.theme.palette.primaryText)
                     Text(" - \(self.promptSectionDescription(for: mode))")
                         .font(.caption)
-                        .foregroundStyle(self.theme.palette.secondaryText)
+                        .foregroundColor(self.theme.palette.secondaryText)
                 }
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -211,7 +211,7 @@ extension AIEnhancementSettingsView {
             if customProfiles.isEmpty {
                 Text("No custom \(self.friendlyModeName(mode).lowercased()) prompts yet.")
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                     .padding(.horizontal, 4)
             } else {
                 ForEach(customProfiles) { profile in
@@ -259,7 +259,7 @@ extension AIEnhancementSettingsView {
             HStack(alignment: .center, spacing: 12) {
                 Text("Edit mode model selection (optional)")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(self.theme.palette.secondaryText)
+                    .foregroundColor(self.theme.palette.secondaryText)
                     .lineLimit(1)
                     .layoutPriority(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -269,10 +269,10 @@ extension AIEnhancementSettingsView {
                 HStack(spacing: 8) {
                     Image(systemName: "info.circle")
                         .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                     Text("No verified providers yet. Verify a provider above to enable Edit Text model selection.")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
                 .padding(10)
                 .background(
@@ -290,9 +290,9 @@ extension AIEnhancementSettingsView {
                     Toggle("Sync with AI Enhancement model", isOn: self.editModeLinkedToGlobalBinding)
                         .toggleStyle(.checkbox)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .fixedSize(horizontal: true, vertical: false)
-                        .onChange(of: self.settings.rewriteModeLinkedToGlobal) { _, linked in
+                        .onChange(of: self.settings.rewriteModeLinkedToGlobal) { linked in
                             if linked {
                                 self.syncEditModeToGlobalSelection()
                             } else {
@@ -303,7 +303,7 @@ extension AIEnhancementSettingsView {
                     HStack(alignment: .center, spacing: 10) {
                         Text("Provider")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         Picker("", selection: self.editModeProviderBinding) {
                             ForEach(verified) { provider in
@@ -317,7 +317,7 @@ extension AIEnhancementSettingsView {
 
                         Text("Model")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         SearchableModelPicker(
                             models: models,
@@ -528,7 +528,7 @@ extension AIEnhancementSettingsView {
                         : "Prompt text is appended to the hidden base prompt for the selected mode."
                     )
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 }
                 Spacer()
             }
@@ -536,7 +536,7 @@ extension AIEnhancementSettingsView {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Mode")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 Picker("Mode", selection: self.$viewModel.draftPromptMode) {
                     ForEach(SettingsStore.PromptMode.visiblePromptModes) { mode in
                         Text(self.friendlyModeName(mode)).tag(mode)
@@ -549,7 +549,7 @@ extension AIEnhancementSettingsView {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Name")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 let isDefaultNameLocked = mode.isDefault
                 TextField("Prompt name", text: self.$viewModel.draftPromptName)
                     .textFieldStyle(.roundedBorder)
@@ -559,7 +559,7 @@ extension AIEnhancementSettingsView {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Prompt")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 PromptTextView(
                     text: self.$viewModel.draftPromptText,
                     isEditable: true,
@@ -575,7 +575,7 @@ extension AIEnhancementSettingsView {
                                 .stroke(self.theme.palette.cardBorder.opacity(0.35), lineWidth: 1)
                         )
                 )
-                .onChange(of: self.viewModel.draftPromptText) { _, newValue in
+                .onChange(of: self.viewModel.draftPromptText) { newValue in
                     guard self.viewModel.draftPromptMode == .dictate else { return }
                     let combined = self.viewModel.combinedDraftPrompt(newValue, mode: self.viewModel.draftPromptMode)
                     self.promptTest.updateDraftPromptText(combined)
@@ -586,11 +586,11 @@ extension AIEnhancementSettingsView {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Selected text is added automatically when text is selected.")
                         .font(.caption)
-                        .foregroundStyle(self.theme.palette.secondaryText)
+                        .foregroundColor(self.theme.palette.secondaryText)
 
                     Text("Context block added automatically:")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
 
                     Text(SettingsStore.contextTemplateText())
                         .font(.system(.caption2, design: .monospaced))
@@ -613,7 +613,7 @@ extension AIEnhancementSettingsView {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 8) {
                         Image(systemName: "waveform")
-                            .foregroundStyle(self.theme.palette.accent)
+                            .foregroundColor(self.theme.palette.accent)
                         Text("Test")
                             .font(.subheadline)
                             .fontWeight(.semibold)
@@ -643,41 +643,41 @@ extension AIEnhancementSettingsView {
                     if !canTest {
                         Text("Testing is disabled because AI post-processing is not configured.")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     } else if self.promptTest.isActive {
                         Text("Press the hotkey to start/stop recording. The transcription will be post-processed using your draft prompt and shown below (nothing will be typed into other apps).")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
 
                     if self.promptTest.isActive {
                         if self.promptTest.isProcessing {
                             HStack(spacing: 8) {
-                                ProgressView().controlSize(.small)
+                                ProgressView()
                                 Text("Processing…")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                             }
                         }
 
                         if !self.promptTest.lastError.isEmpty {
                             Text(self.promptTest.lastError)
                                 .font(.caption2)
-                                .foregroundStyle(.red)
-                                .textSelection(.enabled)
+                                .foregroundColor(.red)
+                                
                         }
 
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Raw transcription")
                                 .font(.caption2)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                             TextEditor(text: Binding(
                                 get: { self.promptTest.lastTranscriptionText },
                                 set: { _ in }
                             ))
                             .font(.system(.caption, design: .monospaced))
                             .frame(minHeight: 70)
-                            .scrollContentBackground(.hidden)
+                            
                             .background(
                                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                                     .fill(self.theme.palette.contentBackground.opacity(0.7))
@@ -691,14 +691,14 @@ extension AIEnhancementSettingsView {
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Post-processed output")
                                 .font(.caption2)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                             TextEditor(text: Binding(
                                 get: { self.promptTest.lastOutputText },
                                 set: { _ in }
                             ))
                             .font(.system(.caption, design: .monospaced))
                             .frame(minHeight: 110)
-                            .scrollContentBackground(.hidden)
+                            
                             .background(
                                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                                     .fill(self.theme.palette.contentBackground.opacity(0.7))
@@ -722,7 +722,7 @@ extension AIEnhancementSettingsView {
             } else if self.promptTest.isActive {
                 Text("Prompt test mode is available only for Dictate prompts.")
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                     .onAppear { self.promptTest.deactivate() }
             }
 
@@ -746,16 +746,16 @@ extension AIEnhancementSettingsView {
         .onDisappear {
             self.promptTest.deactivate()
         }
-        .onChange(of: self.viewModel.enableAIProcessing) { _, _ in
+        .onChange(of: self.viewModel.enableAIProcessing) { _ in
             self.autoDisablePromptTestIfNeeded()
         }
-        .onChange(of: self.viewModel.selectedProviderID) { _, _ in
+        .onChange(of: self.viewModel.selectedProviderID) { _ in
             self.autoDisablePromptTestIfNeeded()
         }
-        .onChange(of: self.viewModel.providerAPIKeys) { _, _ in
+        .onChange(of: self.viewModel.providerAPIKeys) { _ in
             self.autoDisablePromptTestIfNeeded()
         }
-        .onChange(of: self.viewModel.savedProviders) { _, _ in
+        .onChange(of: self.viewModel.savedProviders) { _ in
             self.autoDisablePromptTestIfNeeded()
         }
     }

--- a/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
+++ b/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
@@ -20,7 +20,7 @@ extension VoiceEngineSettingsView {
                 HStack(spacing: 10) {
                     Image(systemName: "waveform")
                         .font(.title2)
-                        .foregroundStyle(self.theme.palette.accent)
+                        .foregroundColor(self.theme.palette.accent)
                     Text("Voice Engine")
                         .font(.title3)
                         .fontWeight(.semibold)
@@ -43,10 +43,10 @@ extension VoiceEngineSettingsView {
                 HStack(spacing: 6) {
                     Image(systemName: "info.circle")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                     Text("Click a row to preview. Press Activate to load the model.")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                     Spacer()
                     Menu {
                         ForEach(SpeechProviderFilter.allCases) { option in
@@ -62,7 +62,7 @@ extension VoiceEngineSettingsView {
                                 .font(.caption)
                                 .fontWeight(.semibold)
                         }
-                        .foregroundStyle(.primary)
+                        .foregroundColor(.primary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 6)
                         .background(
@@ -86,7 +86,7 @@ extension VoiceEngineSettingsView {
                                 .font(.caption)
                                 .fontWeight(.semibold)
                         }
-                        .foregroundStyle(.primary)
+                        .foregroundColor(.primary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 6)
                         .background(
@@ -106,7 +106,7 @@ extension VoiceEngineSettingsView {
                         Text("Active Model")
                             .font(.callout)
                             .fontWeight(.semibold)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                         self.speechModelCard(for: activeModel)
                     }
 
@@ -116,7 +116,7 @@ extension VoiceEngineSettingsView {
                         Text("Other Models")
                             .font(.callout)
                             .fontWeight(.semibold)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                         VStack(spacing: 8) {
                             ForEach(otherModels) { model in
                                 self.speechModelCard(for: model)
@@ -156,7 +156,7 @@ extension VoiceEngineSettingsView {
                         HStack {
                             Text(model.humanReadableName)
                                 .font(.system(size: 16, weight: .bold))
-                                .foregroundStyle(self.theme.palette.primaryText)
+                                .foregroundColor(self.theme.palette.primaryText)
 
                             if let badge = model.badgeText {
                                 Text(badge)
@@ -165,7 +165,7 @@ extension VoiceEngineSettingsView {
                                     .padding(.horizontal, 6)
                                     .padding(.vertical, 2)
                                     .background(Capsule().fill(badge == "FluidVoice Pick" ? .cyan.opacity(0.2) : .orange.opacity(0.2)))
-                                    .foregroundStyle(badge == "FluidVoice Pick" ? .cyan : .orange)
+                                    .foregroundColor(badge == "FluidVoice Pick" ? .cyan : .orange)
                             }
 
                             Spacer()
@@ -173,14 +173,14 @@ extension VoiceEngineSettingsView {
 
                         Text(model.cardDescription)
                             .font(.system(size: 13))
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                             .lineLimit(2)
                     }
 
                     HStack(spacing: 8) {
                         Label(model.downloadSize, systemImage: "internaldrive")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         if model.requiresAppleSilicon {
                             Text("Apple Silicon")
@@ -188,15 +188,15 @@ extension VoiceEngineSettingsView {
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
                                 .background(Capsule().fill(self.theme.palette.accent.opacity(0.2)))
-                                .foregroundStyle(self.theme.palette.accent)
+                                .foregroundColor(self.theme.palette.accent)
                         }
 
                         Text(model.languageSupport)
                             .font(.caption2)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
-                            .background(Capsule().fill(.quaternary))
-                            .foregroundStyle(.secondary)
+                            .background(Capsule().fill(Color.secondary.opacity(0.2)))
+                            .foregroundColor(.secondary)
 
                         Spacer()
                     }
@@ -206,10 +206,10 @@ extension VoiceEngineSettingsView {
                         HStack(spacing: 6) {
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .font(.caption2)
-                                .foregroundStyle(.orange)
+                                .foregroundColor(.orange)
                             Text(memoryWarning)
                                 .font(.caption2)
-                                .foregroundStyle(.orange)
+                                .foregroundColor(.orange)
                         }
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
@@ -250,11 +250,11 @@ extension VoiceEngineSettingsView {
                 HStack(alignment: .center, spacing: 10) {
                     Image(systemName: "checkmark.seal.fill")
                         .font(.caption)
-                        .foregroundStyle(Color.fluidGreen)
+                        .foregroundColor(Color.fluidGreen)
 
                     Text("Custom Words supported on Parakeet. Teach names, product terms, and uncommon words for better accuracy.")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .lineLimit(3)
 
                     Spacer(minLength: 8)
@@ -262,9 +262,9 @@ extension VoiceEngineSettingsView {
                     Button("Open Custom Dictionary") {
                         NotificationCenter.default.post(name: .openCustomDictionaryFromVoiceEngine, object: nil)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(Color.fluidGreen)
-                    .controlSize(.small)
+                    
+                    .accentColor(Color.fluidGreen)
+                    
                 }
                 .padding(.horizontal, 10)
                 .padding(.vertical, 8)
@@ -300,34 +300,34 @@ extension VoiceEngineSettingsView {
             VStack(alignment: .leading, spacing: 2) {
                 Text(model.humanReadableName)
                     .font(.system(size: 14, weight: isSelected ? .semibold : .regular))
-                    .foregroundStyle(isSelected ? self.theme.palette.primaryText : .secondary)
+                    .foregroundColor(isSelected ? self.theme.palette.primaryText : .secondary)
                 Text(model.displayName)
                     .font(.caption)
-                    .foregroundStyle(.secondary.opacity(0.7))
+                    .foregroundColor(.secondary.opacity(0.7))
 
                 HStack(spacing: 10) {
                     HStack(spacing: 4) {
                         Image(systemName: "bolt.fill")
                             .font(.system(size: 10))
-                            .foregroundStyle(.yellow)
+                            .foregroundColor(.yellow)
                         Text("Speed \(Int(model.speedPercent * 100))%")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
 
                     HStack(spacing: 4) {
                         Image(systemName: "target")
                             .font(.system(size: 10))
-                            .foregroundStyle(Color.fluidGreen)
+                            .foregroundColor(Color.fluidGreen)
                         Text("Acc \(Int(model.accuracyPercent * 100))%")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
 
                     if isSelected && !isActive {
                         Text("Previewing")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                 }
             }
@@ -342,7 +342,7 @@ extension VoiceEngineSettingsView {
                         .frame(width: 90)
                     Text("\(Int(self.viewModel.downloadProgress * 100))%")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
             } else if (self.viewModel.asr.isDownloadingModel || self.viewModel.asr.isLoadingModel) && isActive && !self.viewModel.asr.isAsrReady {
                 // Active model is loading/downloading (for Activate flow)
@@ -353,13 +353,13 @@ extension VoiceEngineSettingsView {
                             .frame(width: 90)
                         Text("\(Int(progress * 100))%")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     } else {
                         ProgressView()
-                            .controlSize(.mini)
+                            
                         Text(self.viewModel.asr.isLoadingModel ? "Loading…" : "Downloading…")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                 }
             } else if model.isInstalled {
@@ -372,14 +372,14 @@ extension VoiceEngineSettingsView {
                             .padding(.horizontal, 10)
                             .padding(.vertical, 4)
                             .background(Capsule().fill(isLoading ? .orange.opacity(0.25) : Color.fluidGreen.opacity(0.25)))
-                            .foregroundStyle(isLoading ? .orange : Color.fluidGreen)
+                            .foregroundColor(isLoading ? .orange : Color.fluidGreen)
                     } else {
                         Button("Activate") {
                             self.viewModel.activateSpeechModel(model)
                         }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.small)
-                        .tint(Color.fluidGreen)
+                        
+                        
+                        .accentColor(Color.fluidGreen)
                         .fontWeight(.semibold)
                         .shadow(color: Color.fluidGreen.opacity(0.35), radius: 4, x: 0, y: 1)
                         .disabled(self.viewModel.asr.isRunning || self.viewModel.downloadingModel != nil)
@@ -392,7 +392,7 @@ extension VoiceEngineSettingsView {
                             } label: {
                                 Image(systemName: "trash")
                                     .font(.system(size: 15))
-                                    .foregroundStyle(.red.opacity(0.7))
+                                    .foregroundColor(.red.opacity(0.7))
                             }
                             .buttonStyle(.plain)
                             .disabled(self.viewModel.asr.isRunning || self.viewModel.downloadingModel != nil)
@@ -405,16 +405,16 @@ extension VoiceEngineSettingsView {
                 ZStack(alignment: .trailing) {
                     Text("Not downloaded")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .opacity(isSelected ? 0 : 1)
 
                     Button("Download") {
                         self.viewModel.previewSpeechModel = model
                         self.viewModel.downloadSpeechModel(model)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .tint(.blue)
+                    
+                    
+                    .accentColor(.blue)
                     .disabled(self.viewModel.asr.isRunning || self.viewModel.downloadingModel != nil)
                     .offset(x: isSelected ? 0 : 16)
                     .opacity(isSelected ? 1 : 0)
@@ -449,14 +449,14 @@ extension VoiceEngineSettingsView {
         HStack(spacing: 12) {
             if (self.viewModel.asr.isDownloadingModel || self.viewModel.asr.isLoadingModel) && !self.viewModel.asr.isAsrReady {
                 HStack(spacing: 8) {
-                    ProgressView().controlSize(.small)
+                    ProgressView()
                     Text(self.viewModel.asr.isLoadingModel ? "Loading model…" : "Downloading…")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
             } else if self.viewModel.asr.isAsrReady {
-                Image(systemName: "checkmark.circle.fill").foregroundStyle(Color.fluidGreen).font(.caption)
-                Text("Ready").font(.caption).foregroundStyle(.secondary)
+                Image(systemName: "checkmark.circle.fill").foregroundColor(Color.fluidGreen).font(.caption)
+                Text("Ready").font(.caption).foregroundColor(.secondary)
 
                 Button(action: { Task { await self.viewModel.deleteModels() } }) {
                     HStack(spacing: 4) {
@@ -464,12 +464,12 @@ extension VoiceEngineSettingsView {
                         Text("Delete")
                     }
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundColor(.red)
                 }
                 .buttonStyle(.plain)
             } else if self.viewModel.asr.modelsExistOnDisk {
-                Image(systemName: "doc.fill").foregroundStyle(self.theme.palette.accent).font(.caption)
-                Text("Cached").font(.caption).foregroundStyle(.secondary)
+                Image(systemName: "doc.fill").foregroundColor(self.theme.palette.accent).font(.caption)
+                Text("Cached").font(.caption).foregroundColor(.secondary)
 
                 Button(action: { Task { await self.viewModel.deleteModels() } }) {
                     HStack(spacing: 4) {
@@ -477,7 +477,7 @@ extension VoiceEngineSettingsView {
                         Text("Delete")
                     }
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundColor(.red)
                 }
                 .buttonStyle(.plain)
             } else {
@@ -488,9 +488,9 @@ extension VoiceEngineSettingsView {
                     }
                     .font(.caption)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                .tint(.blue)
+                
+                
+                .accentColor(.blue)
             }
         }
         .padding(.horizontal, 12)
@@ -507,13 +507,13 @@ extension VoiceEngineSettingsView {
                     Text("Remove Filler Words").font(.body)
                     Text("Automatically remove filler sounds like 'um', 'uh', 'er' from transcriptions")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
                 Spacer()
                 Toggle("", isOn: self.$viewModel.removeFillerWordsEnabled)
                     .toggleStyle(.switch)
                     .labelsHidden()
-                    .onChange(of: self.viewModel.removeFillerWordsEnabled) { _, newValue in
+                    .onChange(of: self.viewModel.removeFillerWordsEnabled) { newValue in
                         self.settings.removeFillerWordsEnabled = newValue
                     }
             }
@@ -538,7 +538,7 @@ extension VoiceEngineSettingsView {
             if model.usesAppleLogo {
                 Image(systemName: "apple.logo")
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.primary)
+                    .foregroundColor(.primary)
             } else if let imageName {
                 Image(imageName)
                     .resizable()
@@ -548,7 +548,7 @@ extension VoiceEngineSettingsView {
             } else {
                 Text(String(model.brandName.prefix(2)).uppercased())
                     .font(.system(size: 10, weight: .bold, design: .rounded))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
         }
         .frame(width: 28, height: 28)

--- a/Sources/Fluid/UI/AnalyticsPrivacyView.swift
+++ b/Sources/Fluid/UI/AnalyticsPrivacyView.swift
@@ -12,13 +12,13 @@ struct AnalyticsPrivacyView: View {
                         .font(.system(size: 18, weight: .semibold))
                     Text("What FluidVoice collects when analytics is enabled")
                         .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
 
                 Spacer()
 
                 Button("Done") { self.dismiss() }
-                    .buttonStyle(.bordered)
+                    
             }
 
             Divider().opacity(0.4)
@@ -59,7 +59,7 @@ struct AnalyticsPrivacyView: View {
     private var contactInfoView: some View {
         Text(self.contactInfoText)
             .font(.system(size: 13))
-            .foregroundStyle(.primary)
+            .foregroundColor(.primary)
             .padding(12)
             .background(
                 RoundedRectangle(cornerRadius: 8)
@@ -92,17 +92,17 @@ struct AnalyticsPrivacyView: View {
     private func sectionTitle(_ text: String) -> some View {
         Text(text)
             .font(.system(size: 12, weight: .semibold))
-            .foregroundStyle(self.theme.palette.accent)
+            .foregroundColor(self.theme.palette.accent)
             .padding(.top, 4)
     }
 
     private func bullet(_ text: String) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text("•")
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
             Text(text)
                 .font(.system(size: 13))
-                .foregroundStyle(.primary)
+                .foregroundColor(.primary)
             Spacer(minLength: 0)
         }
     }

--- a/Sources/Fluid/UI/CustomDictionaryView.swift
+++ b/Sources/Fluid/UI/CustomDictionaryView.swift
@@ -83,7 +83,7 @@ struct CustomDictionaryView: View {
             HStack {
                 Image(systemName: "text.book.closed.fill")
                     .font(.title2)
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
                 Text("Custom Dictionary")
                     .font(.title2)
                     .fontWeight(.semibold)
@@ -91,7 +91,7 @@ struct CustomDictionaryView: View {
 
             Text("Improve transcription accuracy with Custom Words for names and product terms, plus Instant Replacement for simple find-and-replace.")
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
         }
     }
 
@@ -109,7 +109,7 @@ struct CustomDictionaryView: View {
                     HStack {
                         Image(systemName: self.isOfflineSectionExpanded ? "chevron.down" : "chevron.right")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                             .frame(width: 16)
 
                         Text("Instant Replacement")
@@ -121,7 +121,7 @@ struct CustomDictionaryView: View {
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
                             .background(RoundedRectangle(cornerRadius: 4).fill(Color.fluidGreen.opacity(0.2)))
-                            .foregroundStyle(Color.fluidGreen)
+                            .foregroundColor(Color.fluidGreen)
 
                         Spacer()
 
@@ -130,8 +130,8 @@ struct CustomDictionaryView: View {
                                 .font(.caption.weight(.medium))
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 2)
-                                .background(Capsule().fill(.quaternary))
-                                .foregroundStyle(.secondary)
+                                .background(Capsule().fill(Color.secondary.opacity(0.2)))
+                                .foregroundColor(.secondary)
                         }
 
                         // Add button (only when expanded and has entries)
@@ -141,8 +141,8 @@ struct CustomDictionaryView: View {
                             } label: {
                                 Image(systemName: "plus")
                             }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
+                            
+                            
                         }
                     }
                     .contentShape(Rectangle())
@@ -156,22 +156,22 @@ struct CustomDictionaryView: View {
                     // Description
                     Text("Simple find-and-replace. Works offline with zero latency. Replacements are applied instantly after transcription.")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .padding(.bottom, 12)
 
                     // Features
                     HStack(spacing: 12) {
                         Label("No AI needed", systemImage: "cpu")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         Label("Zero latency", systemImage: "bolt.fill")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         Label("Case insensitive", systemImage: "textformat")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                     .padding(.bottom, 12)
 
@@ -193,11 +193,11 @@ struct CustomDictionaryView: View {
         VStack(spacing: 12) {
             Image(systemName: "plus.circle.dashed")
                 .font(.system(size: 32))
-                .foregroundStyle(.tertiary)
+                .foregroundColor(.secondary)
 
             Text("No entries yet")
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
 
             Button {
                 self.showAddSheet = true
@@ -207,9 +207,9 @@ struct CustomDictionaryView: View {
                     Text("Add Entry")
                 }
             }
-            .buttonStyle(.borderedProminent)
-            .tint(self.theme.palette.accent)
-            .controlSize(.small)
+            
+            .accentColor(self.theme.palette.accent)
+            
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 16)
@@ -243,7 +243,7 @@ struct CustomDictionaryView: View {
                     HStack {
                         Image(systemName: self.isAISectionExpanded ? "chevron.down" : "chevron.right")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                             .frame(width: 16)
 
                         Text("Custom Words (Parakeet)")
@@ -254,14 +254,14 @@ struct CustomDictionaryView: View {
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
                             .background(RoundedRectangle(cornerRadius: 4).fill(self.theme.palette.accent.opacity(0.2)))
-                            .foregroundStyle(self.theme.palette.accent)
+                            .foregroundColor(self.theme.palette.accent)
 
                         Text("\(self.boostTerms.count)")
                             .font(.caption2.weight(.medium))
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
-                            .background(Capsule().fill(.quaternary))
-                            .foregroundStyle(.secondary)
+                            .background(Capsule().fill(Color.secondary.opacity(0.2)))
+                            .foregroundColor(.secondary)
 
                         Spacer()
 
@@ -271,8 +271,8 @@ struct CustomDictionaryView: View {
                             } label: {
                                 Image(systemName: "plus")
                             }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
+                            
+                            
                         }
                     }
                     .contentShape(Rectangle())
@@ -286,15 +286,15 @@ struct CustomDictionaryView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Add names, product words, and uncommon terms in a simple form.")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         Text("Words from Instant Replacement are also used here automatically.")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         Text("Applies when using a Parakeet voice engine.")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         HStack {
                             Toggle(isOn: self.$vocabBoostingEnabled) {
@@ -303,12 +303,12 @@ struct CustomDictionaryView: View {
                                         .font(.subheadline.weight(.medium))
                                     Text("Uses a secondary ML model to improve recognition of custom words. Disable if you experience issues.")
                                         .font(.caption2)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
                             }
                             .toggleStyle(.switch)
-                            .controlSize(.small)
-                            .onChange(of: self.vocabBoostingEnabled) { _, newValue in
+                            
+                            .onChange(of: self.vocabBoostingEnabled) { newValue in
                                 SettingsStore.shared.vocabularyBoostingEnabled = newValue
                             }
                         }
@@ -322,10 +322,10 @@ struct CustomDictionaryView: View {
                             VStack(spacing: 10) {
                                 Image(systemName: "waveform.and.magnifyingglass")
                                     .font(.system(size: 28))
-                                    .foregroundStyle(.tertiary)
+                                    .foregroundColor(.secondary)
                                 Text("No custom words yet")
                                     .font(.subheadline)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                 Button {
                                     self.showAddBoostSheet = true
                                 } label: {
@@ -334,9 +334,9 @@ struct CustomDictionaryView: View {
                                         Text("Add Custom Word")
                                     }
                                 }
-                                .buttonStyle(.borderedProminent)
-                                .tint(self.theme.palette.accent)
-                                .controlSize(.small)
+                                
+                                .accentColor(self.theme.palette.accent)
+                                
                             }
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 16)
@@ -361,9 +361,9 @@ struct CustomDictionaryView: View {
                                 } label: {
                                     Label("Add Word", systemImage: "plus")
                                 }
-                                .buttonStyle(.borderedProminent)
-                                .tint(self.theme.palette.accent)
-                                .controlSize(.small)
+                                
+                                .accentColor(self.theme.palette.accent)
+                                
 
                                 Spacer()
                             }
@@ -371,10 +371,10 @@ struct CustomDictionaryView: View {
 
                         HStack {
                             Image(systemName: self.boostHasError ? "xmark.circle.fill" : "checkmark.circle.fill")
-                                .foregroundStyle(self.boostHasError ? .red : .secondary)
+                                .foregroundColor(self.boostHasError ? .red : .secondary)
                             Text(self.boostStatusMessage)
                                 .font(.caption)
-                                .foregroundStyle(self.boostHasError ? .red : .secondary)
+                                .foregroundColor(self.boostHasError ? .red : .secondary)
                         }
                         .padding(10)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -502,7 +502,7 @@ struct BoostTermRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(self.term.text)
                     .font(.callout.weight(.medium))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
             }
 
             Spacer()
@@ -512,8 +512,8 @@ struct BoostTermRow: View {
                     .font(.caption2.weight(.semibold))
                     .padding(.horizontal, 6)
                     .padding(.vertical, 3)
-                    .background(Capsule().fill(.quaternary))
-                    .foregroundStyle(.secondary)
+                    .background(Capsule().fill(Color.secondary.opacity(0.2)))
+                    .foregroundColor(.secondary)
             }
 
             HStack(spacing: 6) {
@@ -523,21 +523,21 @@ struct BoostTermRow: View {
                     Image(systemName: "pencil")
                         .font(.caption2)
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.mini)
+                
+                
 
-                Button(role: .destructive) {
+                Button {
                     self.onDelete()
                 } label: {
                     Image(systemName: "trash")
                         .font(.caption2)
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.mini)
+                
+                
             }
         }
         .padding(10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary.opacity(0.5)))
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.5)))
     }
 }
 
@@ -575,7 +575,6 @@ struct AddBoostTermSheet: View {
                         .font(.subheadline.weight(.medium))
                     TextField("FluidVoice", text: self.$termText)
                         .textFieldStyle(.roundedBorder)
-                        .onSubmit { self.saveIfValid() }
                 }
 
                 VStack(alignment: .leading, spacing: 6) {
@@ -589,21 +588,21 @@ struct AddBoostTermSheet: View {
                     .pickerStyle(.segmented)
                     Text(self.strength.hint)
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
 
                 if self.isDuplicate {
                     Text("This term already exists.")
                         .font(.caption)
-                        .foregroundStyle(.orange)
+                        .foregroundColor(.orange)
                 }
 
                 HStack {
                     Button("Cancel") { self.dismiss() }
-                        .buttonStyle(.bordered)
+                        
                     Spacer()
                     Button("Save") { self.saveIfValid() }
-                        .buttonStyle(.borderedProminent)
+                        
                         .disabled(!self.canSave)
                         .keyboardShortcut(.return, modifiers: [])
                 }
@@ -667,7 +666,6 @@ struct EditBoostTermSheet: View {
                         .font(.subheadline.weight(.medium))
                     TextField("FluidVoice", text: self.$termText)
                         .textFieldStyle(.roundedBorder)
-                        .onSubmit { self.saveIfValid() }
                 }
 
                 VStack(alignment: .leading, spacing: 6) {
@@ -681,21 +679,21 @@ struct EditBoostTermSheet: View {
                     .pickerStyle(.segmented)
                     Text(self.strength.hint)
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
 
                 if self.isDuplicate {
                     Text("This term already exists.")
                         .font(.caption)
-                        .foregroundStyle(.orange)
+                        .foregroundColor(.orange)
                 }
 
                 HStack {
                     Button("Cancel") { self.dismiss() }
-                        .buttonStyle(.bordered)
+                        
                     Spacer()
                     Button("Save") { self.saveIfValid() }
-                        .buttonStyle(.borderedProminent)
+                        
                         .disabled(!self.canSave)
                         .keyboardShortcut(.return, modifiers: [])
                 }
@@ -738,7 +736,7 @@ struct DictionaryEntryRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("When heard:")
                     .font(.caption2)
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(.secondary)
 
                 FlowLayout(spacing: 4) {
                     ForEach(self.entry.triggers, id: \.self) { trigger in
@@ -746,7 +744,7 @@ struct DictionaryEntryRow: View {
                             .font(.caption)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 3)
-                            .background(RoundedRectangle(cornerRadius: 4).fill(.quaternary))
+                            .background(RoundedRectangle(cornerRadius: 4).fill(Color.secondary.opacity(0.2)))
                     }
                 }
             }
@@ -755,17 +753,17 @@ struct DictionaryEntryRow: View {
             // Arrow
             Image(systemName: "arrow.right")
                 .font(.caption2)
-                .foregroundStyle(.tertiary)
+                .foregroundColor(.secondary)
 
             // Replacement (right side)
             VStack(alignment: .leading, spacing: 4) {
                 Text("Replace with:")
                     .font(.caption2)
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(.secondary)
 
                 Text(self.entry.replacement)
                     .font(.callout.weight(.medium))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -777,21 +775,21 @@ struct DictionaryEntryRow: View {
                     Image(systemName: "pencil")
                         .font(.caption2)
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.mini)
+                
+                
 
-                Button(role: .destructive) {
+                Button {
                     self.onDelete()
                 } label: {
                     Image(systemName: "trash")
                         .font(.caption2)
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.mini)
+                
+                
             }
         }
         .padding(10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary.opacity(0.5)))
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.5)))
     }
 }
 
@@ -825,7 +823,7 @@ struct AddDictionaryEntrySheet: View {
                     .font(.headline)
                 Spacer()
                 Button("Cancel") { self.dismiss() }
-                    .buttonStyle(.bordered)
+                    
             }
 
             Divider()
@@ -836,18 +834,17 @@ struct AddDictionaryEntrySheet: View {
                     .font(.subheadline.weight(.medium))
                 Text("Enter words separated by commas. These are what the transcription might hear.")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 TextField("fluid voice, fluid boys", text: self.$triggersText)
                     .textFieldStyle(.roundedBorder)
-                    .onSubmit { self.saveIfValid() }
 
                 // Duplicate warning
                 if !self.duplicateTriggers.isEmpty {
                     HStack(spacing: 4) {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
+                            .foregroundColor(.orange)
                         Text("Duplicate triggers: \(self.duplicateTriggers.joined(separator: ", "))")
-                            .foregroundStyle(.orange)
+                            .foregroundColor(.orange)
                     }
                     .font(.caption)
                 }
@@ -859,10 +856,9 @@ struct AddDictionaryEntrySheet: View {
                     .font(.subheadline.weight(.medium))
                 Text("This is what will appear in the final transcription.")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 TextField("FluidVoice", text: self.$replacement)
                     .textFieldStyle(.roundedBorder)
-                    .onSubmit { self.saveIfValid() }
             }
 
             Spacer()
@@ -872,7 +868,7 @@ struct AddDictionaryEntrySheet: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Preview")
                         .font(.caption.weight(.medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
 
                     FlowLayout(spacing: 6) {
                         ForEach(self.parseTriggers(), id: \.self) { trigger in
@@ -883,19 +879,19 @@ struct AddDictionaryEntrySheet: View {
                                 .background(
                                     RoundedRectangle(cornerRadius: 4).fill(
                                         self.duplicateTriggers.contains(trigger)
-                                            ? AnyShapeStyle(Color.orange.opacity(0.3))
-                                            : AnyShapeStyle(.quaternary)
+                                            ? Color.orange.opacity(0.3)
+                                            : Color.secondary.opacity(0.2)
                                     )
                                 )
                         }
 
                         Image(systemName: "arrow.right")
                             .font(.caption)
-                            .foregroundStyle(.tertiary)
+                            .foregroundColor(.secondary)
 
                         Text(self.replacement)
                             .font(.caption.weight(.medium))
-                            .foregroundStyle(self.theme.palette.accent)
+                            .foregroundColor(self.theme.palette.accent)
                     }
                 }
                 .padding(10)
@@ -914,8 +910,8 @@ struct AddDictionaryEntrySheet: View {
             HStack {
                 Spacer()
                 Button("Add Entry") { self.saveIfValid() }
-                    .buttonStyle(.borderedProminent)
-                    .tint(self.theme.palette.accent)
+                    
+                    .accentColor(self.theme.palette.accent)
                     .disabled(!self.canSave)
                     .keyboardShortcut(.return, modifiers: [])
             }
@@ -975,7 +971,7 @@ struct EditDictionaryEntrySheet: View {
                     .font(.headline)
                 Spacer()
                 Button("Cancel") { self.dismiss() }
-                    .buttonStyle(.bordered)
+                    
             }
 
             Divider()
@@ -986,18 +982,17 @@ struct EditDictionaryEntrySheet: View {
                     .font(.subheadline.weight(.medium))
                 Text("Enter words separated by commas. These are what the transcription might hear.")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 TextField("fluid voice, fluid boys", text: self.$triggersText)
                     .textFieldStyle(.roundedBorder)
-                    .onSubmit { self.saveIfValid() }
 
                 // Duplicate warning
                 if !self.duplicateTriggers.isEmpty {
                     HStack(spacing: 4) {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
+                            .foregroundColor(.orange)
                         Text("Duplicate triggers: \(self.duplicateTriggers.joined(separator: ", "))")
-                            .foregroundStyle(.orange)
+                            .foregroundColor(.orange)
                     }
                     .font(.caption)
                 }
@@ -1009,10 +1004,9 @@ struct EditDictionaryEntrySheet: View {
                     .font(.subheadline.weight(.medium))
                 Text("This is what will appear in the final transcription.")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 TextField("FluidVoice", text: self.$replacement)
                     .textFieldStyle(.roundedBorder)
-                    .onSubmit { self.saveIfValid() }
             }
 
             Spacer()
@@ -1022,7 +1016,7 @@ struct EditDictionaryEntrySheet: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Preview")
                         .font(.caption.weight(.medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
 
                     FlowLayout(spacing: 6) {
                         ForEach(self.parseTriggers(), id: \.self) { trigger in
@@ -1033,19 +1027,19 @@ struct EditDictionaryEntrySheet: View {
                                 .background(
                                     RoundedRectangle(cornerRadius: 4).fill(
                                         self.duplicateTriggers.contains(trigger)
-                                            ? AnyShapeStyle(Color.orange.opacity(0.3))
-                                            : AnyShapeStyle(.quaternary)
+                                            ? Color.orange.opacity(0.3)
+                                            : Color.secondary.opacity(0.2)
                                     )
                                 )
                         }
 
                         Image(systemName: "arrow.right")
                             .font(.caption)
-                            .foregroundStyle(.tertiary)
+                            .foregroundColor(.secondary)
 
                         Text(self.replacement)
                             .font(.caption.weight(.medium))
-                            .foregroundStyle(self.theme.palette.accent)
+                            .foregroundColor(self.theme.palette.accent)
                     }
                 }
                 .padding(10)
@@ -1064,8 +1058,8 @@ struct EditDictionaryEntrySheet: View {
             HStack {
                 Spacer()
                 Button("Save Changes") { self.saveIfValid() }
-                    .buttonStyle(.borderedProminent)
-                    .tint(self.theme.palette.accent)
+                    
+                    .accentColor(self.theme.palette.accent)
                     .disabled(!self.canSave)
                     .keyboardShortcut(.return, modifiers: [])
             }

--- a/Sources/Fluid/UI/FeedbackView.swift
+++ b/Sources/Fluid/UI/FeedbackView.swift
@@ -31,13 +31,13 @@ struct FeedbackView: View {
                     HStack {
                         Image(systemName: "envelope.fill")
                             .font(.system(size: 32))
-                            .foregroundStyle(self.theme.palette.accent)
+                            .foregroundColor(self.theme.palette.accent)
                         VStack(alignment: .leading) {
                             Text("Send Feedback")
                                 .font(.system(size: 28, weight: .bold))
                             Text("Help us improve FluidVoice")
                                 .font(.system(size: 16))
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                         }
                     }
                 }
@@ -49,16 +49,16 @@ struct FeedbackView: View {
                         HStack(spacing: 12) {
                             Image(systemName: "heart.fill")
                                 .font(.system(size: 28))
-                                .foregroundStyle(.pink)
+                                .foregroundColor(.pink)
 
                             VStack(alignment: .leading, spacing: 4) {
                                 Text("We'd love to hear from you!")
                                     .font(.system(size: 18, weight: .semibold))
-                                    .foregroundStyle(self.theme.palette.primaryText)
+                                    .foregroundColor(self.theme.palette.primaryText)
 
                                 Text("Your feedback helps us make FluidVoice even better")
                                     .font(.system(size: 14))
-                                    .foregroundStyle(self.theme.palette.secondaryText)
+                                    .foregroundColor(self.theme.palette.secondaryText)
                             }
                         }
 
@@ -68,16 +68,16 @@ struct FeedbackView: View {
                         HStack(spacing: 12) {
                             Image(systemName: "star.fill")
                                 .font(.system(size: 24))
-                                .foregroundStyle(.yellow)
+                                .foregroundColor(.yellow)
 
                             VStack(alignment: .leading, spacing: 6) {
                                 Text("Loving FluidVoice?")
                                     .font(.system(size: 16, weight: .semibold))
-                                    .foregroundStyle(self.theme.palette.primaryText)
+                                    .foregroundColor(self.theme.palette.primaryText)
 
                                 Text("Give us a star on GitHub! It helps others discover the project and motivates us to keep improving.")
                                     .font(.system(size: 13))
-                                    .foregroundStyle(self.theme.palette.secondaryText)
+                                    .foregroundColor(self.theme.palette.secondaryText)
                                     .fixedSize(horizontal: false, vertical: true)
                             }
 
@@ -91,7 +91,7 @@ struct FeedbackView: View {
                                             .fontWeight(.semibold)
                                     }
                                     .font(.system(size: 14))
-                                    .foregroundStyle(.white)
+                                    .foregroundColor(.white)
                                     .padding(.horizontal, 16)
                                     .padding(.vertical, 10)
                                     .background(
@@ -136,13 +136,13 @@ struct FeedbackView: View {
                                     .fill(self.theme.palette.contentBackground)
                                     .overlay(RoundedRectangle(cornerRadius: 8)
                                         .strokeBorder(self.theme.palette.cardBorder.opacity(0.45), lineWidth: 1.2)))
-                                .scrollContentBackground(.hidden)
+                                
                                 .overlay(
                                     Group {
                                         if self.feedbackText.isEmpty {
                                             Text("Share your thoughts, report bugs, or suggest features...")
                                                 .font(.subheadline)
-                                                .foregroundStyle(.secondary)
+                                                .foregroundColor(.secondary)
                                                 .padding(.leading, 4)
                                         }
                                     }
@@ -192,20 +192,24 @@ struct FeedbackView: View {
         .onAppear {
             self.appear = true
         }
-        .alert("Feedback Sent", isPresented: self.$showFeedbackConfirmation) {
-            Button("OK") {}
-        } message: {
-            Text("Thank you for helping us improve FluidVoice.")
+        .alert(isPresented: self.$showFeedbackConfirmation) {
+            Alert(
+                title: Text("Feedback Sent"),
+                message: Text("Thank you for helping us improve FluidVoice."),
+                dismissButton: .default(Text("OK"))
+            )
         }
-        .alert("Feedback Failed", isPresented: self.$showFeedbackError) {
-            Button("Try Again") {
-                Task {
-                    await self.sendFeedback()
-                }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text(self.feedbackErrorMessage)
+        .alert(isPresented: self.$showFeedbackError) {
+            Alert(
+                title: Text("Feedback Failed"),
+                message: Text(self.feedbackErrorMessage),
+                primaryButton: .default(Text("Try Again")) {
+                    Task {
+                        await self.sendFeedback()
+                    }
+                },
+                secondaryButton: .cancel()
+            )
         }
     }
 
@@ -249,7 +253,7 @@ struct FeedbackView: View {
             feedbackContent += "App Version: \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")\n"
             feedbackContent += "Build: \(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown")\n"
             feedbackContent += "macOS Version: \(ProcessInfo.processInfo.operatingSystemVersionString)\n"
-            feedbackContent += "Date: \(Date().formatted())\n\n"
+            feedbackContent += "Date: \(DateFormatter.localizedString(from: Date(), dateStyle: .medium, timeStyle: .short))\n\n"
 
             // Add recent log entries
             let logFileURL = FileLogger.shared.currentLogFileURL()
@@ -284,7 +288,7 @@ struct FeedbackView: View {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONSerialization.data(withJSONObject: data)
 
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await URLSession.shared.compatData(for: request)
 
             if let httpResponse = response as? HTTPURLResponse {
                 let success = (200...299).contains(httpResponse.statusCode)
@@ -309,6 +313,8 @@ struct FeedbackView: View {
     }
 }
 
-#Preview {
-    FeedbackView()
+struct FeedbackView_Previews: PreviewProvider {
+    static var previews: some View {
+        FeedbackView()
+    }
 }

--- a/Sources/Fluid/UI/FluidIcon.swift
+++ b/Sources/Fluid/UI/FluidIcon.swift
@@ -199,41 +199,43 @@ struct FluidIconAdvanced: View {
 }
 
 // Preview for development
-#Preview("Fluid Icon Variants") {
-    VStack(spacing: 20) {
-        Text("Standard Geometric F")
-            .font(.headline)
+struct FluidIcon_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 20) {
+            Text("Standard Geometric F")
+                .font(.headline)
 
-        HStack(spacing: 20) {
-            FluidIcon(size: 24, color: .white)
-                .background(Color.black.opacity(0.3))
+            HStack(spacing: 20) {
+                FluidIcon(size: 24, color: .white)
+                    .background(Color.black.opacity(0.3))
 
-            FluidIcon(size: 32, color: .blue)
+                FluidIcon(size: 32, color: .blue)
 
-            FluidIcon(size: 48, color: .primary)
+                FluidIcon(size: 48, color: .primary)
+            }
+
+            Text("Advanced Angular F")
+                .font(.headline)
+
+            HStack(spacing: 20) {
+                FluidIconAdvanced(size: 24, color: .white)
+                    .background(Color.black.opacity(0.3))
+
+                FluidIconAdvanced(size: 32, color: .blue)
+
+                FluidIconAdvanced(size: 48, color: .primary)
+            }
+
+            HStack(spacing: 20) {
+                FluidIconFilled(size: 32, backgroundColor: .blue)
+                FluidIconFilled(size: 40, backgroundColor: .purple)
+                FluidIconFilled(size: 48, backgroundColor: Color.fluidGreen)
+            }
+
+            // Large version for app icon
+            FluidIconFilled(size: 80, backgroundColor: .black, cornerRadius: 16)
         }
-
-        Text("Advanced Angular F")
-            .font(.headline)
-
-        HStack(spacing: 20) {
-            FluidIconAdvanced(size: 24, color: .white)
-                .background(Color.black.opacity(0.3))
-
-            FluidIconAdvanced(size: 32, color: .blue)
-
-            FluidIconAdvanced(size: 48, color: .primary)
-        }
-
-        HStack(spacing: 20) {
-            FluidIconFilled(size: 32, backgroundColor: .blue)
-            FluidIconFilled(size: 40, backgroundColor: .purple)
-            FluidIconFilled(size: 48, backgroundColor: Color.fluidGreen)
-        }
-
-        // Large version for app icon
-        FluidIconFilled(size: 80, backgroundColor: .black, cornerRadius: 16)
+        .padding()
+        .background(Color.gray.opacity(0.1))
     }
-    .padding()
-    .background(Color.gray.opacity(0.1))
 }

--- a/Sources/Fluid/UI/GlossyEffects.swift
+++ b/Sources/Fluid/UI/GlossyEffects.swift
@@ -19,8 +19,8 @@ struct HoverableGlossyCard<Content: View>: View {
         let cardShadow = self.theme.metrics.cardShadow
 
         return self.content
-            .background(self.theme.materials.card, in: shape)
-            .background {
+            .background(shape.fill(self.theme.materials.card))
+            .background(
                 shape
                     .fill(self.theme.palette.cardBackground)
                     .overlay(
@@ -36,7 +36,7 @@ struct HoverableGlossyCard<Content: View>: View {
                         x: cardShadow.x,
                         y: self.isHovered ? cardShadow.y + 1 : cardShadow.y
                     )
-            }
+            )
             .scaleEffect(self.isHovered && !self.excludeInteractiveElements ? 1.02 : 1.0)
             .onHover { hovering in
                 self.isHovered = hovering

--- a/Sources/Fluid/UI/MeetingTranscriptionView.swift
+++ b/Sources/Fluid/UI/MeetingTranscriptionView.swift
@@ -37,7 +37,7 @@ struct MeetingTranscriptionView: View {
             VStack(spacing: 8) {
                 Image(systemName: "waveform.circle.fill")
                     .font(.system(size: 48))
-                    .foregroundStyle(Color.fluidGreen.gradient)
+                    .foregroundColor(Color.fluidGreen)
 
                 Text("Meeting Transcription")
                     .font(.title2)
@@ -81,19 +81,22 @@ struct MeetingTranscriptionView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(self.theme.palette.windowBackground)
-        .overlay(alignment: .topTrailing) {
-            if self.showingCopyConfirmation {
-                Text("Copied!")
-                    .font(.caption)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(Color.fluidGreen.opacity(0.9))
-                    .foregroundColor(.white)
-                    .cornerRadius(8)
-                    .padding()
-                    .transition(.move(edge: .top).combined(with: .opacity))
-            }
-        }
+        .overlay(
+            Group {
+                if self.showingCopyConfirmation {
+                    Text("Copied!")
+                        .font(.caption)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.fluidGreen.opacity(0.9))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .padding()
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            },
+            alignment: .topTrailing
+        )
     }
 
     // MARK: - File Selection Card
@@ -150,7 +153,7 @@ struct MeetingTranscriptionView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
                 }
-                .buttonStyle(.borderedProminent)
+                
                 .disabled(self.transcriptionService.isTranscribing)
 
             } else {
@@ -225,7 +228,7 @@ struct MeetingTranscriptionView: View {
 
             HStack {
                 ProgressView()
-                    .controlSize(.small)
+                    
 
                 Text(self.transcriptionService.currentStatus)
                     .font(.subheadline)
@@ -292,7 +295,7 @@ struct MeetingTranscriptionView: View {
             ScrollView {
                 Text(result.text)
                     .font(.body)
-                    .textSelection(.enabled)
+                    
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
             }
@@ -502,7 +505,9 @@ struct TranscriptionDocument: FileDocument {
 
 // MARK: - Preview
 
-#Preview {
-    MeetingTranscriptionView(asrService: ASRService())
-        .frame(width: 700, height: 800)
+struct MeetingTranscriptionView_Previews: PreviewProvider {
+    static var previews: some View {
+        MeetingTranscriptionView(asrService: ASRService())
+            .frame(width: 700, height: 800)
+    }
 }

--- a/Sources/Fluid/UI/MouseTracker.swift
+++ b/Sources/Fluid/UI/MouseTracker.swift
@@ -75,7 +75,7 @@ struct MouseTrackingModifier: ViewModifier {
                             let globalFrame = geometry.frame(in: .global)
                             self.tracker.updateWindowFrame(globalFrame)
                         }
-                        .onChange(of: geometry.frame(in: .global)) { _, newFrame in
+                        .onChange(of: geometry.frame(in: .global)) { newFrame in
                             // Skip updates when view is scrolled off-screen (prevents invalid geometry)
                             guard newFrame.minY < NSScreen.main?.frame.height ?? 1000 else { return }
                             guard newFrame.maxY > 0 else { return }

--- a/Sources/Fluid/UI/RecordingView.swift
+++ b/Sources/Fluid/UI/RecordingView.swift
@@ -26,7 +26,7 @@ struct RecordingView: View {
                         HStack {
                             Image(systemName: "waveform.circle.fill")
                                 .font(.system(size: 32))
-                                .foregroundStyle(.white)
+                                .foregroundColor(.white)
 
                             VStack(alignment: .leading, spacing: 4) {
                                 Text("Voice Dictation")
@@ -34,7 +34,7 @@ struct RecordingView: View {
                                     .fontWeight(.bold)
                                 Text("AI-powered speech recognition")
                                     .font(.subheadline)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                             }
 
                             Spacer()
@@ -50,7 +50,7 @@ struct RecordingView: View {
 
                                 Text(self.asr.isRunning ? "Recording..." : self.asr.isAsrReady ? "Ready to record" : "Model not ready")
                                     .font(.subheadline)
-                                    .foregroundStyle(self.asr.isRunning ? .red : self.asr.isAsrReady ? Color.fluidGreen : .secondary)
+                                    .foregroundColor(self.asr.isRunning ? .red : self.asr.isAsrReady ? Color.fluidGreen : .secondary)
                             }
 
                             // Recording Control (Single Toggle Button)

--- a/Sources/Fluid/UI/SearchableModelPicker.swift
+++ b/Sources/Fluid/UI/SearchableModelPicker.swift
@@ -57,11 +57,11 @@ struct SearchableModelPicker: View {
                     Text(self.selectedModel.isEmpty ? "Select Model" : self.selectedModel)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                        .foregroundStyle(self.selectedModel.isEmpty ? .secondary : .primary)
+                        .foregroundColor(self.selectedModel.isEmpty ? .secondary : .primary)
                     Spacer(minLength: 6)
                     Image(systemName: "chevron.down")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .frame(width: 20, height: 20)
                         .background(
                             Circle()
@@ -77,7 +77,7 @@ struct SearchableModelPicker: View {
                 .padding(.vertical, 5)
                 .frame(height: self.controlHeight)
                 .contentShape(Rectangle())
-                .background(self.theme.materials.card, in: RoundedRectangle(cornerRadius: self.theme.metrics.corners.sm, style: .continuous))
+                .background(RoundedRectangle(cornerRadius: self.theme.metrics.corners.sm, style: .continuous).fill(self.theme.materials.card))
                 .background(
                     RoundedRectangle(cornerRadius: self.theme.metrics.corners.sm, style: .continuous)
                         .fill(self.theme.palette.cardBackground)
@@ -101,7 +101,7 @@ struct SearchableModelPicker: View {
                     // Search field
                     HStack {
                         Image(systemName: "magnifyingglass")
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                         TextField("Search models...", text: self.$searchText)
                             .textFieldStyle(.plain)
                     }
@@ -122,13 +122,13 @@ struct SearchableModelPicker: View {
                             VStack(spacing: 8) {
                                 Image(systemName: "tray")
                                     .font(.title2)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                 Text("No models")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                 Text("Click refresh to fetch from API")
                                     .font(.caption2)
-                                    .foregroundStyle(.tertiary)
+                                    .foregroundColor(.secondary)
                             }
                             .frame(height: 100)
                             .frame(maxWidth: .infinity)
@@ -138,7 +138,7 @@ struct SearchableModelPicker: View {
                                     if self.filteredModels.isEmpty {
                                         Text("No models match '\(self.searchText)'")
                                             .font(.caption)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                             .padding()
                                             .frame(maxWidth: .infinity, alignment: .center)
                                     } else {
@@ -154,7 +154,7 @@ struct SearchableModelPicker: View {
                                                     Spacer()
                                                     if model == self.selectedModel {
                                                         Image(systemName: "checkmark")
-                                                            .foregroundStyle(self.theme.palette.accent)
+                                                            .foregroundColor(self.theme.palette.accent)
                                                     }
                                                 }
                                                 .padding(.horizontal, 10)
@@ -173,7 +173,7 @@ struct SearchableModelPicker: View {
                                 Divider()
                                 Text("\(self.filteredModels.count - 100) more (use search)")
                                     .font(.caption2)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                     .padding(6)
                             }
                         }
@@ -225,12 +225,14 @@ struct SearchableModelPicker: View {
     }
 }
 
-#Preview {
-    SearchableModelPicker(
-        models: ["gpt-4.1", "gpt-4o", "gpt-3.5-turbo", "claude-3-opus", "claude-3-sonnet"],
-        selectedModel: .constant("gpt-4.1"),
-        onRefresh: { try? await Task.sleep(nanoseconds: 1_000_000_000) },
-        isRefreshing: false
-    )
-    .padding()
+struct SearchableModelPicker_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchableModelPicker(
+            models: ["gpt-4.1", "gpt-4o", "gpt-3.5-turbo", "claude-3-opus", "claude-3-sonnet"],
+            selectedModel: .constant("gpt-4.1"),
+            onRefresh: { try? await Task.sleep(nanoseconds: 1_000_000_000) },
+            isRefreshing: false
+        )
+        .padding()
+    }
 }

--- a/Sources/Fluid/UI/SearchableProviderPicker.swift
+++ b/Sources/Fluid/UI/SearchableProviderPicker.swift
@@ -75,7 +75,7 @@ struct SearchableProviderPicker: View {
                 Spacer(minLength: 6)
                 Image(systemName: "chevron.down")
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                     .frame(width: 20, height: 20)
                     .background(
                         Circle()
@@ -105,7 +105,7 @@ struct SearchableProviderPicker: View {
                 // Search field
                 HStack {
                     Image(systemName: "magnifyingglass")
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                     TextField("Search providers...", text: self.$searchText)
                         .textFieldStyle(.plain)
                 }
@@ -130,7 +130,7 @@ struct SearchableProviderPicker: View {
                             Text("BUILT-IN")
                                 .font(.caption2)
                                 .fontWeight(.semibold)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                                 .padding(.horizontal, 10)
                                 .padding(.top, 8)
                                 .padding(.bottom, 4)
@@ -151,7 +151,7 @@ struct SearchableProviderPicker: View {
                             Text("CUSTOM")
                                 .font(.caption2)
                                 .fontWeight(.semibold)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                                 .padding(.horizontal, 10)
                                 .padding(.top, 4)
                                 .padding(.bottom, 4)
@@ -164,7 +164,7 @@ struct SearchableProviderPicker: View {
                         if self.filteredProviders.isEmpty {
                             Text("No providers match '\(self.searchText)'")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                                 .padding()
                         }
                     }
@@ -187,7 +187,7 @@ struct SearchableProviderPicker: View {
                 Spacer()
                 if provider.id == self.selectedProviderID {
                     Image(systemName: "checkmark")
-                        .foregroundStyle(self.theme.palette.accent)
+                        .foregroundColor(self.theme.palette.accent)
                 }
             }
             .padding(.horizontal, 10)
@@ -199,15 +199,17 @@ struct SearchableProviderPicker: View {
     }
 }
 
-#Preview {
-    SearchableProviderPicker(
-        builtInProviders: [
-            ("openai", "OpenAI"),
-            ("groq", "Groq"),
-            ("cerebras", "Cerebras"),
-        ],
-        savedProviders: [],
-        selectedProviderID: .constant("openai")
-    )
-    .padding()
+struct SearchableProviderPicker_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchableProviderPicker(
+            builtInProviders: [
+                ("openai", "OpenAI"),
+                ("groq", "Groq"),
+                ("cerebras", "Cerebras"),
+            ],
+            savedProviders: [],
+            selectedProviderID: .constant("openai")
+        )
+        .padding()
+    }
 }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -109,7 +109,7 @@ struct SettingsView: View {
                         // Section header
                         Label("App Settings", systemImage: "power")
                             .font(.headline)
-                            .foregroundStyle(.primary)
+                            .foregroundColor(.primary)
 
                         VStack(spacing: 16) {
                             // Launch at startup
@@ -144,7 +144,7 @@ struct SettingsView: View {
                                             .font(.body)
                                         Text("Pick a preset accent color for the app.")
                                             .font(.subheadline)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
 
                                     Spacer()
@@ -192,7 +192,7 @@ struct SettingsView: View {
                                         .font(.body)
                                     Text("Choose which sound plays when recording starts. Select None to disable.")
                                         .font(.subheadline)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
 
                                 Spacer()
@@ -219,7 +219,7 @@ struct SettingsView: View {
                                             .font(.body)
                                         Text("Check for updates automatically once per hour")
                                             .font(.subheadline)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
 
                                     Spacer()
@@ -229,19 +229,19 @@ struct SettingsView: View {
                                         set: { SettingsStore.shared.autoUpdateCheckEnabled = $0 }
                                     ))
                                     .toggleStyle(.switch)
-                                    .tint(self.theme.palette.accent)
+                                    .accentColor(self.theme.palette.accent)
                                     .labelsHidden()
                                 }
 
                                 if let lastCheck = SettingsStore.shared.lastUpdateCheckDate {
-                                    Text("Last checked: \(lastCheck.formatted(date: .abbreviated, time: .shortened))")
+                                    Text("Last checked: \(DateFormatter.localizedString(from: lastCheck, dateStyle: .medium, timeStyle: .short))")
                                         .font(.caption)
-                                        .foregroundStyle(.tertiary)
+                                        .foregroundColor(.secondary)
                                 }
 
                                 Text("Current version: \(self.currentAppVersion)")
                                     .font(.caption)
-                                    .foregroundStyle(.tertiary)
+                                    .foregroundColor(.secondary)
                             }
 
                             // Update Buttons
@@ -273,17 +273,17 @@ struct SettingsView: View {
                                         }
                                     }
                                 }
-                                .buttonStyle(.borderedProminent)
-                                .tint(self.theme.palette.accent)
-                                .controlSize(.regular)
+                                
+                                .accentColor(self.theme.palette.accent)
+                                
 
                                 Button("Release Notes") {
                                     if let url = URL(string: "https://github.com/altic-dev/Fluid-oss/releases") {
                                         NSWorkspace.shared.open(url)
                                     }
                                 }
-                                .buttonStyle(.bordered)
-                                .controlSize(.regular)
+                                
+                                
 
                                 Button(self.rollbackVersion.isEmpty ? "Rollback" : "Rollback to \(self.rollbackVersion)") {
                                     guard !self.isRollingBack else { return }
@@ -334,27 +334,27 @@ struct SettingsView: View {
                                         }
                                     }
                                 }
-                                .buttonStyle(.bordered)
-                                .controlSize(.regular)
+                                
+                                
                                 .disabled(self.rollbackVersion.isEmpty || self.isRollingBack)
                                 .opacity(self.isRollingBack ? 0.7 : 1.0)
 
                                 Button("Get Previous Builds") {
                                     self.openPreviousBuildPicker()
                                 }
-                                .buttonStyle(.bordered)
-                                .controlSize(.regular)
+                                
+                                
                             }
                             .padding(.top, 12)
 
                             if self.rollbackVersion.isEmpty {
                                 Text("No rollback backup found.")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                             } else {
                                 Text("Rollback target: \(self.rollbackVersion)")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                             }
                         }
                     }
@@ -366,7 +366,7 @@ struct SettingsView: View {
                     VStack(alignment: .leading, spacing: 14) {
                         Label("Microphone Permission", systemImage: "mic.fill")
                             .font(.headline)
-                            .foregroundStyle(.primary)
+                            .foregroundColor(.primary)
 
                         VStack(alignment: .leading, spacing: 12) {
                             HStack(spacing: 10) {
@@ -379,12 +379,12 @@ struct SettingsView: View {
                                         self.asr.micStatus == .denied ? "Microphone access denied" :
                                         "Microphone access not determined")
                                         .font(.body)
-                                        .foregroundStyle(self.asr.micStatus == .authorized ? .primary : self.theme.palette.warning)
+                                        .foregroundColor(self.asr.micStatus == .authorized ? .primary : self.theme.palette.warning)
 
                                     if self.asr.micStatus != .authorized {
                                         Text("Microphone access is required for voice recording")
                                             .font(.subheadline)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
                                 }
                                 Spacer()
@@ -395,17 +395,17 @@ struct SettingsView: View {
                                     } label: {
                                         Label("Grant Access", systemImage: "mic.fill")
                                     }
-                                    .buttonStyle(.borderedProminent)
-                                    .tint(self.theme.palette.accent)
-                                    .controlSize(.regular)
+                                    
+                                    .accentColor(self.theme.palette.accent)
+                                    
                                 } else if self.asr.micStatus == .denied {
                                     Button {
                                         self.asr.openSystemSettingsForMic()
                                     } label: {
                                         Label("Open Settings", systemImage: "gear")
                                     }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.regular)
+                                    
+                                    
                                 }
                             }
 
@@ -428,7 +428,7 @@ struct SettingsView: View {
                         HStack(spacing: 8) {
                             Label("Global Hotkey", systemImage: "keyboard")
                                 .font(.headline)
-                                .foregroundStyle(.primary)
+                                .foregroundColor(.primary)
 
                             Spacer()
 
@@ -436,20 +436,20 @@ struct SettingsView: View {
                                 if self.isRecordingShortcut || self.isRecordingCommandModeShortcut || self.isRecordingRewriteShortcut {
                                     Text("Recording…")
                                         .font(.caption.weight(.semibold))
-                                        .foregroundStyle(.orange)
+                                        .foregroundColor(.orange)
                                 } else if self.hotkeyManagerInitialized {
                                     HStack(spacing: 6) {
                                         Image(systemName: "checkmark.circle.fill")
-                                            .foregroundStyle(Color.fluidGreen)
+                                            .foregroundColor(Color.fluidGreen)
                                             .font(.caption)
                                         Text("Active")
                                             .font(.caption.weight(.semibold))
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
                                 } else {
                                     Text("Initializing…")
                                         .font(.caption.weight(.semibold))
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
                             }
                         }
@@ -459,18 +459,18 @@ struct SettingsView: View {
                                 if self.isRecordingShortcut || self.isRecordingCommandModeShortcut || self.isRecordingRewriteShortcut {
                                     HStack(spacing: 8) {
                                         Image(systemName: "hand.point.up.left.fill")
-                                            .foregroundStyle(.orange)
+                                            .foregroundColor(.orange)
                                         Text("Press your new hotkey combination now…")
                                             .font(.caption)
-                                            .foregroundStyle(.orange)
+                                            .foregroundColor(.orange)
                                     }
                                 } else if !self.hotkeyManagerInitialized {
                                     HStack(spacing: 8) {
                                         ProgressView()
-                                            .controlSize(.small)
+                                            
                                         Text("Hotkey initializing…")
                                             .font(.caption)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
                                 }
 
@@ -479,7 +479,7 @@ struct SettingsView: View {
                                 VStack(alignment: .leading, spacing: 8) {
                                     Text("Keyboard Shortcuts")
                                         .font(.subheadline.weight(.medium))
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
 
                                     self.shortcutRow(
                                         icon: "mic.fill",
@@ -542,7 +542,7 @@ struct SettingsView: View {
                                         description: "The shortcut only records while you hold it down, giving you quick push-to-talk style control.",
                                         isOn: self.$pressAndHoldModeEnabled
                                     )
-                                    .onChange(of: self.pressAndHoldModeEnabled) { _, newValue in
+                                    .onChange(of: self.pressAndHoldModeEnabled) { newValue in
                                         SettingsStore.shared.pressAndHoldMode = newValue
                                         self.hotkeyManager?.enablePressAndHoldMode(newValue)
                                     }
@@ -553,7 +553,7 @@ struct SettingsView: View {
                                         description: "Display transcription text in real-time in the overlay as you speak.",
                                         isOn: self.$enableStreamingPreview
                                     )
-                                    .onChange(of: self.enableStreamingPreview) { _, newValue in
+                                    .onChange(of: self.enableStreamingPreview) { newValue in
                                         SettingsStore.shared.enableStreamingPreview = newValue
                                     }
                                     Divider().opacity(0.2)
@@ -563,7 +563,7 @@ struct SettingsView: View {
                                         description: "Automatically copy transcribed text to clipboard as a backup.",
                                         isOn: self.$copyToClipboard
                                     )
-                                    .onChange(of: self.copyToClipboard) { _, newValue in
+                                    .onChange(of: self.copyToClipboard) { newValue in
                                         SettingsStore.shared.copyTranscriptionToClipboard = newValue
                                     }
                                     Divider().opacity(0.2)
@@ -637,23 +637,23 @@ struct SettingsView: View {
                                     VStack(alignment: .leading, spacing: 2) {
                                         HStack(spacing: 6) {
                                             Image(systemName: "exclamationmark.triangle.fill")
-                                                .foregroundStyle(self.theme.palette.warning)
+                                                .foregroundColor(self.theme.palette.warning)
                                             Text("Accessibility permissions required")
                                                 .font(.body)
-                                                .foregroundStyle(self.theme.palette.warning)
+                                                .foregroundColor(self.theme.palette.warning)
                                         }
                                         Text("Required for global hotkey functionality")
                                             .font(.subheadline)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
                                     Spacer()
 
                                     Button("Open Accessibility Settings") {
                                         self.openAccessibilitySettings()
                                     }
-                                    .buttonStyle(.borderedProminent)
-                                    .tint(self.theme.palette.accent)
-                                    .controlSize(.regular)
+                                    
+                                    .accentColor(self.theme.palette.accent)
+                                    
                                 }
 
                                 self.instructionsBox(
@@ -671,14 +671,14 @@ struct SettingsView: View {
                                     Button("Reveal in Finder") {
                                         self.revealAppInFinder()
                                     }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
+                                    
+                                    
 
                                     Button("Open Applications") {
                                         self.openApplicationsFolder()
                                     }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
+                                    
+                                    
                                 }
                             }
                         }
@@ -692,7 +692,7 @@ struct SettingsView: View {
                         HStack {
                             Label("Audio Devices", systemImage: "speaker.wave.2.fill")
                                 .font(.headline)
-                                .foregroundStyle(.primary)
+                                .foregroundColor(.primary)
 
                             Spacer()
 
@@ -704,18 +704,18 @@ struct SettingsView: View {
                             } label: {
                                 Label("Refresh", systemImage: "arrow.clockwise")
                             }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
+                            
+                            
                         }
 
                         // Info note about device syncing
                         HStack(alignment: .top, spacing: 8) {
                             Image(systemName: "info.circle")
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                                 .font(.body)
                             Text("Audio devices are synced with macOS System Settings.")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         .padding(.vertical, 4)
@@ -758,7 +758,7 @@ struct SettingsView: View {
                                     }
                                 }
                                 // Sync selection when devices load or change
-                                .onChange(of: self.inputDevices) { _, newDevices in
+                                .onChange(of: self.inputDevices) { newDevices in
                                     // Update cached default device name when device list changes
                                     self.cachedDefaultInputName = AudioDevice.getDefaultInputDevice()?.name ?? ""
 
@@ -819,7 +819,7 @@ struct SettingsView: View {
                                     }
                                 }
                                 // Sync selection when devices load or change
-                                .onChange(of: self.outputDevices) { _, newDevices in
+                                .onChange(of: self.outputDevices) { newDevices in
                                     // Update cached default device name when device list changes
                                     self.cachedDefaultOutputName = AudioDevice.getDefaultOutputDevice()?.name ?? ""
 
@@ -849,7 +849,7 @@ struct SettingsView: View {
                                     Spacer()
                                     Text("Default: \(self.cachedDefaultInputName) / \(self.cachedDefaultOutputName)")
                                         .font(.caption)
-                                        .foregroundStyle(.tertiary)
+                                        .foregroundColor(.secondary)
                                         .lineLimit(1)
                                 }
                             }
@@ -868,7 +868,7 @@ struct SettingsView: View {
                     VStack(alignment: .leading, spacing: 14) {
                         Label("Overlay", systemImage: "waveform")
                             .font(.headline)
-                            .foregroundStyle(.primary)
+                            .foregroundColor(.primary)
 
                         VStack(alignment: .leading, spacing: 12) {
                             HStack {
@@ -877,7 +877,7 @@ struct SettingsView: View {
                                         .font(.body)
                                     Text("Control how sensitive the audio visualizer is to sound input")
                                         .font(.subheadline)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
 
                                 Spacer()
@@ -886,27 +886,27 @@ struct SettingsView: View {
                                     self.visualizerNoiseThreshold = 0.4
                                     SettingsStore.shared.visualizerNoiseThreshold = self.visualizerNoiseThreshold
                                 }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
+                                
+                                
                             }
 
                             HStack(spacing: 10) {
                                 Text("More")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                     .frame(width: 36, alignment: .trailing)
 
                                 Slider(value: self.$visualizerNoiseThreshold, in: 0.01...0.8, step: 0.01)
-                                    .controlSize(.regular)
+                                    
 
                                 Text("Less")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                     .frame(width: 36, alignment: .leading)
 
                                 Text(String(format: "%.2f", self.visualizerNoiseThreshold))
-                                    .font(.caption.monospaced())
-                                    .foregroundStyle(.tertiary)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.secondary)
                                     .frame(width: 36)
                             }
 
@@ -919,7 +919,7 @@ struct SettingsView: View {
                                         .font(.body)
                                     Text("Where the recording indicator appears on screen")
                                         .font(.subheadline)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
 
                                 Spacer()
@@ -942,20 +942,20 @@ struct SettingsView: View {
                                             .font(.body)
                                         Text("How many recent characters appear in the notch/pill preview")
                                             .font(.subheadline)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
 
                                     Spacer()
 
                                     Text("\(self.settings.transcriptionPreviewCharLimit) chars")
-                                        .font(.caption.monospaced())
-                                        .foregroundStyle(.secondary)
+                                        .font(.system(.caption, design: .monospaced))
+                                        .foregroundColor(.secondary)
                                 }
 
                                 HStack(spacing: 10) {
                                     Text("Less")
                                         .font(.caption)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                         .frame(width: 36, alignment: .trailing)
 
                                     Slider(
@@ -966,11 +966,11 @@ struct SettingsView: View {
                                         in: Double(SettingsStore.transcriptionPreviewCharLimitRange.lowerBound)...Double(SettingsStore.transcriptionPreviewCharLimitRange.upperBound),
                                         step: Double(SettingsStore.transcriptionPreviewCharLimitStep)
                                     )
-                                    .controlSize(.regular)
+                                    
 
                                     Text("More")
                                         .font(.caption)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                         .frame(width: 36, alignment: .leading)
                                 }
                             }
@@ -986,7 +986,7 @@ struct SettingsView: View {
                                             .font(.body)
                                         Text("How large the recording indicator appears")
                                             .font(.subheadline)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
 
                                     Spacer()
@@ -1007,7 +1007,7 @@ struct SettingsView: View {
                                             .font(.body)
                                         Text("Distance from bottom of screen")
                                             .font(.subheadline)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundColor(.secondary)
                                     }
 
                                     Spacer()
@@ -1015,11 +1015,11 @@ struct SettingsView: View {
                                     HStack(spacing: 6) {
                                         Slider(value: self.$settings.overlayBottomOffset, in: 20...500)
                                             .frame(width: 110)
-                                            .controlSize(.small)
+                                            
 
                                         Text("\(Int(self.settings.overlayBottomOffset)) px")
-                                            .font(.caption.monospaced())
-                                            .foregroundStyle(.secondary)
+                                            .font(.system(.caption, design: .monospaced))
+                                            .foregroundColor(.secondary)
                                             .frame(width: 54, alignment: .trailing)
                                     }
                                     .frame(width: 170, alignment: .trailing)
@@ -1029,7 +1029,7 @@ struct SettingsView: View {
                             if self.asr.isRunning {
                                 Text("Settings are disabled during active recording")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                     .italic()
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .padding(.top, 4)
@@ -1044,7 +1044,7 @@ struct SettingsView: View {
                     VStack(alignment: .leading, spacing: 14) {
                         Label("Debug Settings", systemImage: "ladybug.fill")
                             .font(.headline)
-                            .foregroundStyle(.primary)
+                            .foregroundColor(.primary)
 
                         VStack(alignment: .leading, spacing: 8) {
                             self.settingsToggleRow(
@@ -1068,15 +1068,15 @@ struct SettingsView: View {
                             } label: {
                                 Label("Reveal Log File", systemImage: "doc.richtext")
                             }
-                            .buttonStyle(.bordered)
-                            .controlSize(.regular)
+                            
+                            
 
                             Text("The debug log contains detailed information about app operations and can help with troubleshooting.")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                             Text("Crash diagnostics are written to Library/Logs/Fluid/Fluid.log by default.")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                         }
                     }
                     .padding(16)
@@ -1157,7 +1157,7 @@ struct SettingsView: View {
                 self.refreshRollbackState()
             }
         }
-        .onChange(of: self.visualizerNoiseThreshold) { _, newValue in
+        .onChange(of: self.visualizerNoiseThreshold) { newValue in
             SettingsStore.shared.visualizerNoiseThreshold = newValue
         }
     }
@@ -1243,21 +1243,21 @@ struct SettingsView: View {
                         .font(.body)
                     Text(description)
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
 
                 Spacer()
 
                 Toggle("", isOn: isOn)
                     .toggleStyle(.switch)
-                    .tint(self.theme.palette.accent)
+                    .accentColor(self.theme.palette.accent)
                     .labelsHidden()
             }
 
             if let footnote = footnote {
                 Text(footnote)
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(.secondary)
             }
         }
     }
@@ -1274,14 +1274,14 @@ struct SettingsView: View {
                     .font(.body)
                 Text(description)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
 
             Spacer()
 
             Toggle("", isOn: isOn)
                 .toggleStyle(.switch)
-                .tint(self.theme.palette.accent)
+                .accentColor(self.theme.palette.accent)
                 .labelsHidden()
         }
     }
@@ -1295,11 +1295,11 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
                 Image(systemName: "info.circle.fill")
-                    .foregroundStyle(warningStyle ? self.theme.palette.warning : self.theme.palette.accent)
+                    .foregroundColor(warningStyle ? self.theme.palette.warning : self.theme.palette.accent)
                     .font(.caption)
                 Text(title)
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -1307,12 +1307,12 @@ struct SettingsView: View {
                     HStack(alignment: .top, spacing: 8) {
                         Text("\(index + 1).")
                             .font(.caption)
-                            .foregroundStyle(warningStyle ? self.theme.palette.warning : self.theme.palette.accent)
+                            .foregroundColor(warningStyle ? self.theme.palette.warning : self.theme.palette.accent)
                             .fontWeight(.semibold)
                             .frame(width: 16, alignment: .trailing)
                         Text(.init(step))
                             .font(.caption)
-                            .foregroundStyle(.primary)
+                            .foregroundColor(.primary)
                     }
                 }
             }
@@ -1340,7 +1340,7 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 10) {
                 Image(systemName: icon)
-                    .foregroundStyle(iconColor)
+                    .foregroundColor(iconColor)
                     .frame(width: 20)
 
                 VStack(alignment: .leading, spacing: 1) {
@@ -1348,7 +1348,7 @@ struct SettingsView: View {
                         .font(.body)
                     Text(description)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                         .lineLimit(1)
                 }
 
@@ -1357,7 +1357,7 @@ struct SettingsView: View {
                 if let isEnabled {
                     Toggle("", isOn: isEnabled)
                         .toggleStyle(.switch)
-                        .tint(self.theme.palette.accent)
+                        .accentColor(self.theme.palette.accent)
                         .labelsHidden()
                 }
             }
@@ -1369,18 +1369,18 @@ struct SettingsView: View {
                 if isRecording && enabledValue {
                     Text("Press shortcut...")
                         .font(.caption.weight(.medium))
-                        .foregroundStyle(.orange)
+                        .foregroundColor(.orange)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
                         .background(RoundedRectangle(cornerRadius: 5, style: .continuous)
                             .fill(.orange.opacity(0.2)))
                 } else {
                     Text(shortcut.displayString)
-                        .font(.caption.monospaced().weight(.medium))
+                        .font(.system(.caption, design: .monospaced).weight(.medium))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
                         .background(RoundedRectangle(cornerRadius: 5, style: .continuous)
-                            .fill(.quaternary.opacity(0.5))
+                            .fill(Color.secondary.opacity(0.5))
                             .overlay(RoundedRectangle(cornerRadius: 5, style: .continuous)
                                 .stroke(.primary.opacity(0.15), lineWidth: 1)))
                 }
@@ -1388,8 +1388,8 @@ struct SettingsView: View {
                 Button("Change") {
                     onChangePressed()
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                
+                
                 .disabled(isRecording || !enabledValue)
             }
         }
@@ -1408,7 +1408,7 @@ struct FillerWordsEditor: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Filler words to remove:")
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
 
             // Word chips
             FlowLayout(spacing: 6) {
@@ -1427,7 +1427,7 @@ struct FillerWordsEditor: View {
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(.quaternary))
+                        .fill(Color.secondary.opacity(0.2)))
                 }
             }
 
@@ -1436,11 +1436,10 @@ struct FillerWordsEditor: View {
                 TextField("Add word", text: self.$newWord)
                     .textFieldStyle(.roundedBorder)
                     .frame(width: 100)
-                    .onSubmit { self.addWord() }
 
                 Button("Add") { self.addWord() }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                    
+                    
                     .disabled(self.newWord.trimmingCharacters(in: .whitespaces).isEmpty)
 
                 Spacer()
@@ -1449,8 +1448,8 @@ struct FillerWordsEditor: View {
                     self.fillerWords = SettingsStore.defaultFillerWords
                     SettingsStore.shared.fillerWords = self.fillerWords
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                
+                
             }
         }
     }
@@ -1577,7 +1576,7 @@ struct AnalyticsConfirmationView: View {
 
             Text("By sharing anonymous usage data, you help us build the features you care about most. We never collect personal information (Audio, Transcription text etc), ever. Your support simply helps us make FluidVoice better for you.")
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
                 .padding(12)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
@@ -1590,8 +1589,8 @@ struct AnalyticsConfirmationView: View {
 
             Text(self.contactInfoText)
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .textSelection(.enabled)
+                .foregroundColor(.secondary)
+                
 
             Divider()
 
@@ -1605,8 +1604,8 @@ struct AnalyticsConfirmationView: View {
                 Button("Yes") {
                     self.onConfirm()
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.red)
+                
+                .accentColor(.red)
             }
         }
         .padding(20)

--- a/Sources/Fluid/UI/StatsView.swift
+++ b/Sources/Fluid/UI/StatsView.swift
@@ -51,7 +51,7 @@ struct StatsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text(self.historyStore.formattedTimeSaved(typingWPM: self.settings.userTypingWPM))
                     .font(.system(size: 32, weight: .bold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .foregroundColor(.primary)
 
                 Button {
                     self.editingWPM = "\(self.settings.userTypingWPM)"
@@ -63,7 +63,7 @@ struct StatsView: View {
                         Image(systemName: "pencil")
                             .font(.system(size: 9))
                     }
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
             }
@@ -86,18 +86,18 @@ struct StatsView: View {
 
                 Text("words per minute")
                     .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
 
             Text("Average typing: 40 WPM\nProfessional: 65-75 WPM")
                 .font(.system(size: 10))
-                .foregroundStyle(.tertiary)
+                .foregroundColor(.secondary)
 
             HStack {
                 Button("Cancel") {
                     self.showWPMEditor = false
                 }
-                .buttonStyle(.bordered)
+                
 
                 Button("Save") {
                     if let wpm = Int(editingWPM), wpm > 0 {
@@ -105,7 +105,7 @@ struct StatsView: View {
                     }
                     self.showWPMEditor = false
                 }
-                .buttonStyle(.borderedProminent)
+                
             }
         }
         .padding(16)
@@ -119,17 +119,17 @@ struct StatsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text(self.formatNumber(self.historyStore.totalWords))
                     .font(.system(size: 32, weight: .bold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .foregroundColor(.primary)
 
                 let today = self.historyStore.wordsToday
                 if today > 0 {
                     Text("+\(self.formatNumber(today)) today")
                         .font(.system(size: 11))
-                        .foregroundStyle(self.theme.palette.success)
+                        .foregroundColor(self.theme.palette.success)
                 } else {
                     Text("Start dictating")
                         .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
             }
         }
@@ -143,16 +143,16 @@ struct StatsView: View {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text("\(self.historyStore.currentStreak)")
                         .font(.system(size: 32, weight: .bold, design: .rounded))
-                        .foregroundStyle(self.historyStore.currentStreak > 0 ? self.theme.palette.warning : .primary)
+                        .foregroundColor(self.historyStore.currentStreak > 0 ? self.theme.palette.warning : .primary)
 
                     Text(self.historyStore.currentStreak == 1 ? "day" : "days")
                         .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
 
                 Text("Best: \(self.historyStore.bestStreak) days")
                     .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
         }
     }
@@ -164,11 +164,11 @@ struct StatsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("\(self.historyStore.entries.count)")
                     .font(.system(size: 32, weight: .bold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .foregroundColor(.primary)
 
                 Text("Avg: \(self.historyStore.averageWordsPerTranscription) words each")
                     .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
         }
     }
@@ -181,7 +181,7 @@ struct StatsView: View {
                 HStack {
                     Label("ACTIVITY", systemImage: "chart.bar.fill")
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
 
                     Spacer()
 
@@ -203,10 +203,10 @@ struct StatsView: View {
                         VStack(spacing: 8) {
                             Image(systemName: "chart.bar")
                                 .font(.system(size: 24))
-                                .foregroundStyle(.tertiary)
+                                .foregroundColor(.secondary)
                             Text("No activity yet")
                                 .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                         }
                         .padding(.vertical, 30)
                         Spacer()
@@ -227,7 +227,7 @@ struct StatsView: View {
                                 if self.chartDays == 7 {
                                     Text(self.dayLabel(item.date))
                                         .font(.system(size: 9, weight: .medium))
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
                             }
                         }
@@ -242,11 +242,11 @@ struct StatsView: View {
 
                         Text("\(self.formatNumber(totalPeriod)) words")
                             .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.primary)
+                            .foregroundColor(.primary)
 
                         Text("across \(activeDays) active days")
                             .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         Spacer()
                     }
@@ -263,13 +263,13 @@ struct StatsView: View {
                 HStack {
                     Label("MILESTONES", systemImage: "flag.fill")
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
 
                     Spacer()
 
                     Text("\(self.historyStore.totalMilestonesAchieved)/\(self.historyStore.totalMilestonesPossible)")
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(self.theme.palette.accent)
+                        .foregroundColor(self.theme.palette.accent)
                 }
 
                 VStack(alignment: .leading, spacing: 10) {
@@ -299,18 +299,18 @@ struct StatsView: View {
         HStack(spacing: 8) {
             Text(title)
                 .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
                 .frame(width: 80, alignment: .leading)
 
             ForEach(Array(milestones.enumerated()), id: \.offset) { _, milestone in
                 HStack(spacing: 3) {
                     Image(systemName: milestone.achieved ? "checkmark.circle.fill" : "circle")
                         .font(.system(size: 10))
-                        .foregroundStyle(milestone.achieved ? self.theme.palette.success : Color.secondary.opacity(0.4))
+                        .foregroundColor(milestone.achieved ? self.theme.palette.success : Color.secondary.opacity(0.4))
 
                     Text(milestone.label)
                         .font(.system(size: 10, weight: milestone.achieved ? .semibold : .regular))
-                        .foregroundStyle(milestone.achieved ? .primary : .secondary)
+                        .foregroundColor(milestone.achieved ? .primary : .secondary)
                 }
                 .padding(.horizontal, 6)
                 .padding(.vertical, 3)
@@ -331,7 +331,7 @@ struct StatsView: View {
             VStack(alignment: .leading, spacing: 12) {
                 Label("INSIGHTS", systemImage: "lightbulb.fill")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
 
                 LazyVGrid(columns: [
                     GridItem(.flexible(), spacing: 12),
@@ -377,17 +377,17 @@ struct StatsView: View {
         HStack(spacing: 10) {
             Image(systemName: icon)
                 .font(.system(size: 12))
-                .foregroundStyle(.tertiary)
+                .foregroundColor(.secondary)
                 .frame(width: 20)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
 
                 Text(value.isEmpty ? fallback : value)
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.primary)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
             }
 
@@ -395,7 +395,7 @@ struct StatsView: View {
         }
         .padding(10)
         .background(RoundedRectangle(cornerRadius: 8)
-            .fill(.quaternary.opacity(0.3)))
+            .fill(Color.secondary.opacity(0.3)))
     }
 
     // MARK: - Personal Records Card
@@ -405,7 +405,7 @@ struct StatsView: View {
             VStack(alignment: .leading, spacing: 12) {
                 Label("PERSONAL RECORDS", systemImage: "trophy.fill")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
 
                 HStack(spacing: 12) {
                     self.recordItem(
@@ -431,11 +431,11 @@ struct StatsView: View {
         VStack(alignment: .leading, spacing: 4) {
             Text(title)
                 .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
 
             Text(value)
                 .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary)
+                .foregroundColor(.primary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(10)
@@ -460,7 +460,7 @@ struct StatsView: View {
             } label: {
                 Label("Reset All Stats", systemImage: "trash")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
             .opacity(self.historyStore.entries.isEmpty ? 0.3 : 0.7)
@@ -469,13 +469,15 @@ struct StatsView: View {
             Spacer()
         }
         .padding(.top, 8)
-        .alert("Reset All Stats", isPresented: self.$showResetConfirmation) {
-            Button("Cancel", role: .cancel) {}
-            Button("Reset Everything", role: .destructive) {
-                self.historyStore.clearAllHistory()
-            }
-        } message: {
-            Text("This will permanently delete all \(self.historyStore.entries.count) transcriptions and reset all statistics. This action cannot be undone.")
+        .alert(isPresented: self.$showResetConfirmation) {
+            Alert(
+                title: Text("Reset All Stats"),
+                message: Text("This will permanently delete all \(self.historyStore.entries.count) transcriptions and reset all statistics. This action cannot be undone."),
+                primaryButton: .destructive(Text("Reset Everything")) {
+                    self.historyStore.clearAllHistory()
+                },
+                secondaryButton: .cancel()
+            )
         }
     }
 
@@ -506,7 +508,7 @@ private struct StatCard<Content: View>: View {
             VStack(alignment: .leading, spacing: 10) {
                 Label(self.title, systemImage: self.icon)
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
 
                 self.content
             }
@@ -515,8 +517,10 @@ private struct StatCard<Content: View>: View {
     }
 }
 
-#Preview {
-    StatsView()
-        .frame(width: 600, height: 800)
-        .environment(\.theme, AppTheme.dark)
+struct StatsView_Previews: PreviewProvider {
+    static var previews: some View {
+        StatsView()
+            .frame(width: 600, height: 800)
+            .environment(\.theme, AppTheme.dark)
+    }
 }

--- a/Sources/Fluid/UI/TranscriptionHistoryView.swift
+++ b/Sources/Fluid/UI/TranscriptionHistoryView.swift
@@ -57,16 +57,18 @@ struct TranscriptionHistoryView: View {
                 self.selectedEntryID = self.filteredEntries.first?.id
             }
         }
-        .alert("Clear All History", isPresented: self.$showClearConfirmation) {
-            Button("Cancel", role: .cancel) {}
-            Button("Clear All", role: .destructive) {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    self.historyStore.clearAllHistory()
-                    self.selectedEntryID = nil
-                }
-            }
-        } message: {
-            Text("This will permanently delete all \(self.historyStore.entries.count) transcription entries. This action cannot be undone.")
+        .alert(isPresented: self.$showClearConfirmation) {
+            Alert(
+                title: Text("Clear All History"),
+                message: Text("This will permanently delete all \(self.historyStore.entries.count) transcription entries. This action cannot be undone."),
+                primaryButton: .destructive(Text("Clear All")) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        self.historyStore.clearAllHistory()
+                        self.selectedEntryID = nil
+                    }
+                },
+                secondaryButton: .cancel()
+            )
         }
     }
 
@@ -76,7 +78,7 @@ struct TranscriptionHistoryView: View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
 
             TextField("Search transcriptions...", text: self.$searchQuery)
                 .textFieldStyle(.plain)
@@ -88,7 +90,7 @@ struct TranscriptionHistoryView: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
             }
@@ -128,13 +130,13 @@ struct TranscriptionHistoryView: View {
                 HStack(spacing: 6) {
                     Text(entry.appName.isEmpty ? "Unknown App" : entry.appName)
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(isSelected ? .white : .secondary)
+                        .foregroundColor(isSelected ? .white : .secondary)
                         .lineLimit(1)
 
                     if entry.wasAIProcessed {
                         Text("AI")
                             .font(.system(size: 9, weight: .bold))
-                            .foregroundStyle(isSelected ? .white.opacity(0.8) : self.theme.palette.accent)
+                            .foregroundColor(isSelected ? .white.opacity(0.8) : self.theme.palette.accent)
                             .padding(.horizontal, 4)
                             .padding(.vertical, 1)
                             .background(
@@ -147,13 +149,13 @@ struct TranscriptionHistoryView: View {
 
                     Text(entry.relativeTimeString)
                         .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(isSelected ? .white.opacity(0.7) : Color.secondary.opacity(0.6))
+                        .foregroundColor(isSelected ? .white.opacity(0.7) : Color.secondary.opacity(0.6))
                 }
 
                 // Preview text
                 Text(entry.previewText)
                     .font(.system(size: 12))
-                    .foregroundStyle(isSelected ? .white.opacity(0.9) : .primary)
+                    .foregroundColor(isSelected ? .white.opacity(0.9) : .primary)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
             }
@@ -186,7 +188,7 @@ struct TranscriptionHistoryView: View {
 
             Divider()
 
-            Button(role: .destructive) {
+            Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     self.historyStore.deleteEntry(id: entry.id)
                     if self.selectedEntryID == entry.id {
@@ -207,18 +209,18 @@ struct TranscriptionHistoryView: View {
 
             Image(systemName: self.searchQuery.isEmpty ? "clock.arrow.circlepath" : "magnifyingglass")
                 .font(.system(size: 36, weight: .light))
-                .foregroundStyle(.tertiary)
+                .foregroundColor(.secondary)
 
             VStack(spacing: 4) {
                 Text(self.searchQuery.isEmpty ? "No History Yet" : "No Results")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
 
                 Text(self.searchQuery.isEmpty
                     ? "Your transcriptions will appear here"
                     : "Try a different search term")
                     .font(.system(size: 12))
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
             }
 
@@ -239,7 +241,7 @@ struct TranscriptionHistoryView: View {
                 // Stats
                 Text("\(self.historyStore.entries.count) entries")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(.secondary)
 
                 Spacer()
 
@@ -250,7 +252,7 @@ struct TranscriptionHistoryView: View {
                     } label: {
                         Text("Clear All")
                             .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                     .buttonStyle(.plain)
                     .opacity(0.8)
@@ -282,13 +284,13 @@ struct TranscriptionHistoryView: View {
                             Label("Copy", systemImage: "doc.on.doc")
                                 .font(.system(size: 12, weight: .medium))
                         }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
+                        
+                        
                     }
 
                     Text(entry.fullDateString)
                         .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
 
                 Divider()
@@ -322,7 +324,7 @@ struct TranscriptionHistoryView: View {
                 // Delete Button
                 HStack {
                     Spacer()
-                    Button(role: .destructive) {
+                    Button {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             let nextEntry = self.filteredEntries.first(where: { $0.id != entry.id })
                             self.historyStore.deleteEntry(id: entry.id)
@@ -332,9 +334,9 @@ struct TranscriptionHistoryView: View {
                         Label("Delete Entry", systemImage: "trash")
                             .font(.system(size: 12, weight: .medium))
                     }
-                    .buttonStyle(.bordered)
-                    .tint(.red)
-                    .controlSize(.small)
+                    
+                    .accentColor(.red)
+                    
                 }
             }
             .padding(24)
@@ -352,14 +354,14 @@ struct TranscriptionHistoryView: View {
             HStack(spacing: 8) {
                 Text(title)
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
                     .textCase(.uppercase)
                     .tracking(0.5)
 
                 if let badge = badge {
                     Text(badge)
                         .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(self.theme.palette.accent)
+                        .foregroundColor(self.theme.palette.accent)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
                         .background(
@@ -371,8 +373,8 @@ struct TranscriptionHistoryView: View {
 
             Text(content)
                 .font(.system(size: 14, design: .default))
-                .foregroundStyle(isSecondary ? .secondary : .primary)
-                .textSelection(.enabled)
+                .foregroundColor(isSecondary ? .secondary : .primary)
+                
                 .padding(14)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(RoundedRectangle(cornerRadius: 10)
@@ -386,7 +388,7 @@ struct TranscriptionHistoryView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Details")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
                 .textCase(.uppercase)
                 .tracking(0.5)
 
@@ -406,17 +408,17 @@ struct TranscriptionHistoryView: View {
         HStack(spacing: 10) {
             Image(systemName: icon)
                 .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.tertiary)
+                .foregroundColor(.secondary)
                 .frame(width: 20)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(label)
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(.secondary)
 
                 Text(value)
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.primary)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
             }
 
@@ -433,19 +435,21 @@ struct TranscriptionHistoryView: View {
         VStack(spacing: 16) {
             Image(systemName: "text.quote")
                 .font(.system(size: 40, weight: .light))
-                .foregroundStyle(.tertiary)
+                .foregroundColor(.secondary)
 
             Text("Select a transcription")
                 .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(self.theme.palette.contentBackground)
     }
 }
 
-#Preview {
-    TranscriptionHistoryView()
-        .frame(width: 800, height: 600)
-        .environment(\.theme, AppTheme.dark)
+struct TranscriptionHistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        TranscriptionHistoryView()
+            .frame(width: 800, height: 600)
+            .environment(\.theme, AppTheme.dark)
+    }
 }

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -38,7 +38,7 @@ struct WelcomeView: View {
                 HStack(spacing: 10) {
                     Image(systemName: "book.fill")
                         .font(.title2)
-                        .foregroundStyle(self.theme.palette.accent)
+                        .foregroundColor(self.theme.palette.accent)
                     Text((self.asr.isAsrReady || self.asr.modelsExistOnDisk) ? "Getting Started" : "Welcome to FluidVoice")
                         .font(.title2.weight(.bold))
                 }
@@ -49,7 +49,7 @@ struct WelcomeView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Label("Quick Setup", systemImage: "checkmark.circle.fill")
                             .font(.headline)
-                            .foregroundStyle(self.theme.palette.accent)
+                            .foregroundColor(self.theme.palette.accent)
 
                         VStack(alignment: .leading, spacing: 8) {
                             SetupStepView(
@@ -141,7 +141,7 @@ struct WelcomeView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Label("How to Use", systemImage: "play.fill")
                             .font(.headline)
-                            .foregroundStyle(Color.fluidGreen)
+                            .foregroundColor(Color.fluidGreen)
 
                         VStack(alignment: .leading, spacing: 10) {
                             self.howToStep(number: 1, title: "Start Recording", description: "Press your hotkey (default: Right Option/Alt) or click the button")
@@ -160,7 +160,7 @@ struct WelcomeView: View {
                         HStack(spacing: 8) {
                             Label("Command Mode", systemImage: "terminal.fill")
                                 .font(.headline)
-                                .foregroundStyle(Color(red: 1.0, green: 0.35, blue: 0.35))
+                                .foregroundColor(Color(red: 1.0, green: 0.35, blue: 0.35))
 
                             self.featureBadge("New", color: Color(red: 1.0, green: 0.35, blue: 0.35))
                             self.featureBadge("Alpha", color: Color(red: 1.0, green: 0.35, blue: 0.35).opacity(0.7))
@@ -170,18 +170,18 @@ struct WelcomeView: View {
                             Button("Open") {
                                 self.selectedSidebarItem = .commandMode
                             }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
+                            
+                            
                         }
 
                         Text("Control your Mac with voice commands. Execute terminal commands, open apps, and more.")
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Getting Started")
                                 .font(.subheadline.weight(.medium))
-                                .foregroundStyle(.orange)
+                                .foregroundColor(.orange)
 
                             HStack(spacing: 4) {
                                 Text("Press")
@@ -189,13 +189,13 @@ struct WelcomeView: View {
                                 Text("to open, speak your command, then press again to send.")
                             }
                             .font(.caption)
-                            .foregroundStyle(.primary.opacity(0.8))
+                            .foregroundColor(.primary.opacity(0.8))
                         }
 
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Examples")
                                 .font(.subheadline.weight(.medium))
-                                .foregroundStyle(.orange)
+                                .foregroundColor(.orange)
                             self.commandModeExample(icon: "folder", text: "\"List files in my Downloads folder\"")
                             self.commandModeExample(icon: "plus.rectangle.on.folder", text: "\"Create a folder called Projects on Desktop\"")
                             self.commandModeExample(icon: "network", text: "\"What's my IP address?\"")
@@ -205,10 +205,10 @@ struct WelcomeView: View {
                         HStack(spacing: 4) {
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .font(.caption2)
-                                .foregroundStyle(.orange)
+                                .foregroundColor(.orange)
                             Text("AI can make mistakes. Avoid destructive commands.")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                         }
                     }
                     .padding(16)
@@ -221,7 +221,7 @@ struct WelcomeView: View {
                         HStack(spacing: 8) {
                             Label("Edit Mode", systemImage: "pencil.and.outline")
                                 .font(.headline)
-                                .foregroundStyle(.blue)
+                                .foregroundColor(.blue)
 
                             self.featureBadge("New", color: .blue)
 
@@ -230,19 +230,19 @@ struct WelcomeView: View {
                             Button("Open AI Settings") {
                                 self.selectedSidebarItem = .aiEnhancements
                             }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
+                            
+                            
                         }
 
                         Text("AI-powered editing assistant. Write fresh content or edit selected text with voice.")
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         VStack(alignment: .leading, spacing: 10) {
                             VStack(alignment: .leading, spacing: 6) {
                                 Text("Create New Text")
                                     .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(.blue)
+                                    .foregroundColor(.blue)
 
                                 HStack(spacing: 4) {
                                     Text("Press")
@@ -250,7 +250,7 @@ struct WelcomeView: View {
                                     Text("and speak what you want to write.")
                                 }
                                 .font(.caption)
-                                .foregroundStyle(.primary.opacity(0.8))
+                                .foregroundColor(.primary.opacity(0.8))
 
                                 self.writeModeExample(text: "\"Write an email asking for time off\"")
                                 self.writeModeExample(text: "\"Draft a thank you note\"")
@@ -259,7 +259,7 @@ struct WelcomeView: View {
                             VStack(alignment: .leading, spacing: 6) {
                                 Text("Edit Selected Text")
                                     .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(.blue)
+                                    .foregroundColor(.blue)
 
                                 HStack(spacing: 4) {
                                     Text("Select text first, then press")
@@ -267,7 +267,7 @@ struct WelcomeView: View {
                                     Text("and speak your instruction.")
                                 }
                                 .font(.caption)
-                                .foregroundStyle(.primary.opacity(0.8))
+                                .foregroundColor(.primary.opacity(0.8))
 
                                 self.writeModeExample(text: "\"Make this more formal\"")
                                 self.writeModeExample(text: "\"Fix grammar and spelling\"")
@@ -289,7 +289,7 @@ struct WelcomeView: View {
                                         .font(.headline)
                                     Text("Click record, speak, and see your transcription")
                                         .font(.caption)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
                             } icon: {
                                 Image(systemName: "text.bubble")
@@ -305,12 +305,12 @@ struct WelcomeView: View {
                                         .frame(width: 6, height: 6)
                                     Text("Recording...")
                                         .font(.caption.weight(.medium))
-                                        .foregroundStyle(.red)
+                                        .foregroundColor(.red)
                                 }
                             } else if !self.asr.finalText.isEmpty {
                                 Text("\(self.asr.finalText.count) characters")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                             }
 
                             if !self.asr.finalText.isEmpty {
@@ -320,8 +320,8 @@ struct WelcomeView: View {
                                 } label: {
                                     Label("Copy", systemImage: "doc.on.doc")
                                 }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
+                                
+                                
                             }
                         }
 
@@ -329,10 +329,10 @@ struct WelcomeView: View {
                             HStack(spacing: 6) {
                                 Image(systemName: "text.magnifyingglass")
                                     .font(.caption)
-                                    .foregroundStyle(self.theme.palette.accent)
+                                    .foregroundColor(self.theme.palette.accent)
                                 Text(self.asr.wordBoostStatusText)
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                     .lineLimit(1)
                             }
                             .padding(.horizontal, 10)
@@ -373,8 +373,8 @@ struct WelcomeView: View {
                                     Button("Clear Results") {
                                         self.asr.finalText = ""
                                     }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
+                                    
+                                    
                                 }
                             }
 
@@ -385,7 +385,7 @@ struct WelcomeView: View {
                                     set: { self.asr.finalText = $0 }
                                 ))
                                 .font(.body)
-                                .focused(self.isTranscriptionFocused)
+                                // Note: .focused() requires macOS 12+, omitted for Big Sur compatibility
                                 .frame(height: 140)
                                 .padding(10)
                                 .background(
@@ -401,28 +401,28 @@ struct WelcomeView: View {
                                                 )
                                         )
                                 )
-                                .scrollContentBackground(.hidden)
+                                
                                 .overlay(
                                     VStack(spacing: 8) {
                                         if self.asr.isRunning {
                                             Image(systemName: "waveform")
                                                 .font(.title2)
-                                                .foregroundStyle(self.theme.palette.accent)
+                                                .foregroundColor(self.theme.palette.accent)
                                             Text("Listening... Speak now!")
                                                 .font(.subheadline.weight(.medium))
-                                                .foregroundStyle(self.theme.palette.accent)
+                                                .foregroundColor(self.theme.palette.accent)
                                             Text("Transcription will appear when you stop recording")
                                                 .font(.caption)
-                                                .foregroundStyle(self.theme.palette.accent.opacity(0.7))
+                                                .foregroundColor(self.theme.palette.accent.opacity(0.7))
                                         } else if self.asr.finalText.isEmpty {
                                             Image(systemName: "text.bubble")
                                                 .font(.title2)
-                                                .foregroundStyle(.secondary.opacity(0.5))
+                                                .foregroundColor(.secondary.opacity(0.5))
                                             Text("Ready to test!")
                                                 .font(.subheadline.weight(.medium))
                                             Text("Click 'Start Recording' or press your hotkey")
                                                 .font(.caption)
-                                                .foregroundStyle(.secondary)
+                                                .foregroundColor(.secondary)
                                         }
                                     }
                                     .allowsHitTesting(false)
@@ -436,15 +436,15 @@ struct WelcomeView: View {
                                         } label: {
                                             Label("Copy Text", systemImage: "doc.on.doc")
                                         }
-                                        .buttonStyle(.borderedProminent)
-                                        .tint(self.theme.palette.accent)
-                                        .controlSize(.small)
+                                        
+                                        .accentColor(self.theme.palette.accent)
+                                        
 
                                         Button("Clear & Test Again") {
                                             self.asr.finalText = ""
                                         }
-                                        .buttonStyle(.bordered)
-                                        .controlSize(.small)
+                                        
+                                        
 
                                         Spacer()
                                     }
@@ -480,14 +480,14 @@ struct WelcomeView: View {
                     .frame(width: 28, height: 28)
                 Text("\(number)")
                     .font(.caption.weight(.bold))
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
             }
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.body.weight(.medium))
                 Text(description)
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
             Spacer()
         }
@@ -496,10 +496,10 @@ struct WelcomeView: View {
     private func featureBadge(_ text: String, color: Color) -> some View {
         Text(text)
             .font(.caption2.weight(.semibold))
-            .foregroundStyle(.white)
+            .foregroundColor(.white)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(color, in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+            .background(RoundedRectangle(cornerRadius: 4, style: .continuous).fill(color))
     }
 
     private func keyboardBadge(_ text: String) -> some View {
@@ -507,28 +507,28 @@ struct WelcomeView: View {
             .font(.caption.weight(.medium))
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(self.theme.palette.cardBackground.opacity(0.7), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+            .background(RoundedRectangle(cornerRadius: 4, style: .continuous).fill(self.theme.palette.cardBackground.opacity(0.7)))
     }
 
     private func commandModeExample(icon: String, text: String) -> some View {
         HStack(spacing: 6) {
             Image(systemName: icon)
                 .font(.caption2)
-                .foregroundStyle(.orange.opacity(0.8))
+                .foregroundColor(.orange.opacity(0.8))
                 .frame(width: 14)
             Text(text)
                 .font(.caption)
-                .foregroundStyle(.primary.opacity(0.8))
+                .foregroundColor(.primary.opacity(0.8))
         }
     }
 
     private func writeModeExample(text: String) -> some View {
         HStack(spacing: 6) {
             Text("•")
-                .foregroundStyle(.blue.opacity(0.6))
+                .foregroundColor(.blue.opacity(0.6))
             Text(text)
                 .font(.caption)
-                .foregroundStyle(.primary.opacity(0.8))
+                .foregroundColor(.primary.opacity(0.8))
         }
     }
 }

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -1148,7 +1148,7 @@ private struct BottomOverlayModeMenuView: View {
                 if !shortcut.isEmpty {
                     Text(shortcut)
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.7))
+                        .foregroundColor(.white.opacity(0.7))
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
                         .background(Color.white.opacity(0.08))
@@ -1935,17 +1935,17 @@ struct BottomOverlayView: View {
             if !self.isCompactControls {
                 Text("Mode:")
                     .font(.system(size: self.promptSelectorFontSize, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.5))
+                    .foregroundColor(.white.opacity(0.5))
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
             }
             Text(self.modeLabel)
                 .font(.system(size: self.promptSelectorFontSize, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.75))
+                .foregroundColor(.white.opacity(0.75))
                 .lineLimit(1)
             Image(systemName: "chevron.up")
                 .font(.system(size: max(self.promptSelectorFontSize - 1, 8), weight: .semibold))
-                .foregroundStyle(.white.opacity(0.45))
+                .foregroundColor(.white.opacity(0.45))
         }
         .fixedSize(horizontal: true, vertical: false)
         .padding(.horizontal, 8)
@@ -1986,17 +1986,17 @@ struct BottomOverlayView: View {
             if !self.isCompactControls {
                 Text("Prompt:")
                     .font(.system(size: self.promptSelectorFontSize, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.5))
+                    .foregroundColor(.white.opacity(0.5))
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
             }
             Text(self.selectedPromptLabel)
                 .font(.system(size: self.promptSelectorFontSize, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.75))
+                .foregroundColor(.white.opacity(0.75))
                 .lineLimit(1)
             Image(systemName: "chevron.up")
                 .font(.system(size: max(self.promptSelectorFontSize - 1, 8), weight: .semibold))
-                .foregroundStyle(.white.opacity(0.45))
+                .foregroundColor(.white.opacity(0.45))
         }
         .fixedSize(horizontal: true, vertical: false)
         .padding(.horizontal, 8)
@@ -2050,11 +2050,11 @@ struct BottomOverlayView: View {
         return HStack(spacing: 5) {
             Text("Actions")
                 .font(.system(size: self.promptSelectorFontSize, weight: .medium))
-                .foregroundStyle(.white.opacity(0.75))
+                .foregroundColor(.white.opacity(0.75))
                 .lineLimit(1)
             Image(systemName: "chevron.up")
                 .font(.system(size: max(self.promptSelectorFontSize - 1, 8), weight: .semibold))
-                .foregroundStyle(.white.opacity(0.45))
+                .foregroundColor(.white.opacity(0.45))
         }
         .fixedSize(horizontal: true, vertical: false)
         .padding(.horizontal, 8)
@@ -2074,20 +2074,20 @@ struct BottomOverlayView: View {
             if self.isCompactControls {
                 Text(isEnabled ? "AI On" : "AI Off")
                     .font(.system(size: self.promptSelectorFontSize, weight: .semibold))
-                    .foregroundStyle(isEnabled ? .white.opacity(0.82) : .white.opacity(0.7))
+                    .foregroundColor(isEnabled ? .white.opacity(0.82) : .white.opacity(0.7))
                     .lineLimit(1)
             } else {
                 Text("AI:")
                     .font(.system(size: self.promptSelectorFontSize, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.5))
+                    .foregroundColor(.white.opacity(0.5))
                     .lineLimit(1)
                 Text(isEnabled ? "On" : "Off")
                     .font(.system(size: self.promptSelectorFontSize, weight: .semibold))
-                    .foregroundStyle(isEnabled ? .white.opacity(0.82) : .white.opacity(0.7))
+                    .foregroundColor(isEnabled ? .white.opacity(0.82) : .white.opacity(0.7))
                     .lineLimit(1)
                 Image(systemName: isEnabled ? "brain.fill" : "brain")
                     .font(.system(size: max(self.promptSelectorFontSize - 1, 8), weight: .semibold))
-                    .foregroundStyle(isEnabled ? .white.opacity(0.65) : .white.opacity(0.45))
+                    .foregroundColor(isEnabled ? .white.opacity(0.65) : .white.opacity(0.45))
             }
         }
         .fixedSize(horizontal: true, vertical: false)
@@ -2152,7 +2152,7 @@ struct BottomOverlayView: View {
         return HStack(spacing: 0) {
             Image(systemName: "gearshape")
                 .font(.system(size: max(self.promptSelectorFontSize + 1, 10), weight: .semibold))
-                .foregroundStyle(.white.opacity(0.72))
+                .foregroundColor(.white.opacity(0.72))
         }
         .padding(.horizontal, 9)
         .padding(.vertical, self.promptSelectorVerticalPadding)
@@ -2211,7 +2211,7 @@ struct BottomOverlayView: View {
                                         ScrollView(.vertical, showsIndicators: false) {
                                             Text(previewText)
                                                 .font(.system(size: self.layout.transFontSize, weight: .medium))
-                                                .foregroundStyle(.white.opacity(0.9))
+                                                .foregroundColor(.white.opacity(0.9))
                                                 .multilineTextAlignment(.leading)
                                                 .lineLimit(nil)
                                                 .fixedSize(horizontal: false, vertical: true)
@@ -2225,7 +2225,7 @@ struct BottomOverlayView: View {
                                                 proxy.scrollTo("bottom", anchor: .bottom)
                                             }
                                         }
-                                        .onChange(of: previewText) { _, _ in
+                                        .onChange(of: previewText) { _ in
                                             DispatchQueue.main.async {
                                                 proxy.scrollTo("bottom", anchor: .bottom)
                                             }
@@ -2252,7 +2252,7 @@ struct BottomOverlayView: View {
                                     if self.settings.overlaySize == .small {
                                         Text(previewText)
                                             .font(.system(size: self.layout.transFontSize, weight: .medium))
-                                            .foregroundStyle(.white.opacity(0.9))
+                                            .foregroundColor(.white.opacity(0.9))
                                             .multilineTextAlignment(.leading)
                                             .lineLimit(1)
                                             .truncationMode(.head)
@@ -2263,7 +2263,7 @@ struct BottomOverlayView: View {
                                             ScrollView(.vertical, showsIndicators: false) {
                                                 Text(previewText)
                                                     .font(.system(size: self.layout.transFontSize, weight: .medium))
-                                                    .foregroundStyle(.white.opacity(0.9))
+                                                    .foregroundColor(.white.opacity(0.9))
                                                     .multilineTextAlignment(.leading)
                                                     .lineLimit(nil)
                                                     .fixedSize(horizontal: false, vertical: true)
@@ -2278,7 +2278,7 @@ struct BottomOverlayView: View {
                                                     proxy.scrollTo("bottom", anchor: .bottom)
                                                 }
                                             }
-                                            .onChange(of: previewText) { _, _ in
+                                            .onChange(of: previewText) { _ in
                                                 DispatchQueue.main.async {
                                                     proxy.scrollTo("bottom", anchor: .bottom)
                                                 }
@@ -2314,7 +2314,7 @@ struct BottomOverlayView: View {
                         VStack(spacing: 2) {
                             if showModelLoading {
                                 ProgressView()
-                                    .controlSize(.mini)
+                                    
                             }
                             if let appIcon = appIcon {
                                 Image(nsImage: appIcon)
@@ -2336,7 +2336,7 @@ struct BottomOverlayView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(self.modeLabel)
                             .font(.system(size: self.layout.modeFontSize, weight: .semibold))
-                            .foregroundStyle(self.modeColor)
+                            .foregroundColor(self.modeColor)
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
 
@@ -2346,7 +2346,7 @@ struct BottomOverlayView: View {
                         {
                             Text("Loading model…")
                                 .font(.system(size: max(self.layout.modeFontSize - 2, 9), weight: .medium))
-                                .foregroundStyle(.orange.opacity(0.85))
+                                .foregroundColor(.orange.opacity(0.85))
                                 .lineLimit(1)
                         }
                     }
@@ -2383,15 +2383,15 @@ struct BottomOverlayView: View {
             height: self.layout.usesFixedCanvas ? self.layout.overlayHeight : nil,
             alignment: .top
         )
-        .onChange(of: self.settings.overlaySize) { _, _ in
+        .onChange(of: self.settings.overlaySize) { _ in
             BottomOverlayWindowController.shared.refreshSizeForContent()
         }
-        .onChange(of: self.contentState.cachedPreviewText) { _, _ in
+        .onChange(of: self.contentState.cachedPreviewText) { _ in
             if !self.layout.usesFixedCanvas {
                 BottomOverlayWindowController.shared.refreshSizeForContent()
             }
         }
-        .onChange(of: self.contentState.mode) { _, _ in
+        .onChange(of: self.contentState.mode) { _ in
             if !self.isPromptSelectableMode || self.contentState.isProcessing {
                 self.closePromptMenu()
             }
@@ -2411,7 +2411,7 @@ struct BottomOverlayView: View {
                 BottomOverlayWindowController.shared.refreshSizeForContent()
             }
         }
-        .onChange(of: self.contentState.isProcessing) { _, processing in
+        .onChange(of: self.contentState.isProcessing) { processing in
             if processing {
                 self.closePromptMenu()
                 self.closeModeMenu()
@@ -2491,12 +2491,12 @@ struct BottomWaveformView: View {
                     .shadow(color: self.color.opacity(self.currentGlowIntensity), radius: self.currentGlowRadius, x: 0, y: 0)
             }
         }
-        .onChange(of: self.contentState.bottomOverlayAudioLevel) { _, level in
+        .onChange(of: self.contentState.bottomOverlayAudioLevel) { level in
             if !self.contentState.isProcessing {
                 self.updateBars(level: level)
             }
         }
-        .onChange(of: self.contentState.isProcessing) { _, processing in
+        .onChange(of: self.contentState.isProcessing) { processing in
             if processing {
                 self.setFlatProcessingBars()
             } else {
@@ -2504,7 +2504,7 @@ struct BottomWaveformView: View {
                 self.updateBars(level: 0)
             }
         }
-        .onChange(of: self.layout.barCount) { _, newCount in
+        .onChange(of: self.layout.barCount) { newCount in
             self.barHeights = Array(repeating: self.minHeight, count: newCount)
         }
         .onAppear {

--- a/Sources/Fluid/Views/CommandModeView.swift
+++ b/Sources/Fluid/Views/CommandModeView.swift
@@ -51,12 +51,12 @@ struct CommandModeView: View {
             // Re-enable notch output when leaving in-app UI
             self.service.enableNotchOutput = true
         }
-        .onChange(of: self.asr.finalText) { _, newText in
+        .onChange(of: self.asr.finalText) { newText in
             if !newText.isEmpty {
                 self.inputText = newText
             }
         }
-        .onChange(of: self.settings.commandModeSelectedProviderID) { _, _ in
+        .onChange(of: self.settings.commandModeSelectedProviderID) { _ in
             self.updateAvailableModels()
         }
         .onExitCommand {
@@ -76,7 +76,7 @@ struct CommandModeView: View {
                 Text("Alpha")
                     .font(.caption2)
                     .fontWeight(.semibold)
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
                     .background(Color(red: 1.0, green: 0.35, blue: 0.35)) // Command mode red
@@ -91,7 +91,7 @@ struct CommandModeView: View {
                 Button(action: { self.service.createNewChat() }) {
                     Image(systemName: "plus")
                 }
-                .buttonStyle(.bordered)
+                
                 .help("New chat")
                 .disabled(self.service.isProcessing)
 
@@ -100,7 +100,7 @@ struct CommandModeView: View {
                     let recentChats = self.service.getRecentChats()
                     if recentChats.isEmpty {
                         Text("No recent chats")
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     } else {
                         ForEach(recentChats) { chat in
                             Button(action: {
@@ -118,7 +118,7 @@ struct CommandModeView: View {
                                     Spacer()
                                     Text(chat.relativeTimeString)
                                         .font(.caption)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
                             }
                             .disabled(self.service.isProcessing)
@@ -135,7 +135,7 @@ struct CommandModeView: View {
                 Button(action: { self.showingClearConfirmation = true }) {
                     Image(systemName: "trash")
                 }
-                .buttonStyle(.bordered)
+                
                 .help("Delete chat")
                 .disabled(self.service.isProcessing)
             }
@@ -154,15 +154,14 @@ struct CommandModeView: View {
         }
         .padding()
         .background(self.theme.palette.windowBackground)
-        .confirmationDialog(
-            "Delete this chat?",
-            isPresented: self.$showingClearConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button("Delete", role: .destructive) {
-                self.service.deleteCurrentChat()
-            }
-            Button("Cancel", role: .cancel) {}
+        .alert(isPresented: self.$showingClearConfirmation) {
+            Alert(
+                title: Text("Delete this chat?"),
+                primaryButton: .destructive(Text("Delete")) {
+                    self.service.deleteCurrentChat()
+                },
+                secondaryButton: .cancel()
+            )
         }
     }
 
@@ -185,7 +184,7 @@ struct CommandModeView: View {
                     Image(systemName: self.showHowTo ? "chevron.up" : "chevron.down")
                         .font(.caption2)
                 }
-                .foregroundStyle(self.isHoveringHowTo ? .primary : .secondary)
+                .foregroundColor(self.isHoveringHowTo ? .primary : .secondary)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
                 .background(self.isHoveringHowTo ? self.theme.palette.cardBackground.opacity(0.6) : Color.clear)
@@ -203,7 +202,7 @@ struct CommandModeView: View {
                         Text("Getting Started")
                             .font(.caption)
                             .fontWeight(.semibold)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         HStack(spacing: 4) {
                             Text("Press")
@@ -218,7 +217,7 @@ struct CommandModeView: View {
                             Text("to open Command Mode, speak your command, then press again to send.")
                                 .font(.caption)
                         }
-                        .foregroundStyle(.primary.opacity(0.8))
+                        .foregroundColor(.primary.opacity(0.8))
                     }
 
                     // Examples
@@ -226,7 +225,7 @@ struct CommandModeView: View {
                         Text("Examples")
                             .font(.caption)
                             .fontWeight(.semibold)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         VStack(alignment: .leading, spacing: 4) {
                             self.howToItem("\"List files in my Downloads folder\"")
@@ -240,7 +239,7 @@ struct CommandModeView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack(spacing: 4) {
                             Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.orange)
+                                .foregroundColor(.orange)
                             Text("Caution")
                                 .fontWeight(.semibold)
                         }
@@ -248,7 +247,7 @@ struct CommandModeView: View {
 
                         Text("AI can make mistakes. Avoid dangerous commands like deleting important files. Destructive actions will ask for confirmation.")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                 }
                 .padding(.horizontal, 16)
@@ -262,10 +261,10 @@ struct CommandModeView: View {
     private func howToItem(_ text: String) -> some View {
         HStack(spacing: 6) {
             Text("•")
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
             Text(text)
                 .font(.caption)
-                .foregroundStyle(.primary.opacity(0.8))
+                .foregroundColor(.primary.opacity(0.8))
         }
     }
 
@@ -314,17 +313,17 @@ struct CommandModeView: View {
                             .stroke(self.theme.palette.cardBorder.opacity(0.45), lineWidth: 1)
                     )
             )
-            .onChange(of: self.service.conversationHistory.count) { _, _ in
+            .onChange(of: self.service.conversationHistory.count) { _ in
                 self.scrollToBottom(proxy)
             }
-            .onChange(of: self.service.isProcessing) { _, isProcessing in
+            .onChange(of: self.service.isProcessing) { isProcessing in
                 // Scroll when processing starts, not on every streaming update
                 if isProcessing {
                     self.scrollToBottom(proxy)
                     self.isThinkingExpanded = false // Collapse thinking for new request
                 }
             }
-            .onChange(of: self.service.currentStep) { _, _ in
+            .onChange(of: self.service.currentStep) { _ in
                 self.scrollToBottom(proxy)
             }
             // Removed: .onChange(of: service.streamingText) - causes scroll on every token, too expensive
@@ -344,7 +343,7 @@ struct CommandModeView: View {
 
                     Image(systemName: self.isThinkingExpanded ? "chevron.up" : "chevron.down")
                         .font(.caption2)
-                        .foregroundStyle(.secondary.opacity(0.6))
+                        .foregroundColor(.secondary.opacity(0.6))
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
@@ -356,8 +355,8 @@ struct CommandModeView: View {
                 ScrollView(.vertical, showsIndicators: true) {
                     Text(self.service.streamingThinkingText)
                         .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
+                        .foregroundColor(.secondary)
+                        
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 12)
                         .padding(.bottom, 10)
@@ -368,7 +367,7 @@ struct CommandModeView: View {
                 if !self.service.streamingThinkingText.isEmpty {
                     Text(String(self.service.streamingThinkingText.prefix(150)) + (self.service.streamingThinkingText.count > 150 ? "..." : ""))
                         .font(.system(size: 11))
-                        .foregroundStyle(.secondary.opacity(0.7))
+                        .foregroundColor(.secondary.opacity(0.7))
                         .lineLimit(2)
                         .padding(.horizontal, 12)
                         .padding(.bottom, 8)
@@ -396,7 +395,7 @@ struct CommandModeView: View {
         // Use fixedSize to prevent expensive re-layout on every update
         Text(self.service.streamingText)
             .font(.system(size: 13))
-            .foregroundStyle(.primary.opacity(0.9))
+            .foregroundColor(.primary.opacity(0.9))
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
             .frame(maxWidth: 520, alignment: .leading)
@@ -440,7 +439,7 @@ struct CommandModeView: View {
 
             HStack {
                 Image(systemName: "exclamationmark.shield.fill")
-                    .foregroundStyle(.orange)
+                    .foregroundColor(.orange)
                     .font(.title3)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Confirm Execution")
@@ -448,7 +447,7 @@ struct CommandModeView: View {
                     if let purpose = pending.purpose {
                         Text(purpose)
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     }
                 }
                 Spacer()
@@ -472,7 +471,7 @@ struct CommandModeView: View {
 
                 Text(pending.command)
                     .font(.system(.callout, design: .monospaced))
-                    .textSelection(.enabled)
+                    
                     .padding(10)
             }
             .background(self.theme.palette.contentBackground)
@@ -486,7 +485,7 @@ struct CommandModeView: View {
                 Button(action: { self.service.cancelPendingCommand() }) {
                     Label("Cancel", systemImage: "xmark")
                 }
-                .buttonStyle(.bordered)
+                
                 .keyboardShortcut(.escape, modifiers: [])
 
                 Button(action: {
@@ -494,8 +493,8 @@ struct CommandModeView: View {
                 }) {
                     Label("Run Command", systemImage: "play.fill")
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.orange)
+                
+                .accentColor(.orange)
                 .keyboardShortcut(.return, modifiers: [])
             }
         }
@@ -539,9 +538,6 @@ struct CommandModeView: View {
             // Input field (flexible)
             TextField("Type a command or ask a question...", text: self.$inputText)
                 .textFieldStyle(.roundedBorder)
-                .onSubmit {
-                    self.submitCommand()
-                }
 
             Button(action: self.submitCommand) {
                 Image(systemName: "arrow.up.circle.fill")
@@ -554,7 +550,7 @@ struct CommandModeView: View {
             Button(action: self.toggleRecording) {
                 Image(systemName: self.asr.isRunning ? "stop.circle.fill" : "mic.circle.fill")
                     .font(.title2)
-                    .foregroundStyle(self.asr.isRunning ? Color.red : self.theme.palette.accent)
+                    .foregroundColor(self.asr.isRunning ? Color.red : self.theme.palette.accent)
             }
             .buttonStyle(.plain)
         }
@@ -628,7 +624,7 @@ struct CommandShimmerText: View {
     var body: some View {
         Text(self.text)
             .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(
+            .foregroundColor(
                 LinearGradient(
                     colors: [
                         Color.primary.opacity(0.4),
@@ -669,7 +665,7 @@ struct ThinkingShimmerLabel: View {
             // Shimmering "Think" text
             Text("Think")
                 .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(
+                .foregroundColor(
                     LinearGradient(
                         stops: [
                             .init(color: Color.primary.opacity(0.35), location: 0),
@@ -751,7 +747,7 @@ struct MessageBubble: View {
             if let tc = message.toolCall, let purpose = tc.purpose {
                 Text(purpose)
                     .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
 
             // Main content
@@ -782,17 +778,17 @@ struct MessageBubble: View {
                     }
                     Text("Think")
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
 
                     Spacer()
 
                     Text("\(thinking.count) chars")
                         .font(.system(size: 9))
-                        .foregroundStyle(.tertiary)
+                        .foregroundColor(.secondary)
 
                     Image(systemName: self.isThinkingExpanded ? "chevron.up" : "chevron.down")
                         .font(.system(size: 9))
-                        .foregroundStyle(.tertiary)
+                        .foregroundColor(.secondary)
                 }
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
@@ -804,8 +800,8 @@ struct MessageBubble: View {
                 ScrollView(.vertical, showsIndicators: true) {
                     Text(thinking)
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
+                        .foregroundColor(.secondary)
+                        
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 10)
                         .padding(.bottom, 8)
@@ -815,7 +811,7 @@ struct MessageBubble: View {
                 // Preview - first 80 chars
                 Text(String(thinking.prefix(80)) + (thinking.count > 80 ? "..." : ""))
                     .font(.system(size: 10))
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(.secondary)
                     .lineLimit(1)
                     .padding(.horizontal, 10)
                     .padding(.bottom, 6)
@@ -837,14 +833,14 @@ struct MessageBubble: View {
             {
                 Text(self.message.content)
                     .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(.secondary)
             }
 
             // Command block - clean and simple
             Text(tc.command)
                 .font(.system(size: 12, design: .monospaced))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
+                .foregroundColor(.primary)
+                
                 .padding(.horizontal, 10)
                 .padding(.vertical, 8)
                 .background(self.theme.palette.contentBackground)
@@ -862,14 +858,14 @@ struct MessageBubble: View {
             HStack(spacing: 6) {
                 Text(parsed.success ? "Success" : "Error")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(parsed.success ? .primary : .secondary)
+                    .foregroundColor(parsed.success ? .primary : .secondary)
 
                 Spacer()
 
                 if parsed.executionTime > 0 {
                     Text("\(parsed.executionTime)ms")
                         .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
+                        .foregroundColor(.secondary)
                 }
             }
             .padding(.horizontal, 10)
@@ -885,15 +881,15 @@ struct MessageBubble: View {
                         if !parsed.output.isEmpty {
                             Text(self.markdownAttributedString(from: parsed.output))
                                 .font(.system(size: 11, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                                .textSelection(.enabled)
+                                .foregroundColor(.secondary)
+                                
                         }
 
                         if let error = parsed.error, !error.isEmpty {
                             Text(error)
                                 .font(.system(size: 11, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                                .textSelection(.enabled)
+                                .foregroundColor(.secondary)
+                                
                         }
                     }
                     .padding(.horizontal, 10)
@@ -912,7 +908,7 @@ struct MessageBubble: View {
     private var textContentView: some View {
         Text(self.markdownAttributedString(from: self.message.content))
             .font(.system(size: 13))
-            .textSelection(.enabled)
+            
     }
 
     // MARK: - Markdown Rendering

--- a/Sources/Fluid/Views/NotchContentViews.swift
+++ b/Sources/Fluid/Views/NotchContentViews.swift
@@ -247,7 +247,7 @@ struct ShimmerText: View {
 
             Text(self.text)
                 .font(self.font)
-                .foregroundStyle(
+                .foregroundColor(
                     LinearGradient(
                         colors: [
                             self.color.opacity(0.35),
@@ -455,7 +455,7 @@ struct NotchExpandedView: View {
                 } else {
                     Text(self.modeLabel)
                         .font(.system(size: 9, weight: .medium))
-                        .foregroundStyle(self.modeColor)
+                        .foregroundColor(self.modeColor)
                         .opacity(0.9)
                         .onHover { hovering in
                             self.handlePromptHover(hovering)
@@ -469,14 +469,14 @@ struct NotchExpandedView: View {
                     HStack(spacing: 6) {
                         Text("Prompt:")
                             .font(.system(size: 9, weight: .medium))
-                            .foregroundStyle(.white.opacity(0.5))
+                            .foregroundColor(.white.opacity(0.5))
                         Text(self.selectedPromptLabel)
                             .font(.system(size: 9, weight: .medium))
-                            .foregroundStyle(.white.opacity(0.75))
+                            .foregroundColor(.white.opacity(0.75))
                             .lineLimit(1)
                         Image(systemName: "chevron.down")
                             .font(.system(size: 8, weight: .semibold))
-                            .foregroundStyle(.white.opacity(0.45))
+                            .foregroundColor(.white.opacity(0.45))
                     }
                     .padding(.horizontal, 6)
                     .padding(.vertical, 4)
@@ -506,7 +506,7 @@ struct NotchExpandedView: View {
                         ScrollView(.vertical, showsIndicators: false) {
                             Text(previewText)
                                 .font(.system(size: 10, weight: .medium))
-                                .foregroundStyle(.white.opacity(0.75))
+                                .foregroundColor(.white.opacity(0.75))
                                 .multilineTextAlignment(.leading)
                                 .lineLimit(nil)
                                 .fixedSize(horizontal: false, vertical: true)
@@ -521,7 +521,7 @@ struct NotchExpandedView: View {
                                 proxy.scrollTo("bottom", anchor: .bottom)
                             }
                         }
-                        .onChange(of: previewText) { _, _ in
+                        .onChange(of: previewText) { _ in
                             DispatchQueue.main.async {
                                 proxy.scrollTo("bottom", anchor: .bottom)
                             }
@@ -541,7 +541,7 @@ struct NotchExpandedView: View {
                 NotchOverlayManager.shared.onNotchClicked?()
             }
         }
-        .onChange(of: self.contentState.mode) { _, _ in
+        .onChange(of: self.contentState.mode) { _ in
             if !self.isPromptSelectableMode {
                 self.showPromptHoverMenu = false
             }
@@ -602,12 +602,12 @@ struct NotchWaveformView: View {
                     .shadow(color: self.color.opacity(self.currentGlowIntensity * 0.5), radius: self.currentOuterGlowRadius, x: 0, y: 0)
             }
         }
-        .onChange(of: self.data.audioLevel) { _, level in
+        .onChange(of: self.data.audioLevel) { level in
             if !self.contentState.isProcessing {
                 self.updateBars(level: level)
             }
         }
-        .onChange(of: self.contentState.isProcessing) { _, processing in
+        .onChange(of: self.contentState.isProcessing) { processing in
             if processing {
                 self.setFlatProcessingBars()
             } else {
@@ -675,7 +675,7 @@ struct NotchCompactLeadingView: View {
     var body: some View {
         Image(systemName: "waveform")
             .font(.system(size: 9, weight: .medium))
-            .foregroundStyle(self.contentState.mode.notchColor)
+            .foregroundColor(self.contentState.mode.notchColor)
             .scaleEffect(self.isPulsing ? 1.1 : 1.0)
             .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: self.isPulsing)
             .onAppear { self.isPulsing = true }
@@ -712,7 +712,7 @@ struct NotchCommandOutputExpandedView: View {
     @ObservedObject private var contentState = NotchContentState.shared
     @Environment(\.theme) private var theme
     @State private var inputText: String = ""
-    @FocusState private var isInputFocused: Bool
+    @State private var isInputFocused: Bool = false
     @State private var scrollProxy: ScrollViewProxy?
     @State private var isHoveringNewChat = false
     @State private var isHoveringRecent = false
@@ -802,13 +802,13 @@ struct NotchCommandOutputExpandedView: View {
                 if self.contentState.isRecordingInExpandedMode {
                     Text("Listening...")
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(self.commandRed)
+                        .foregroundColor(self.commandRed)
                 } else if self.contentState.isCommandProcessing {
                     ShimmerText(text: "Working...", color: self.commandRed)
                 } else {
                     Text("Command")
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(self.commandRed.opacity(0.7))
+                        .foregroundColor(self.commandRed.opacity(0.7))
                 }
             }
 
@@ -824,7 +824,7 @@ struct NotchCommandOutputExpandedView: View {
                             .frame(width: 22, height: 22)
                         Image(systemName: "plus")
                             .font(.system(size: 10, weight: .semibold))
-                            .foregroundStyle(self.contentState.isCommandProcessing ? .white.opacity(0.3) : self.commandRed.opacity(0.85))
+                            .foregroundColor(self.contentState.isCommandProcessing ? .white.opacity(0.3) : self.commandRed.opacity(0.85))
                     }
                 }
                 .buttonStyle(.plain)
@@ -839,7 +839,7 @@ struct NotchCommandOutputExpandedView: View {
                     let currentID = ChatHistoryStore.shared.currentChatID
                     if recentChats.isEmpty {
                         Text("No recent chats")
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
                     } else {
                         ForEach(recentChats) { chat in
                             Button(action: {
@@ -857,7 +857,7 @@ struct NotchCommandOutputExpandedView: View {
                                     Spacer()
                                     Text(chat.relativeTimeString)
                                         .font(.caption)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundColor(.secondary)
                                 }
                             }
                             .disabled(self.contentState.isCommandProcessing)
@@ -870,7 +870,7 @@ struct NotchCommandOutputExpandedView: View {
                             .frame(width: 22, height: 22)
                         Image(systemName: "clock.arrow.circlepath")
                             .font(.system(size: 9, weight: .semibold))
-                            .foregroundStyle(self.commandRed.opacity(0.85))
+                            .foregroundColor(self.commandRed.opacity(0.85))
                     }
                 }
                 .menuIndicator(.hidden)
@@ -888,7 +888,7 @@ struct NotchCommandOutputExpandedView: View {
                             .frame(width: 22, height: 22)
                         Image(systemName: "trash")
                             .font(.system(size: 9, weight: .semibold))
-                            .foregroundStyle(self.contentState.isCommandProcessing ? .white.opacity(0.3) : self.commandRed.opacity(0.85))
+                            .foregroundColor(self.contentState.isCommandProcessing ? .white.opacity(0.3) : self.commandRed.opacity(0.85))
                     }
                 }
                 .buttonStyle(.plain)
@@ -911,7 +911,7 @@ struct NotchCommandOutputExpandedView: View {
                             .frame(width: 22, height: 22)
                         Image(systemName: "xmark")
                             .font(.system(size: 9, weight: .bold))
-                            .foregroundStyle(self.commandRed.opacity(0.85))
+                            .foregroundColor(self.commandRed.opacity(0.85))
                     }
                 }
                 .buttonStyle(.plain)
@@ -938,7 +938,7 @@ struct NotchCommandOutputExpandedView: View {
                         ScrollView(.vertical, showsIndicators: false) {
                             Text(previewText)
                                 .font(.system(size: 11, weight: .medium))
-                                .foregroundStyle(.white.opacity(0.75))
+                                .foregroundColor(.white.opacity(0.75))
                                 .multilineTextAlignment(.leading)
                                 .lineLimit(nil)
                                 .fixedSize(horizontal: false, vertical: true)
@@ -952,7 +952,7 @@ struct NotchCommandOutputExpandedView: View {
                                 proxy.scrollTo("bottom", anchor: .bottom)
                             }
                         }
-                        .onChange(of: previewText) { _, _ in
+                        .onChange(of: previewText) { _ in
                             DispatchQueue.main.async {
                                 proxy.scrollTo("bottom", anchor: .bottom)
                             }
@@ -1002,14 +1002,14 @@ struct NotchCommandOutputExpandedView: View {
                 // Always scroll to bottom when view appears
                 self.scrollToBottom(proxy, animated: false)
             }
-            .onChange(of: self.contentState.commandConversationHistory.count) { _, _ in
+            .onChange(of: self.contentState.commandConversationHistory.count) { _ in
                 self.scrollToBottom(proxy, animated: true)
             }
-            .onChange(of: self.contentState.commandStreamingText) { _, _ in
+            .onChange(of: self.contentState.commandStreamingText) { _ in
                 // Disable animation for streaming text to prevent scroll bar jitter
                 self.scrollToBottom(proxy, animated: false)
             }
-            .onChange(of: self.contentState.isCommandProcessing) { _, _ in
+            .onChange(of: self.contentState.isCommandProcessing) { _ in
                 // Scroll when processing state changes
                 self.scrollToBottom(proxy, animated: true)
             }
@@ -1037,24 +1037,24 @@ struct NotchCommandOutputExpandedView: View {
                 Spacer()
                 Text(message.content)
                     .font(.system(size: 11))
-                    .foregroundStyle(.white.opacity(0.9))
+                    .foregroundColor(.white.opacity(0.9))
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .background(self.commandRed.opacity(0.25))
                     .cornerRadius(8)
                     .frame(maxWidth: 280, alignment: .trailing)
-                    .textSelection(.enabled)
+                    
 
             case .assistant:
                 Text(message.content)
                     .font(.system(size: 11))
-                    .foregroundStyle(.white.opacity(0.85))
+                    .foregroundColor(.white.opacity(0.85))
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .background(Color.white.opacity(0.08))
                     .cornerRadius(8)
                     .frame(maxWidth: 320, alignment: .leading)
-                    .textSelection(.enabled)
+                    
                 Spacer()
 
             case .status:
@@ -1064,7 +1064,7 @@ struct NotchCommandOutputExpandedView: View {
                         .frame(width: 4, height: 4)
                     Text(message.content)
                         .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.5))
+                        .foregroundColor(.white.opacity(0.5))
                 }
                 .padding(.vertical, 2)
                 Spacer()
@@ -1076,7 +1076,7 @@ struct NotchCommandOutputExpandedView: View {
         HStack(alignment: .top) {
             Text(self.contentState.commandStreamingText)
                 .font(.system(size: 11))
-                .foregroundStyle(.white.opacity(0.85))
+                .foregroundColor(.white.opacity(0.85))
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
                 .background(Color.white.opacity(0.08))
@@ -1115,20 +1115,17 @@ struct NotchCommandOutputExpandedView: View {
             TextField("Ask follow-up...", text: self.$inputText)
                 .textFieldStyle(.plain)
                 .font(.system(size: 11))
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
                 .background(Color.white.opacity(0.08))
                 .cornerRadius(8)
-                .focused(self.$isInputFocused)
-                .onSubmit {
-                    self.submitFollowUp()
-                }
+                // Note: .focused() requires macOS 12+, omitted for Big Sur compatibility
 
             Button(action: self.submitFollowUp) {
                 Image(systemName: "arrow.up.circle.fill")
                     .font(.system(size: 16))
-                    .foregroundStyle(self.inputText.isEmpty ? .white.opacity(0.3) : self.commandRed)
+                    .foregroundColor(self.inputText.isEmpty ? .white.opacity(0.3) : self.commandRed)
             }
             .buttonStyle(.plain)
             .disabled(self.inputText.isEmpty || self.contentState.isCommandProcessing)
@@ -1173,7 +1170,7 @@ struct ExpandedModeWaveformView: View {
                     .shadow(color: self.color.opacity(0.4), radius: 2, x: 0, y: 0)
             }
         }
-        .onChange(of: self.contentState.expandedModeAudioLevel) { _, level in
+        .onChange(of: self.contentState.expandedModeAudioLevel) { level in
             self.updateBars(level: level)
         }
         .onAppear {

--- a/Sources/Fluid/Views/RewriteModeView.swift
+++ b/Sources/Fluid/Views/RewriteModeView.swift
@@ -24,7 +24,7 @@ struct RewriteModeView: View {
             HStack {
                 Image(systemName: "pencil.and.outline")
                     .font(.title2)
-                    .foregroundStyle(self.theme.palette.accent)
+                    .foregroundColor(self.theme.palette.accent)
                 Text("Edit Mode")
                     .font(.title2)
                     .fontWeight(.bold)
@@ -33,7 +33,7 @@ struct RewriteModeView: View {
 
                 Button(action: { self.onClose?() }) {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
             }
@@ -43,10 +43,10 @@ struct RewriteModeView: View {
             HStack(spacing: 6) {
                 Image(systemName: "info.circle")
                     .font(.caption)
-                    .foregroundStyle(self.theme.palette.secondaryText)
+                    .foregroundColor(self.theme.palette.secondaryText)
                 Text("Edit Mode is powered by Custom Prompts.")
                     .font(.caption)
-                    .foregroundStyle(self.theme.palette.secondaryText)
+                    .foregroundColor(self.theme.palette.secondaryText)
                 Spacer(minLength: 0)
             }
             .padding(.horizontal)
@@ -67,7 +67,7 @@ struct RewriteModeView: View {
                                 Text("Original Text")
                                     .font(.caption)
                                     .fontWeight(.bold)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundColor(.secondary)
                                 Spacer()
                                 if !self.service.rewrittenText.isEmpty {
                                     Button(self.showOriginal ? "Hide" : "Show") {
@@ -84,24 +84,24 @@ struct RewriteModeView: View {
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .background(self.theme.palette.cardBackground)
                                     .cornerRadius(8)
-                                    .textSelection(.enabled)
+                                    
                             }
                         }
                     } else {
                         VStack(spacing: 12) {
                             Image(systemName: "text.bubble")
                                 .font(.system(size: 48))
-                                .foregroundStyle(self.theme.palette.accent)
+                                .foregroundColor(self.theme.palette.accent)
                             Text("Edit Mode")
                                 .font(.title2)
                                 .fontWeight(.bold)
                             Text("Ask the AI to write anything for you - emails, replies, summaries, answers, and more.")
-                                .foregroundStyle(.secondary)
+                                .foregroundColor(.secondary)
                                 .multilineTextAlignment(.center)
 
                             Text("Or select text first to rewrite existing content.")
                                 .font(.caption)
-                                .foregroundStyle(.tertiary)
+                                .foregroundColor(.secondary)
                                 .multilineTextAlignment(.center)
                                 .padding(.top, 4)
                         }
@@ -115,20 +115,20 @@ struct RewriteModeView: View {
                             Text("Rewritten Text")
                                 .font(.caption)
                                 .fontWeight(.bold)
-                                .foregroundStyle(self.theme.palette.accent)
+                                .foregroundColor(self.theme.palette.accent)
 
                             Text(self.service.rewrittenText)
                                 .padding()
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .background(self.theme.palette.accent.opacity(0.1))
                                 .cornerRadius(8)
-                                .textSelection(.enabled)
+                                
 
                             HStack {
                                 Button("Try Again") {
                                     self.service.rewrittenText = ""
                                 }
-                                .buttonStyle(.bordered)
+                                
 
                                 Spacer()
 
@@ -136,8 +136,8 @@ struct RewriteModeView: View {
                                     self.service.acceptRewrite()
                                     self.onClose?()
                                 }
-                                .buttonStyle(.borderedProminent)
-                                .tint(self.theme.palette.accent)
+                                
+                                .accentColor(self.theme.palette.accent)
                             }
                             .padding(.top, 8)
                         }
@@ -149,7 +149,7 @@ struct RewriteModeView: View {
                        service.rewrittenText.isEmpty
                     {
                         Text(lastMsg.content) // Error message usually
-                            .foregroundStyle(.red)
+                            .foregroundColor(.red)
                             .padding()
                             .background(Color.red.opacity(0.1))
                             .cornerRadius(8)
@@ -211,7 +211,6 @@ struct RewriteModeView: View {
                     text: self.$inputText
                 )
                 .textFieldStyle(.roundedBorder)
-                .onSubmit(self.submitRequest)
 
                 Button(action: self.submitRequest) {
                     Image(systemName: "arrow.up.circle.fill")
@@ -224,13 +223,13 @@ struct RewriteModeView: View {
                 Button(action: self.toggleRecording) {
                     Image(systemName: self.asr.isRunning ? "stop.circle.fill" : "mic.circle.fill")
                         .font(.title2)
-                        .foregroundStyle(self.asr.isRunning ? Color.red : self.theme.palette.accent)
+                        .foregroundColor(self.asr.isRunning ? Color.red : self.theme.palette.accent)
                 }
                 .buttonStyle(.plain)
 
                 if self.service.isProcessing {
                     ProgressView()
-                        .controlSize(.small)
+                        
                 }
             }
             .padding()
@@ -243,7 +242,7 @@ struct RewriteModeView: View {
                     .padding(.bottom, 8)
             }
         }
-        .onChange(of: self.asr.finalText) { _, newText in
+        .onChange(of: self.asr.finalText) { newText in
             if !newText.isEmpty {
                 self.inputText = newText
             }
@@ -333,7 +332,7 @@ struct RewriteModeView: View {
                     Image(systemName: self.showHowTo ? "chevron.up" : "chevron.down")
                         .font(.caption2)
                 }
-                .foregroundStyle(self.isHoveringHowTo ? .primary : .secondary)
+                .foregroundColor(self.isHoveringHowTo ? .primary : .secondary)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
                 .background(self.isHoveringHowTo ? Color.primary.opacity(0.05) : Color.clear)
@@ -351,7 +350,7 @@ struct RewriteModeView: View {
                         Text("Create New Text")
                             .font(.caption)
                             .fontWeight(.semibold)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         HStack(spacing: 4) {
                             Text("Press")
@@ -366,7 +365,7 @@ struct RewriteModeView: View {
                             Text("and speak what you want to write.")
                                 .font(.caption)
                         }
-                        .foregroundStyle(.primary.opacity(0.8))
+                        .foregroundColor(.primary.opacity(0.8))
 
                         self.howToItem("\"Write an email asking for time off\"")
                         self.howToItem("\"Draft a thank you note\"")
@@ -377,7 +376,7 @@ struct RewriteModeView: View {
                         Text("Edit Selected Text")
                             .font(.caption)
                             .fontWeight(.semibold)
-                            .foregroundStyle(.secondary)
+                            .foregroundColor(.secondary)
 
                         HStack(spacing: 4) {
                             Text("Select text first, then press")
@@ -392,7 +391,7 @@ struct RewriteModeView: View {
                             Text("and speak your instruction.")
                                 .font(.caption)
                         }
-                        .foregroundStyle(.primary.opacity(0.8))
+                        .foregroundColor(.primary.opacity(0.8))
 
                         self.howToItem("\"Make this more formal\"")
                         self.howToItem("\"Fix grammar and spelling\"")
@@ -410,10 +409,10 @@ struct RewriteModeView: View {
     private func howToItem(_ text: String) -> some View {
         HStack(spacing: 6) {
             Text("•")
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
             Text(text)
                 .font(.caption)
-                .foregroundStyle(.primary.opacity(0.8))
+                .foregroundColor(.primary.opacity(0.8))
         }
     }
 
@@ -430,7 +429,7 @@ struct RewriteModeView: View {
 
                     Image(systemName: self.isThinkingExpanded ? "chevron.up" : "chevron.down")
                         .font(.caption2)
-                        .foregroundStyle(.secondary.opacity(0.6))
+                        .foregroundColor(.secondary.opacity(0.6))
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
@@ -442,8 +441,8 @@ struct RewriteModeView: View {
                 ScrollView(.vertical, showsIndicators: true) {
                     Text(self.service.streamingThinkingText)
                         .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
+                        .foregroundColor(.secondary)
+                        
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 12)
                         .padding(.bottom, 10)
@@ -454,7 +453,7 @@ struct RewriteModeView: View {
                 if !self.service.streamingThinkingText.isEmpty {
                     Text(String(self.service.streamingThinkingText.prefix(100)) + (self.service.streamingThinkingText.count > 100 ? "..." : ""))
                         .font(.system(size: 11))
-                        .foregroundStyle(.secondary.opacity(0.7))
+                        .foregroundColor(.secondary.opacity(0.7))
                         .lineLimit(2)
                         .padding(.horizontal, 12)
                         .padding(.bottom, 8)

--- a/Sources/Fluid/fluidApp.swift
+++ b/Sources/Fluid/fluidApp.swift
@@ -22,14 +22,13 @@ struct FluidApp: App {
     }
 
     var body: some Scene {
-        WindowGroup(id: "main") {
+        WindowGroup {
             ContentView()
                 .environmentObject(self.menuBarManager)
                 .environmentObject(self.appServices)
                 .appTheme(AppTheme.dark(accent: self.settings.accentColor))
                 .preferredColorScheme(.dark)
+                .frame(minWidth: 800, idealWidth: 1000, minHeight: 500, idealHeight: 700)
         }
-        .defaultSize(width: 1000, height: 700)
-        .windowResizability(.contentSize)
     }
 }


### PR DESCRIPTION
Lower deployment target from macOS 14.0 to macOS 11.0 across Package.swift and Xcode project. Key changes:

- Replace NavigationSplitView with NavigationView for macOS 11 support
- Replace WindowGroup(id:), .defaultSize, .windowResizability with macOS 11 equivalents
- Convert all .onChange(of:) { _, newValue in } (macOS 14+) to { newValue in } form
- Replace @FocusState (macOS 12+) with @State and remove .focused() modifiers
- Add URLSession compatibility layer (compatData/compatStreamLines) for async APIs that require macOS 12+, with completion-handler fallback for macOS 11
- Replace .foregroundStyle() (macOS 12+) with .foregroundColor() throughout
- Convert #Preview macros (macOS 14+) to PreviewProvider structs
- Replace Material types with Color-based alternatives for macOS 11
- Convert .alert with actions/message closures (macOS 12+) to Alert() struct
- Replace .confirmationDialog (macOS 12+) with .alert/Alert
- Remove .buttonStyle(.bordered/.borderedProminent) (macOS 12+)
- Remove Button(role:) parameter (macOS 12+)
- Remove .controlSize() modifier (macOS 12+)
- Replace .tint() with .accentColor()
- Replace .formatted() with DateFormatter
- Remove .onSubmit (macOS 12+), .scrollContentBackground, .textSelection
- Replace .background { } block syntax with .background() call syntax
- Replace .overlay(alignment:) { } with .overlay(_, alignment:) form
- Replace AnyShapeStyle with direct Color usage
- Update README to reflect macOS 11+ support with compatibility notes

https://claude.ai/code/session_01DjX52humspsVdxMfxZH7ro

## Description
Brief description of what this PR does.

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
Closes #(issue number)

## Testing
- [ ] Tested on Intel/Apple Silicon Mac
- [ ] Tested on Apple Silicon Mac
- [ ] Tested on macOS [version]
- [ ] Ran linter locally: `brew install swiftlint && swiftlint --strict --config .swiftlint.yml`
- [ ] Ran formatter locally: `brew install swiftformat && swiftformat --config .swiftformat Sources`

## Screenshots / Video 
Add screenshots or Video recording of the app after you have made your changes 