### PR TITLE
Throw AI post-processing errors instead of typing them into the user's document

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -13,6 +13,22 @@ import CoreGraphics
 import Security
 import SwiftUI
 
+// MARK: - AI Processing Errors
+
+enum AIProcessingError: LocalizedError {
+    case missingAPIKey(provider: String)
+    case emptyResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey(let provider):
+            return "API key not set for \(provider)"
+        case .emptyResponse:
+            return "AI returned an empty response"
+        }
+    }
+}
+
 // MARK: - Sidebar Item Enum
 
 enum SidebarItem: Hashable {
@@ -1491,7 +1507,7 @@ struct ContentView: View {
         _ inputText: String,
         overrideSystemPrompt: String? = nil,
         dictationSlot: SettingsStore.DictationShortcutSlot? = nil
-    ) async -> String {
+    ) async throws -> String {
         // CRITICAL FIX: Read current settings from SettingsStore, not stale @State copies
         // This ensures AI provider/model changes in AISettingsView take effect immediately
         let currentSelectedProviderID = SettingsStore.shared.selectedProviderID
@@ -1564,7 +1580,7 @@ struct ContentView: View {
                     self.logDictationPromptTrace("Selected context text", value: "<none (dictation mode)>")
                 }
                 DebugLogger.shared.debug("Using Apple Intelligence for transcription cleanup", source: "ContentView")
-                let output = await provider.process(systemPrompt: systemPrompt, userText: inputText)
+                let output = try await provider.process(systemPrompt: systemPrompt, userText: inputText)
                 if self.shouldTracePromptProcessing {
                     self.logDictationPromptTrace("Model answer (A)", value: output)
                 }
@@ -1580,7 +1596,7 @@ struct ContentView: View {
 
         if !isLocal {
             guard !apiKey.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty else {
-                return "Error: API Key not set for \(derivedCurrentProvider)"
+                throw AIProcessingError.missingAPIKey(provider: derivedCurrentProvider)
             }
         }
 
@@ -1667,26 +1683,24 @@ struct ContentView: View {
 
         DebugLogger.shared.info("Using LLMClient for transcription (streaming=\(enableStreaming))", source: "ContentView")
 
-        do {
-            let response = try await LLMClient.shared.call(config)
+        let response = try await LLMClient.shared.call(config)
 
-            // Log thinking if present (for debugging)
-            if let thinking = response.thinking {
-                DebugLogger.shared.debug("LLM thinking tokens extracted (\(thinking.count) chars)", source: "ContentView")
-                if self.shouldTracePromptProcessing {
-                    self.logDictationPromptTrace("Model thinking", value: thinking)
-                }
-            }
-
+        // Log thinking if present (for debugging)
+        if let thinking = response.thinking {
+            DebugLogger.shared.debug("LLM thinking tokens extracted (\(thinking.count) chars)", source: "ContentView")
             if self.shouldTracePromptProcessing {
-                self.logDictationPromptTrace("Model answer (A)", value: response.content)
+                self.logDictationPromptTrace("Model thinking", value: thinking)
             }
-
-            return response.content.isEmpty ? "<no content>" : response.content
-        } catch {
-            DebugLogger.shared.error("AI API error: \(error.localizedDescription)", source: "ContentView")
-            return "Error: \(error.localizedDescription)"
         }
+
+        if self.shouldTracePromptProcessing {
+            self.logDictationPromptTrace("Model answer (A)", value: response.content)
+        }
+
+        guard !response.content.isEmpty else {
+            throw AIProcessingError.emptyResponse
+        }
+        return response.content
     }
 
     // MARK: - Streaming Response Handler (DEPRECATED - Now handled by LLMClient)
@@ -1757,9 +1771,13 @@ struct ContentView: View {
                 promptTest.isProcessing = false
             }
 
-            let result = await self.processTextWithAI(transcribedText, overrideSystemPrompt: promptTest.draftPromptText)
-            let finalText = ASRService.applyGAAVFormatting(result)
-            promptTest.lastOutputText = finalText
+            do {
+                let result = try await self.processTextWithAI(transcribedText, overrideSystemPrompt: promptTest.draftPromptText)
+                promptTest.lastOutputText = ASRService.applyGAAVFormatting(result)
+            } catch {
+                DebugLogger.shared.error("Prompt test AI call failed: \(error.localizedDescription)", source: "ContentView")
+                promptTest.lastError = error.localizedDescription
+            }
             return
         }
 
@@ -1812,11 +1830,21 @@ struct ContentView: View {
             // Ensure the status label becomes visible immediately.
             await Task.yield()
 
-            finalText = await self.processTextWithAI(
-                transcribedText,
-                overrideSystemPrompt: promptOverride,
-                dictationSlot: activeDictationSlot
-            )
+            do {
+                finalText = try await self.processTextWithAI(
+                    transcribedText,
+                    overrideSystemPrompt: promptOverride,
+                    dictationSlot: activeDictationSlot
+                )
+            } catch {
+                // Fall back to the raw transcription so the user still gets
+                // their words typed instead of an error string.
+                DebugLogger.shared.error(
+                    "AI post-processing failed, falling back to raw transcription: \(error.localizedDescription)",
+                    source: "ContentView"
+                )
+                finalText = transcribedText
+            }
             let postProcessingLatencyMs = Int((Date().timeIntervalSince(postProcessingStart) * 1000).rounded())
             AnalyticsService.shared.capture(
                 .dictationPostProcessingCompleted,
@@ -2092,7 +2120,15 @@ struct ContentView: View {
         var finalText = transcribedText
         let shouldUseAI = DictationAIPostProcessingGate.isConfigured()
         if shouldUseAI {
-            finalText = await self.processTextWithAI(transcribedText)
+            do {
+                finalText = try await self.processTextWithAI(transcribedText)
+            } catch {
+                DebugLogger.shared.error(
+                    "AI reprocess failed, falling back to raw transcription: \(error.localizedDescription)",
+                    source: "ContentView"
+                )
+                finalText = transcribedText
+            }
         }
 
         NotchOverlayManager.shared.updateTranscriptionText("")
@@ -2852,8 +2888,13 @@ extension ContentView {
         await MainActor.run { self.isCallingAI = true }
         defer { Task { await MainActor.run { isCallingAI = false } } }
 
-        let result = await processTextWithAI(aiInputText)
-        await MainActor.run { self.aiOutputText = result }
+        do {
+            let result = try await processTextWithAI(aiInputText)
+            await MainActor.run { self.aiOutputText = result }
+        } catch {
+            DebugLogger.shared.error("callOpenAIChat failed: \(error.localizedDescription)", source: "ContentView")
+            await MainActor.run { self.aiOutputText = "Error: \(error.localizedDescription)" }
+        }
     }
 
     private func getModelStatusText() -> String {

--- a/Sources/Fluid/Networking/AppleIntelligenceProvider.swift
+++ b/Sources/Fluid/Networking/AppleIntelligenceProvider.swift
@@ -44,25 +44,17 @@ enum AppleIntelligenceService {
 @available(macOS 26.0, *)
 final class AppleIntelligenceProvider {
     /// Process text with a system prompt (for transcription cleanup)
-    func process(systemPrompt: String, userText: String) async -> String {
-        do {
-            let session = LanguageModelSession()
+    func process(systemPrompt: String, userText: String) async throws -> String {
+        let session = LanguageModelSession()
 
-            let fullPrompt = """
-            \(systemPrompt)
+        let fullPrompt = """
+        \(systemPrompt)
 
-            \(userText)
-            """
+        \(userText)
+        """
 
-            let response = try await session.respond(to: fullPrompt)
-            return response.content
-        } catch {
-            DebugLogger.shared.error(
-                "Apple Intelligence error: \(error.localizedDescription)",
-                source: "AppleIntelligenceProvider"
-            )
-            return "Error: \(error.localizedDescription)"
-        }
+        let response = try await session.respond(to: fullPrompt)
+        return response.content
     }
 
     /// Process rewrite/write requests with conversation history


### PR DESCRIPTION
## Summary

Fixes #242.

When AI post-processing failed (rate limit, network blip, missing API key, empty response, etc.), `processTextWithAI` converted the failure into a String like `"Error: HTTP 503: This model is currently experiencing high demand…"` and the dictation callsites treated that string as the text to type. Users saw the error message inserted into whatever app they were dictating into.

### Changes

- **`ContentView.processTextWithAI` now throws.** Return type becomes `async throws -> String`. The three failure modes throw instead of string-returning: missing API key, empty response, and underlying `LLMClient` errors propagate directly.
- **Added `AIProcessingError`** (a `LocalizedError`) for the two synthesised failure cases so the catch sites get a useful `localizedDescription` to log / display.
- **`AppleIntelligenceProvider.process` also throws now.** It had the same `return "Error: …"` pattern on FoundationModels errors, so the AI path via Apple Intelligence had the same bug. Made it `async throws -> String` too and let its single caller propagate.
- **Four callsites updated:**
  | Callsite | Behaviour on error |
  |---|---|
  | Dictation (main flow) | Fall back to the raw transcription, log the error |
  | Dictation (reprocess flow) | Same — fall back to raw transcription |
  | Prompt-test UI | Surface error in the existing `promptTest.lastError` slot (matches the already-handled 'not configured' case) |
  | AI chat tab (`callOpenAIChat`) | Keep showing `"Error: …"` since that panel is purely display, not typed anywhere |

The bug report suggested gracefully degrading to raw transcription and logging the error — that's what the dictation callsites now do. The display-only callsites keep showing errors because for them the error text is informative, not destructive.

## Test plan

- [ ] Configure a valid provider + model but set an obviously wrong API key (e.g. `"sk-invalid"`). Dictate a sentence into a text field. Confirm the raw transcription is typed instead of `"Error: HTTP 401 …"`, and the log contains `"AI post-processing failed, falling back to raw transcription: …"`.
- [ ] Remove the API key entirely (blank) and dictate. Confirm the raw transcription is typed and the log shows `"API key not set for …"`.
- [ ] Force an empty model response (e.g. via a test provider returning `"choices": []`). Confirm fallback behaviour.
- [ ] Prompt-test UI: trigger an error and confirm the error banner appears in the testing card (no output written to `lastOutputText`).
- [ ] AI chat tab: trigger an error and confirm it's still shown in `aiOutputText` as before (display-only, no regression).
- [ ] Happy path still works end-to-end across OpenAI / Anthropic / Groq / Apple Intelligence.

## Notes

- I couldn't run `xcodebuild` locally (Command Line Tools only, no full Xcode). Please verify CI is green — the diff is mechanical but the throw-propagation touches a few signatures so it's worth a compile pass.
- `OpenAICompatibleProvider` in `AIProvider.swift` has the same string-error pattern but is dead code (declared and never referenced) — left alone for this PR.