### PR TITLE
Fix notch dismissal when hover state is stale

### DIFF
--- a/Sources/Fluid/Services/NotchOverlayManager.swift
+++ b/Sources/Fluid/Services/NotchOverlayManager.swift
@@ -242,7 +242,7 @@ final class NotchOverlayManager {
 
         // Create notch with SwiftUI views
         let newNotch = DynamicNotch(
-            hoverBehavior: [.keepVisible],
+            hoverBehavior: [], // Recording overlays should dismiss even if hover state gets stale.
             style: .auto
         ) {
             NotchExpandedView(audioPublisher: audioLevelPublisher)


### PR DESCRIPTION
## Description
Prevents the recording notch from staying visible when DynamicNotchKit has a stale hover state. The normal notch now uses force-dismiss behavior instead of allowing hover to veto hide requests.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- N/A

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.3
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Release notes updated locally under `RELEASE_NOTES_1.5.13-beta.1.md`; file is intentionally gitignored and not committed.
- The expanded command output notch already used this no-keepVisible behavior.

## Screenshots / Video 
Not included; behavior was verified with local build/install/launch.