### PR TITLE
Drop temperature for Anthropic models that deprecate it

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1615,9 +1615,8 @@ struct ContentView: View {
             self.logDictationPromptTrace("Selected context text", value: "<none (dictation mode)>")
         }
 
-        // Check if this is a reasoning model that doesn't support temperature parameter
-        let modelLower = derivedSelectedModel.lowercased()
-        let isReasoningModel = modelLower.hasPrefix("o1") || modelLower.hasPrefix("o3") || modelLower.hasPrefix("gpt-5")
+        // Check if this model doesn't support the temperature parameter
+        let isTemperatureUnsupported = SettingsStore.shared.isTemperatureUnsupported(derivedSelectedModel)
 
         // Get reasoning config for this model (uses per-model settings or auto-detection)
         // This handles custom parameters like reasoning_effort, enable_thinking, etc.
@@ -1661,7 +1660,7 @@ struct ContentView: View {
             apiKey: apiKey,
             streaming: enableStreaming,
             tools: [],
-            temperature: isReasoningModel ? nil : 0.2,
+            temperature: isTemperatureUnsupported ? nil : 0.2,
             extraParameters: extraParams
         )
 

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2047,6 +2047,15 @@ final class SettingsStore: ObservableObject {
             (modelLower.contains("deepseek") && modelLower.contains("reasoner"))
     }
 
+    /// Whether the model rejects the `temperature` parameter.
+    /// Covers reasoning models plus Anthropic models that have deprecated temperature
+    /// (Claude Opus 4.7+, which use extended thinking by default).
+    func isTemperatureUnsupported(_ model: String) -> Bool {
+        if self.isReasoningModel(model) { return true }
+        let modelLower = model.lowercased()
+        return modelLower.contains("claude-opus-4-7")
+    }
+
     /// Whether to display thinking tokens in the UI (Command Mode, Rewrite Mode)
     /// If false, thinking tokens are extracted but not shown to user
     var showThinkingTokens: Bool {

--- a/Sources/Fluid/Services/CommandModeService.swift
+++ b/Sources/Fluid/Services/CommandModeService.swift
@@ -843,6 +843,7 @@ final class CommandModeService: ObservableObject {
 
         // Reasoning models (o1, o3, gpt-5) don't support temperature parameter at all
         let isReasoningModel = settings.isReasoningModel(model)
+        let isTemperatureUnsupported = settings.isTemperatureUnsupported(model)
 
         // Get reasoning config for this model (e.g., reasoning_effort, enable_thinking)
         let reasoningConfig = SettingsStore.shared.getReasoningConfig(forModel: model, provider: providerID)
@@ -872,7 +873,7 @@ final class CommandModeService: ObservableObject {
             apiKey: apiKey,
             streaming: enableStreaming,
             tools: [TerminalService.toolDefinition],
-            temperature: isReasoningModel ? nil : 0.1,
+            temperature: isTemperatureUnsupported ? nil : 0.1,
             maxTokens: isReasoningModel ? 32_000 : nil, // Reasoning models like o1 need a large budget for extended thought chains
             extraParameters: extraParams
         )

--- a/Sources/Fluid/Services/RewriteModeService.swift
+++ b/Sources/Fluid/Services/RewriteModeService.swift
@@ -314,6 +314,7 @@ final class RewriteModeService: ObservableObject {
 
         // Reasoning models (o1, o3, gpt-5) don't support temperature parameter at all
         let isReasoningModel = settings.isReasoningModel(model)
+        let isTemperatureUnsupported = settings.isTemperatureUnsupported(model)
 
         // Get reasoning config for this model (e.g., reasoning_effort, enable_thinking)
         let reasoningConfig = settings.getReasoningConfig(forModel: model, provider: providerID)
@@ -335,7 +336,7 @@ final class RewriteModeService: ObservableObject {
             apiKey: apiKey,
             streaming: enableStreaming,
             tools: [],
-            temperature: isReasoningModel ? nil : 0.7,
+            temperature: isTemperatureUnsupported ? nil : 0.7,
             maxTokens: isReasoningModel ? 32_000 : nil, // Reasoning models like o1 need a large budget for extended thought chains
             extraParameters: extraParams
         )


### PR DESCRIPTION
## Summary
- Claude Opus 4.7 rejects the `temperature` parameter (it uses extended thinking by default), so every request sent to it via the Anthropic provider fails with `HTTP 400: temperature is deprecated for this model`.
- Adds `SettingsStore.isTemperatureUnsupported(_:)` covering reasoning models (o1/o3/gpt-5/...) plus Claude Opus 4.7+, and uses it at the three live call sites that build an `LLMClient.Config` (`ContentView`, `CommandModeService`, `RewriteModeService`).
- `isReasoningModel` still gates `max_completion_tokens` and the reasoning token budget — those are OpenAI-specific and shouldn't fire for Anthropic models.

Fixes #285.

## Test plan
- [ ] Select the Anthropic provider with model `claude-opus-4-7` and confirm transcription cleanup, Command Mode, and Rewrite Mode no longer return the HTTP 400 temperature error.
- [ ] Regression-check an OpenAI reasoning model (e.g. `gpt-5`) still sends no `temperature`.
- [ ] Regression-check a non-reasoning model (e.g. `gpt-4.1`, `claude-sonnet-4-20250514`) still sends `temperature: 0.2 / 0.1 / 0.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)