### PR TITLE
Flag AI post-processing fallbacks in transcription history (builds on #279)

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1851,6 +1851,7 @@ struct ContentView: View {
         }
 
         var finalText: String
+        var aiFallbackReason: String?
 
         let shouldUseAI = activeDictationSlot.map { DictationAIPostProcessingGate.isConfigured(for: $0) } ??
             DictationAIPostProcessingGate.isConfigured()
@@ -1881,6 +1882,7 @@ struct ContentView: View {
                     "AI post-processing failed, falling back to raw transcription: \(error.localizedDescription)",
                     source: "ContentView"
                 )
+                aiFallbackReason = error.localizedDescription
                 finalText = transcribedText
             }
             let postProcessingLatencyMs = Int((Date().timeIntervalSince(postProcessingStart) * 1000).rounded())
@@ -1946,7 +1948,8 @@ struct ContentView: View {
                 rawText: transcribedText,
                 processedText: finalText,
                 appName: appInfo.name,
-                windowTitle: appInfo.windowTitle
+                windowTitle: appInfo.windowTitle,
+                aiProcessingError: aiFallbackReason
             )
         }
 
@@ -2156,6 +2159,7 @@ struct ContentView: View {
         await Task.yield()
 
         var finalText = transcribedText
+        var aiFallbackReason: String?
         let shouldUseAI = DictationAIPostProcessingGate.isConfigured()
         if shouldUseAI {
             do {
@@ -2165,6 +2169,7 @@ struct ContentView: View {
                     "AI reprocess failed, falling back to raw transcription: \(error.localizedDescription)",
                     source: "ContentView"
                 )
+                aiFallbackReason = error.localizedDescription
                 finalText = transcribedText
             }
         }
@@ -2180,7 +2185,8 @@ struct ContentView: View {
                 rawText: transcribedText,
                 processedText: finalText,
                 appName: appInfo.name,
-                windowTitle: appInfo.windowTitle
+                windowTitle: appInfo.windowTitle,
+                aiProcessingError: aiFallbackReason
             )
         }
 

--- a/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
+++ b/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
@@ -19,6 +19,10 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
     let windowTitle: String
     let characterCount: Int
     let wasAIProcessed: Bool
+    /// Non-nil when AI post-processing was configured but failed and we fell
+    /// back to typing the raw transcription. The string carries the error
+    /// message for display / debugging.
+    let aiProcessingError: String?
 
     init(
         id: UUID = UUID(),
@@ -26,7 +30,8 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         rawText: String,
         processedText: String,
         appName: String,
-        windowTitle: String
+        windowTitle: String,
+        aiProcessingError: String? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -36,6 +41,25 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         self.windowTitle = windowTitle
         self.characterCount = processedText.count
         self.wasAIProcessed = rawText != processedText
+        self.aiProcessingError = aiProcessingError
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.timestamp = try container.decode(Date.self, forKey: .timestamp)
+        self.rawText = try container.decode(String.self, forKey: .rawText)
+        self.processedText = try container.decode(String.self, forKey: .processedText)
+        self.appName = try container.decode(String.self, forKey: .appName)
+        self.windowTitle = try container.decode(String.self, forKey: .windowTitle)
+        self.characterCount = try container.decode(Int.self, forKey: .characterCount)
+        self.wasAIProcessed = try container.decode(Bool.self, forKey: .wasAIProcessed)
+        self.aiProcessingError = try container.decodeIfPresent(String.self, forKey: .aiProcessingError)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, timestamp, rawText, processedText, appName, windowTitle
+        case characterCount, wasAIProcessed, aiProcessingError
     }
 
     /// Preview text for list display (first 80 chars)
@@ -95,7 +119,8 @@ final class TranscriptionHistoryStore: ObservableObject {
         rawText: String,
         processedText: String,
         appName: String,
-        windowTitle: String
+        windowTitle: String,
+        aiProcessingError: String? = nil
     ) {
         // Skip empty transcriptions
         guard !processedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
@@ -104,7 +129,8 @@ final class TranscriptionHistoryStore: ObservableObject {
             rawText: rawText,
             processedText: processedText,
             appName: appName,
-            windowTitle: windowTitle
+            windowTitle: windowTitle,
+            aiProcessingError: aiProcessingError
         )
 
         // Insert at beginning (newest first)

--- a/Sources/Fluid/UI/TranscriptionHistoryView.swift
+++ b/Sources/Fluid/UI/TranscriptionHistoryView.swift
@@ -143,6 +143,13 @@ struct TranscriptionHistoryView: View {
                             )
                     }
 
+                    if entry.aiProcessingError != nil {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(isSelected ? .white : Color.orange)
+                            .help(entry.aiProcessingError ?? "")
+                    }
+
                     Spacer()
 
                     Text(entry.relativeTimeString)
@@ -293,6 +300,31 @@ struct TranscriptionHistoryView: View {
 
                 Divider()
                     .opacity(0.3)
+
+                if let aiError = entry.aiProcessingError {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(Color.orange)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("AI cleanup failed - raw transcription was typed instead")
+                                .font(.system(size: 12, weight: .semibold))
+                            Text(aiError)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                    }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(Color.orange.opacity(0.08))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .stroke(Color.orange.opacity(0.3), lineWidth: 1)
+                            )
+                    )
+                }
 
                 // Final Text Section
                 self.detailSection(


### PR DESCRIPTION
## Summary

Stacked on top of #279. Please merge that first — this PR's diff will shrink to just the history-flag changes once it does, but GitHub can't target a head branch that isn't merged yet, so for now the diff here shows both sets of changes.

The problem: after #279 a failed AI cleanup silently falls back to the raw transcription, with only a line in `~/Library/Logs/Fluid/Fluid.log`. A broken API key or expired credit can go unnoticed for days.

### Durable history flag

Added `aiProcessingError: String?` to `TranscriptionHistoryEntry` (Codable via `decodeIfPresent` — fully back-compat with existing persisted history, old entries decode with `nil`). Threaded the fallback reason into `addEntry` at the two dictation callsites (main dictation flow and the reprocess flow).

UI:

- **History list row**: orange ⚠ triangle next to entries where `aiProcessingError` is set; hover reveals the error message.
- **History detail view**: orange callout card at the top of the detail pane with the full error message.

Screenshot in the comment below.

### What I dropped

Initially I also tried surfacing failures as a transient message in the notch / bottom overlay ("⚠︎ AI cleanup failed — typed raw", held for ~4s). I couldn't get it to actually persist long enough to be readable — the post-typing `NotchOverlayManager.hide()` fires immediately after typing completes and overrode the transient status each time. Left that out of the final PR; the history flag is the durable signal and is the part that worked reliably. Happy to revisit the overlay approach in a follow-up if maintainers have a cleaner hook point.

## Notes

- Could not run CI locally (CLT was insufficient — needed full Xcode). Built and ran on Apple Silicon / macOS 26.3.1 with Xcode 26.4 to verify. One unrelated local-only change (bumping `modelcontextprotocol/swift-sdk` from 0.10.2 → 0.12.0 in `Package.resolved`) was needed to get past a Swift 6 concurrency error in the MCP transport — not included in this PR since CI on Xcode 26.3 doesn't need it.
- Orange colour for the warning is hardcoded; could be themed if maintainers prefer.