### PR TITLE
Fix AI cleanup prompt controls

### DIFF
--- a/Sources/Fluid/Services/DictationAIPostProcessingGate.swift
+++ b/Sources/Fluid/Services/DictationAIPostProcessingGate.swift
@@ -1,11 +1,11 @@
+import CryptoKit
 import Foundation
 
 /// Shared gating logic for whether dictation AI post-processing is usable/configured.
 enum DictationAIPostProcessingGate {
     /// Returns true if dictation AI post-processing should be allowed, given current settings.
     /// - Requires dictation prompt selection to not be `Off`
-    /// - For Apple Intelligence: requires `AppleIntelligenceService.isAvailable`
-    /// - For other providers: requires a local endpoint OR a non-empty API key
+    /// - Requires the selected provider connection to still be verified
     static func isConfigured() -> Bool {
         self.isConfigured(for: .primary)
     }
@@ -17,18 +17,23 @@ enum DictationAIPostProcessingGate {
         return self.isProviderConfigured()
     }
 
-    /// Returns true if the selected AI provider is reachable/configured (API key or local endpoint),
+    /// Returns true if the selected AI provider is currently verified/configured,
     /// regardless of the AI toggle or prompt selection. Used to gate prompt-mode hotkey AI processing.
     static func isProviderConfigured() -> Bool {
         let settings = SettingsStore.shared
         let providerID = settings.selectedProviderID
+        let key = self.providerKey(for: providerID)
+        guard let storedFingerprint = settings.verifiedProviderFingerprints[key] else { return false }
+
         if providerID == "apple-intelligence" {
-            return AppleIntelligenceService.isAvailable
+            return storedFingerprint == "apple-intelligence" && AppleIntelligenceService.isAvailable
         }
+
         let baseURL = self.baseURL(for: providerID, settings: settings)
-        if self.isLocalEndpoint(baseURL) { return true }
         let apiKey = (settings.getAPIKey(for: providerID) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        return !apiKey.isEmpty
+        guard self.isLocalEndpoint(baseURL) || !apiKey.isEmpty else { return false }
+
+        return self.providerFingerprint(baseURL: baseURL, apiKey: apiKey) == storedFingerprint
     }
 
     static func baseURL(for providerID: String, settings: SettingsStore) -> String {
@@ -41,6 +46,22 @@ enum DictationAIPostProcessingGate {
         }
         // Unknown provider - fallback to OpenAI
         return ModelRepository.shared.defaultBaseURL(for: "openai")
+    }
+
+    static func providerKey(for providerID: String) -> String {
+        if ModelRepository.shared.isBuiltIn(providerID) { return providerID }
+        if providerID.hasPrefix("custom:") { return providerID }
+        return "custom:\(providerID)"
+    }
+
+    static func providerFingerprint(baseURL: String, apiKey: String) -> String? {
+        let trimmedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBase.isEmpty else { return nil }
+
+        let input = "\(trimmedBase)|\(trimmedKey)"
+        let digest = SHA256.hash(data: Data(input.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 
     static func isLocalEndpoint(_ urlString: String) -> Bool {

--- a/Sources/Fluid/Theme/NativeButtonStyles.swift
+++ b/Sources/Fluid/Theme/NativeButtonStyles.swift
@@ -1,5 +1,73 @@
 import SwiftUI
 
+enum FluidInteractionVisuals {
+    static let hoverScale: CGFloat = 1.01
+    static let pressedScale: CGFloat = 0.97
+    static let hoverAnimation: Animation = .spring(response: 0.18, dampingFraction: 0.78)
+    static let pressedAnimation: Animation = .spring(response: 0.2, dampingFraction: 0.8)
+
+    static func scale(isPressed: Bool, isHovered: Bool) -> CGFloat {
+        if isPressed { return self.pressedScale }
+        return isHovered ? self.hoverScale : 1
+    }
+}
+
+extension View {
+    func fluidControlSurface(
+        isSelected: Bool,
+        isHovered: Bool,
+        tone: Color,
+        cornerRadius: CGFloat
+    ) -> some View {
+        self.modifier(FluidControlSurfaceModifier(
+            isSelected: isSelected,
+            isHovered: isHovered,
+            tone: tone,
+            cornerRadius: cornerRadius
+        ))
+    }
+}
+
+private struct FluidControlSurfaceModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+    let isSelected: Bool
+    let isHovered: Bool
+    let tone: Color
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: self.cornerRadius, style: .continuous)
+        let fillOpacity = self.isSelected ? 0.96 : (self.isHovered ? 0.42 : 0)
+        let shineOpacity = self.isSelected ? 0.14 : (self.isHovered ? 0.07 : 0)
+        let strokeColor = self.isSelected
+            ? self.tone.opacity(0.24)
+            : (self.isHovered ? self.theme.palette.cardBorder.opacity(0.28) : .clear)
+
+        content
+            .background(
+                shape
+                    .fill(self.theme.palette.cardBackground.opacity(fillOpacity))
+                    .overlay(
+                        LinearGradient(
+                            colors: [.white.opacity(shineOpacity), .clear],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                        .clipShape(shape)
+                    )
+                    .overlay(shape.stroke(strokeColor, lineWidth: 1))
+                    .shadow(
+                        color: .black.opacity(self.isSelected ? 0.16 : (self.isHovered ? 0.08 : 0)),
+                        radius: self.isSelected || self.isHovered ? 5 : 0,
+                        y: self.isSelected || self.isHovered ? 1 : 0
+                    )
+            )
+            .scaleEffect(self.isHovered && !self.isSelected ? FluidInteractionVisuals.hoverScale : 1)
+            .animation(FluidInteractionVisuals.hoverAnimation, value: self.isSelected)
+            .animation(FluidInteractionVisuals.hoverAnimation, value: self.isHovered)
+    }
+}
+
 // MARK: - Primary (Prominent) Button
 
 struct GlassButtonStyle: ButtonStyle {
@@ -48,9 +116,9 @@ struct GlassButtonStyle: ButtonStyle {
                     x: 0,
                     y: self.isHovered ? self.theme.metrics.cardShadow.y : self.theme.metrics.cardShadow.y - 2
                 )
-                .scaleEffect(self.configuration.isPressed ? 0.97 : (self.isHovered ? 1.01 : 1.0))
-                .animation(.spring(response: 0.18, dampingFraction: 0.78), value: self.isHovered)
-                .animation(.spring(response: 0.2, dampingFraction: 0.8), value: self.configuration.isPressed)
+                .scaleEffect(FluidInteractionVisuals.scale(isPressed: self.configuration.isPressed, isHovered: self.isHovered))
+                .animation(FluidInteractionVisuals.hoverAnimation, value: self.isHovered)
+                .animation(FluidInteractionVisuals.pressedAnimation, value: self.configuration.isPressed)
                 .onHover { self.isHovered = $0 }
         }
     }
@@ -122,9 +190,9 @@ struct PremiumButtonStyle: ButtonStyle {
                     x: 0,
                     y: self.isHovered ? self.theme.metrics.elevatedCardShadow.y : self.theme.metrics.cardShadow.y
                 )
-                .scaleEffect(self.configuration.isPressed ? 0.98 : (self.isHovered ? 1.01 : 1.0))
-                .animation(.spring(response: 0.18, dampingFraction: 0.75), value: self.isHovered)
-                .animation(.spring(response: 0.18, dampingFraction: 0.75), value: self.configuration.isPressed)
+                .scaleEffect(FluidInteractionVisuals.scale(isPressed: self.configuration.isPressed, isHovered: self.isHovered))
+                .animation(FluidInteractionVisuals.hoverAnimation, value: self.isHovered)
+                .animation(FluidInteractionVisuals.pressedAnimation, value: self.configuration.isPressed)
                 .onHover { self.isHovered = $0 }
         }
     }
@@ -169,9 +237,9 @@ struct SecondaryButtonStyle: ButtonStyle {
                     x: 0,
                     y: self.isHovered ? self.theme.metrics.cardShadow.y : self.theme.metrics.cardShadow.y - 2
                 )
-                .scaleEffect(self.configuration.isPressed ? 0.98 : (self.isHovered ? 1.01 : 1.0))
-                .animation(.spring(response: 0.18, dampingFraction: 0.78), value: self.isHovered)
-                .animation(.spring(response: 0.2, dampingFraction: 0.8), value: self.configuration.isPressed)
+                .scaleEffect(FluidInteractionVisuals.scale(isPressed: self.configuration.isPressed, isHovered: self.isHovered))
+                .animation(FluidInteractionVisuals.hoverAnimation, value: self.isHovered)
+                .animation(FluidInteractionVisuals.pressedAnimation, value: self.configuration.isPressed)
                 .onHover { self.isHovered = $0 }
         }
     }
@@ -231,9 +299,9 @@ struct CompactButtonStyle: ButtonStyle {
                     x: 0,
                     y: self.isHovered ? self.theme.metrics.cardShadow.y - 1 : 1
                 )
-                .scaleEffect(self.configuration.isPressed ? 0.97 : (self.isHovered ? 1.01 : 1.0))
-                .animation(.spring(response: 0.18, dampingFraction: 0.78), value: self.isHovered)
-                .animation(.spring(response: 0.2, dampingFraction: 0.8), value: self.configuration.isPressed)
+                .scaleEffect(FluidInteractionVisuals.scale(isPressed: self.configuration.isPressed, isHovered: self.isHovered))
+                .animation(FluidInteractionVisuals.hoverAnimation, value: self.isHovered)
+                .animation(FluidInteractionVisuals.pressedAnimation, value: self.configuration.isPressed)
                 .onHover { self.isHovered = $0 }
         }
     }
@@ -288,9 +356,9 @@ struct AccentButtonStyle: ButtonStyle {
                     x: 0,
                     y: self.isHovered ? 3 : 2
                 )
-                .scaleEffect(self.configuration.isPressed ? 0.97 : (self.isHovered ? 1.02 : 1.0))
-                .animation(.spring(response: 0.18, dampingFraction: 0.78), value: self.isHovered)
-                .animation(.spring(response: 0.2, dampingFraction: 0.8), value: self.configuration.isPressed)
+                .scaleEffect(FluidInteractionVisuals.scale(isPressed: self.configuration.isPressed, isHovered: self.isHovered))
+                .animation(FluidInteractionVisuals.hoverAnimation, value: self.isHovered)
+                .animation(FluidInteractionVisuals.pressedAnimation, value: self.configuration.isPressed)
                 .onHover { self.isHovered = $0 }
         }
     }
@@ -329,9 +397,9 @@ struct InlineButtonStyle: ButtonStyle {
                     x: 0,
                     y: self.isHovered ? 3 : 1
                 )
-                .scaleEffect(self.configuration.isPressed ? 0.96 : (self.isHovered ? 1.03 : 1.0))
-                .animation(.easeOut(duration: 0.15), value: self.isHovered)
-                .animation(.easeOut(duration: 0.15), value: self.configuration.isPressed)
+                .scaleEffect(FluidInteractionVisuals.scale(isPressed: self.configuration.isPressed, isHovered: self.isHovered))
+                .animation(FluidInteractionVisuals.hoverAnimation, value: self.isHovered)
+                .animation(FluidInteractionVisuals.pressedAnimation, value: self.configuration.isPressed)
                 .onHover { self.isHovered = $0 }
         }
     }

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsView.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsView.swift
@@ -11,6 +11,9 @@ struct AIEnhancementSettingsView: View {
     @State var fluid1InterestErrorMessage: String = ""
     @State var fluid1InterestIsSubmitting: Bool = false
     @State var hoveredPromptCardKey: String? = nil
+    @State var selectedPromptMode: SettingsStore.PromptMode = .dictate
+    @State var hoveredPromptModeKey: String? = nil
+    @State var hoveredCleanupControlKey: String? = nil
 
     var body: some View {
         self.aiConfigurationCard

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -44,48 +44,14 @@ extension AIEnhancementSettingsView {
             .cornerRadius(6)
     }
 
-    func aiOnboardingInfoRow(_ body: String) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Circle()
-                .fill(self.theme.palette.accent.opacity(0.9))
-                .frame(width: 5, height: 5)
-                .padding(.top, 5)
-            Text(body)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
-
     // MARK: - AI Configuration Card
 
     var aiConfigurationCard: some View {
         VStack(spacing: 14) {
             ThemedCard(style: .prominent, hoverEffect: false) {
                 VStack(alignment: .leading, spacing: 16) {
-                    HStack(spacing: 12) {
-                        HStack(spacing: 10) {
-                            Image(systemName: "brain")
-                                .font(.title3)
-                                .foregroundStyle(self.theme.palette.accent)
-                            Text("AI Setup")
-                                .font(.title3)
-                                .fontWeight(.semibold)
-                        }
-                        Spacer()
-                    }
-
-                    Divider()
-                        .background(self.theme.palette.separator.opacity(0.5))
-
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Choose a provider, model, and dictation prompt. Select `Off` in Dictate prompts for raw transcription.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
-                        self.aiOnboardingInfoRow("Local models run on your Mac. Examples: Ollama and LM Studio.")
-                        self.aiOnboardingInfoRow("Cloud models use a provider of your choice. Examples: OpenAI, Anthropic, Groq, and OpenRouter.")
-                        self.aiOnboardingInfoRow("Dictation uses AI when Dictate prompt is `Default` or a custom prompt.")
-                    }
+                    self.aiSetupHeader
+                    self.aiSetupSummaryBar
 
                     HStack(spacing: 12) {
                         VStack(alignment: .leading, spacing: 2) {
@@ -132,6 +98,85 @@ extension AIEnhancementSettingsView {
                 }
                 .padding(16)
             }
+        }
+    }
+
+    private var aiSetupHeader: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(self.theme.palette.contentBackground.opacity(0.82))
+                    .overlay(
+                        LinearGradient(
+                            colors: [.white.opacity(0.1), .clear],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(self.theme.palette.accent.opacity(0.35), lineWidth: 1)
+                    )
+
+                Image(systemName: "brain")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(self.theme.palette.accent)
+            }
+            .frame(width: 34, height: 34)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("AI Enhancements")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(self.theme.palette.primaryText)
+                Text("Choose the model used for AI Cleanup.")
+                    .font(.caption)
+                    .foregroundStyle(self.theme.palette.secondaryText)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var aiSetupSummaryBar: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 12) {
+                self.aiSetupSummaryItem(icon: "cpu", text: "Local models run on Mac")
+                self.aiSetupSummaryDivider
+                self.aiSetupSummaryItem(icon: "cloud", text: "Cloud models use provider APIs")
+                self.aiSetupSummaryDivider
+                self.aiSetupSummaryItem(icon: "slider.horizontal.3", text: "AI Cleanup enables dictation prompts")
+            }
+
+            VStack(alignment: .leading, spacing: 7) {
+                self.aiSetupSummaryItem(icon: "cpu", text: "Local models run on Mac")
+                self.aiSetupSummaryItem(icon: "cloud", text: "Cloud models use provider APIs")
+                self.aiSetupSummaryItem(icon: "slider.horizontal.3", text: "AI Cleanup enables dictation prompts")
+            }
+        }
+        .padding(.horizontal, 2)
+        .padding(.vertical, 2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var aiSetupSummaryDivider: some View {
+        Rectangle()
+            .fill(self.theme.palette.separator.opacity(0.45))
+            .frame(width: 1, height: 14)
+    }
+
+    private func aiSetupSummaryItem(icon: String, text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(self.theme.palette.accent.opacity(0.95))
+                .frame(width: 14)
+
+            Text(text)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(self.theme.palette.secondaryText)
+                .lineLimit(1)
         }
     }
 

--- a/Sources/Fluid/UI/AISettingsView+AdvancedSettings.swift
+++ b/Sources/Fluid/UI/AISettingsView+AdvancedSettings.swift
@@ -26,28 +26,10 @@ extension AIEnhancementSettingsView {
                         }
                         .lineLimit(1)
                         .truncationMode(.tail)
-                        Spacer()
-                        Button("+ Add Prompt") {
-                            self.viewModel.openNewPromptEditor(prefillMode: .edit)
-                        }
-                        .buttonStyle(CompactButtonStyle(isReady: true))
-                        .frame(minWidth: AISettingsLayout.actionMinWidth, minHeight: AISettingsLayout.controlHeight)
                     }
 
-                    ViewThatFits(in: .horizontal) {
-                        HStack(alignment: .top, spacing: 12) {
-                            ForEach(SettingsStore.PromptMode.visiblePromptModes) { mode in
-                                self.promptModeSection(mode: mode)
-                                    .frame(maxWidth: .infinity, alignment: .topLeading)
-                            }
-                        }
-
-                        VStack(spacing: 14) {
-                            ForEach(SettingsStore.PromptMode.visiblePromptModes) { mode in
-                                self.promptModeSection(mode: mode)
-                            }
-                        }
-                    }
+                    self.promptControlsRow
+                    self.promptModeSection(mode: self.selectedPromptMode)
                 }
                 .padding(.horizontal, 4)
             }
@@ -168,6 +150,96 @@ extension AIEnhancementSettingsView {
         .animation(.easeOut(duration: 0.1), value: isHovering)
     }
 
+    private var promptControlsRow: some View {
+        ZStack {
+            HStack(alignment: .center, spacing: 12) {
+                Button("+ Add Prompt") {
+                    self.viewModel.openNewPromptEditor(prefillMode: self.selectedPromptMode)
+                }
+                .buttonStyle(CompactButtonStyle(isReady: true))
+                .frame(minWidth: AISettingsLayout.actionMinWidth, minHeight: AISettingsLayout.controlHeight)
+
+                Spacer(minLength: 8)
+
+                self.promptProcessingControl
+            }
+
+            self.promptModeTabSelector
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var promptProcessingControl: some View {
+        let isOff = self.viewModel.isPrimaryDictationPromptSelectionOff()
+
+        return HStack(alignment: .center, spacing: 7) {
+            Text("AI Cleanup")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(self.theme.palette.secondaryText)
+                .lineLimit(1)
+
+            self.cleanupSegmentedControl(isOff: isOff, mode: .dictate)
+        }
+        .help(isOff ? "Off: dictation types the raw transcript. Prompts and app overrides are paused." : "On: dictation uses the default prompt, then app overrides when matched.")
+    }
+
+    private var promptModeTabSelector: some View {
+        HStack(spacing: 2) {
+            ForEach(SettingsStore.PromptMode.visiblePromptModes) { mode in
+                self.promptModeTabButton(mode: mode)
+            }
+        }
+        .padding(3)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(self.theme.palette.contentBackground.opacity(0.78))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(self.theme.palette.cardBorder.opacity(0.22), lineWidth: 1)
+                )
+        )
+    }
+
+    private func promptModeTabButton(mode: SettingsStore.PromptMode) -> some View {
+        let isSelected = mode.normalized == self.selectedPromptMode.normalized
+        let isHovering = self.hoveredPromptModeKey == mode.normalized.rawValue
+        let tone = self.modeAccentColor(mode)
+        let cornerRadius: CGFloat = 12
+
+        return Button {
+            self.selectedPromptMode = mode.normalized
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: self.modeSymbol(mode))
+                    .font(.system(size: 11, weight: .semibold))
+                Text(self.friendlyModeName(mode))
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(isSelected ? tone : (isHovering ? self.theme.palette.primaryText : self.theme.palette.secondaryText))
+            .frame(width: self.promptTabWidth(for: mode), height: 32)
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .fluidControlSurface(
+                isSelected: isSelected,
+                isHovered: isHovering,
+                tone: tone,
+                cornerRadius: cornerRadius
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            self.hoveredPromptModeKey = hovering ? mode.normalized.rawValue : nil
+        }
+    }
+
+    private func promptTabWidth(for mode: SettingsStore.PromptMode) -> CGFloat {
+        switch mode.normalized {
+        case .dictate:
+            return 116
+        case .edit, .write, .rewrite:
+            return 124
+        }
+    }
+
     @ViewBuilder
     private func promptModeSection(mode: SettingsStore.PromptMode) -> some View {
         let customProfiles = self.viewModel.dictationPromptProfiles
@@ -205,77 +277,161 @@ extension AIEnhancementSettingsView {
                 self.editModeProviderModelRow
             }
 
-            if mode.normalized == .dictate {
-                self.promptProfileCard(
-                    cardKey: "\(mode.normalized.rawValue)-off",
-                    title: "Off",
-                    subtitle: "Use raw transcription for the primary dictation shortcut with no AI post-processing.",
-                    mode: mode,
-                    isSelected: self.viewModel.isPrimaryDictationPromptSelectionOff(),
-                    onUse: {
-                        self.viewModel.selectPrimaryDictationPromptOff()
-                    }
-                )
-            }
-
-            self.promptProfileCard(
-                cardKey: "\(mode.normalized.rawValue)-default",
-                title: mode.normalized == .dictate ? "Default Dictation Prompt" : "Default \(self.friendlyModeName(mode))",
-                subtitle: self.viewModel.promptPreview(self.viewModel.defaultPromptBodyPreview(for: mode)),
-                mode: mode,
-                isSelected: mode.normalized == .dictate
-                    ? (!self.viewModel.isPrimaryDictationPromptSelectionOff() && self.viewModel.selectedPromptID(for: mode) == nil)
-                    : self.viewModel.selectedPromptID(for: mode) == nil,
-                onUse: {
-                    self.viewModel.setSelectedPromptID(nil, for: mode)
-                },
-                onManage: { self.viewModel.openDefaultPromptViewer(for: mode) },
-                onResetDefault: { self.viewModel.resetDefaultPromptOverride(for: mode) },
-                canResetDefault: self.viewModel.hasDefaultPromptOverride(for: mode)
-            )
-
-            if customProfiles.isEmpty {
-                Text("No custom \(self.friendlyModeName(mode).lowercased()) prompts yet.")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 4)
+            if mode.normalized == .dictate && self.viewModel.isPrimaryDictationPromptSelectionOff() {
+                self.promptRoutingDisabledRow(mode: mode)
             } else {
-                ForEach(customProfiles) { profile in
-                    self.promptProfileCard(
-                        cardKey: "\(profile.mode.normalized.rawValue)-\(profile.id)",
-                        title: profile.name.isEmpty ? "Untitled Prompt" : profile.name,
-                        subtitle: SettingsStore.stripBasePrompt(for: profile.mode, from: profile.prompt).isEmpty
-                            ? "Empty prompt (uses Default)"
-                            : self.viewModel.promptPreview(SettingsStore.stripBasePrompt(for: profile.mode, from: profile.prompt)),
-                        mode: profile.mode,
-                        isSelected: self.viewModel.selectedPromptID(for: profile.mode) == profile.id,
-                        onUse: {
-                            self.viewModel.setSelectedPromptID(profile.id, for: profile.mode)
-                        },
-                        onManage: { self.viewModel.openEditor(for: profile) },
-                        onDelete: { self.viewModel.requestDeletePrompt(profile) }
-                    )
+                if mode.normalized == .dictate {
+                    self.promptRoutingHeader("Default Prompt")
                 }
-            }
 
-            self.appPromptBindingsSection(mode: mode)
+                self.promptProfileCard(
+                    cardKey: "\(mode.normalized.rawValue)-default",
+                    title: mode.normalized == .dictate ? "Built-in Default" : "Default \(self.friendlyModeName(mode))",
+                    subtitle: self.viewModel.promptPreview(self.viewModel.defaultPromptBodyPreview(for: mode)),
+                    mode: mode,
+                    isSelected: mode.normalized == .dictate
+                        ? (!self.viewModel.isPrimaryDictationPromptSelectionOff() && self.viewModel.selectedPromptID(for: mode) == nil)
+                        : self.viewModel.selectedPromptID(for: mode) == nil,
+                    onUse: {
+                        self.viewModel.setSelectedPromptID(nil, for: mode)
+                    },
+                    onManage: { self.viewModel.openDefaultPromptViewer(for: mode) },
+                    onResetDefault: { self.viewModel.resetDefaultPromptOverride(for: mode) },
+                    canResetDefault: self.viewModel.hasDefaultPromptOverride(for: mode)
+                )
+
+                if customProfiles.isEmpty {
+                    Text("No custom \(self.friendlyModeName(mode).lowercased()) prompts yet.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                } else {
+                    ForEach(customProfiles) { profile in
+                        self.promptProfileCard(
+                            cardKey: "\(profile.mode.normalized.rawValue)-\(profile.id)",
+                            title: profile.name.isEmpty ? "Untitled Prompt" : profile.name,
+                            subtitle: SettingsStore.stripBasePrompt(for: profile.mode, from: profile.prompt).isEmpty
+                                ? "Empty prompt (uses Default)"
+                                : self.viewModel.promptPreview(SettingsStore.stripBasePrompt(for: profile.mode, from: profile.prompt)),
+                            mode: profile.mode,
+                            isSelected: self.viewModel.selectedPromptID(for: profile.mode) == profile.id,
+                            onUse: {
+                                self.viewModel.setSelectedPromptID(profile.id, for: profile.mode)
+                            },
+                            onManage: { self.viewModel.openEditor(for: profile) },
+                            onDelete: { self.viewModel.requestDeletePrompt(profile) }
+                        )
+                    }
+                }
+
+                self.appPromptBindingsSection(mode: mode)
+            }
         }
         .padding(12)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(
-                    LinearGradient(
-                        colors: [
-                            tone.opacity(mode.normalized == .dictate ? 0.14 : 0.08),
-                            self.theme.palette.contentBackground.opacity(0.28),
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
+                .fill(self.theme.palette.cardBackground.opacity(0.68))
                 .overlay(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .stroke(tone.opacity(mode.normalized == .dictate ? 0.34 : 0.22), lineWidth: 1)
+                        .stroke(self.theme.palette.cardBorder.opacity(0.3), lineWidth: 1)
+                )
+        )
+    }
+
+    private func cleanupSegmentedControl(isOff: Bool, mode: SettingsStore.PromptMode) -> some View {
+        let tone = self.modeAccentColor(mode)
+
+        return
+            HStack(spacing: 4) {
+                self.cleanupSegmentButton(
+                    title: "Off",
+                    key: "off",
+                    isSelected: isOff,
+                    tone: tone,
+                    action: { self.viewModel.selectPrimaryDictationPromptOff() }
+                )
+
+                self.cleanupSegmentButton(
+                    title: "On",
+                    key: "on",
+                    isSelected: !isOff,
+                    tone: tone,
+                    action: { self.viewModel.setSelectedPromptID(nil, for: mode) }
+                )
+            }
+            .font(.system(size: 12, weight: .semibold))
+            .padding(3)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(self.theme.palette.contentBackground.opacity(0.78))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(self.theme.palette.cardBorder.opacity(0.22), lineWidth: 1)
+                    )
+            )
+    }
+
+    private func cleanupSegmentButton(
+        title: String,
+        key: String,
+        isSelected: Bool,
+        tone: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        let isHovering = self.hoveredCleanupControlKey == key
+        let cornerRadius: CGFloat = 9
+
+        return Button(title, action: action)
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12)
+            .frame(height: 26)
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .fluidControlSurface(
+                isSelected: isSelected,
+                isHovered: isHovering,
+                tone: tone,
+                cornerRadius: cornerRadius
+            )
+            .foregroundStyle(isSelected ? tone : (isHovering ? self.theme.palette.primaryText : self.theme.palette.secondaryText))
+            .onHover { hovering in
+                self.hoveredCleanupControlKey = hovering ? key : nil
+            }
+    }
+
+    private func promptRoutingHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(self.theme.palette.secondaryText)
+            .padding(.horizontal, 4)
+            .padding(.top, 4)
+    }
+
+    private func promptRoutingDisabledRow(mode: SettingsStore.PromptMode) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "lock")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(self.theme.palette.secondaryText)
+                .frame(width: 20, height: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("AI Cleanup is Off")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(self.theme.palette.primaryText)
+                Text("Dictation will type raw transcript. Prompts and app overrides won't run.")
+                    .font(.caption2)
+                    .foregroundStyle(self.theme.palette.secondaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(self.theme.palette.cardBackground.opacity(0.34))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(self.theme.palette.cardBorder.opacity(0.22), lineWidth: 1)
                 )
         )
     }
@@ -390,46 +546,43 @@ extension AIEnhancementSettingsView {
             .filter { $0.mode.normalized == mode.normalized }
 
         VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                Text("App-Based Prompts")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(self.theme.palette.secondaryText)
-                Spacer()
+            Text("App Overrides")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(self.theme.palette.secondaryText)
 
-                Menu {
-                    if appTargets.isEmpty {
-                        Text("No unassigned running apps")
-                    } else {
-                        ForEach(appTargets) { target in
-                            Button(self.appBindingTargetMenuTitle(target)) {
-                                self.viewModel.addAppPromptBinding(
-                                    for: mode,
-                                    appBundleID: target.bundleID,
-                                    appName: target.name
-                                )
-                            }
-                        }
-                    }
-
-                    Divider()
-
-                    Button("Choose App…") {
-                        self.viewModel.addAppPromptBindingFromFilePicker(for: mode)
-                    }
-                } label: {
-                    Text("+ Add App")
-                }
-                .buttonStyle(CompactButtonStyle())
-                .frame(minHeight: 26)
-            }
-
-            Text("Pick from running apps, or choose any .app to add an app not shown in the list.")
+            Text("Use a different prompt only in selected apps.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 4)
 
+            Menu {
+                if appTargets.isEmpty {
+                    Text("No unassigned running apps")
+                } else {
+                    ForEach(appTargets) { target in
+                        Button(self.appBindingTargetMenuTitle(target)) {
+                            self.viewModel.addAppPromptBinding(
+                                for: mode,
+                                appBundleID: target.bundleID,
+                                appName: target.name
+                            )
+                        }
+                    }
+                }
+
+                Divider()
+
+                Button("Choose App…") {
+                    self.viewModel.addAppPromptBindingFromFilePicker(for: mode)
+                }
+            } label: {
+                Text("+ Add App")
+            }
+            .buttonStyle(CompactButtonStyle(isReady: true))
+            .frame(minHeight: 26)
+
             if bindings.isEmpty {
-                Text("No app-specific overrides yet. Add one to route this mode to a different prompt in a specific app.")
+                Text("No app overrides yet. Add one to use a different prompt for a specific app.")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 4)
@@ -663,7 +816,7 @@ extension AIEnhancementSettingsView {
 
     private func modeAccentColor(_ mode: SettingsStore.PromptMode) -> Color {
         _ = mode
-        return Color.fluidGreen
+        return self.theme.palette.accent
     }
 
     private func appBindingTargetMenuTitle(_ target: AIEnhancementSettingsViewModel.AppBindingTarget) -> String {

--- a/Sources/Fluid/UI/GlossyEffects.swift
+++ b/Sources/Fluid/UI/GlossyEffects.swift
@@ -59,7 +59,7 @@ struct ButtonHoverModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .scaleEffect(self.isHovered ? 1.05 : 1.0)
+            .scaleEffect(self.isHovered ? FluidInteractionVisuals.hoverScale : 1.0)
             .shadow(
                 color: self.theme.palette.accent.opacity(self.isHovered ? 0.35 : 0.0),
                 radius: self.isHovered ? 8 : 0,
@@ -69,7 +69,7 @@ struct ButtonHoverModifier: ViewModifier {
             .onHover { hovering in
                 self.isHovered = hovering
             }
-            .animation(.spring(response: 0.2, dampingFraction: 0.7), value: self.isHovered)
+            .animation(FluidInteractionVisuals.hoverAnimation, value: self.isHovered)
     }
 }
 

--- a/Sources/Fluid/UI/TranscriptionHistoryView.swift
+++ b/Sources/Fluid/UI/TranscriptionHistoryView.swift
@@ -176,18 +176,22 @@ struct TranscriptionHistoryView: View {
         .buttonStyle(.plain)
         .contextMenu {
             Button {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(entry.processedText, forType: .string)
+                self.copyToClipboard(entry.processedText)
             } label: {
-                Label("Copy Text", systemImage: "doc.on.doc")
+                Label(entry.wasAIProcessed ? "Copy AI Text" : "Copy Text", systemImage: "doc.on.doc")
             }
 
             if entry.wasAIProcessed {
                 Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(entry.rawText, forType: .string)
+                    self.copyToClipboard(entry.rawText)
                 } label: {
                     Label("Copy Raw Text", systemImage: "doc.on.doc.fill")
+                }
+
+                Button {
+                    self.copyToClipboard(self.combinedText(for: entry))
+                } label: {
+                    Label("Copy Both", systemImage: "doc.on.doc")
                 }
             }
 
@@ -275,22 +279,40 @@ struct TranscriptionHistoryView: View {
             VStack(alignment: .leading, spacing: 20) {
                 // Header
                 VStack(alignment: .leading, spacing: 8) {
-                    HStack {
+                    HStack(spacing: 8) {
                         Text("Transcription Details")
                             .font(.system(size: 18, weight: .semibold))
 
                         Spacer()
 
-                        // Copy button
                         Button {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(entry.processedText, forType: .string)
+                            self.copyToClipboard(entry.processedText)
                         } label: {
-                            Label("Copy", systemImage: "doc.on.doc")
+                            Label(entry.wasAIProcessed ? "Copy AI" : "Copy", systemImage: "doc.on.doc")
                                 .font(.system(size: 12, weight: .medium))
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+
+                        if entry.wasAIProcessed {
+                            Button {
+                                self.copyToClipboard(entry.rawText)
+                            } label: {
+                                Label("Raw", systemImage: "doc.on.doc.fill")
+                                    .font(.system(size: 12, weight: .medium))
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+
+                            Button {
+                                self.copyToClipboard(self.combinedText(for: entry))
+                            } label: {
+                                Label("Both", systemImage: "doc.on.doc")
+                                    .font(.system(size: 12, weight: .medium))
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                        }
                     }
 
                     Text(entry.fullDateString)
@@ -457,6 +479,15 @@ struct TranscriptionHistoryView: View {
         .padding(10)
         .background(RoundedRectangle(cornerRadius: 8)
             .fill(self.theme.palette.cardBackground.opacity(0.9)))
+    }
+
+    private func copyToClipboard(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    private func combinedText(for entry: TranscriptionHistoryEntry) -> String {
+        "\(entry.rawText)\n\n\(entry.processedText)"
     }
 
     // MARK: - No Selection View


### PR DESCRIPTION
## Description
Clarifies the AI Cleanup prompt controls and fixes provider reset behavior so dictation AI cleanup only runs when the selected provider is still verified.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #321
- Closes #320

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.3
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- `RELEASE_NOTES_1.5.14.md` was updated locally and intentionally left uncommitted because release notes are gitignored.
- Provider reset now removes the verification fingerprint from the runtime gate, so existing Keychain API keys do not keep AI cleanup active after reset.

## Screenshots / Video 
Not attached.
