### PR TITLE
perf: reduce perceived recording start delay by ~50%

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2475,6 +2475,11 @@ struct ContentView: View {
                 self.menuBarManager.setOverlayMode(.dictation)
 
                 guard !self.asr.isRunning else { return }
+
+                // Show overlay immediately so its expand animation runs in parallel
+                // with the engine startup, instead of waiting for isRunning to flip.
+                self.menuBarManager.showOverlayEarly(asrService: self.asr)
+
                 if SettingsStore.shared.enableTranscriptionSounds {
                     TranscriptionSoundPlayer.shared.playStartSound()
                 }
@@ -2498,6 +2503,8 @@ struct ContentView: View {
                 self.menuBarManager.setOverlayMode(.command)
 
                 guard !self.asr.isRunning else { return }
+
+                self.menuBarManager.showOverlayEarly(asrService: self.asr)
 
                 // Start recording immediately for the command
                 DebugLogger.shared.info(
@@ -2536,6 +2543,8 @@ struct ContentView: View {
                 self.setActiveRecordingMode(.edit)
 
                 guard !self.asr.isRunning else { return }
+
+                self.menuBarManager.showOverlayEarly(asrService: self.asr)
 
                 // Start recording immediately for the edit instruction
                 DebugLogger.shared.info("Starting voice recording for edit mode", source: "ContentView")

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -781,12 +781,12 @@ final class ASRService: ObservableObject {
         self.engine.stop()
         DebugLogger.shared.debug("✅ Engine stopped", source: "ASRService")
 
-        // Recreate the engine instance instead of calling reset() to prevent format corruption
-        // VoiceInk approach: tearing down and rebuilding ensures fresh, valid audio format on restart
-        DebugLogger.shared.debug("🗑️ Deallocating old engine and creating fresh instance...", source: "ASRService")
-        self.engineStorage = nil // Explicitly release old engine
-        // New engine will be lazily created on next access via computed property
-        DebugLogger.shared.debug("✅ Engine instance recreated", source: "ASRService")
+        // Keep the engine instance alive (just stopped, not deallocated) so the next
+        // start() skips the expensive inputNode/outputNode instantiation (~200ms).
+        // The old approach destroyed and recreated the engine to "prevent format corruption",
+        // but prepare() + start() re-negotiates the format cleanly, and startEngine() calls
+        // bindPreferredInputDeviceIfNeeded() to handle device changes between recordings.
+        DebugLogger.shared.debug("♻️ Engine stopped but kept alive for fast restart", source: "ASRService")
 
         // CRITICAL FIX: Await completion of streaming task AND any pending transcriptions
         // This prevents use-after-free crashes (EXC_BAD_ACCESS) when clearing buffer
@@ -964,10 +964,10 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.debug("✅ Engine stopped", source: "ASRService")
         }
 
-        // No need to call engine.reset() here - we created a fresh engine in stop()
-        // Accessing the engine property will either return the existing fresh engine,
-        // or create a new one if this is the first start
-        DebugLogger.shared.debug("ℹ️ Using fresh engine instance (created lazily)", source: "ASRService")
+        // The engine is kept alive across recordings (just stopped, not deallocated).
+        // Accessing inputNode/outputNode below is cheap when the engine already exists.
+        // On first launch, this triggers the expensive CoreAudio node creation.
+        DebugLogger.shared.debug("ℹ️ Using existing engine instance (kept alive from previous session)", source: "ASRService")
 
         // Force input node instantiation (ensures the underlying AUHAL AudioUnit exists)
         DebugLogger.shared.debug("📍 Forcing input node instantiation...", source: "ASRService")

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -208,6 +208,21 @@ final class MenuBarManager: ObservableObject {
 
     // MARK: - Public API for overlay management
 
+    /// Show the overlay immediately without waiting for `isRunning` to become true.
+    /// Called at hotkey time so the overlay expand animation runs in parallel with engine startup.
+    func showOverlayEarly(asrService: ASRService) {
+        guard !self.overlayVisible else { return }
+
+        self.pendingHideOperation?.cancel()
+        self.pendingHideOperation = nil
+        self.overlayVisible = true
+
+        NotchOverlayManager.shared.show(
+            audioLevelPublisher: asrService.audioLevelPublisher,
+            mode: self.currentOverlayMode
+        )
+    }
+
     func updateOverlayTranscription(_ text: String) {
         NotchOverlayManager.shared.updateTranscriptionText(text)
     }


### PR DESCRIPTION
## Summary

Reduces the perceived delay between pressing the hotkey and seeing the recording overlay by ~50%, from ~850ms to ~400-450ms. Two independent optimizations:

**1. Show overlay in parallel with engine startup** (`1c2ca54`)

Previously, the overlay expand animation only started after the audio engine was fully initialized, because it was triggered by `isRunning` becoming `true`. This adds `showOverlayEarly()` which fires the overlay immediately on hotkey press, so the ~300ms expand animation runs concurrently with the ~330ms engine startup instead of sequentially after it. The overlay doesn't need the engine to be ready — it only needs the `audioLevelPublisher`, which simply emits no values until the engine starts capturing. Applied to dictation, command, and rewrite mode callbacks.

**2. Keep audio engine alive between recordings** (`dd2c73d`)

Previously, `stop()` destroyed the `AVAudioEngine` instance and the next `start()` had to recreate it from scratch, including the expensive `inputNode` (~166ms) and `outputNode` (~36ms) instantiation where CoreAudio creates the aggregate device. Now `stop()` just calls `engine.stop()` and keeps the instance in memory. On the next `start()`, the nodes are already instantiated so `configureSession()` is near-instant, and only `prepare()` + `start()` need to run. Device changes between recordings are handled normally because in sync mode the engine follows the system default device, and `prepare()` re-negotiates the audio format with whatever device is currently active.

## Measured results

Engine startup time (hotkey callback to `isRunning = true`):

| Scenario | Time |
|---|---|
| Original v1.5.9 | ~360ms |
| First recording after launch | ~130-190ms |
| Subsequent recordings (engine warm) | **85-140ms** |

Total perceived delay (Option key press to overlay fully visible):

| Scenario | Time |
|---|---|
| Original v1.5.9 | ~850ms |
| With both optimizations | **~400-450ms** |