### PR TITLE
Pad short audio with trailing silence instead of dropping it

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -927,22 +927,35 @@ final class ASRService: ObservableObject {
 
         // NOW it's safe to access the buffer - all pending tasks have completed
         // Thread-safe copy of recorded audio
-        let pcm = self.audioBuffer.getAll()
+        var pcm = self.audioBuffer.getAll()
         self.audioBuffer.clear()
 
-        // Avoid whisper.cpp assertions by skipping too-short audio buffers
-        let minSamples = 16_000
-        guard pcm.count >= minSamples else {
+        // Drop recordings with no audio at all — nothing to transcribe.
+        guard !pcm.isEmpty else {
             DebugLogger.shared.debug(
-                "stop(): insufficient audio for transcription (\(pcm.count)/\(minSamples) samples)",
+                "stop(): no audio captured, skipping transcription",
                 source: "ASRService"
             )
-            // Resume media playback if we paused it
             if shouldResumeMedia {
                 await MediaPlaybackService.shared.resumeIfWePaused(true)
-                DebugLogger.shared.info("🎵 Resumed system media after insufficient audio", source: "ASRService")
+                DebugLogger.shared.info("🎵 Resumed system media after empty audio", source: "ASRService")
             }
             return ""
+        }
+
+        // Pad sub-1s buffers with trailing silence so short utterances (e.g.
+        // "yes", "stop") still transcribe. whisper.cpp asserts on buffers
+        // shorter than 1s; every other provider handles silence padding
+        // without issue, so we pad unconditionally rather than branching per
+        // provider.
+        let minSamples = 16_000
+        if pcm.count < minSamples {
+            let originalCount = pcm.count
+            pcm.append(contentsOf: repeatElement(0.0, count: minSamples - pcm.count))
+            DebugLogger.shared.debug(
+                "stop(): padded short audio with silence (\(originalCount) → \(pcm.count) samples)",
+                source: "ASRService"
+            )
         }
 
         do {


### PR DESCRIPTION
## Summary

Fixes #276.

Sub-1s recordings currently return an empty string silently — short single-word utterances like \"yes\", \"no\", \"stop\" never reach the transcription provider and the user sees no feedback that anything went wrong. The guard was added to dodge a whisper.cpp assertion on buffers shorter than 1s, but it applied to every provider, so Parakeet / Apple Speech / Cohere lost short utterances too.

This PR replaces the early-return with zero-padding:

- Empty buffer (no audio captured at all) → still an early-return, since padding zero samples is pointless.
- Non-empty buffer shorter than 16,000 samples (1s @ 16 kHz) → pad with trailing silence up to 16,000 samples before handing to the provider.

Padding unconditionally (rather than branching per provider) keeps the code simple — whisper.cpp gets the 1s minimum it needs, and every other provider just sees a brief silent tail after the speech, which they all handle fine.

No API surface changes; the only observable behaviour change is that short utterances now transcribe instead of being dropped.

## Test plan

- [ ] Set the speech model to Parakeet TDT v3 (or Apple Speech). Press-and-release the hotkey quickly while saying a single short word (\"yes\"). Confirm the transcription appears rather than nothing.
- [ ] Set the speech model to Whisper Base. Repeat the same short-word test — confirm it still works and no whisper.cpp assertion fires.
- [ ] Long (>1s) recordings still transcribe normally across all providers (no regression).
- [ ] Press-and-release the hotkey so fast that no audio is captured — confirm the debug log shows \"no audio captured, skipping transcription\" and nothing is typed (same as before).

## Notes

- I couldn't run `xcodebuild` locally (Command Line Tools only, no full Xcode). The diff is small and mechanical — please verify CI is green.