### PR TITLE
Fix startup focus retry stealing focus

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -104,13 +104,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     private func forceFrontOnLaunch() {
         // Login-item launches can take longer before SwiftUI's main window exists.
-        // Keep retrying for a few seconds so the existing ContentView startup path runs.
+        // Keep retrying while FluidVoice is still foregrounded, but stop if the user switches away.
         for delay in [0.0, 0.12, 0.35, 1.0, 2.0, 4.0] {
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
                 guard let self else { return }
+                guard delay == 0.0 || self.shouldContinueLaunchForegroundRetry() else {
+                    DebugLogger.shared.debug("Skipped launch-front retry because another app is active", source: "AppDelegate")
+                    return
+                }
                 self.bringMainWindowToFront()
             }
         }
+    }
+
+    private func shouldContinueLaunchForegroundRetry() -> Bool {
+        if NSApp.isActive { return true }
+        return NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier
     }
 
     private func bringMainWindowToFront() {

--- a/Sources/Fluid/Models/HotkeyShortcut.swift
+++ b/Sources/Fluid/Models/HotkeyShortcut.swift
@@ -21,7 +21,7 @@ struct HotkeyShortcut: Codable, Equatable {
         if self.modifierFlags.contains(.option) { parts.append("⌥") }
         if self.modifierFlags.contains(.control) { parts.append("⌃") }
         if self.modifierFlags.contains(.shift) { parts.append("⇧") }
-        parts.append(Self.keyCodeToString(keyCode) ?? "?")
+        parts.append(Self.keyCodeToString(self.keyCode) ?? "?")
 
         if self.modifierFlags.isEmpty {
             return parts.last ?? "Unknown"
@@ -50,7 +50,7 @@ struct HotkeyShortcut: Codable, Equatable {
         case 124: return "Right"
         case 125: return "Down"
         case 126: return "Up"
-        default: return characterForKeyCode(keyCode) ?? qwertyFallback[keyCode]
+        default: return self.characterForKeyCode(keyCode) ?? self.qwertyFallback[keyCode]
         }
     }
 


### PR DESCRIPTION
## Description
Stops delayed startup foreground retries from reactivating FluidVoice after the user has already clicked into another app. The initial launch foreground behavior remains, but later retries now bail when FluidVoice is no longer active/frontmost.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #315

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.3
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Release notes updated locally under `RELEASE_NOTES_1.5.13-beta.1.md`; file is gitignored by design.
- SwiftFormat also normalized two `self.` references in `HotkeyShortcut.swift`.

## Screenshots / Video 
Not included; behavior verified by local build/install/launch.