### PR TITLE
Fix Swift concurrency CI failures

### DIFF
--- a/Sources/Fluid/Analytics/AnalyticsBuckets.swift
+++ b/Sources/Fluid/Analytics/AnalyticsBuckets.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum AnalyticsBuckets {
-    static func wordCount(in text: String) -> Int {
+    nonisolated static func wordCount(in text: String) -> Int {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return 0 }
         return trimmed
@@ -9,7 +9,7 @@ enum AnalyticsBuckets {
             .count
     }
 
-    static func bucketWords(_ count: Int) -> String {
+    nonisolated static func bucketWords(_ count: Int) -> String {
         switch count {
         case ...0: return "0"
         case 1...5: return "1-5"
@@ -21,7 +21,7 @@ enum AnalyticsBuckets {
         }
     }
 
-    static func bucketSeconds(_ seconds: Double) -> String {
+    nonisolated static func bucketSeconds(_ seconds: Double) -> String {
         switch seconds {
         case ..<0.5: return "<0.5s"
         case 0.5..<2: return "0.5-2s"
@@ -32,7 +32,7 @@ enum AnalyticsBuckets {
         }
     }
 
-    static func bucketMs(_ ms: Double) -> String {
+    nonisolated static func bucketMs(_ ms: Double) -> String {
         switch ms {
         case ..<100: return "<100ms"
         case 100..<300: return "100-300ms"

--- a/Sources/Fluid/Analytics/AnalyticsConfig.swift
+++ b/Sources/Fluid/Analytics/AnalyticsConfig.swift
@@ -5,14 +5,14 @@ struct AnalyticsConfig {
     let postHogHost: String
 
     /// Default EU ingestion host.
-    static let defaultEUHost = "https://eu.i.posthog.com"
+    nonisolated static let defaultEUHost = "https://eu.i.posthog.com"
 
-    static func fromBundle() -> AnalyticsConfig {
+    nonisolated static func fromBundle() -> AnalyticsConfig {
         let info = Bundle.main.infoDictionary ?? [:]
         let key = (info["POSTHOG_API_KEY"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let host = (info["POSTHOG_HOST"] as? String ?? AnalyticsConfig.defaultEUHost).trimmingCharacters(in: .whitespacesAndNewlines)
         return AnalyticsConfig(postHogApiKey: key, postHogHost: host.isEmpty ? AnalyticsConfig.defaultEUHost : host)
     }
 
-    var isConfigured: Bool { !self.postHogApiKey.isEmpty }
+    nonisolated var isConfigured: Bool { !self.postHogApiKey.isEmpty }
 }

--- a/Sources/Fluid/Analytics/AnalyticsIdentityStore.swift
+++ b/Sources/Fluid/Analytics/AnalyticsIdentityStore.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Stores anonymous analytics identifiers. This is intentionally NOT tied to any user identity.
 final class AnalyticsIdentityStore {
-    static let shared = AnalyticsIdentityStore()
+    nonisolated static let shared = AnalyticsIdentityStore()
 
     private let defaults = UserDefaults.standard
 
@@ -13,7 +13,7 @@ final class AnalyticsIdentityStore {
 
     private init() {}
 
-    var anonymousInstallID: String {
+    nonisolated var anonymousInstallID: String {
         if let existing = defaults.string(forKey: Keys.anonymousInstallID), existing.isEmpty == false {
             return existing
         }
@@ -24,7 +24,7 @@ final class AnalyticsIdentityStore {
 
     /// Returns true if this is the first time we've ever recorded an app open on this install.
     @discardableResult
-    func ensureFirstOpenRecorded() -> Bool {
+    nonisolated func ensureFirstOpenRecorded() -> Bool {
         if self.defaults.object(forKey: Keys.firstOpenAt) == nil {
             self.defaults.set(Date().timeIntervalSince1970, forKey: Keys.firstOpenAt)
             return true
@@ -32,7 +32,7 @@ final class AnalyticsIdentityStore {
         return false
     }
 
-    var firstOpenAt: Date? {
+    nonisolated var firstOpenAt: Date? {
         let ts = self.defaults.double(forKey: Keys.firstOpenAt)
         if ts <= 0 { return nil }
         return Date(timeIntervalSince1970: ts)

--- a/Sources/Fluid/Analytics/PostTranscriptionEditTracker.swift
+++ b/Sources/Fluid/Analytics/PostTranscriptionEditTracker.swift
@@ -51,7 +51,7 @@ actor PostTranscriptionEditTracker {
         )
     }
 
-    func handleKeyDown(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) {
+    func handleKeyDown(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) async {
         guard let active else { return }
 
         let elapsed = Date().timeIntervalSince(active.completedAt)
@@ -88,7 +88,10 @@ actor PostTranscriptionEditTracker {
             props["ai_provider"] = provider
         }
 
-        AnalyticsService.shared.capture(.postTranscriptionEdit, properties: props)
+        let properties = props
+        await MainActor.run {
+            AnalyticsService.shared.capture(.postTranscriptionEdit, properties: properties)
+        }
 
         // Single-fire per transcription window.
         self.active = nil

--- a/Sources/Fluid/Services/ActiveAppMonitor.swift
+++ b/Sources/Fluid/Services/ActiveAppMonitor.swift
@@ -43,7 +43,7 @@ final class ActiveAppMonitor: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
                 self?.updateActiveApp()
             }
         }

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 @testable import FluidVoice_Debug
 
+@MainActor
 final class DictationE2ETests: XCTestCase {
     private let enableTranscriptionSoundsKey = "EnableTranscriptionSounds"
     private let transcriptionStartSoundKey = "TranscriptionStartSound"


### PR DESCRIPTION
## Summary
- fix actor-isolation issues in analytics helpers and post-transcription tracking
- make the active-app monitor notification task capture `self` safely
- run dictation integration tests on the main actor where they touch main-actor-bound services

## Verification
- `sh build_incremental.sh`
- `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

## Notes
- leaves the unrelated local change in `Sources/Fluid/Services/TypingService.swift` out of this PR
- intended to validate whether GitHub Actions now passes on a dedicated CI-fix branch