### PR TITLE
Notify on AI cleanup fallback

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -8,14 +8,16 @@
 import AppKit
 import PromiseKit
 import SwiftUI
+import UserNotifications
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
     private var updateCheckTimer: Timer?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Bring up file logging + crash handlers immediately during launch.
         _ = FileLogger.shared
         DebugLogger.shared.info("Application launched", source: "AppDelegate")
+        UNUserNotificationCenter.current().delegate = self
 
         // Initialize app settings (dock visibility, etc.)
         SettingsStore.shared.initializeAppSettings()
@@ -74,6 +76,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         return true
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .list])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        if userInfo[NotificationService.UserInfoKey.kind] as? String == NotificationService.Kind.aiProcessingFallback {
+            DispatchQueue.main.async {
+                AppNavigationRouter.shared.request(.history)
+                self.bringMainWindowToFront()
+            }
+        }
+
+        completionHandler()
     }
 
     private func forceFrontOnLaunch() {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -254,6 +254,7 @@ struct ContentView: View {
                 let isOnboarded = self.asr.isAsrReady || self.asr.modelsExistOnDisk
                 self.selectedSidebarItem = isOnboarded ? .preferences : .welcome
             }
+            self.handlePendingAppNavigation()
 
             // Reset auto-restart flag if permission was revoked (allows re-triggering if user re-grants)
             if !self.accessibilityEnabled {
@@ -605,6 +606,9 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openCustomDictionaryFromVoiceEngine)) { _ in
             self.selectedSidebarItem = .customDictionary
         }
+        .onReceive(NotificationCenter.default.publisher(for: .appNavigationRequested)) { _ in
+            self.handlePendingAppNavigation()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .settingsBackupDidRestore)) { _ in
             self.reloadSettingsStateAfterBackupRestore()
         }
@@ -794,6 +798,15 @@ struct ContentView: View {
         switch destination {
         case .preferences:
             self.selectedSidebarItem = .preferences
+        }
+    }
+
+    private func handlePendingAppNavigation() {
+        guard let destination = AppNavigationRouter.shared.consumePendingDestination() else { return }
+
+        switch destination {
+        case .history:
+            self.selectedSidebarItem = .history
         }
     }
 
@@ -1883,6 +1896,7 @@ struct ContentView: View {
                     source: "ContentView"
                 )
                 aiFallbackReason = error.localizedDescription
+                NotificationService.showAIProcessingFallback(error: error.localizedDescription)
                 finalText = transcribedText
             }
             let postProcessingLatencyMs = Int((Date().timeIntervalSince(postProcessingStart) * 1000).rounded())
@@ -2170,6 +2184,7 @@ struct ContentView: View {
                     source: "ContentView"
                 )
                 aiFallbackReason = error.localizedDescription
+                NotificationService.showAIProcessingFallback(error: error.localizedDescription)
                 finalText = transcribedText
             }
         }

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -55,6 +55,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let transcriptionPreviewCharLimit: Int
     let userTypingWPM: Int
     let saveTranscriptionHistory: Bool
+    let notifyAIProcessingFailures: Bool?
     let weekendsDontBreakStreak: Bool
     let fillerWords: [String]
     let removeFillerWordsEnabled: Bool

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2218,6 +2218,7 @@ final class SettingsStore: ObservableObject {
             transcriptionPreviewCharLimit: self.transcriptionPreviewCharLimit,
             userTypingWPM: self.userTypingWPM,
             saveTranscriptionHistory: self.saveTranscriptionHistory,
+            notifyAIProcessingFailures: self.notifyAIProcessingFailures,
             weekendsDontBreakStreak: self.weekendsDontBreakStreak,
             fillerWords: self.fillerWords,
             removeFillerWordsEnabled: self.removeFillerWordsEnabled,
@@ -2287,6 +2288,9 @@ final class SettingsStore: ObservableObject {
         self.transcriptionPreviewCharLimit = payload.transcriptionPreviewCharLimit
         self.userTypingWPM = payload.userTypingWPM
         self.saveTranscriptionHistory = payload.saveTranscriptionHistory
+        if let notifyAIProcessingFailures = payload.notifyAIProcessingFailures {
+            self.notifyAIProcessingFailures = notifyAIProcessingFailures
+        }
         self.weekendsDontBreakStreak = payload.weekendsDontBreakStreak
         self.fillerWords = payload.fillerWords
         self.removeFillerWordsEnabled = payload.removeFillerWordsEnabled

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2157,6 +2157,18 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Whether to show a native notification when AI post-processing fails and raw text is used
+    var notifyAIProcessingFailures: Bool {
+        get {
+            let value = self.defaults.object(forKey: Keys.notifyAIProcessingFailures)
+            return value as? Bool ?? true
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.notifyAIProcessingFailures)
+        }
+    }
+
     func makeBackupPayload() -> SettingsBackupPayload {
         SettingsBackupPayload(
             selectedProviderID: self.selectedProviderID,
@@ -3585,6 +3597,7 @@ private extension SettingsStore {
         // Stats Keys
         static let userTypingWPM = "UserTypingWPM"
         static let saveTranscriptionHistory = "SaveTranscriptionHistory"
+        static let notifyAIProcessingFailures = "NotifyAIProcessingFailures"
 
         // Filler Words
         static let fillerWords = "FillerWords"

--- a/Sources/Fluid/Services/AppNavigationRouter.swift
+++ b/Sources/Fluid/Services/AppNavigationRouter.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum AppNavigationDestination {
+    case history
+}
+
+final class AppNavigationRouter {
+    static let shared = AppNavigationRouter()
+
+    private var pendingDestination: AppNavigationDestination?
+
+    private init() {}
+
+    func request(_ destination: AppNavigationDestination) {
+        self.pendingDestination = destination
+        NotificationCenter.default.post(name: .appNavigationRequested, object: nil)
+    }
+
+    func consumePendingDestination() -> AppNavigationDestination? {
+        let destination = self.pendingDestination
+        self.pendingDestination = nil
+        return destination
+    }
+}
+
+extension Notification.Name {
+    static let appNavigationRequested = Notification.Name("AppNavigationRequested")
+}

--- a/Sources/Fluid/Services/NotificationService.swift
+++ b/Sources/Fluid/Services/NotificationService.swift
@@ -1,0 +1,66 @@
+import Foundation
+import UserNotifications
+
+enum NotificationService {
+    enum UserInfoKey {
+        static let kind = "kind"
+    }
+
+    enum Kind {
+        static let aiProcessingFallback = "aiProcessingFallback"
+    }
+
+    static func showAIProcessingFallback(error: String) {
+        guard SettingsStore.shared.notifyAIProcessingFailures else { return }
+
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                self.deliverAIProcessingFallback(error: error, using: center)
+            case .notDetermined:
+                center.requestAuthorization(options: [.alert, .sound]) { granted, requestError in
+                    if let requestError {
+                        DebugLogger.shared.warning(
+                            "Notification permission request failed: \(requestError.localizedDescription)",
+                            source: "NotificationService"
+                        )
+                    }
+                    guard granted else { return }
+                    self.deliverAIProcessingFallback(error: error, using: center)
+                }
+            case .denied:
+                DebugLogger.shared.debug(
+                    "Skipping AI fallback notification because notification permission is denied",
+                    source: "NotificationService"
+                )
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    private static func deliverAIProcessingFallback(error: String, using center: UNUserNotificationCenter) {
+        let content = UNMutableNotificationContent()
+        content.title = "AI cleanup failed"
+        content.body = "Typed raw transcription instead."
+        content.subtitle = error
+        content.sound = nil
+        content.userInfo = [UserInfoKey.kind: Kind.aiProcessingFallback]
+
+        let request = UNNotificationRequest(
+            identifier: "ai-cleanup-fallback-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+
+        center.add(request) { addError in
+            if let addError {
+                DebugLogger.shared.warning(
+                    "Failed to show AI fallback notification: \(addError.localizedDescription)",
+                    source: "NotificationService"
+                )
+            }
+        }
+    }
+}

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -817,6 +817,16 @@ struct SettingsView: View {
                                     Divider().opacity(0.2)
 
                                     self.optionToggleRow(
+                                        title: "Notify AI Cleanup Failures",
+                                        description: "Show a macOS notification when AI cleanup fails and raw transcription is typed.",
+                                        isOn: Binding(
+                                            get: { SettingsStore.shared.notifyAIProcessingFailures },
+                                            set: { SettingsStore.shared.notifyAIProcessingFailures = $0 }
+                                        )
+                                    )
+                                    Divider().opacity(0.2)
+
+                                    self.optionToggleRow(
                                         title: "Weekends Don't Break Streak",
                                         description: "Skip Saturday and Sunday when calculating usage streaks. Perfect for weekday-only users.",
                                         isOn: Binding(


### PR DESCRIPTION
## Description
Adds optional macOS notifications when AI cleanup fails and raw transcription is used. Clicking the notification opens FluidVoice to History.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Follows #281

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Updated local ignored release notes for `1.5.13-beta.1`.
- Notification click currently opens History, not a specific failed entry.

## Screenshots / Video
<img width="407" height="129" alt="image" src="https://github.com/user-attachments/assets/8f0334a3-25e0-4736-a992-b36584df74c6" />
