### PR TITLE
Stop invalidating ContentView on streaming partial transcription updates

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -100,7 +100,14 @@ private actor ModelDownloadRegistry {
 final class ASRService: ObservableObject {
     @Published var isRunning: Bool = false
     @Published var finalText: String = ""
-    @Published var partialTranscription: String = ""
+    // Not @Published: writes fire 1-5x/s during streaming ASR. Routing them through
+    // objectWillChange invalidates every ContentView subscriber of AppServices, even
+    // though ContentView never reads this value. MenuBarManager subscribes directly.
+    private let partialTranscriptionSubject = CurrentValueSubject<String, Never>("")
+    var partialTranscription: String { self.partialTranscriptionSubject.value }
+    var partialTranscriptionPublisher: AnyPublisher<String, Never> {
+        self.partialTranscriptionSubject.eraseToAnyPublisher()
+    }
     @Published var wordBoostStatusText: String = "Word boost: off"
     @Published var micStatus: AVAuthorizationStatus = .notDetermined
     @Published var isAsrReady: Bool = false
@@ -749,7 +756,7 @@ final class ASRService: ObservableObject {
         DebugLogger.shared.debug("🧹 Clearing buffers and state", source: "ASRService")
         self.finalText.removeAll()
         self.audioBuffer.clear(keepingCapacity: true) // specific optimization for restart
-        self.partialTranscription.removeAll()
+        self.partialTranscriptionSubject.send("")
         self.previousFullTranscription.removeAll()
         self.lastBoostHitTerm = nil
         self.lastProcessedSampleCount = 0
@@ -1080,7 +1087,7 @@ final class ASRService: ObservableObject {
 
         // NOW it's safe to clear the buffer
         self.audioBuffer.clear()
-        self.partialTranscription.removeAll()
+        self.partialTranscriptionSubject.send("")
         self.previousFullTranscription.removeAll()
         self.lastBoostHitTerm = nil
         self.lastProcessedSampleCount = 0
@@ -2478,7 +2485,7 @@ final class ASRService: ObservableObject {
             if !newText.isEmpty {
                 // Smart diff: only show truly new words
                 let updatedText = self.smartDiffUpdate(previous: self.previousFullTranscription, current: newText)
-                self.partialTranscription = updatedText
+                self.partialTranscriptionSubject.send(updatedText)
                 self.previousFullTranscription = newText
 
                 DebugLogger.shared.debug("✅ Streaming: '\(updatedText)' (\(String(format: "%.2f", duration))s)", source: "ASRService")

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -83,7 +83,7 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
             .store(in: &self.cancellables)
 
         // Subscribe to partial transcription updates for streaming preview
-        asrService.$partialTranscription
+        asrService.partialTranscriptionPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newText in
                 guard self != nil else { return }


### PR DESCRIPTION
## What this changes

`ASRService.partialTranscription` moves from `@Published` to a private `CurrentValueSubject<String, Never>` exposed to subscribers via an `AnyPublisher`. The value getter and the single Combine consumer (`MenuBarManager`) are updated accordingly. No other `@Published` properties on `ASRService` are affected.

## Why

During streaming ASR, `partialTranscription` is written 1-5 times per second depending on the model (`parakeetRealtime` runs at 0.2s intervals, default models at 0.6s, Cohere at 1.0s per `SettingsStore.swift`).

Because it was `@Published`, every write fired Combine's synthesized `objectWillChange.send()`. `AppServices.setupASRForwarding` pipes `ASRService.objectWillChange` into `AppServices.objectWillChange`, and `ContentView` observes `AppServices` via `@EnvironmentObject`. SwiftUI's legacy `ObservableObject` protocol has no per-property dependency tracking, so every tick invalidated `ContentView` and forced its 3,061-line body to re-evaluate, even though `ContentView` never reads `partialTranscription`.

`MenuBarManager` is the only consumer of this value (it forwards to the notch overlay when streaming preview is enabled). Moving the hot path off `objectWillChange` eliminates the invalidation storm without touching any legitimate cold-signal forwarding (`isRunning`, `isAsrReady`, `micStatus`, `errorTitle`, etc. stay `@Published` and `ContentView` continues to react to them correctly).

## Approach

1. Replace `@Published var partialTranscription: String = ""` with `private let partialTranscriptionSubject = CurrentValueSubject<String, Never>("")`.
2. Expose `var partialTranscription: String { subject.value }` for synchronous reads and `var partialTranscriptionPublisher: AnyPublisher<String, Never>` for subscription.
3. Update the three writers in `ASRService` to call `partialTranscriptionSubject.send(...)` instead of assigning the property.
4. Update `MenuBarManager.configure(asrService:)` to subscribe via `asrService.partialTranscriptionPublisher` instead of `asrService.$partialTranscription`.

Non-goals: no changes to any other `@Published` property, no migration to `@Observable`, no changes to `AppServices` forwarding or `ContentView`. This is the minimal surgical fix to the documented hot path.

## Validation

- SwiftLint strict: 0 violations on both edited files.
- `xcodebuild build`: clean with respect to this change. (The swift-sdk MCP transport has two pre-existing data-race errors on `upstream/main` that remain; confirmed identical on the unmodified branch.)
- Manual verification of the value flow: `partialTranscriptionSubject.send(x)` updates the getter and the published publisher on the next subscription tick. `MenuBarManager`'s `.receive(on: DispatchQueue.main).sink { ... }` still delivers on main as before.

## Risks / follow-ups

- Any future code that subscribes to `$partialTranscription` via the Combine projected value will break and must use `partialTranscriptionPublisher` instead. Currently there are no other consumers.
- Broader cleanup opportunities remain in the AppServices forwarding design (blanket `objectWillChange` forwarding for `AudioHardwareObserver` still exists, and migrating `ASRService` to the `@Observable` macro would give per-property tracking across all fields). Those are out of scope for this PR.