### PR TITLE
Update Anthropic API key URL to platform.claude.com

### DIFF
--- a/Sources/Fluid/Services/ModelRepository.swift
+++ b/Sources/Fluid/Services/ModelRepository.swift
@@ -106,7 +106,7 @@ final class ModelRepository {
         case "openai":
             return ("https://platform.openai.com/api-keys", "Get API Key")
         case "anthropic":
-            return ("https://console.anthropic.com/settings/keys", "Get API Key")
+            return ("https://platform.claude.com/settings/keys", "Get API Key")
         case "xai":
             return ("https://console.x.ai/", "Get API Key")
         case "groq":


### PR DESCRIPTION
## Summary
- Update the "Get API Key" link for the Anthropic provider from `https://console.anthropic.com/settings/keys` to `https://platform.claude.com/settings/keys`.

Anthropic has migrated its developer console to `platform.claude.com`. The old `console.anthropic.com` URL still redirects today, but pointing users directly at the new canonical location avoids an extra hop (and future-proofs the link if/when the redirect is removed).

Single-line change in `Sources/Fluid/Services/ModelRepository.swift`.

## Test plan
- [ ] Open Settings → pick the Anthropic provider → click "Get API Key" and confirm it opens `https://platform.claude.com/settings/keys` in the browser.