### PR TITLE
Fix custom AI provider persistence

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1310,6 +1310,14 @@ struct ContentView: View {
     }
 
     private func saveSavedProviders() {
+        let storedProviders = SettingsStore.shared.savedProviders
+        if self.savedProviders.isEmpty, !storedProviders.isEmpty {
+            DebugLogger.shared.warning(
+                "Skipped stale empty savedProviders write from ContentView.",
+                source: "ContentView"
+            )
+            return
+        }
         SettingsStore.shared.savedProviders = self.savedProviders
     }
 

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -146,6 +146,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.selectedEditPromptID = self.settings.selectedEditPromptID
         self.isDictationPromptOff = self.settings.isDictationPromptOff
 
+        if !ModelRepository.shared.isBuiltIn(self.selectedProviderID),
+           self.savedProviders.contains(where: { $0.id == self.selectedProviderID }) == false
+        {
+            self.selectedProviderID = "openai"
+        }
+
         // Normalize provider keys
         var normalized: [String: [String]] = [:]
         for (key, models) in self.availableModelsByProvider {
@@ -380,6 +386,10 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
     func saveSavedProviders() {
         self.settings.savedProviders = self.savedProviders
+        self.settings.availableModelsByProvider = self.availableModelsByProvider
+        self.settings.selectedModelByProvider = self.selectedModelByProvider
+        self.settings.selectedProviderID = self.selectedProviderID
+        self.refreshProviderItems()
     }
 
     func isLocalEndpoint(_ urlString: String) -> Bool {

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -13,6 +13,10 @@ final class DictationE2ETests: XCTestCase {
     private let selectedEditPromptIDKey = "SelectedEditPromptID"
     private let defaultDictationPromptOverrideKey = "DefaultDictationPromptOverride"
     private let defaultEditPromptOverrideKey = "DefaultEditPromptOverride"
+    private let savedProvidersKey = "SavedProviders"
+    private let selectedProviderIDKey = "SelectedProviderID"
+    private let availableModelsByProviderKey = "AvailableModelsByProvider"
+    private let selectedModelByProviderKey = "SelectedModelByProvider"
 
     func testTranscriptionStartSound_noneOptionHasNoFile() {
         XCTAssertEqual(SettingsStore.TranscriptionStartSound.none.displayName, "None")
@@ -178,6 +182,29 @@ final class DictationE2ETests: XCTestCase {
         }
     }
 
+    func testCustomProviderSettingsRoundTripThroughSettingsStore() {
+        self.withProviderSettingsRestored {
+            let settings = SettingsStore.shared
+            let provider = SettingsStore.SavedProvider(
+                id: "custom-provider-test",
+                name: "Issue299 Temp",
+                baseURL: "http://10.0.0.138:1234/v1",
+                models: ["google/gemma-4-e4b"]
+            )
+            let providerKey = "custom:\(provider.id)"
+
+            settings.savedProviders = [provider]
+            settings.availableModelsByProvider = [providerKey: provider.models]
+            settings.selectedModelByProvider = [providerKey: provider.models[0]]
+            settings.selectedProviderID = provider.id
+
+            XCTAssertEqual(settings.selectedProviderID, provider.id)
+            XCTAssertEqual(settings.savedProviders, [provider])
+            XCTAssertEqual(settings.availableModelsByProvider[providerKey], provider.models)
+            XCTAssertEqual(settings.selectedModelByProvider[providerKey], provider.models[0])
+        }
+    }
+
     private static func modelDirectoryForRun() -> URL {
         // Use a stable path on CI so GitHub Actions cache can speed up runs.
         if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" ||
@@ -241,6 +268,18 @@ final class DictationE2ETests: XCTestCase {
                 self.selectedEditPromptIDKey,
                 self.defaultDictationPromptOverrideKey,
                 self.defaultEditPromptOverrideKey,
+            ],
+            run: run
+        )
+    }
+
+    private func withProviderSettingsRestored(run: () -> Void) {
+        self.withRestoredDefaults(
+            keys: [
+                self.savedProvidersKey,
+                self.selectedProviderIDKey,
+                self.availableModelsByProviderKey,
+                self.selectedModelByProviderKey,
             ],
             run: run
         )


### PR DESCRIPTION
## Description
Fixes custom AI providers resetting after closing and reopening Settings while FluidVoice keeps running.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #299

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 15
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Added ignored release note under `RELEASE_NOTES_1.5.13-beta.1.md`.
- Manually verified the custom provider name, base URL, and selected model persist after reopening Settings.

## Screenshots / Video 
N/A
