### PR TITLE
Fix Cohere long-audio duplication

### DIFF
--- a/Sources/Fluid/Services/ExternalCoreMLTranscriptionProvider.swift
+++ b/Sources/Fluid/Services/ExternalCoreMLTranscriptionProvider.swift
@@ -154,7 +154,10 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
             source: "ExternalCoreML"
         )
         let promptIDs = self.coherePromptIDsForCurrentLanguage()
-        let text = try await self.transcribeByManifestWindow(samples, manager: manager, promptIDs: promptIDs)
+        let text = try await manager.transcribe(
+            audioSamples: samples,
+            promptIDs: promptIDs.isEmpty ? nil : promptIDs
+        )
         let elapsed = Date().timeIntervalSince(startedAt)
         let rtf = audioSeconds > 0 ? elapsed / audioSeconds : 0
         DebugLogger.shared.info(
@@ -421,52 +424,6 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         let maxPreviewSamples = Int(Double(sampleRate) * self.streamingPreviewMaxSeconds)
         guard samples.count > maxPreviewSamples else { return samples }
         return Array(samples.suffix(maxPreviewSamples))
-    }
-
-    private func transcribeByManifestWindow(
-        _ samples: [Float],
-        manager: CohereTranscribeAsrManager,
-        promptIDs: [Int]
-    ) async throws -> String {
-        let runtimePromptIDs = promptIDs.isEmpty ? nil : promptIDs
-        let maxAudioSamples = self.loadedManifest?.maxAudioSamples ?? 0
-        guard maxAudioSamples > 0 else {
-            return try await manager.transcribe(
-                audioSamples: samples,
-                promptIDs: runtimePromptIDs
-            )
-        }
-
-        if samples.count <= maxAudioSamples {
-            return try await manager.transcribe(
-                audioSamples: self.paddedSamplesToModelLimit(samples),
-                promptIDs: runtimePromptIDs
-            )
-        }
-
-        let overlapSamples = min(self.loadedManifest?.overlapSamples ?? 0, maxAudioSamples / 2)
-        let step = max(maxAudioSamples - overlapSamples, 1)
-        var chunkTexts: [String] = []
-        var startIndex = 0
-
-        while startIndex < samples.count {
-            let endIndex = min(startIndex + maxAudioSamples, samples.count)
-            let chunk = Array(samples[startIndex..<endIndex])
-            let text = try await manager.transcribe(
-                audioSamples: self.paddedSamplesToModelLimit(chunk),
-                promptIDs: runtimePromptIDs
-            )
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.isEmpty == false {
-                chunkTexts.append(trimmed)
-            }
-            if endIndex >= samples.count {
-                break
-            }
-            startIndex += step
-        }
-
-        return chunkTexts.joined(separator: " ")
     }
 
     private func paddedSamplesToModelLimit(_ samples: [Float]) -> [Float] {


### PR DESCRIPTION
## Description
Routes final Cohere sample-buffer transcription directly through FluidAudio instead of chunking and plain-joining overlapping windows in FluidVoice. This lets FluidAudio own long-audio chunking and merge behavior.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #267

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.3
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Updated `RELEASE_NOTES_1.5.13-beta.1.md` locally; release notes are intentionally gitignored and not committed.
- Manual repro before the fix showed repeated count phrases around a Cohere chunk boundary; this change removes the FluidVoice-side overlap join that caused that class of duplicate.

## Screenshots / Video 
N/A - transcription pipeline fix.