### PR TITLE
Polish onboarding recovery and clarify Parakeet language support

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -953,6 +953,7 @@ struct ContentView: View {
                 self.completeOnboardingIfPossible()
             },
             openAccessibilitySettings: self.openAccessibilitySettings,
+            restartApp: self.restartApp,
             menuBarManager: self.menuBarManager,
             theme: self.theme
         )
@@ -969,7 +970,8 @@ struct ContentView: View {
             accessibilityEnabled: self.accessibilityEnabled,
             stopAndProcessTranscription: { await self.stopAndProcessTranscription() },
             startRecording: self.startRecording,
-            openAccessibilitySettings: self.openAccessibilitySettings
+            openAccessibilitySettings: self.openAccessibilitySettings,
+            restartApp: self.restartApp
         )
     }
 

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2649,6 +2649,30 @@ extension SettingsStore {
     }
 }
 
+extension SettingsStore.SpeechModel {
+    var supportedLanguageCodes: String? {
+        switch self {
+        case .parakeetTDT:
+            return "BG, HR, CS, DA, NL, EN, ET, FI, FR, DE, EL, HU, IT, LV, LT, MT, PL, PT, RO, SK, SL, ES, SV, RU, UK"
+        case .appleSpeechAnalyzer:
+            return "EN, ES, FR, DE, IT, JA, KO, PT, ZH"
+        default:
+            return nil
+        }
+    }
+
+    var supportedLanguageNames: String? {
+        switch self {
+        case .parakeetTDT:
+            return """
+            Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Slovak, Slovenian, Spanish, Swedish, Russian, and Ukrainian
+            """
+        default:
+            return nil
+        }
+    }
+}
+
 extension SettingsStore {
     // MARK: - Unified Speech Model Selection
 

--- a/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
+++ b/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
@@ -218,6 +218,13 @@ extension VoiceEngineSettingsView {
                         Spacer()
                     }
 
+                    if let supportedLanguageCodes = model.supportedLanguageCodes {
+                        Text(supportedLanguageCodes)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+
                     // Memory warning for large models
                     if let memoryWarning = model.memoryWarning {
                         HStack(spacing: 6) {

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -22,6 +22,7 @@ struct WelcomeView: View {
     let stopAndProcessTranscription: () async -> Void
     let startRecording: () -> Void
     let openAccessibilitySettings: () -> Void
+    let restartApp: () -> Void
 
     private var commandModeShortcutDisplay: String {
         self.settings.commandModeHotkeyShortcut.displayString
@@ -31,431 +32,449 @@ struct WelcomeView: View {
         self.settings.rewriteModeHotkeyShortcut.displayString
     }
 
+    private let playgroundSectionID = "welcome-playground-section"
+
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                // Header
-                HStack(spacing: 10) {
-                    Image(systemName: "book.fill")
-                        .font(.title2)
-                        .foregroundStyle(self.theme.palette.accent)
-                    Text((self.asr.isAsrReady || self.asr.modelsExistOnDisk) ? "Getting Started" : "Welcome to FluidVoice")
-                        .font(.title2.weight(.bold))
-                }
-                .padding(.bottom, 4)
-
-                // Quick Setup Checklist
-                ThemedCard(style: .prominent) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Label("Quick Setup", systemImage: "checkmark.circle.fill")
-                            .font(.headline)
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    // Header
+                    HStack(spacing: 10) {
+                        Image(systemName: "book.fill")
+                            .font(.title2)
                             .foregroundStyle(self.theme.palette.accent)
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            SetupStepView(
-                                step: 1,
-                                // Consider model step complete if ready OR downloaded (even if not loaded)
-                                title: (self.asr.isAsrReady || self.asr.modelsExistOnDisk) ? "Voice Model Ready" : "Download Voice Model",
-                                description: self.asr.isAsrReady
-                                    ? "Speech recognition model is loaded and ready"
-                                    : (self.asr.modelsExistOnDisk
-                                        ? "Model downloaded, will load when needed"
-                                        : "Download the AI model for offline voice transcription (~500MB)"),
-                                status: (self.asr.isAsrReady || self.asr.modelsExistOnDisk) ? .completed : .pending,
-                                action: {
-                                    self.selectedSidebarItem = .voiceEngine
-                                },
-                                actionButtonTitle: "Go to Voice Engine",
-                                showActionButton: !(self.asr.isAsrReady || self.asr.modelsExistOnDisk)
-                            )
-
-                            SetupStepView(
-                                step: 2,
-                                title: self.asr.micStatus == .authorized ? "Microphone Permission Granted" : "Grant Microphone Permission",
-                                description: self.asr.micStatus == .authorized
-                                    ? "FluidVoice has access to your microphone"
-                                    : "Allow FluidVoice to access your microphone for voice input",
-                                status: self.asr.micStatus == .authorized ? .completed : .pending,
-                                action: {
-                                    if self.asr.micStatus == .notDetermined {
-                                        self.asr.requestMicAccess()
-                                    } else if self.asr.micStatus == .denied {
-                                        self.asr.openSystemSettingsForMic()
-                                    }
-                                },
-                                actionButtonTitle: self.asr.micStatus == .notDetermined ? "Grant Access" : "Open Settings",
-                                showActionButton: self.asr.micStatus != .authorized
-                            )
-
-                            SetupStepView(
-                                step: 3,
-                                title: self.accessibilityEnabled ? "Accessibility Enabled" : "Enable Accessibility",
-                                description: self.accessibilityEnabled
-                                    ? "Accessibility permission granted for typing into apps"
-                                    : "Grant accessibility permission to type text into other apps",
-                                status: self.accessibilityEnabled ? .completed : .pending,
-                                action: {
-                                    self.openAccessibilitySettings()
-                                },
-                                actionButtonTitle: "Open Settings",
-                                showActionButton: !self.accessibilityEnabled
-                            )
-
-                            SetupStepView(
-                                step: 4,
-                                title: self.settings.isAIConfigured ? "AI Enhancement Configured" : "Set Up AI Enhancement (Optional)",
-                                description: self.settings.isAIConfigured
-                                    ? "AI-powered text enhancement is ready to use"
-                                    : "Configure API keys for AI-powered text enhancement",
-                                status: self.settings.isAIConfigured ? .completed : .pending,
-                                action: {
-                                    self.selectedSidebarItem = .aiEnhancements
-                                },
-                                actionButtonTitle: "Configure AI"
-                            )
-
-                            SetupStepView(
-                                step: 5,
-                                title: self.playgroundUsed ? "Setup Tested Successfully" : "Test Your Setup",
-                                description: self.playgroundUsed
-                                    ? "You've successfully tested voice transcription"
-                                    : "Try the playground below to test your complete setup",
-                                status: self.playgroundUsed ? .completed : .pending,
-                                action: {
-                                    // Scroll to playground or focus on it
-                                    withAnimation {
-                                        self.isTranscriptionFocused.wrappedValue = true
-                                    }
-                                },
-                                actionButtonTitle: "Go to Playground",
-                                showActionButton: !self.playgroundUsed
-                            )
-                            .id("playground-step-\(self.playgroundUsed)")
-                        }
+                        Text((self.asr.isAsrReady || self.asr.modelsExistOnDisk) ? "Getting Started" : "Welcome to FluidVoice")
+                            .font(.title2.weight(.bold))
                     }
-                    .padding(14)
-                }
+                    .padding(.bottom, 4)
 
-                // How to Use
-                ThemedCard(style: .standard) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Label("How to Use", systemImage: "play.fill")
-                            .font(.headline)
-                            .foregroundStyle(Color.fluidGreen)
+                    // Quick Setup Checklist
+                    ThemedCard(style: .prominent) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack(spacing: 10) {
+                                Label("Quick Setup", systemImage: "checkmark.circle.fill")
+                                    .font(.headline)
+                                    .foregroundStyle(self.theme.palette.accent)
 
-                        VStack(alignment: .leading, spacing: 10) {
-                            self.howToStep(number: 1, title: "Start Recording", description: "Press your hotkey (default: Right Option/Alt) or click the button")
-                            self.howToStep(number: 2, title: "Speak Clearly", description: "Speak naturally - works best in quiet environments")
-                            self.howToStep(number: 3, title: "Auto-Type Result", description: "Transcription is automatically typed into your focused app")
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(16)
-                }
-                .frame(maxWidth: .infinity)
+                                Spacer()
 
-                // Command Mode
-                ThemedCard(style: .standard) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        HStack(spacing: 8) {
-                            Label("Command Mode", systemImage: "terminal.fill")
-                                .font(.headline)
-                                .foregroundStyle(Color(red: 1.0, green: 0.35, blue: 0.35))
-
-                            self.featureBadge("New", color: Color(red: 1.0, green: 0.35, blue: 0.35))
-                            self.featureBadge("Alpha", color: Color(red: 1.0, green: 0.35, blue: 0.35).opacity(0.7))
-
-                            Spacer()
-
-                            Button("Open") {
-                                self.selectedSidebarItem = .commandMode
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-
-                        Text("Control your Mac with voice commands. Execute terminal commands, open apps, and more.")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Getting Started")
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(.orange)
-
-                            HStack(spacing: 4) {
-                                Text("Press")
-                                self.keyboardBadge(self.commandModeShortcutDisplay)
-                                Text("to open, speak your command, then press again to send.")
-                            }
-                            .font(.caption)
-                            .foregroundStyle(.primary.opacity(0.8))
-                        }
-
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Examples")
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(.orange)
-                            self.commandModeExample(icon: "folder", text: "\"List files in my Downloads folder\"")
-                            self.commandModeExample(icon: "plus.rectangle.on.folder", text: "\"Create a folder called Projects on Desktop\"")
-                            self.commandModeExample(icon: "network", text: "\"What's my IP address?\"")
-                            self.commandModeExample(icon: "safari", text: "\"Open Safari\"")
-                        }
-
-                        HStack(spacing: 4) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .font(.caption2)
-                                .foregroundStyle(.orange)
-                            Text("AI can make mistakes. Avoid destructive commands.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .padding(16)
-                }
-                .frame(maxWidth: .infinity)
-
-                // Edit Mode
-                ThemedCard(style: .standard) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        HStack(spacing: 8) {
-                            Label("Edit Mode", systemImage: "pencil.and.outline")
-                                .font(.headline)
-                                .foregroundStyle(.blue)
-
-                            self.featureBadge("New", color: .blue)
-
-                            Spacer()
-
-                            Button("Open AI Settings") {
-                                self.selectedSidebarItem = .aiEnhancements
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-
-                        Text("AI-powered editing assistant. Write fresh content or edit selected text with voice.")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-
-                        VStack(alignment: .leading, spacing: 10) {
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Create New Text")
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(.blue)
-
-                                HStack(spacing: 4) {
-                                    Text("Press")
-                                    self.keyboardBadge(self.writeModeShortcutDisplay)
-                                    Text("and speak what you want to write.")
-                                }
-                                .font(.caption)
-                                .foregroundStyle(.primary.opacity(0.8))
-
-                                self.writeModeExample(text: "\"Write an email asking for time off\"")
-                                self.writeModeExample(text: "\"Draft a thank you note\"")
-                            }
-
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Edit Selected Text")
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(.blue)
-
-                                HStack(spacing: 4) {
-                                    Text("Select text first, then press")
-                                    self.keyboardBadge(self.writeModeShortcutDisplay)
-                                    Text("and speak your instruction.")
-                                }
-                                .font(.caption)
-                                .foregroundStyle(.primary.opacity(0.8))
-
-                                self.writeModeExample(text: "\"Make this more formal\"")
-                                self.writeModeExample(text: "\"Fix grammar and spelling\"")
-                                self.writeModeExample(text: "\"Summarize this\"")
-                            }
-                        }
-                    }
-                    .padding(16)
-                }
-                .frame(maxWidth: .infinity)
-
-                // Test Playground
-                ThemedCard(hoverEffect: false) {
-                    VStack(alignment: .leading, spacing: 14) {
-                        HStack {
-                            Label {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text("Test Playground")
-                                        .font(.headline)
-                                    Text("Click record, speak, and see your transcription")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                            } icon: {
-                                Image(systemName: "text.bubble")
-                                    .font(.title3)
-                            }
-
-                            Spacer()
-
-                            if self.asr.isRunning {
-                                HStack(spacing: 6) {
-                                    Circle()
-                                        .fill(.red)
-                                        .frame(width: 6, height: 6)
-                                    Text("Recording...")
-                                        .font(.caption.weight(.medium))
-                                        .foregroundStyle(.red)
-                                }
-                            } else if !self.asr.finalText.isEmpty {
-                                Text("\(self.asr.finalText.count) characters")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            if !self.asr.finalText.isEmpty {
                                 Button {
-                                    NSPasteboard.general.clearContents()
-                                    NSPasteboard.general.setString(self.asr.finalText, forType: .string)
+                                    self.settings.resetOnboardingProgress()
+                                    self.playgroundUsed = false
                                 } label: {
-                                    Label("Copy", systemImage: "doc.on.doc")
+                                    Label("Run Onboarding Again", systemImage: "arrow.counterclockwise")
                                 }
                                 .buttonStyle(.bordered)
                                 .controlSize(.small)
                             }
-                        }
 
-                        if self.settings.selectedSpeechModel == .parakeetTDT || self.settings.selectedSpeechModel == .parakeetTDTv2 {
-                            HStack(spacing: 6) {
-                                Image(systemName: "text.magnifyingglass")
-                                    .font(.caption)
-                                    .foregroundStyle(self.theme.palette.accent)
-                                Text(self.asr.wordBoostStatusText)
+                            VStack(alignment: .leading, spacing: 8) {
+                                SetupStepView(
+                                    step: 1,
+                                    // Consider model step complete if ready OR downloaded (even if not loaded)
+                                    title: (self.asr.isAsrReady || self.asr.modelsExistOnDisk) ? "Voice Model Ready" : "Download Voice Model",
+                                    description: self.asr.isAsrReady
+                                        ? "Speech recognition model is loaded and ready"
+                                        : (self.asr.modelsExistOnDisk
+                                            ? "Model downloaded, will load when needed"
+                                            : "Download the AI model for offline voice transcription (~500MB)"),
+                                    status: (self.asr.isAsrReady || self.asr.modelsExistOnDisk) ? .completed : .pending,
+                                    action: {
+                                        self.selectedSidebarItem = .voiceEngine
+                                    },
+                                    actionButtonTitle: "Go to Voice Engine",
+                                    showActionButton: !(self.asr.isAsrReady || self.asr.modelsExistOnDisk)
+                                )
+
+                                SetupStepView(
+                                    step: 2,
+                                    title: self.asr.micStatus == .authorized ? "Microphone Permission Granted" : "Grant Microphone Permission",
+                                    description: self.asr.micStatus == .authorized
+                                        ? "FluidVoice has access to your microphone"
+                                        : "Allow FluidVoice to access your microphone for voice input",
+                                    status: self.asr.micStatus == .authorized ? .completed : .pending,
+                                    action: {
+                                        if self.asr.micStatus == .notDetermined {
+                                            self.asr.requestMicAccess()
+                                        } else if self.asr.micStatus == .denied {
+                                            self.asr.openSystemSettingsForMic()
+                                        }
+                                    },
+                                    actionButtonTitle: self.asr.micStatus == .notDetermined ? "Grant Access" : "Open Settings",
+                                    showActionButton: self.asr.micStatus != .authorized
+                                )
+
+                                SetupStepView(
+                                    step: 3,
+                                    title: self.accessibilityEnabled ? "Accessibility Enabled" : "Enable Accessibility",
+                                    description: self.accessibilityEnabled
+                                        ? "Accessibility permission granted for typing into apps"
+                                        : "Grant accessibility permission to type text into other apps",
+                                    status: self.accessibilityEnabled ? .completed : .pending,
+                                    action: {
+                                        self.openAccessibilitySettings()
+                                    },
+                                    actionButtonTitle: "Open Settings",
+                                    showActionButton: !self.accessibilityEnabled
+                                )
+
+                                SetupStepView(
+                                    step: 4,
+                                    title: self.settings.isAIConfigured ? "AI Enhancement Configured" : "Set Up AI Enhancement (Optional)",
+                                    description: self.settings.isAIConfigured
+                                        ? "AI-powered text enhancement is ready to use"
+                                        : "Configure API keys for AI-powered text enhancement",
+                                    status: self.settings.isAIConfigured ? .completed : .pending,
+                                    action: {
+                                        self.selectedSidebarItem = .aiEnhancements
+                                    },
+                                    actionButtonTitle: "Configure AI"
+                                )
+
+                                SetupStepView(
+                                    step: 5,
+                                    title: self.playgroundUsed ? "Setup Tested Successfully" : "Test Your Setup",
+                                    description: self.playgroundUsed
+                                        ? "You've successfully tested voice transcription"
+                                        : "Try the playground below to test your complete setup",
+                                    status: self.playgroundUsed ? .completed : .pending,
+                                    action: {
+                                        withAnimation(.easeInOut(duration: 0.25)) {
+                                            proxy.scrollTo(self.playgroundSectionID, anchor: .top)
+                                        }
+                                        self.isTranscriptionFocused.wrappedValue = true
+                                    },
+                                    actionButtonTitle: "Go to Playground",
+                                    showActionButton: !self.playgroundUsed
+                                )
+                                .id("playground-step-\(self.playgroundUsed)")
+                            }
+                        }
+                        .padding(14)
+                    }
+
+                    // How to Use
+                    ThemedCard(style: .standard) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Label("How to Use", systemImage: "play.fill")
+                                .font(.headline)
+                                .foregroundStyle(Color.fluidGreen)
+
+                            VStack(alignment: .leading, spacing: 10) {
+                                self.howToStep(number: 1, title: "Start Recording", description: "Press your hotkey (default: Right Option/Alt) or click the button")
+                                self.howToStep(number: 2, title: "Speak Clearly", description: "Speak naturally - works best in quiet environments")
+                                self.howToStep(number: 3, title: "Auto-Type Result", description: "Transcription is automatically typed into your focused app")
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(16)
+                    }
+                    .frame(maxWidth: .infinity)
+
+                    // Command Mode
+                    ThemedCard(style: .standard) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack(spacing: 8) {
+                                Label("Command Mode", systemImage: "terminal.fill")
+                                    .font(.headline)
+                                    .foregroundStyle(Color(red: 1.0, green: 0.35, blue: 0.35))
+
+                                self.featureBadge("New", color: Color(red: 1.0, green: 0.35, blue: 0.35))
+                                self.featureBadge("Alpha", color: Color(red: 1.0, green: 0.35, blue: 0.35).opacity(0.7))
+
+                                Spacer()
+
+                                Button("Open") {
+                                    self.selectedSidebarItem = .commandMode
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                            }
+
+                            Text("Control your Mac with voice commands. Execute terminal commands, open apps, and more.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Getting Started")
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(.orange)
+
+                                HStack(spacing: 4) {
+                                    Text("Press")
+                                    self.keyboardBadge(self.commandModeShortcutDisplay)
+                                    Text("to open, speak your command, then press again to send.")
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.primary.opacity(0.8))
+                            }
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Examples")
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(.orange)
+                                self.commandModeExample(icon: "folder", text: "\"List files in my Downloads folder\"")
+                                self.commandModeExample(icon: "plus.rectangle.on.folder", text: "\"Create a folder called Projects on Desktop\"")
+                                self.commandModeExample(icon: "network", text: "\"What's my IP address?\"")
+                                self.commandModeExample(icon: "safari", text: "\"Open Safari\"")
+                            }
+
+                            HStack(spacing: 4) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .font(.caption2)
+                                    .foregroundStyle(.orange)
+                                Text("AI can make mistakes. Avoid destructive commands.")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
-                                    .lineLimit(1)
                             }
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(self.theme.palette.contentBackground.opacity(0.6))
-                            )
                         }
+                        .padding(16)
+                    }
+                    .frame(maxWidth: .infinity)
 
+                    // Edit Mode
+                    ThemedCard(style: .standard) {
                         VStack(alignment: .leading, spacing: 12) {
-                            // Recording Control
-                            VStack(spacing: 10) {
-                                Button {
-                                    if self.asr.isRunning {
-                                        Task {
-                                            await self.stopAndProcessTranscription()
-                                        }
-                                    } else {
-                                        self.startRecording()
-                                        self.playgroundUsed = true
-                                        SettingsStore.shared.playgroundUsed = true
-                                    }
-                                } label: {
-                                    HStack {
-                                        Image(systemName: self.asr.isRunning ? "stop.fill" : "mic.fill")
-                                        Text(self.asr.isRunning ? "Stop Recording" : "Start Recording")
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                }
-                                .buttonStyle(PremiumButtonStyle(isRecording: self.asr.isRunning))
-                                .buttonHoverEffect()
-                                .scaleEffect(self.asr.isRunning ? 1.02 : 1.0)
-                                .animation(.spring(response: 0.3), value: self.asr.isRunning)
-                                .disabled(!self.asr.isAsrReady && !self.asr.isRunning)
+                            HStack(spacing: 8) {
+                                Label("Edit Mode", systemImage: "pencil.and.outline")
+                                    .font(.headline)
+                                    .foregroundStyle(.blue)
 
-                                if !self.asr.isRunning && !self.asr.finalText.isEmpty {
-                                    Button("Clear Results") {
-                                        self.asr.finalText = ""
+                                self.featureBadge("New", color: .blue)
+
+                                Spacer()
+
+                                Button("Open AI Settings") {
+                                    self.selectedSidebarItem = .aiEnhancements
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                            }
+
+                            Text("AI-powered editing assistant. Write fresh content or edit selected text with voice.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+
+                            VStack(alignment: .leading, spacing: 10) {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Create New Text")
+                                        .font(.subheadline.weight(.medium))
+                                        .foregroundStyle(.blue)
+
+                                    HStack(spacing: 4) {
+                                        Text("Press")
+                                        self.keyboardBadge(self.writeModeShortcutDisplay)
+                                        Text("and speak what you want to write.")
+                                    }
+                                    .font(.caption)
+                                    .foregroundStyle(.primary.opacity(0.8))
+
+                                    self.writeModeExample(text: "\"Write an email asking for time off\"")
+                                    self.writeModeExample(text: "\"Draft a thank you note\"")
+                                }
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Edit Selected Text")
+                                        .font(.subheadline.weight(.medium))
+                                        .foregroundStyle(.blue)
+
+                                    HStack(spacing: 4) {
+                                        Text("Select text first, then press")
+                                        self.keyboardBadge(self.writeModeShortcutDisplay)
+                                        Text("and speak your instruction.")
+                                    }
+                                    .font(.caption)
+                                    .foregroundStyle(.primary.opacity(0.8))
+
+                                    self.writeModeExample(text: "\"Make this more formal\"")
+                                    self.writeModeExample(text: "\"Fix grammar and spelling\"")
+                                    self.writeModeExample(text: "\"Summarize this\"")
+                                }
+                            }
+                        }
+                        .padding(16)
+                    }
+                    .frame(maxWidth: .infinity)
+
+                    // Test Playground
+                    ThemedCard(hoverEffect: false) {
+                        VStack(alignment: .leading, spacing: 14) {
+                            HStack {
+                                Label {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text("Test Playground")
+                                            .font(.headline)
+                                        Text("Click record, speak, and see your transcription")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                } icon: {
+                                    Image(systemName: "text.bubble")
+                                        .font(.title3)
+                                }
+
+                                Spacer()
+
+                                if self.asr.isRunning {
+                                    HStack(spacing: 6) {
+                                        Circle()
+                                            .fill(.red)
+                                            .frame(width: 6, height: 6)
+                                        Text("Recording...")
+                                            .font(.caption.weight(.medium))
+                                            .foregroundStyle(.red)
+                                    }
+                                } else if !self.asr.finalText.isEmpty {
+                                    Text("\(self.asr.finalText.count) characters")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                if !self.asr.finalText.isEmpty {
+                                    Button {
+                                        NSPasteboard.general.clearContents()
+                                        NSPasteboard.general.setString(self.asr.finalText, forType: .string)
+                                    } label: {
+                                        Label("Copy", systemImage: "doc.on.doc")
                                     }
                                     .buttonStyle(.bordered)
                                     .controlSize(.small)
                                 }
                             }
 
-                            // Text Area
-                            VStack(alignment: .leading, spacing: 8) {
-                                TextEditor(text: Binding(
-                                    get: { self.asr.finalText },
-                                    set: { self.asr.finalText = $0 }
-                                ))
-                                .font(.body)
-                                .focused(self.isTranscriptionFocused)
-                                .frame(height: 140)
-                                .padding(10)
+                            if self.settings.selectedSpeechModel == .parakeetTDT || self.settings.selectedSpeechModel == .parakeetTDTv2 {
+                                HStack(spacing: 6) {
+                                    Image(systemName: "text.magnifyingglass")
+                                        .font(.caption)
+                                        .foregroundStyle(self.theme.palette.accent)
+                                    Text(self.asr.wordBoostStatusText)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
                                 .background(
-                                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                        .fill(
-                                            self.asr.isRunning ? self.theme.palette.accent.opacity(0.06) : self.theme.palette.cardBackground
-                                        )
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                                .strokeBorder(
-                                                    self.asr.isRunning ? self.theme.palette.accent.opacity(0.4) : self.theme.palette.cardBorder.opacity(0.6),
-                                                    lineWidth: self.asr.isRunning ? 2 : 1
-                                                )
-                                        )
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .fill(self.theme.palette.contentBackground.opacity(0.6))
                                 )
-                                .scrollContentBackground(.hidden)
-                                .overlay(
-                                    VStack(spacing: 8) {
+                            }
+
+                            VStack(alignment: .leading, spacing: 12) {
+                                // Recording Control
+                                VStack(spacing: 10) {
+                                    Button {
                                         if self.asr.isRunning {
-                                            Image(systemName: "waveform")
-                                                .font(.title2)
-                                                .foregroundStyle(self.theme.palette.accent)
-                                            Text("Listening... Speak now!")
-                                                .font(.subheadline.weight(.medium))
-                                                .foregroundStyle(self.theme.palette.accent)
-                                            Text("Transcription will appear when you stop recording")
-                                                .font(.caption)
-                                                .foregroundStyle(self.theme.palette.accent.opacity(0.7))
-                                        } else if self.asr.finalText.isEmpty {
-                                            Image(systemName: "text.bubble")
-                                                .font(.title2)
-                                                .foregroundStyle(.secondary.opacity(0.5))
-                                            Text("Ready to test!")
-                                                .font(.subheadline.weight(.medium))
-                                            Text("Click 'Start Recording' or press your hotkey")
-                                                .font(.caption)
-                                                .foregroundStyle(.secondary)
+                                            Task {
+                                                await self.stopAndProcessTranscription()
+                                            }
+                                        } else {
+                                            self.startRecording()
+                                            self.playgroundUsed = true
+                                            SettingsStore.shared.playgroundUsed = true
                                         }
+                                    } label: {
+                                        HStack {
+                                            Image(systemName: self.asr.isRunning ? "stop.fill" : "mic.fill")
+                                            Text(self.asr.isRunning ? "Stop Recording" : "Start Recording")
+                                        }
+                                        .frame(maxWidth: .infinity)
                                     }
-                                    .allowsHitTesting(false)
-                                )
+                                    .buttonStyle(PremiumButtonStyle(isRecording: self.asr.isRunning))
+                                    .buttonHoverEffect()
+                                    .scaleEffect(self.asr.isRunning ? 1.02 : 1.0)
+                                    .animation(.spring(response: 0.3), value: self.asr.isRunning)
+                                    .disabled(!self.asr.isAsrReady && !self.asr.isRunning)
 
-                                if !self.asr.finalText.isEmpty {
-                                    HStack(spacing: 8) {
-                                        Button {
-                                            NSPasteboard.general.clearContents()
-                                            NSPasteboard.general.setString(self.asr.finalText, forType: .string)
-                                        } label: {
-                                            Label("Copy Text", systemImage: "doc.on.doc")
-                                        }
-                                        .buttonStyle(.borderedProminent)
-                                        .tint(self.theme.palette.accent)
-                                        .controlSize(.small)
-
-                                        Button("Clear & Test Again") {
+                                    if !self.asr.isRunning && !self.asr.finalText.isEmpty {
+                                        Button("Clear Results") {
                                             self.asr.finalText = ""
                                         }
                                         .buttonStyle(.bordered)
                                         .controlSize(.small)
+                                    }
+                                }
 
-                                        Spacer()
+                                // Text Area
+                                VStack(alignment: .leading, spacing: 8) {
+                                    TextEditor(text: Binding(
+                                        get: { self.asr.finalText },
+                                        set: { self.asr.finalText = $0 }
+                                    ))
+                                    .font(.body)
+                                    .focused(self.isTranscriptionFocused)
+                                    .frame(height: 140)
+                                    .padding(10)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                            .fill(
+                                                self.asr.isRunning ? self.theme.palette.accent.opacity(0.06) : self.theme.palette.cardBackground
+                                            )
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                                    .strokeBorder(
+                                                        self.asr.isRunning ? self.theme.palette.accent.opacity(0.4) : self.theme.palette.cardBorder.opacity(0.6),
+                                                        lineWidth: self.asr.isRunning ? 2 : 1
+                                                    )
+                                            )
+                                    )
+                                    .scrollContentBackground(.hidden)
+                                    .overlay(
+                                        VStack(spacing: 8) {
+                                            if self.asr.isRunning {
+                                                Image(systemName: "waveform")
+                                                    .font(.title2)
+                                                    .foregroundStyle(self.theme.palette.accent)
+                                                Text("Listening... Speak now!")
+                                                    .font(.subheadline.weight(.medium))
+                                                    .foregroundStyle(self.theme.palette.accent)
+                                                Text("Transcription will appear when you stop recording")
+                                                    .font(.caption)
+                                                    .foregroundStyle(self.theme.palette.accent.opacity(0.7))
+                                            } else if self.asr.finalText.isEmpty {
+                                                Image(systemName: "text.bubble")
+                                                    .font(.title2)
+                                                    .foregroundStyle(.secondary.opacity(0.5))
+                                                Text("Ready to test!")
+                                                    .font(.subheadline.weight(.medium))
+                                                Text("Click 'Start Recording' or press your hotkey")
+                                                    .font(.caption)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                        }
+                                        .allowsHitTesting(false)
+                                    )
+
+                                    if !self.asr.finalText.isEmpty {
+                                        HStack(spacing: 8) {
+                                            Button {
+                                                NSPasteboard.general.clearContents()
+                                                NSPasteboard.general.setString(self.asr.finalText, forType: .string)
+                                            } label: {
+                                                Label("Copy Text", systemImage: "doc.on.doc")
+                                            }
+                                            .buttonStyle(.borderedProminent)
+                                            .tint(self.theme.palette.accent)
+                                            .controlSize(.small)
+
+                                            Button("Clear & Test Again") {
+                                                self.asr.finalText = ""
+                                            }
+                                            .buttonStyle(.bordered)
+                                            .controlSize(.small)
+
+                                            Spacer()
+                                        }
                                     }
                                 }
                             }
                         }
+                        .padding(16)
                     }
-                    .padding(16)
+                    .id(self.playgroundSectionID)
                 }
+                .padding(16)
             }
-            .padding(16)
         }
         .onAppear {
             // CRITICAL FIX: Refresh microphone and model status immediately on appear
@@ -544,6 +563,7 @@ struct OnboardingFlowView: View {
     let markPlaygroundValidated: () -> Void
     let finishOnboarding: () -> Void
     let openAccessibilitySettings: () -> Void
+    let restartApp: () -> Void
     let menuBarManager: MenuBarManager
     let theme: AppTheme
 
@@ -689,10 +709,6 @@ struct OnboardingFlowView: View {
 
     private var shouldShowAlternativeModels: Bool {
         !self.shouldShowLanguageChoice || self.preferredLanguageChoice == .other
-    }
-
-    private var parakeetV3LanguageNames: String {
-        "Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Hungarian, Italian, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Slovak, Slovenian, Spanish, Swedish, Russian, and Ukrainian"
     }
 
     private var isRecommendedModelSelected: Bool {
@@ -888,8 +904,14 @@ struct OnboardingFlowView: View {
                                     .foregroundStyle(.secondary)
                             }
 
-                            if self.recommendedOnboardingModel == .parakeetTDT {
-                                Text("Supported languages: \(self.parakeetV3LanguageNames)")
+                            if let supportedLanguageCodes = self.recommendedOnboardingModel.supportedLanguageCodes {
+                                Text(supportedLanguageCodes)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            if let supportedLanguageNames = self.recommendedOnboardingModel.supportedLanguageNames {
+                                Text("Supported languages: \(supportedLanguageNames)")
                                     .font(.caption2)
                                     .foregroundStyle(.secondary)
                             }
@@ -1076,10 +1098,17 @@ struct OnboardingFlowView: View {
                                     .foregroundStyle(.secondary)
                                 Text("1. Click \"Enable Accessibility\"")
                                 Text("2. Add or enable FluidVoice in Accessibility")
-                                Text("3. Return here and continue")
+                                Text("3. FluidVoice should restart automatically")
+                                Text("4. If it does not, use Restart FluidVoice below")
                             }
                             .font(.caption)
                             .foregroundStyle(.secondary)
+
+                            Button("Restart FluidVoice") {
+                                self.restartApp()
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
                         }
                     }
                     .padding(16)
@@ -1296,8 +1325,14 @@ struct OnboardingFlowView: View {
                                 .foregroundStyle(.secondary)
                         }
 
-                        if model == .parakeetTDT {
-                            Text("Supported languages: \(self.parakeetV3LanguageNames)")
+                        if let supportedLanguageCodes = model.supportedLanguageCodes {
+                            Text(supportedLanguageCodes)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        if let supportedLanguageNames = model.supportedLanguageNames {
+                            Text("Supported languages: \(supportedLanguageNames)")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }


### PR DESCRIPTION
## Summary
- add a visible way to replay onboarding from Getting Started
- scroll the setup checklist's playground step directly to the playground section
- clarify Parakeet v3 language coverage with short codes in onboarding and voice engine settings
- add a manual accessibility restart fallback while keeping the existing auto-restart path

## Verification
- swiftformat --config .swiftformat Sources
- swiftlint --strict --config .swiftlint.yml Sources/
- sh build_incremental.sh