### PR TITLE
Stop Reliable Paste after successful paste dispatch

### DIFF
--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -31,12 +31,6 @@ final class TypingService {
         let items: [PasteboardItemSnapshot]
     }
 
-    private struct FocusedTextSnapshot {
-        let pid: pid_t
-        let value: String?
-        let selectedRange: CFRange?
-    }
-
     private static let focusSnapshotQueue = DispatchQueue(label: "TypingService.FocusSnapshot")
     private static var focusSnapshot: FocusSnapshot?
 
@@ -299,33 +293,21 @@ final class TypingService {
 
     private func tryReliablePasteInsertion(_ text: String, preferredTargetPID: pid_t?) -> Bool {
         self.log("[TypingService] Trying global clipboard insertion")
-        if self.performVerifiedPasteAttempt(
-            methodName: "Global clipboard",
-            action: { self.insertTextViaClipboard(text) }
-        ) {
+        if self.insertTextViaClipboard(text) {
+            self.log("[TypingService] Reliable Paste dispatched via global clipboard paste")
             return true
         }
 
         self.log("[TypingService] Global clipboard insertion failed, trying menu paste")
-        if self.performVerifiedPasteAttempt(
-            methodName: "Menu paste",
-            action: { self.insertTextViaMenuPaste(text) }
-        ) {
+        if self.insertTextViaMenuPaste(text) {
+            self.log("[TypingService] Reliable Paste dispatched via menu paste")
             return true
         }
 
         if let preferredTargetPID, preferredTargetPID > 0 {
             self.log("[TypingService] Menu paste failed, trying clipboard-to-PID fallback")
-            if NSWorkspace.shared.frontmostApplication?.processIdentifier != preferredTargetPID {
-                _ = Self.activateApp(pid: preferredTargetPID)
-                usleep(80_000)
-            }
-
-            if self.performVerifiedPasteAttempt(
-                methodName: "Clipboard-to-PID",
-                expectedPID: preferredTargetPID,
-                action: { self.insertTextViaClipboardToPid(text, targetPID: preferredTargetPID, activateTargetFirst: false) }
-            ) {
+            if self.insertTextViaClipboardToPid(text, targetPID: preferredTargetPID) {
+                self.log("[TypingService] Reliable Paste dispatched via clipboard-to-PID")
                 return true
             }
         }
@@ -814,67 +796,6 @@ final class TypingService {
         var range = CFRange()
         let ok = AXValueGetValue(unsafeBitCast(axValue, to: AXValue.self), .cfRange, &range)
         return ok ? range : nil
-    }
-
-    private func captureFocusedTextSnapshot() -> FocusedTextSnapshot? {
-        guard let focusInfo = self.getSystemFocusedElementAndPID() else { return nil }
-        return FocusedTextSnapshot(
-            pid: focusInfo.pid,
-            value: self.getElementStringValue(focusInfo.element),
-            selectedRange: self.getSelectedTextRange(focusInfo.element)
-        )
-    }
-
-    private func focusedTextChanged(from snapshot: FocusedTextSnapshot, expectedPID: pid_t) -> Bool {
-        for _ in 0..<4 {
-            usleep(40_000)
-
-            guard let current = self.captureFocusedTextSnapshot(),
-                  current.pid == expectedPID
-            else {
-                continue
-            }
-
-            if current.value != snapshot.value {
-                return true
-            }
-
-            if let before = snapshot.selectedRange,
-               let after = current.selectedRange,
-               before.location != after.location || before.length != after.length
-            {
-                return true
-            }
-        }
-
-        return false
-    }
-
-    private func performVerifiedPasteAttempt(
-        methodName: String,
-        expectedPID: pid_t? = nil,
-        action: () -> Bool
-    ) -> Bool {
-        let snapshot = self.captureFocusedTextSnapshot()
-
-        guard action() else {
-            self.log("[TypingService] \(methodName) paste dispatch failed")
-            return false
-        }
-
-        guard let snapshot else {
-            self.log("[TypingService] \(methodName) paste dispatched but could not be verified; continuing fallbacks")
-            return false
-        }
-
-        let expectedPID = expectedPID ?? snapshot.pid
-        if self.focusedTextChanged(from: snapshot, expectedPID: expectedPID) {
-            self.log("[TypingService] SUCCESS: \(methodName) insertion verified")
-            return true
-        }
-
-        self.log("[TypingService] \(methodName) paste dispatched but no text change was observed; continuing fallbacks")
-        return false
     }
 
     private func insertTextAtCursorUsingSelectedRange(_ element: AXUIElement, _ text: String) -> Bool {


### PR DESCRIPTION
## Description
Simplifies Reliable Paste mode so it stops after the first successful paste dispatch instead of falling through to direct typing when paste verification is inconclusive. This avoids duplicate insertions in apps where paste succeeds but Accessibility state cannot be confirmed reliably.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Follow-up to #204
- Related to #174
- Related to #125

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 15.x
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources/`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Reliable Paste now favors avoiding duplicate insertion over continuing into deep direct-typing fallbacks after a successful paste dispatch.
- Experimental Direct Typing still preserves the deeper fallback pipeline.