### PR TITLE
Fix broken Ollama setup guide link

### DIFF
--- a/Sources/Fluid/Services/ModelRepository.swift
+++ b/Sources/Fluid/Services/ModelRepository.swift
@@ -118,7 +118,7 @@ final class ModelRepository {
         case "openrouter":
             return ("https://openrouter.ai/settings/keys", "Get API Key")
         case "ollama":
-            return ("https://github.com/ollama/ollama/blob/main/docs/openai.md", "Setup Guide")
+            return ("https://docs.ollama.com/api/openai-compatibility", "Setup Guide")
         case "lmstudio":
             return ("https://lmstudio.ai/docs/local-server", "Setup Guide")
         default:


### PR DESCRIPTION
## Summary
- The Ollama "Setup Guide" link for the `ollama` provider currently points at `https://github.com/ollama/ollama/blob/main/docs/openai.md`, which now 404s — the file was moved upstream to `docs/api/openai-compatibility.mdx`.
- Updated to `https://docs.ollama.com/api/openai-compatibility` (the published version of the same doc). Verified HTTP 200.

## Test plan
- [ ] Open AI settings, select the Ollama provider, click the Setup Guide link, confirm it opens the Ollama OpenAI-compatibility docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)