### PR TITLE
Fix LM Studio setup guide link

### DIFF
--- a/Sources/Fluid/Services/ModelRepository.swift
+++ b/Sources/Fluid/Services/ModelRepository.swift
@@ -120,7 +120,7 @@ final class ModelRepository {
         case "ollama":
             return ("https://docs.ollama.com/api/openai-compatibility", "Setup Guide")
         case "lmstudio":
-            return ("https://lmstudio.ai/docs/local-server", "Setup Guide")
+            return ("https://lmstudio.ai/docs/developer/openai-compat/chat-completions", "Setup Guide")
         default:
             return nil
         }


### PR DESCRIPTION
## Description
Updates the LM Studio setup guide link to point at the OpenAI-compatible chat completions documentation.

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update

## Related Issues
- Closes #291

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.0 SDK build environment
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Release notes updated locally in `RELEASE_NOTES_1.5.13-beta.1.md`; file is gitignored intentionally.

## Screenshots / Video 
Not applicable; link-only settings metadata change.