### PR TITLE
Add hotkey activation modes

### DIFF
--- a/Sources/Fluid/Analytics/AnalyticsService.swift
+++ b/Sources/Fluid/Analytics/AnalyticsService.swift
@@ -89,6 +89,7 @@ final class AnalyticsService {
             "ai_processing_enabled": anyDictationShortcutUsesAI,
             "streaming_preview_enabled": settings.enableStreamingPreview,
             "press_and_hold_mode": settings.pressAndHoldMode,
+            "hotkey_activation_mode": settings.hotkeyMode.rawValue,
             "copy_to_clipboard_enabled": settings.copyTranscriptionToClipboard,
         ]
 

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -169,7 +169,7 @@ struct ContentView: View {
     @State private var openAIBaseURL: String = ModelRepository.shared.defaultBaseURL(for: "openai")
 
     @State private var enableDebugLogs: Bool = SettingsStore.shared.enableDebugLogs
-    @State private var pressAndHoldModeEnabled: Bool = SettingsStore.shared.pressAndHoldMode
+    @State private var hotkeyMode: HotkeyActivationMode = SettingsStore.shared.hotkeyMode
     @State private var enableStreamingPreview: Bool = SettingsStore.shared.enableStreamingPreview
     @State private var copyToClipboard: Bool = SettingsStore.shared.copyTranscriptionToClipboard
 
@@ -1258,7 +1258,7 @@ struct ContentView: View {
             commandModeShortcutEnabled: self.$isCommandModeShortcutEnabled,
             rewriteShortcutEnabled: self.$isRewriteModeShortcutEnabled,
             hotkeyManagerInitialized: self.$hotkeyManagerInitialized,
-            pressAndHoldModeEnabled: self.$pressAndHoldModeEnabled,
+            hotkeyMode: self.$hotkeyMode,
             enableStreamingPreview: self.$enableStreamingPreview,
             copyToClipboard: self.$copyToClipboard,
             hotkeyManager: self.hotkeyManager,
@@ -1561,9 +1561,9 @@ struct ContentView: View {
             derivedBaseURL = ModelRepository.shared.defaultBaseURL(for: currentSelectedProviderID)
             derivedSelectedModel = storedSelectedModelByProvider[currentSelectedProviderID] ?? ModelRepository.shared.defaultModels(for: currentSelectedProviderID).first ?? ""
         } else {
-            // Unknown provider - fallback to OpenAI
+            // Unknown provider - fail closed instead of silently sending to OpenAI.
             derivedCurrentProvider = currentSelectedProviderID
-            derivedBaseURL = ModelRepository.shared.defaultBaseURL(for: "openai")
+            derivedBaseURL = ""
             derivedSelectedModel = storedSelectedModelByProvider[currentSelectedProviderID] ?? ""
         }
 
@@ -2683,7 +2683,7 @@ struct ContentView: View {
 
         self.hotkeyManagerInitialized = self.hotkeyManager?.validateEventTapHealth() ?? false
 
-        self.hotkeyManager?.enablePressAndHoldMode(self.pressAndHoldModeEnabled)
+        self.hotkeyManager?.setHotkeyMode(self.hotkeyMode)
 
         // Set cancel callback for Escape key handling (closes mode views, resets recording state)
         // Returns true if it handled something (so GlobalHotkeyManager knows to consume the event)
@@ -3128,7 +3128,7 @@ private extension ContentView {
         self.selectedInputUID = AudioDevice.getDefaultInputDevice()?.uid ?? ""
         self.selectedOutputUID = SettingsStore.shared.preferredOutputDeviceUID ?? ""
         self.enableDebugLogs = SettingsStore.shared.enableDebugLogs
-        self.pressAndHoldModeEnabled = SettingsStore.shared.pressAndHoldMode
+        self.hotkeyMode = SettingsStore.shared.hotkeyMode
         self.enableStreamingPreview = SettingsStore.shared.enableStreamingPreview
         self.copyToClipboard = SettingsStore.shared.copyTranscriptionToClipboard
         self.launchAtStartup = SettingsStore.shared.launchAtStartup

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -42,6 +42,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let enableDebugLogs: Bool
     let shareAnonymousAnalytics: Bool
     let pressAndHoldMode: Bool
+    let hotkeyMode: HotkeyActivationMode?
     let enableStreamingPreview: Bool
     let enableAIStreaming: Bool
     let copyTranscriptionToClipboard: Bool

--- a/Sources/Fluid/Persistence/HotkeyActivationMode.swift
+++ b/Sources/Fluid/Persistence/HotkeyActivationMode.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum HotkeyActivationMode: String, Codable, CaseIterable, Identifiable {
+    case toggle, hold, automatic
+
+    var id: String { self.rawValue }
+
+    var displayName: String {
+        switch self {
+        case .toggle: return "Toggle"
+        case .hold: return "Hold"
+        case .automatic: return "Automatic (Both)"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .toggle: return "Tap once to start, tap again to stop."
+        case .hold: return "Record only while the shortcut is held."
+        case .automatic: return "Tap to toggle, hold for push-to-talk."
+        }
+    }
+}

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1275,9 +1275,11 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    var pressAndHoldMode: Bool {
-        get { self.defaults.bool(forKey: Keys.pressAndHoldMode) }
-        set { self.defaults.set(newValue, forKey: Keys.pressAndHoldMode) }
+    var pressAndHoldMode: Bool { get { self.defaults.object(forKey: Keys.hotkeyMode) != nil ? self.hotkeyMode == .hold : self.defaults.bool(forKey: Keys.pressAndHoldMode) } set { self.hotkeyMode = newValue ? .hold : .toggle } }
+
+    var hotkeyMode: HotkeyActivationMode {
+        get { self.defaults.string(forKey: Keys.hotkeyMode).flatMap(HotkeyActivationMode.init(rawValue:)) ?? (self.defaults.bool(forKey: Keys.pressAndHoldMode) ? .hold : .toggle) }
+        set { objectWillChange.send(); self.defaults.set(newValue.rawValue, forKey: Keys.hotkeyMode); self.defaults.set(newValue == .hold, forKey: Keys.pressAndHoldMode) }
     }
 
     var enableStreamingPreview: Bool {
@@ -2262,6 +2264,7 @@ final class SettingsStore: ObservableObject {
             enableDebugLogs: self.enableDebugLogs,
             shareAnonymousAnalytics: self.shareAnonymousAnalytics,
             pressAndHoldMode: self.pressAndHoldMode,
+            hotkeyMode: self.hotkeyMode,
             enableStreamingPreview: self.enableStreamingPreview,
             enableAIStreaming: self.enableAIStreaming,
             copyTranscriptionToClipboard: self.copyTranscriptionToClipboard,
@@ -2333,7 +2336,7 @@ final class SettingsStore: ObservableObject {
         self.betaReleasesEnabled = payload.betaReleasesEnabled
         self.enableDebugLogs = payload.enableDebugLogs
         self.shareAnonymousAnalytics = payload.shareAnonymousAnalytics
-        self.pressAndHoldMode = payload.pressAndHoldMode
+        self.hotkeyMode = payload.hotkeyMode ?? (payload.pressAndHoldMode ? .hold : .toggle)
         self.enableStreamingPreview = payload.enableStreamingPreview
         self.enableAIStreaming = payload.enableAIStreaming
         self.copyTranscriptionToClipboard = payload.copyTranscriptionToClipboard
@@ -3618,6 +3621,7 @@ private extension SettingsStore {
         static let transcriptionSoundVolume = "TranscriptionSoundVolume"
         static let transcriptionSoundIndependentVolume = "TranscriptionSoundIndependentVolume"
         static let pressAndHoldMode = "PressAndHoldMode"
+        static let hotkeyMode = "HotkeyMode"
         static let enableStreamingPreview = "EnableStreamingPreview"
         static let enableAIStreaming = "EnableAIStreaming"
         static let copyTranscriptionToClipboard = "CopyTranscriptionToClipboard"

--- a/Sources/Fluid/Services/CommandModeService.swift
+++ b/Sources/Fluid/Services/CommandModeService.swift
@@ -486,6 +486,7 @@ final class CommandModeService: ObservableObject {
 
         } catch {
             let errorMsg = "Error: \(error.localizedDescription)"
+            DebugLogger.shared.error("Command mode failed: \(error.localizedDescription)", source: "CommandModeService")
             self.conversationHistory.append(Message(
                 role: .assistant,
                 content: errorMsg,
@@ -717,7 +718,7 @@ final class CommandModeService: ObservableObject {
         } else if ModelRepository.shared.isBuiltIn(providerID) {
             baseURL = ModelRepository.shared.defaultBaseURL(for: providerID)
         } else {
-            baseURL = ModelRepository.shared.defaultBaseURL(for: "openai")
+            baseURL = ""
         }
 
         // Build conversation with agentic system prompt

--- a/Sources/Fluid/Services/DictationAIPostProcessingGate.swift
+++ b/Sources/Fluid/Services/DictationAIPostProcessingGate.swift
@@ -50,8 +50,8 @@ enum DictationAIPostProcessingGate {
         if ModelRepository.shared.isBuiltIn(providerID) {
             return ModelRepository.shared.defaultBaseURL(for: providerID)
         }
-        // Unknown provider - fallback to OpenAI
-        return ModelRepository.shared.defaultBaseURL(for: "openai")
+        // Unknown provider: fail closed instead of silently treating it as OpenAI.
+        return ""
     }
 
     static func providerKey(for providerID: String) -> String {

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -1,14 +1,14 @@
 import AppKit
 import Foundation
 
-private enum HotkeyHoldModeType {
+private nonisolated enum HotkeyHoldModeType: Hashable {
     case transcription
     case promptMode
     case commandMode
     case rewriteMode
 }
 
-private final class HotkeyState: @unchecked Sendable {
+private final nonisolated class HotkeyState: @unchecked Sendable {
     private let lock = NSLock()
     var isKeyPressed = false
     var isPromptModeKeyPressed = false
@@ -20,6 +20,12 @@ private final class HotkeyState: @unchecked Sendable {
     var modifierPressStartTime: Date?
     var pendingHoldModeStart: Task<Void, Never>?
     var pendingHoldModeType: HotkeyHoldModeType?
+    var holdModeStartTriggeredTypes: Set<HotkeyHoldModeType> = []
+    var pendingReleaseStopTasks: [HotkeyHoldModeType: Task<Void, Never>] = [:]
+    var pendingReleaseStopTokens: [HotkeyHoldModeType: UUID] = [:]
+    var automaticPressStartTimes: [HotkeyHoldModeType: Date] = [:]
+    var automaticPressWasTargetActive: [HotkeyHoldModeType: Bool] = [:]
+    var automaticPressStartedTypes: Set<HotkeyHoldModeType> = []
 
     func withLock<T>(_ block: () -> T) -> T {
         self.lock.lock()
@@ -53,7 +59,8 @@ final class GlobalHotkeyManager: NSObject {
     private var isRewriteRecordingProvider: (() -> Bool)?
     private var isShortcutCaptureActiveProvider: (() -> Bool)?
     private var cancelCallback: (() -> Bool)? // Returns true if handled
-    private var pressAndHoldMode: Bool = SettingsStore.shared.pressAndHoldMode
+    private var hotkeyMode: HotkeyActivationMode = SettingsStore.shared.hotkeyMode
+    private let automaticTapThresholdSeconds: TimeInterval = 0.4
 
     private struct ModifierOnlyShortcutBehavior {
         let shortcut: HotkeyShortcut
@@ -67,6 +74,7 @@ final class GlobalHotkeyManager: NSObject {
         let setModeKeyPressed: (Bool) -> Void
         let onHoldStart: () -> Void
         let onToggleRelease: () -> Void
+        let isTargetModeActive: () -> Bool
     }
 
     enum ModifierTrackingResetReason {
@@ -126,6 +134,115 @@ final class GlobalHotkeyManager: NSObject {
     private nonisolated var pendingHoldModeType: HotkeyHoldModeType? {
         get { self.state.withLock { self.state.pendingHoldModeType } }
         set { self.state.withLock { self.state.pendingHoldModeType = newValue } }
+    }
+
+    private func cancelPendingReleaseStop(for type: HotkeyHoldModeType) {
+        let task = self.state.withLock { () -> Task<Void, Never>? in
+            _ = self.state.pendingReleaseStopTokens.removeValue(forKey: type)
+            return self.state.pendingReleaseStopTasks.removeValue(forKey: type)
+        }
+        task?.cancel()
+    }
+
+    private func cancelPendingReleaseStops() {
+        let tasks = self.state.withLock { () -> [Task<Void, Never>] in
+            let tasks = Array(self.state.pendingReleaseStopTasks.values)
+            self.state.pendingReleaseStopTasks.removeAll()
+            self.state.pendingReleaseStopTokens.removeAll()
+            return tasks
+        }
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    private func beginPendingReleaseStop(for type: HotkeyHoldModeType) -> UUID {
+        let token = UUID()
+        let task = self.state.withLock { () -> Task<Void, Never>? in
+            self.state.pendingReleaseStopTokens[type] = token
+            return self.state.pendingReleaseStopTasks.removeValue(forKey: type)
+        }
+        task?.cancel()
+        return token
+    }
+
+    private func storePendingReleaseStopTask(_ task: Task<Void, Never>, for type: HotkeyHoldModeType, token: UUID) {
+        let taskToCancel = self.state.withLock { () -> Task<Void, Never>? in
+            guard self.state.pendingReleaseStopTokens[type] == token else { return task }
+            let previousTask = self.state.pendingReleaseStopTasks[type]
+            self.state.pendingReleaseStopTasks[type] = task
+            return previousTask
+        }
+        taskToCancel?.cancel()
+    }
+
+    private func isPendingReleaseStopCurrent(for type: HotkeyHoldModeType, token: UUID) -> Bool {
+        self.state.withLock {
+            self.state.pendingReleaseStopTokens[type] == token
+        }
+    }
+
+    private func clearPendingReleaseStop(for type: HotkeyHoldModeType, token: UUID) {
+        self.state.withLock {
+            guard self.state.pendingReleaseStopTokens[type] == token else { return }
+            _ = self.state.pendingReleaseStopTokens.removeValue(forKey: type)
+            _ = self.state.pendingReleaseStopTasks.removeValue(forKey: type)
+        }
+    }
+
+    private func beginAutomaticPress(for type: HotkeyHoldModeType, wasTargetActive: Bool) {
+        self.cancelPendingReleaseStop(for: type)
+        self.state.withLock {
+            self.state.automaticPressStartTimes[type] = Date()
+            self.state.automaticPressWasTargetActive[type] = wasTargetActive
+            _ = self.state.automaticPressStartedTypes.remove(type)
+        }
+    }
+
+    private func markAutomaticPressStarted(for type: HotkeyHoldModeType) {
+        self.state.withLock {
+            _ = self.state.automaticPressStartedTypes.insert(type)
+        }
+    }
+
+    private func clearHoldModeStartTriggered(for type: HotkeyHoldModeType) {
+        self.state.withLock {
+            _ = self.state.holdModeStartTriggeredTypes.remove(type)
+        }
+    }
+
+    private func markHoldModeStartTriggered(for type: HotkeyHoldModeType) {
+        self.state.withLock {
+            _ = self.state.holdModeStartTriggeredTypes.insert(type)
+        }
+    }
+
+    private func finishHoldModeStartTriggered(for type: HotkeyHoldModeType) -> Bool {
+        self.state.withLock {
+            self.state.holdModeStartTriggeredTypes.remove(type) != nil
+        }
+    }
+
+    private func finishAutomaticPress(
+        for type: HotkeyHoldModeType
+    ) -> (duration: TimeInterval, wasTargetActive: Bool, started: Bool) {
+        let now = Date()
+        return self.state.withLock {
+            let startTime = self.state.automaticPressStartTimes.removeValue(forKey: type) ?? now
+            let wasTargetActive = self.state.automaticPressWasTargetActive.removeValue(forKey: type) ?? false
+            let started = self.state.automaticPressStartedTypes.remove(type) != nil
+            return (now.timeIntervalSince(startTime), wasTargetActive, started)
+        }
+    }
+
+    private func clearAutomaticPressTracking() {
+        self.cancelPendingReleaseStops()
+        self.state.withLock {
+            self.state.holdModeStartTriggeredTypes.removeAll()
+            self.state.automaticPressStartTimes.removeAll()
+            self.state.automaticPressWasTargetActive.removeAll()
+            self.state.automaticPressStartedTypes.removeAll()
+        }
     }
 
     /// Busy flag to prevent race conditions during stop processing
@@ -425,14 +542,37 @@ final class GlobalHotkeyManager: NSObject {
 
             // Check command mode hotkey first
             if self.commandModeShortcutEnabled, self.matchesCommandModeShortcut(keyCode: keyCode, modifiers: eventModifiers) {
-                if self.pressAndHoldMode {
+                switch self.hotkeyMode {
+                case .hold:
                     // Press and hold: start on keyDown, stop on keyUp
                     if !self.isCommandModeKeyPressed {
+                        self.cancelPendingReleaseStop(for: .commandMode)
+                        self.clearHoldModeStartTriggered(for: .commandMode)
                         self.isCommandModeKeyPressed = true
                         DebugLogger.shared.info("Command mode shortcut pressed (hold mode) - starting", source: "GlobalHotkeyManager")
                         self.triggerCommandMode()
+                        self.markHoldModeStartTriggered(for: .commandMode)
                     }
-                } else {
+                case .automatic:
+                    if !self.isCommandModeKeyPressed {
+                        self.isCommandModeKeyPressed = true
+                        let isSameMode = self.asrService.isRunning && (self.isCommandRecordingProvider?() ?? false)
+                        self.beginAutomaticPress(for: .commandMode, wasTargetActive: isSameMode)
+                        if self.asrService.isRunning {
+                            if isSameMode {
+                                DebugLogger.shared.info("Command mode shortcut pressed (automatic, same mode) - waiting for release", source: "GlobalHotkeyManager")
+                            } else {
+                                DebugLogger.shared.info("Command mode shortcut pressed (automatic, switch mode)", source: "GlobalHotkeyManager")
+                                self.triggerCommandMode()
+                                self.markAutomaticPressStarted(for: .commandMode)
+                            }
+                        } else {
+                            DebugLogger.shared.info("Command mode shortcut triggered (automatic) - starting", source: "GlobalHotkeyManager")
+                            self.triggerCommandMode()
+                            self.markAutomaticPressStarted(for: .commandMode)
+                        }
+                    }
+                case .toggle:
                     // Toggle mode: press to start, press again to stop
                     if self.asrService.isRunning {
                         if self.isCommandRecordingProvider?() ?? false {
@@ -453,14 +593,37 @@ final class GlobalHotkeyManager: NSObject {
             // Check dedicated rewrite mode hotkey
             if self.rewriteModeShortcutEnabled {
                 if self.matchesRewriteModeShortcut(keyCode: keyCode, modifiers: eventModifiers) {
-                    if self.pressAndHoldMode {
+                    switch self.hotkeyMode {
+                    case .hold:
                         // Press and hold: start on keyDown, stop on keyUp
                         if !self.isRewriteKeyPressed {
+                            self.cancelPendingReleaseStop(for: .rewriteMode)
+                            self.clearHoldModeStartTriggered(for: .rewriteMode)
                             self.isRewriteKeyPressed = true
                             DebugLogger.shared.info("Rewrite mode shortcut pressed (hold mode) - starting", source: "GlobalHotkeyManager")
                             self.triggerRewriteMode()
+                            self.markHoldModeStartTriggered(for: .rewriteMode)
                         }
-                    } else {
+                    case .automatic:
+                        if !self.isRewriteKeyPressed {
+                            self.isRewriteKeyPressed = true
+                            let isSameMode = self.asrService.isRunning && (self.isRewriteRecordingProvider?() ?? false)
+                            self.beginAutomaticPress(for: .rewriteMode, wasTargetActive: isSameMode)
+                            if self.asrService.isRunning {
+                                if isSameMode {
+                                    DebugLogger.shared.info("Rewrite mode shortcut pressed (automatic, same mode) - waiting for release", source: "GlobalHotkeyManager")
+                                } else {
+                                    DebugLogger.shared.info("Rewrite mode shortcut pressed (automatic, switch mode)", source: "GlobalHotkeyManager")
+                                    self.triggerRewriteMode()
+                                    self.markAutomaticPressStarted(for: .rewriteMode)
+                                }
+                            } else {
+                                DebugLogger.shared.info("Rewrite mode shortcut triggered (automatic) - starting", source: "GlobalHotkeyManager")
+                                self.triggerRewriteMode()
+                                self.markAutomaticPressStarted(for: .rewriteMode)
+                            }
+                        }
+                    case .toggle:
                         // Toggle mode: press to start, press again to stop
                         if self.asrService.isRunning {
                             if self.isRewriteRecordingProvider?() ?? false {
@@ -481,8 +644,11 @@ final class GlobalHotkeyManager: NSObject {
 
             // Then check transcription hotkey
             if self.matchesShortcut(keyCode: keyCode, modifiers: eventModifiers) {
-                if self.pressAndHoldMode {
+                switch self.hotkeyMode {
+                case .hold:
                     if !self.isKeyPressed {
+                        self.cancelPendingReleaseStop(for: .transcription)
+                        self.clearHoldModeStartTriggered(for: .transcription)
                         self.isKeyPressed = true
                         if self.asrService.isRunning {
                             let isSameMode = self.isDictateRecordingProvider?() ?? false
@@ -504,8 +670,32 @@ final class GlobalHotkeyManager: NSObject {
                             )
                             self.startRecordingIfNeeded()
                         }
+                        self.markHoldModeStartTriggered(for: .transcription)
                     }
-                } else {
+                case .automatic:
+                    if !self.isKeyPressed {
+                        self.isKeyPressed = true
+                        let isSameMode = self.asrService.isRunning && (self.isDictateRecordingProvider?() ?? false)
+                        self.beginAutomaticPress(for: .transcription, wasTargetActive: isSameMode)
+                        if self.asrService.isRunning {
+                            DebugLogger.shared.info(
+                                "Hotkey route | pressed=dictate | active=\(isSameMode ? "dictate" : "other") | asrRunning=true | action=\(isSameMode ? "release-stop" : "switch")",
+                                source: "GlobalHotkeyManager"
+                            )
+                            if !isSameMode {
+                                self.triggerDictationMode()
+                                self.markAutomaticPressStarted(for: .transcription)
+                            }
+                        } else {
+                            DebugLogger.shared.info(
+                                "Hotkey route | pressed=dictate | active=none | asrRunning=false | action=start",
+                                source: "GlobalHotkeyManager"
+                            )
+                            self.triggerDictationMode()
+                            self.markAutomaticPressStarted(for: .transcription)
+                        }
+                    }
+                case .toggle:
                     if self.asrService.isRunning {
                         let isSameMode = self.isDictateRecordingProvider?() ?? false
                         DebugLogger.shared.debug(
@@ -536,29 +726,56 @@ final class GlobalHotkeyManager: NSObject {
             // Prompt mode key up (press and hold mode)
             if self.handlePromptModeKeyUp(keyCode: keyCode) { return nil }
 
-            // Command mode key up (press and hold mode)
+            // Command mode key up
             // Note: Only check keyCode, not modifiers - user may release modifier before/with main key
-            if self.commandModeShortcutEnabled, self.pressAndHoldMode, self.isCommandModeKeyPressed, keyCode == self.commandModeShortcut.keyCode {
-                self.isCommandModeKeyPressed = false
-                DebugLogger.shared.info("Command mode shortcut released (hold mode) - stopping", source: "GlobalHotkeyManager")
-                self.stopRecordingIfNeeded()
+            if self.commandModeShortcutEnabled, self.isCommandModeKeyPressed, keyCode == self.commandModeShortcut.keyCode {
+                switch self.hotkeyMode {
+                case .hold:
+                    self.isCommandModeKeyPressed = false
+                    _ = self.finishHoldModeStartTriggered(for: .commandMode)
+                    DebugLogger.shared.info("Command mode shortcut released (hold mode) - stopping", source: "GlobalHotkeyManager")
+                    self.stopRecordingAfterRelease(for: .commandMode, label: "Command mode")
+                case .automatic:
+                    self.isCommandModeKeyPressed = false
+                    self.handleAutomaticKeyRelease(for: .commandMode, label: "Command mode")
+                case .toggle:
+                    break
+                }
                 return nil
             }
 
-            // Rewrite mode key up (press and hold mode)
+            // Rewrite mode key up
             // Note: Only check keyCode, not modifiers - user may release modifier before/with main key
-            if self.rewriteModeShortcutEnabled, self.pressAndHoldMode, self.isRewriteKeyPressed, keyCode == self.rewriteModeShortcut.keyCode {
-                self.isRewriteKeyPressed = false
-                DebugLogger.shared.info("Rewrite mode shortcut released (hold mode) - stopping", source: "GlobalHotkeyManager")
-                self.stopRecordingIfNeeded()
+            if self.rewriteModeShortcutEnabled, self.isRewriteKeyPressed, keyCode == self.rewriteModeShortcut.keyCode {
+                switch self.hotkeyMode {
+                case .hold:
+                    self.isRewriteKeyPressed = false
+                    _ = self.finishHoldModeStartTriggered(for: .rewriteMode)
+                    DebugLogger.shared.info("Rewrite mode shortcut released (hold mode) - stopping", source: "GlobalHotkeyManager")
+                    self.stopRecordingAfterRelease(for: .rewriteMode, label: "Rewrite mode")
+                case .automatic:
+                    self.isRewriteKeyPressed = false
+                    self.handleAutomaticKeyRelease(for: .rewriteMode, label: "Rewrite mode")
+                case .toggle:
+                    break
+                }
                 return nil
             }
 
             // Transcription key up
             // Note: Only check keyCode, not modifiers - user may release modifier before/with main key
-            if self.pressAndHoldMode, self.isKeyPressed, keyCode == self.shortcut.keyCode {
-                self.isKeyPressed = false
-                self.stopRecordingIfNeeded()
+            if self.isKeyPressed, keyCode == self.shortcut.keyCode {
+                switch self.hotkeyMode {
+                case .hold:
+                    self.isKeyPressed = false
+                    _ = self.finishHoldModeStartTriggered(for: .transcription)
+                    self.stopRecordingAfterRelease(for: .transcription, label: "Transcription")
+                case .automatic:
+                    self.isKeyPressed = false
+                    self.handleAutomaticKeyRelease(for: .transcription, label: "Transcription")
+                case .toggle:
+                    break
+                }
                 return nil
             }
 
@@ -597,7 +814,8 @@ final class GlobalHotkeyManager: NSObject {
                             DebugLogger.shared.info("Command mode modifier released (toggle) - starting", source: "GlobalHotkeyManager")
                             self.triggerCommandMode()
                         }
-                    }
+                    },
+                    isTargetModeActive: { self.isCommandRecordingProvider?() ?? false }
                 ),
                 keyCode: keyCode,
                 modifiers: eventModifiers
@@ -628,7 +846,8 @@ final class GlobalHotkeyManager: NSObject {
                             DebugLogger.shared.info("Rewrite mode modifier released (toggle) - starting", source: "GlobalHotkeyManager")
                             self.triggerRewriteMode()
                         }
-                    }
+                    },
+                    isTargetModeActive: { self.isRewriteRecordingProvider?() ?? false }
                 ),
                 keyCode: keyCode,
                 modifiers: eventModifiers
@@ -665,7 +884,8 @@ final class GlobalHotkeyManager: NSObject {
                             )
                             self.triggerDictationMode()
                         }
-                    }
+                    },
+                    isTargetModeActive: { self.isDictateRecordingProvider?() ?? false }
                 ),
                 keyCode: keyCode,
                 modifiers: eventModifiers
@@ -753,8 +973,191 @@ final class GlobalHotkeyManager: NSObject {
         DebugLogger.shared.info(message, source: "GlobalHotkeyManager")
     }
 
+    private func handleAutomaticKeyRelease(
+        for type: HotkeyHoldModeType,
+        label: String,
+        onUnstartedTap: (() -> Void)? = nil
+    ) {
+        let press = self.finishAutomaticPress(for: type)
+        let duration = String(format: "%.2f", press.duration)
+
+        if press.duration < self.automaticTapThresholdSeconds {
+            if press.wasTargetActive {
+                DebugLogger.shared.info("\(label) tap (\(duration)s) - stopping", source: "GlobalHotkeyManager")
+                self.stopRecordingIfNeeded()
+            } else if press.started {
+                DebugLogger.shared.info("\(label) tap (\(duration)s) - continuing", source: "GlobalHotkeyManager")
+            } else {
+                DebugLogger.shared.info("\(label) tap (\(duration)s) - toggling", source: "GlobalHotkeyManager")
+                onUnstartedTap?()
+            }
+            return
+        }
+
+        if press.wasTargetActive || press.started {
+            DebugLogger.shared.info("\(label) hold (\(duration)s) - stopping", source: "GlobalHotkeyManager")
+            self.stopRecordingAfterRelease(for: type, label: label)
+        } else {
+            DebugLogger.shared.debug("\(label) hold (\(duration)s) ignored - no automatic start", source: "GlobalHotkeyManager")
+        }
+    }
+
+    private func isRecordingTargetActive(for type: HotkeyHoldModeType) -> Bool {
+        switch type {
+        case .transcription:
+            guard let provider = self.isDictateRecordingProvider else { return true }
+            return provider()
+        case .promptMode:
+            guard let provider = self.isPromptModeRecordingProvider else { return true }
+            return provider()
+        case .commandMode:
+            guard let provider = self.isCommandRecordingProvider else { return true }
+            return provider()
+        case .rewriteMode:
+            guard let provider = self.isRewriteRecordingProvider else { return true }
+            return provider()
+        }
+    }
+
+    private func stopRecordingAfterRelease(for type: HotkeyHoldModeType, label: String) {
+        if self.asrService.isRunning {
+            self.cancelPendingReleaseStop(for: type)
+            self.stopRecordingIfNeeded()
+            return
+        }
+
+        let token = self.beginPendingReleaseStop(for: type)
+        DebugLogger.shared.debug("\(label) release stop deferred until recording starts", source: "GlobalHotkeyManager")
+
+        let task = Task { @MainActor [weak self] in
+            let maxAttempts = 60
+            let retryDelayNanoseconds: UInt64 = 50_000_000
+
+            for _ in 0..<maxAttempts {
+                guard !Task.isCancelled else { return }
+                guard let self = self else { return }
+                guard self.isPendingReleaseStopCurrent(for: type, token: token) else { return }
+
+                if self.asrService.isRunning {
+                    guard self.isRecordingTargetActive(for: type) else {
+                        DebugLogger.shared.debug("\(label) deferred stop skipped - active mode changed", source: "GlobalHotkeyManager")
+                        self.clearPendingReleaseStop(for: type, token: token)
+                        return
+                    }
+
+                    DebugLogger.shared.info("\(label) deferred stop after recording start", source: "GlobalHotkeyManager")
+                    self.clearPendingReleaseStop(for: type, token: token)
+                    await self.stopRecordingInternal()
+                    return
+                }
+
+                try? await Task.sleep(nanoseconds: retryDelayNanoseconds)
+            }
+
+            guard !Task.isCancelled else { return }
+            guard let self = self else { return }
+            guard self.isPendingReleaseStopCurrent(for: type, token: token) else { return }
+            DebugLogger.shared.warning("\(label) deferred stop expired before recording started", source: "GlobalHotkeyManager")
+            self.clearPendingReleaseStop(for: type, token: token)
+        }
+
+        self.storePendingReleaseStopTask(task, for: type, token: token)
+    }
+
+    private func label(for type: HotkeyHoldModeType) -> String {
+        switch type {
+        case .transcription:
+            return "Transcription"
+        case .promptMode:
+            return "Prompt mode"
+        case .commandMode:
+            return "Command mode"
+        case .rewriteMode:
+            return "Rewrite mode"
+        }
+    }
+
+    private func scheduleModifierOnlyStart(for behavior: ModifierOnlyShortcutBehavior) {
+        guard self.hotkeyMode != .toggle, !behavior.isModeKeyPressed() else { return }
+
+        self.cancelPendingReleaseStop(for: behavior.holdModeType)
+        self.clearHoldModeStartTriggered(for: behavior.holdModeType)
+        behavior.setModeKeyPressed(true)
+        self.pendingHoldModeStart?.cancel()
+        self.pendingHoldModeType = behavior.holdModeType
+
+        let wasTargetActive = self.asrService.isRunning && behavior.isTargetModeActive()
+        if self.hotkeyMode == .automatic {
+            self.beginAutomaticPress(for: behavior.holdModeType, wasTargetActive: wasTargetActive)
+        }
+
+        self.pendingHoldModeStart = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard let self = self, !Task.isCancelled else { return }
+            guard behavior.isModeKeyPressed(), !self.otherKeyPressedDuringModifier else {
+                DebugLogger.shared.debug(behavior.holdStartCancelledMessage, source: "GlobalHotkeyManager")
+                return
+            }
+            guard self.hotkeyMode != .automatic || !wasTargetActive else { return }
+            DebugLogger.shared.info(behavior.holdStartMessage, source: "GlobalHotkeyManager")
+            if self.hotkeyMode == .hold {
+                self.markHoldModeStartTriggered(for: behavior.holdModeType)
+            }
+            behavior.onHoldStart()
+            if self.hotkeyMode == .automatic {
+                self.markAutomaticPressStarted(for: behavior.holdModeType)
+            }
+        }
+    }
+
+    private func finishModifierOnlyPress(
+        for behavior: ModifierOnlyShortcutBehavior,
+        wasCleanPress: Bool
+    ) {
+        self.pendingHoldModeStart?.cancel()
+        self.pendingHoldModeStart = nil
+        self.pendingHoldModeType = nil
+
+        switch self.hotkeyMode {
+        case .hold:
+            if behavior.isModeKeyPressed() {
+                behavior.setModeKeyPressed(false)
+                let didStart = self.finishHoldModeStartTriggered(for: behavior.holdModeType)
+                if self.asrService.isRunning || didStart {
+                    DebugLogger.shared.info(behavior.holdReleaseMessage, source: "GlobalHotkeyManager")
+                    self.stopRecordingAfterRelease(for: behavior.holdModeType, label: self.label(for: behavior.holdModeType))
+                }
+            }
+        case .automatic:
+            if behavior.isModeKeyPressed() {
+                behavior.setModeKeyPressed(false)
+            }
+            if wasCleanPress {
+                self.handleAutomaticKeyRelease(
+                    for: behavior.holdModeType,
+                    label: self.label(for: behavior.holdModeType),
+                    onUnstartedTap: behavior.onToggleRelease
+                )
+            } else {
+                let press = self.finishAutomaticPress(for: behavior.holdModeType)
+                if press.started {
+                    DebugLogger.shared.info("\(self.label(for: behavior.holdModeType)) modifier released after combo - stopping automatic start", source: "GlobalHotkeyManager")
+                    self.stopRecordingAfterRelease(for: behavior.holdModeType, label: self.label(for: behavior.holdModeType))
+                } else {
+                    DebugLogger.shared.debug(behavior.toggleIgnoredMessage, source: "GlobalHotkeyManager")
+                }
+            }
+        case .toggle:
+            if wasCleanPress {
+                behavior.onToggleRelease()
+            } else {
+                DebugLogger.shared.debug(behavior.toggleIgnoredMessage, source: "GlobalHotkeyManager")
+            }
+        }
+    }
+
     func resetModifierOnlyShortcutTracking(reason: ModifierTrackingResetReason = .shortcutCapture) {
-        let shouldStopActiveHold = self.pressAndHoldMode
+        let shouldStopActiveHold = self.hotkeyMode != .toggle
             && self.asrService.isRunning
             && (self.isKeyPressed || self.isPromptModeKeyPressed || self.isCommandModeKeyPressed || self.isRewriteKeyPressed)
 
@@ -765,6 +1168,7 @@ final class GlobalHotkeyManager: NSObject {
         self.pendingHoldModeStart?.cancel()
         self.pendingHoldModeStart = nil
         self.pendingHoldModeType = nil
+        self.clearAutomaticPressTracking()
         self.isKeyPressed = false
         self.isPromptModeKeyPressed = false
         self.isCommandModeKeyPressed = false
@@ -785,13 +1189,36 @@ final class GlobalHotkeyManager: NSObject {
 
     private func handlePromptModeKeyDown(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> Bool {
         guard self.promptModeShortcutEnabled, self.matchesPromptModeShortcut(keyCode: keyCode, modifiers: modifiers) else { return false }
-        if self.pressAndHoldMode {
+        switch self.hotkeyMode {
+        case .hold:
             if !self.isPromptModeKeyPressed {
+                self.cancelPendingReleaseStop(for: .promptMode)
+                self.clearHoldModeStartTriggered(for: .promptMode)
                 self.isPromptModeKeyPressed = true
                 DebugLogger.shared.info("Prompt mode shortcut pressed (hold mode) - starting", source: "GlobalHotkeyManager")
                 self.triggerPromptMode()
+                self.markHoldModeStartTriggered(for: .promptMode)
             }
-        } else {
+        case .automatic:
+            if !self.isPromptModeKeyPressed {
+                self.isPromptModeKeyPressed = true
+                let isSameMode = self.asrService.isRunning && (self.isPromptModeRecordingProvider?() ?? false)
+                self.beginAutomaticPress(for: .promptMode, wasTargetActive: isSameMode)
+                if self.asrService.isRunning {
+                    if isSameMode {
+                        DebugLogger.shared.info("Prompt mode shortcut pressed (automatic, same mode) - waiting for release", source: "GlobalHotkeyManager")
+                    } else {
+                        DebugLogger.shared.info("Prompt mode shortcut pressed (automatic, switch mode)", source: "GlobalHotkeyManager")
+                        self.triggerPromptMode()
+                        self.markAutomaticPressStarted(for: .promptMode)
+                    }
+                } else {
+                    DebugLogger.shared.info("Prompt mode shortcut triggered (automatic) - starting", source: "GlobalHotkeyManager")
+                    self.triggerPromptMode()
+                    self.markAutomaticPressStarted(for: .promptMode)
+                }
+            }
+        case .toggle:
             if self.asrService.isRunning {
                 if self.isPromptModeRecordingProvider?() ?? false {
                     DebugLogger.shared.info("Prompt mode shortcut pressed in Prompt mode - stopping", source: "GlobalHotkeyManager")
@@ -809,11 +1236,20 @@ final class GlobalHotkeyManager: NSObject {
     }
 
     private func handlePromptModeKeyUp(keyCode: UInt16) -> Bool {
-        guard self.promptModeShortcutEnabled, self.pressAndHoldMode,
+        guard self.promptModeShortcutEnabled,
               self.isPromptModeKeyPressed, keyCode == self.promptModeShortcut.keyCode else { return false }
-        self.isPromptModeKeyPressed = false
-        DebugLogger.shared.info("Prompt mode shortcut released (hold mode) - stopping", source: "GlobalHotkeyManager")
-        self.stopRecordingIfNeeded()
+        switch self.hotkeyMode {
+        case .hold:
+            self.isPromptModeKeyPressed = false
+            _ = self.finishHoldModeStartTriggered(for: .promptMode)
+            DebugLogger.shared.info("Prompt mode shortcut released (hold mode) - stopping", source: "GlobalHotkeyManager")
+            self.stopRecordingAfterRelease(for: .promptMode, label: "Prompt mode")
+        case .automatic:
+            self.isPromptModeKeyPressed = false
+            self.handleAutomaticKeyRelease(for: .promptMode, label: "Prompt mode")
+        case .toggle:
+            break
+        }
         return true
     }
 
@@ -843,7 +1279,8 @@ final class GlobalHotkeyManager: NSObject {
                         DebugLogger.shared.info("Prompt mode modifier released (toggle) - starting", source: "GlobalHotkeyManager")
                         self.triggerPromptMode()
                     }
-                }
+                },
+                isTargetModeActive: { self.isPromptModeRecordingProvider?() ?? false }
             ),
             keyCode: keyCode,
             modifiers: modifiers
@@ -867,21 +1304,7 @@ final class GlobalHotkeyManager: NSObject {
                 self.otherKeyPressedDuringModifier = false
                 self.modifierPressStartTime = Date()
 
-                if self.pressAndHoldMode, !behavior.isModeKeyPressed() {
-                    behavior.setModeKeyPressed(true)
-                    self.pendingHoldModeStart?.cancel()
-                    self.pendingHoldModeType = behavior.holdModeType
-                    self.pendingHoldModeStart = Task { @MainActor [weak self] in
-                        try? await Task.sleep(nanoseconds: 150_000_000)
-                        guard let self = self, !Task.isCancelled else { return }
-                        guard behavior.isModeKeyPressed(), !self.otherKeyPressedDuringModifier else {
-                            DebugLogger.shared.debug(behavior.holdStartCancelledMessage, source: "GlobalHotkeyManager")
-                            return
-                        }
-                        DebugLogger.shared.info(behavior.holdStartMessage, source: "GlobalHotkeyManager")
-                        behavior.onHoldStart()
-                    }
-                }
+                self.scheduleModifierOnlyStart(for: behavior)
                 return true
             }
 
@@ -907,23 +1330,7 @@ final class GlobalHotkeyManager: NSObject {
             self.otherKeyPressedDuringModifier = false
             self.modifierPressStartTime = nil
 
-            if self.pressAndHoldMode {
-                self.pendingHoldModeStart?.cancel()
-                self.pendingHoldModeStart = nil
-                self.pendingHoldModeType = nil
-
-                if behavior.isModeKeyPressed() {
-                    behavior.setModeKeyPressed(false)
-                    if self.asrService.isRunning {
-                        DebugLogger.shared.info(behavior.holdReleaseMessage, source: "GlobalHotkeyManager")
-                        self.stopRecordingIfNeeded()
-                    }
-                }
-            } else if wasCleanPress {
-                behavior.onToggleRelease()
-            } else {
-                DebugLogger.shared.debug(behavior.toggleIgnoredMessage, source: "GlobalHotkeyManager")
-            }
+            self.finishModifierOnlyPress(for: behavior, wasCleanPress: wasCleanPress)
             return true
         }
 
@@ -938,21 +1345,7 @@ final class GlobalHotkeyManager: NSObject {
             self.otherKeyPressedDuringModifier = false
             self.modifierPressStartTime = Date()
 
-            if self.pressAndHoldMode, !behavior.isModeKeyPressed() {
-                behavior.setModeKeyPressed(true)
-                self.pendingHoldModeStart?.cancel()
-                self.pendingHoldModeType = behavior.holdModeType
-                self.pendingHoldModeStart = Task { @MainActor [weak self] in
-                    try? await Task.sleep(nanoseconds: 150_000_000)
-                    guard let self = self, !Task.isCancelled else { return }
-                    guard behavior.isModeKeyPressed(), !self.otherKeyPressedDuringModifier else {
-                        DebugLogger.shared.debug(behavior.holdStartCancelledMessage, source: "GlobalHotkeyManager")
-                        return
-                    }
-                    DebugLogger.shared.info(behavior.holdStartMessage, source: "GlobalHotkeyManager")
-                    behavior.onHoldStart()
-                }
-            }
+            self.scheduleModifierOnlyStart(for: behavior)
             return true
         }
 
@@ -978,23 +1371,7 @@ final class GlobalHotkeyManager: NSObject {
         self.otherKeyPressedDuringModifier = false
         self.modifierPressStartTime = nil
 
-        if self.pressAndHoldMode {
-            self.pendingHoldModeStart?.cancel()
-            self.pendingHoldModeStart = nil
-            self.pendingHoldModeType = nil
-
-            if behavior.isModeKeyPressed() {
-                behavior.setModeKeyPressed(false)
-                if self.asrService.isRunning {
-                    DebugLogger.shared.info(behavior.holdReleaseMessage, source: "GlobalHotkeyManager")
-                    self.stopRecordingIfNeeded()
-                }
-            }
-        } else if wasCleanPress {
-            behavior.onToggleRelease()
-        } else {
-            DebugLogger.shared.debug(behavior.toggleIgnoredMessage, source: "GlobalHotkeyManager")
-        }
+        self.finishModifierOnlyPress(for: behavior, wasCleanPress: wasCleanPress)
         return true
     }
 
@@ -1058,14 +1435,29 @@ final class GlobalHotkeyManager: NSObject {
         }
     }
 
-    func enablePressAndHoldMode(_ enable: Bool) {
-        self.pressAndHoldMode = enable
-        if !enable, self.isKeyPressed {
-            self.isKeyPressed = false
+    func setHotkeyMode(_ mode: HotkeyActivationMode) {
+        let shouldStopActivePress = self.hotkeyMode != .toggle
+            && self.asrService.isRunning
+            && (self.isKeyPressed || self.isPromptModeKeyPressed || self.isCommandModeKeyPressed || self.isRewriteKeyPressed)
+
+        self.hotkeyMode = mode
+        self.pendingHoldModeStart?.cancel()
+        self.pendingHoldModeStart = nil
+        self.pendingHoldModeType = nil
+        self.clearAutomaticPressTracking()
+        self.isKeyPressed = false
+        self.isPromptModeKeyPressed = false
+        self.isCommandModeKeyPressed = false
+        self.isRewriteKeyPressed = false
+
+        if shouldStopActivePress {
             self.stopRecordingIfNeeded()
-        } else if enable {
-            self.isKeyPressed = false
         }
+        DebugLogger.shared.info("Hotkey activation mode set to \(mode.displayName)", source: "GlobalHotkeyManager")
+    }
+
+    func enablePressAndHoldMode(_ enable: Bool) {
+        self.setHotkeyMode(enable ? .hold : .toggle)
     }
 
     private func toggleRecording() {
@@ -1121,18 +1513,15 @@ final class GlobalHotkeyManager: NSObject {
     }
 
     private func stopRecordingIfNeeded() {
-        // Capture state at event time
-        let shouldStop = self.asrService.isRunning
-        let alreadyProcessing = self.isProcessingStop
-
         Task { @MainActor [weak self] in
             guard let self = self else { return }
 
-            // Only stop if was running and not already processing
-            if !shouldStop || alreadyProcessing {
-                if alreadyProcessing {
-                    DebugLogger.shared.debug("Ignoring stop - already processing", source: "GlobalHotkeyManager")
-                }
+            if self.isProcessingStop {
+                DebugLogger.shared.debug("Ignoring stop - already processing", source: "GlobalHotkeyManager")
+                return
+            }
+
+            guard self.asrService.isRunning else {
                 return
             }
 

--- a/Sources/Fluid/Services/LLMClient.swift
+++ b/Sources/Fluid/Services/LLMClient.swift
@@ -187,6 +187,11 @@ final class LLMClient {
     private func buildRequest(_ config: Config) throws -> URLRequest {
         // Build endpoint URL
         let baseURL = config.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !baseURL.isEmpty else {
+            DebugLogger.shared.error("LLMClient: Missing base URL; refusing to fall back to OpenAI", source: "LLMClient")
+            throw LLMError.invalidURL
+        }
+
         let endpoint: String
         if baseURL.contains("/chat/completions") ||
             baseURL.contains("/api/chat") ||
@@ -194,61 +199,14 @@ final class LLMClient {
         {
             endpoint = baseURL
         } else {
-            endpoint = baseURL.isEmpty ? "\(ModelRepository.shared.defaultBaseURL(for: "openai"))/chat/completions" : "\(baseURL)/chat/completions"
+            endpoint = self.appendingPath("chat/completions", to: baseURL)
         }
 
         guard let url = URL(string: endpoint) else {
             throw LLMError.invalidURL
         }
 
-        // Detect if this is a local endpoint (skip auth for local)
-        let isLocal = self.isLocalEndpoint(baseURL)
-
-        // Build request body
-        var body: [String: Any] = [
-            "model": config.model,
-            "messages": config.messages,
-        ]
-
-        // Add temperature if provided (reasoning models like o1/o3/gpt-5 don't support it)
-        if let temp = config.temperature {
-            body["temperature"] = temp
-        }
-
-        // Add tools if provided
-        if !config.tools.isEmpty {
-            body["tools"] = config.tools
-            body["tool_choice"] = "auto"
-        }
-
-        // Add streaming flag
-        if config.streaming {
-            body["stream"] = true
-        }
-
-        // Add extra parameters in layers:
-        // 1. Model-specific parameters (from ThinkingParserFactory)
-        // 2. User-provided parameters (can override model defaults)
-
-        // Layer 1: Model-specific parameters (e.g., enable_thinking for Nemotron)
-        let modelExtras = ThinkingParserFactory.getExtraParameters(for: config.model)
-        for (key, value) in modelExtras {
-            body[key] = value
-        }
-
-        // Layer 2: User-provided extra parameters (e.g., reasoning_effort from settings)
-        for (key, value) in config.extraParameters {
-            body[key] = value
-        }
-
-        // Final Layer: Common parameters with model-specific keys
-        if let tokens = config.maxTokens {
-            if SettingsStore.shared.isReasoningModel(config.model) {
-                body["max_completion_tokens"] = tokens
-            } else {
-                body["max_tokens"] = tokens
-            }
-        }
+        let body = self.buildChatCompletionsBody(config)
 
         // Serialize to JSON
         guard let jsonData = try? JSONSerialization.data(withJSONObject: body, options: []) else {
@@ -277,6 +235,55 @@ final class LLMClient {
         return request
     }
 
+    private func appendingPath(_ path: String, to baseURL: String) -> String {
+        baseURL.hasSuffix("/") ? "\(baseURL)\(path)" : "\(baseURL)/\(path)"
+    }
+
+    private func buildChatCompletionsBody(_ config: Config) -> [String: Any] {
+        var body: [String: Any] = [
+            "model": config.model,
+            "messages": config.messages,
+        ]
+
+        // Add temperature if provided (reasoning models like o1/o3/gpt-5 don't support it)
+        if let temp = config.temperature {
+            body["temperature"] = temp
+        }
+
+        // Add tools if provided
+        if !config.tools.isEmpty {
+            body["tools"] = config.tools
+            body["tool_choice"] = "auto"
+        }
+
+        // Add streaming flag
+        if config.streaming {
+            body["stream"] = true
+        }
+
+        // Layer 1: Model-specific parameters (e.g., enable_thinking for Nemotron)
+        let modelExtras = ThinkingParserFactory.getExtraParameters(for: config.model)
+        for (key, value) in modelExtras {
+            body[key] = value
+        }
+
+        // Layer 2: User-provided extra parameters (e.g., reasoning_effort from settings)
+        for (key, value) in config.extraParameters {
+            body[key] = value
+        }
+
+        // Final Layer: Common parameters with model-specific keys
+        if let tokens = config.maxTokens {
+            if SettingsStore.shared.isReasoningModel(config.model) {
+                body["max_completion_tokens"] = tokens
+            } else {
+                body["max_tokens"] = tokens
+            }
+        }
+
+        return body
+    }
+
     // MARK: - Non-Streaming Response
 
     private func processNonStreaming(request: URLRequest) async throws -> Response {
@@ -292,13 +299,14 @@ final class LLMClient {
 
         DebugLogger.shared.debug("LLMClient: Non-streaming response received (\(data.count) bytes)", source: "LLMClient")
 
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = json["choices"] as? [[String: Any]],
-              let choice = choices.first,
-              let message = choice["message"] as? [String: Any]
-        else {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw LLMError.invalidResponse
         }
+
+        guard let choices = json["choices"] as? [[String: Any]],
+              let choice = choices.first,
+              let message = choice["message"] as? [String: Any]
+        else { throw LLMError.invalidResponse }
 
         return self.parseMessageResponse(message)
     }

--- a/Sources/Fluid/Services/RewriteModeService.swift
+++ b/Sources/Fluid/Services/RewriteModeService.swift
@@ -296,7 +296,7 @@ final class RewriteModeService: ObservableObject {
         } else if ModelRepository.shared.isBuiltIn(providerID) {
             baseURL = ModelRepository.shared.defaultBaseURL(for: providerID)
         } else {
-            baseURL = ModelRepository.shared.defaultBaseURL(for: "openai")
+            baseURL = ""
         }
 
         // Build messages array for LLMClient

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -222,6 +222,11 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         return providerID.isEmpty ? self.currentProvider : "custom:\(providerID)"
     }
 
+    func providerAPIKey(for providerID: String) -> String {
+        let key = self.providerKey(for: providerID)
+        return self.providerAPIKeys[key] ?? self.providerAPIKeys[providerID] ?? ""
+    }
+
     func providerDisplayName(for providerID: String) -> String {
         switch providerID {
         case "openai": return "OpenAI"
@@ -448,7 +453,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     func handleAPIKeyButtonTapped() {
         switch self.probeKeychainAccess() {
         case .granted:
-            self.newProviderApiKey = self.providerAPIKeys[self.currentProvider] ?? ""
+            self.newProviderApiKey = self.providerAPIKey(for: self.selectedProviderID)
             self.showAPIKeyEditor = true
         case let .denied(status):
             self.keychainPermissionMessage = self.keychainPermissionExplanation(for: status)
@@ -539,8 +544,8 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
         let providerID = self.selectedProviderID
         let providerName = ModelRepository.shared.displayName(for: providerID)
-        let apiKey = self.providerAPIKeys[self.currentProvider] ?? ""
-        let baseURL = self.openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiKey = self.providerAPIKey(for: providerID)
+        let baseURL = self.providerBaseURL(for: providerID)
         let isLocal = self.isLocalEndpoint(baseURL)
         let isAnthropic = providerID == "anthropic" || baseURL.contains("anthropic.com")
 
@@ -1064,14 +1069,23 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     }
 
     private func providerBaseURL(for providerID: String) -> String {
-        if providerID == self.selectedProviderID {
-            return self.openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
+        let currentBaseURL = self.openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         if let saved = self.savedProviders.first(where: { $0.id == providerID }) {
             return saved.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         if ModelRepository.shared.isBuiltIn(providerID) {
-            return ModelRepository.shared.defaultBaseURL(for: providerID).trimmingCharacters(in: .whitespacesAndNewlines)
+            let defaultBaseURL = ModelRepository.shared.defaultBaseURL(for: providerID).trimmingCharacters(in: .whitespacesAndNewlines)
+            let openAIDefaultURL = ModelRepository.shared.defaultBaseURL(for: "openai").trimmingCharacters(in: .whitespacesAndNewlines)
+            if providerID == self.selectedProviderID,
+               !currentBaseURL.isEmpty,
+               providerID == "openai" || currentBaseURL != openAIDefaultURL
+            {
+                return currentBaseURL
+            }
+            return defaultBaseURL
+        }
+        if providerID == self.selectedProviderID {
+            return currentBaseURL
         }
         return ""
     }
@@ -1099,7 +1113,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let key = self.providerKey(for: providerID)
         guard let stored = self.settings.verifiedProviderFingerprints[key] else { return }
         let baseURL = self.providerBaseURL(for: providerID)
-        let apiKey = self.providerAPIKeys[key] ?? ""
+        let apiKey = self.providerAPIKey(for: providerID)
         let current = self.fingerprint(baseURL: baseURL, apiKey: apiKey)
         if current != stored {
             self.settings.verifiedProviderFingerprints.removeValue(forKey: key)
@@ -1131,7 +1145,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
                 continue
             }
             let baseURL = self.providerBaseURL(for: providerID)
-            let apiKey = self.providerAPIKeys[key] ?? ""
+            let apiKey = self.providerAPIKey(for: providerID)
             let current = self.fingerprint(baseURL: baseURL, apiKey: apiKey)
             if current == stored {
                 statuses[providerID] = .success

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -1764,7 +1764,9 @@ extension AIEnhancementSettingsView {
     }
 
     var connectionTestSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        let selectedProviderAPIKey = self.viewModel.providerAPIKey(for: self.viewModel.selectedProviderID)
+
+        return VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 12) {
                 Button(action: { Task { await self.viewModel.testAPIConnection() } }) {
                     Text(self.viewModel.isTestingConnection ? "Verifying..." : "Verify Connection")
@@ -1775,7 +1777,7 @@ extension AIEnhancementSettingsView {
                 .frame(minWidth: AISettingsLayout.primaryActionMinWidth, minHeight: AISettingsLayout.controlHeight)
                 .disabled(self.viewModel.isTestingConnection ||
                     (!self.viewModel.isLocalEndpoint(self.viewModel.openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)) &&
-                        (self.viewModel.providerAPIKeys[self.viewModel.currentProvider] ?? "").isEmpty))
+                        selectedProviderAPIKey.isEmpty))
             }
 
             // Connection Status Display
@@ -1846,7 +1848,8 @@ extension AIEnhancementSettingsView {
                     .frame(minWidth: AISettingsLayout.actionMinWidth, minHeight: AISettingsLayout.controlHeight)
                 Button("OK") {
                     let trimmedKey = self.viewModel.newProviderApiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-                    self.viewModel.providerAPIKeys[self.viewModel.currentProvider] = trimmedKey
+                    let providerKey = self.viewModel.providerKey(for: self.viewModel.selectedProviderID)
+                    self.viewModel.providerAPIKeys[providerKey] = trimmedKey
                     self.viewModel.saveProviderAPIKeys()
                     if self.viewModel.connectionStatus != .unknown {
                         self.viewModel.connectionStatus = .unknown

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -44,7 +44,7 @@ struct SettingsView: View {
     @Binding var commandModeShortcutEnabled: Bool
     @Binding var rewriteShortcutEnabled: Bool
     @Binding var hotkeyManagerInitialized: Bool
-    @Binding var pressAndHoldModeEnabled: Bool
+    @Binding var hotkeyMode: HotkeyActivationMode
     @Binding var enableStreamingPreview: Bool
     @Binding var copyToClipboard: Bool
 
@@ -751,14 +751,28 @@ struct SettingsView: View {
                                 // MARK: - Options Section
 
                                 VStack(spacing: 12) {
-                                    self.optionToggleRow(
-                                        title: "Press and Hold Mode",
-                                        description: "The shortcut only records while you hold it down, giving you quick push-to-talk style control.",
-                                        isOn: self.$pressAndHoldModeEnabled
-                                    )
-                                    .onChange(of: self.pressAndHoldModeEnabled) { _, newValue in
-                                        SettingsStore.shared.pressAndHoldMode = newValue
-                                        self.hotkeyManager?.enablePressAndHoldMode(newValue)
+                                    HStack(alignment: .center) {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text("Activation Mode")
+                                                .font(.body)
+                                            Text(self.hotkeyMode.description)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+
+                                        Spacer()
+
+                                        Picker("", selection: self.$hotkeyMode) {
+                                            ForEach(HotkeyActivationMode.allCases) { mode in
+                                                Text(mode.displayName).tag(mode)
+                                            }
+                                        }
+                                        .pickerStyle(.menu)
+                                        .frame(width: 170, alignment: .trailing)
+                                    }
+                                    .onChange(of: self.hotkeyMode) { _, newValue in
+                                        SettingsStore.shared.hotkeyMode = newValue
+                                        self.hotkeyManager?.setHotkeyMode(newValue)
                                     }
                                     Divider().opacity(0.2)
 


### PR DESCRIPTION
## Description
Adds hotkey Activation Mode settings for Toggle, Hold, and Automatic behavior. Automatic supports tap-to-toggle plus push-to-talk, with deferred release-stop handling so a key-up during startup still stops recording once ASR begins.

Also tightens AI provider verification by using the selected provider key lookup consistently and failing closed when provider config is missing instead of falling back to OpenAI.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- None

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.3
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Updated `RELEASE_NOTES_1.5.14.md` locally; it is gitignored and intentionally not included in this PR.
- Credits @hkay-dev for the original activation mode PR inspiration in local release notes.

## Screenshots / Video 
Not included; behavior/settings change only.