### PR TITLE
Fix rollback backup selection

### DIFF
--- a/Sources/Fluid/Services/SimpleUpdater.swift
+++ b/Sources/Fluid/Services/SimpleUpdater.swift
@@ -110,8 +110,12 @@ final class SimpleUpdater {
         return Bundle.main.bundleURL.deletingPathExtension().lastPathComponent
     }
 
+    private var currentAppVersion: String {
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
     func hasRollbackBackup() -> Bool {
-        return !self.availableRollbackBackups().isEmpty
+        return self.latestRollbackBackup() != nil
     }
 
     func latestRollbackVersion() -> String? {
@@ -445,17 +449,16 @@ final class SimpleUpdater {
             return []
         }
 
-        return urls
-            .filter { $0.pathExtension == "app" }
-            .compactMap { url in
-                (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate.map { (url, $0) }
-            }
-            .sorted { $0.1 > $1.1 }
-            .map { $0.0 }
+        return Self.sortedRollbackBackups(urls.filter { $0.pathExtension == "app" }) { url in
+            (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        }
     }
 
     private func latestRollbackBackup() -> URL? {
-        return self.availableRollbackBackups().first
+        let currentVersion = self.currentAppVersion
+        return self.availableRollbackBackups().first {
+            Self.isRollbackVersion(self.versionString(for: $0), differentFrom: currentVersion)
+        }
     }
 
     private func versionString(for appURL: URL) -> String? {
@@ -471,7 +474,7 @@ final class SimpleUpdater {
     }
 
     private func createRollbackBackup(beforeRollback: Bool) {
-        let currentAppVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let currentAppVersion = self.currentAppVersion
         let appURL = Bundle.main.bundleURL
         let backupRoot = self.rollbackRootDirectory()
 
@@ -494,6 +497,10 @@ final class SimpleUpdater {
 
         do {
             try self.fileManager.copyItem(at: appURL, to: backupURL)
+            try? self.fileManager.setAttributes(
+                [.modificationDate: Date()],
+                ofItemAtPath: backupURL.path
+            )
             self.pruneRollbackBackups()
             DebugLogger.shared.info(
                 "SimpleUpdater: Created rollback backup at \(backupURL.path)",
@@ -521,6 +528,51 @@ final class SimpleUpdater {
                 )
             }
         }
+    }
+
+    static func sortedRollbackBackups(
+        _ urls: [URL],
+        modificationDate: (URL) -> Date?
+    ) -> [URL] {
+        return urls
+            .compactMap { url -> (URL, Date)? in
+                guard let createdAt = self.rollbackBackupCreationDate(
+                    from: url,
+                    fallbackModificationDate: modificationDate(url)
+                ) else {
+                    return nil
+                }
+                return (url, createdAt)
+            }
+            .sorted { $0.1 > $1.1 }
+            .map { $0.0 }
+    }
+
+    static func isRollbackVersion(_ version: String?, differentFrom currentVersion: String) -> Bool {
+        guard let version else { return false }
+        return version != currentVersion
+    }
+
+    private static func rollbackBackupCreationDate(
+        from url: URL,
+        fallbackModificationDate: Date?
+    ) -> Date? {
+        if let timestamp = self.rollbackBackupTimestamp(from: url) {
+            return Date(timeIntervalSince1970: timestamp)
+        }
+
+        return fallbackModificationDate
+    }
+
+    private static func rollbackBackupTimestamp(from url: URL) -> TimeInterval? {
+        let name = url.deletingPathExtension().lastPathComponent
+        guard let suffix = name.split(separator: "-").last,
+              let timestamp = TimeInterval(suffix)
+        else {
+            return nil
+        }
+
+        return timestamp
     }
 
     private func parseSemanticVersion(_ version: String) -> SemanticVersion? {

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -205,6 +205,54 @@ final class DictationE2ETests: XCTestCase {
         }
     }
 
+    func testRollbackBackupsPreferFilenameTimestampOverModificationDate() {
+        let firstBackupWithNewestModificationDate = URL(
+            fileURLWithPath: "/tmp/FluidVoice-1.5.11-beta.1-100.app"
+        )
+        let secondBackup = URL(
+            fileURLWithPath: "/tmp/FluidVoice-1.5.11-beta.2-150.app"
+        )
+        let thirdBackup = URL(
+            fileURLWithPath: "/tmp/FluidVoice-1.5.11-beta.3-rollback-200.app"
+        )
+        let fourthBackupWithOldestModificationDate = URL(
+            fileURLWithPath: "/tmp/FluidVoice-1.5.11-beta.4-rollback-300.app"
+        )
+        let modificationDates = [
+            firstBackupWithNewestModificationDate: Date(timeIntervalSince1970: 500),
+            secondBackup: Date(timeIntervalSince1970: 300),
+            thirdBackup: Date(timeIntervalSince1970: 50),
+            fourthBackupWithOldestModificationDate: Date(timeIntervalSince1970: 10),
+        ]
+
+        let sorted = SimpleUpdater.sortedRollbackBackups(
+            [
+                firstBackupWithNewestModificationDate,
+                secondBackup,
+                thirdBackup,
+                fourthBackupWithOldestModificationDate,
+            ]
+        ) { url in
+            modificationDates[url]
+        }
+
+        XCTAssertEqual(
+            sorted,
+            [
+                fourthBackupWithOldestModificationDate,
+                thirdBackup,
+                secondBackup,
+                firstBackupWithNewestModificationDate,
+            ]
+        )
+    }
+
+    func testRollbackVersionIgnoresCurrentAppVersion() {
+        XCTAssertFalse(SimpleUpdater.isRollbackVersion("1.5.11-beta.3", differentFrom: "1.5.11-beta.3"))
+        XCTAssertTrue(SimpleUpdater.isRollbackVersion("1.5.11-beta.2", differentFrom: "1.5.11-beta.3"))
+        XCTAssertFalse(SimpleUpdater.isRollbackVersion(nil, differentFrom: "1.5.11-beta.3"))
+    }
+
     private static func modelDirectoryForRun() -> URL {
         // Use a stable path on CI so GitHub Actions cache can speed up runs.
         if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" ||


### PR DESCRIPTION
## Description
Fixes rollback target selection so FluidVoice chooses the newest rollback backup by the timestamp embedded in the backup filename, not copied app bundle modification date. Also prevents rollback from targeting the currently running app version.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #266

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 15
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Added ignored release note under `RELEASE_NOTES_1.5.13-beta.1.md`.
- Added focused tests for four rollback backup versions and current-version filtering.
- Local app had no rollback backups, so Settings correctly showed rollback disabled.

## Screenshots / Video 
N/A
