### PR TITLE
fix: #232 Update Authorization header logic for API requests

### DIFF
--- a/Sources/Fluid/Services/LLMClient.swift
+++ b/Sources/Fluid/Services/LLMClient.swift
@@ -267,8 +267,8 @@ final class LLMClient {
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        // Only add Authorization header for non-local endpoints
-        if !isLocal && !config.apiKey.isEmpty {
+        // Send Authorization whenever a key exists; some localhost endpoints still require auth.
+        if !config.apiKey.isEmpty {
             request.addValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
         }
 


### PR DESCRIPTION
Ensure the Authorization header is sent whenever an API key exists, regardless of the endpoint's locality. This change accommodates localhost endpoints that may still require authentication.

## Description
This fixes #232 
Fix custom-provider localhost requests so configured API keys are still sent to the model endpoint, and update package pins needed for the local Debug build to succeed.

## Type of Change
- [ x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #232 

## Testing
- [ ] Tested on Intel Mac
- [ x] Tested on Apple Silicon Mac
- [ ] Tested on macOS [version]
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Built locally: `sh build_incremental.sh`

## Notes

What Changed

Updated LLMClient.swift:269 so the Authorization header is added whenever an API key exists, even for localhost or private-network endpoints.
Kept the package updates in Package.swift, Package.resolved, project.pbxproj, and Package.resolved to unblock current local builds with the newer toolchain.
Why
Custom provider requests to localhost were reaching the server without an Authorization header, which caused 401 API key required responses even when a key was configured. The request logging confirmed the outgoing cURL contained Content-Type only and no auth header. This change fixes that behavior with the smallest app-level code change.

Testing

Reproduced the issue from runtime logs: localhost custom-provider requests returned 401 API key required.
Rebuilt locally with the narrowed patch set.
Verified the Debug build succeeds with the remaining changes.
