### PR TITLE
Polish Command Mode AI settings

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -812,6 +812,8 @@ struct ContentView: View {
         guard let destination = AppNavigationRouter.shared.consumePendingDestination() else { return }
 
         switch destination {
+        case .aiEnhancements:
+            self.selectedSidebarItem = .aiEnhancements
         case .history:
             self.selectedSidebarItem = .history
         }
@@ -2407,7 +2409,7 @@ struct ContentView: View {
 
         // Process the command through CommandModeService
         // This stores the conversation history and executes any terminal commands
-        await self.commandModeService.processUserCommand(command)
+        await self.commandModeService.processUserCommand(command, notifyInvalidRequest: true)
 
         // Hide processing animation
         self.menuBarManager.setProcessing(false)
@@ -2685,7 +2687,7 @@ struct ContentView: View {
 
         self.hotkeyManager?.setHotkeyMode(self.hotkeyMode)
 
-        // Set cancel callback for Escape key handling (closes mode views, resets recording state)
+        // Set cancel callback for Escape key handling (closes transient UI, resets recording state)
         // Returns true if it handled something (so GlobalHotkeyManager knows to consume the event)
         self.hotkeyManager?.setCancelCallback {
             var handled = false
@@ -2703,8 +2705,8 @@ struct ContentView: View {
                 handled = true
             }
 
-            // Close mode views if open
-            if self.selectedSidebarItem == .commandMode || self.selectedSidebarItem == .rewriteMode {
+            // Close rewrite mode if open. Command Mode stays open so Escape can cancel voice capture without leaving the tool.
+            if self.selectedSidebarItem == .rewriteMode {
                 DebugLogger.shared.debug("Cancel callback: closing mode view", source: "ContentView")
                 DispatchQueue.main.async {
                     self.selectedSidebarItem = .welcome
@@ -2762,7 +2764,7 @@ struct ContentView: View {
             handled = true
         }
 
-        if self.selectedSidebarItem == .commandMode || self.selectedSidebarItem == .rewriteMode {
+        if self.selectedSidebarItem == .rewriteMode {
             DebugLogger.shared.debug("Cancel shortcut: closing mode view", source: "ContentView")
             let isOnboarded = self.asr.isAsrReady || self.asr.modelsExistOnDisk
             self.selectedSidebarItem = isOnboarded ? .preferences : .welcome

--- a/Sources/Fluid/Persistence/SettingsStore+CommandMode.swift
+++ b/Sources/Fluid/Persistence/SettingsStore+CommandMode.swift
@@ -1,0 +1,141 @@
+import Combine
+import CryptoKit
+import Foundation
+
+extension SettingsStore {
+    private var commandModeLinkedToGlobalKey: String { "CommandModeLinkedToGlobal" }
+
+    var commandModeLinkedToGlobal: Bool {
+        get {
+            if let value = UserDefaults.standard.object(forKey: self.commandModeLinkedToGlobalKey) as? Bool {
+                return value
+            }
+            return true
+        }
+        set {
+            objectWillChange.send()
+            UserDefaults.standard.set(newValue, forKey: self.commandModeLinkedToGlobalKey)
+        }
+    }
+
+    var effectiveCommandModeProviderID: String {
+        if self.commandModeLinkedToGlobal,
+           let providerID = self.supportedCommandModeProviderID(self.selectedProviderID)
+        {
+            return providerID
+        }
+
+        if let providerID = self.supportedCommandModeProviderID(self.commandModeSelectedProviderID) {
+            return providerID
+        }
+
+        return "openai"
+    }
+
+    var effectiveCommandModeSelectedModel: String {
+        let providerID = self.effectiveCommandModeProviderID
+        let models = self.commandModeModels(for: providerID)
+
+        if self.commandModeLinkedToGlobal,
+           self.supportedCommandModeProviderID(self.selectedProviderID) == providerID
+        {
+            let key = ModelRepository.shared.providerKey(for: providerID)
+            return self.nonEmptyModel(self.selectedModelByProvider[key])
+                ?? self.providerScopedModel(self.selectedModel, in: models)
+                ?? models.first
+                ?? "gpt-4.1"
+        }
+
+        return self.nonEmptyModel(self.commandModeSelectedModel) ?? models.first ?? "gpt-4.1"
+    }
+
+    var commandModeReadinessIssue: String? {
+        let sourceProviderID = self.commandModeLinkedToGlobal ? self.selectedProviderID : self.commandModeSelectedProviderID
+        if sourceProviderID == "apple-intelligence" || sourceProviderID == "apple-intelligence-disabled" {
+            return "Command Mode cannot use Apple Intelligence because terminal tools require a chat API. Choose a verified chat provider or turn Sync off."
+        }
+
+        let providerID = self.effectiveCommandModeProviderID
+        let model = self.effectiveCommandModeSelectedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !model.isEmpty else {
+            return "Command Mode needs a selected chat model."
+        }
+
+        if self.isUnsupportedCommandModeModel(model) {
+            return "Command Mode needs a chat model. The selected model is not supported by the chat/completions endpoint."
+        }
+
+        guard self.isCommandModeProviderVerified(providerID) else {
+            if self.commandModeLinkedToGlobal {
+                return "Command Mode needs a verified chat provider. Verify the synced AI Enhancement provider, or turn Sync off and choose one for Command Mode."
+            }
+            return "Command Mode needs a verified chat provider. Verify this provider in AI Enhancement before using Command Mode."
+        }
+
+        return nil
+    }
+
+    func commandModeModels(for providerID: String) -> [String] {
+        let storedList = ModelRepository.shared.providerKeys(for: providerID).lazy
+            .compactMap { self.availableModelsByProvider[$0] }
+            .first { !$0.isEmpty }
+
+        return storedList ?? ModelRepository.shared.defaultModels(for: providerID)
+    }
+
+    private func supportedCommandModeProviderID(_ providerID: String) -> String? {
+        let trimmed = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard trimmed != "apple-intelligence", trimmed != "apple-intelligence-disabled" else { return nil }
+        return trimmed
+    }
+
+    private func isCommandModeProviderVerified(_ providerID: String) -> Bool {
+        let key = ModelRepository.shared.providerKey(for: providerID)
+        guard let stored = self.verifiedProviderFingerprints[key] else { return false }
+
+        let baseURL = self.commandModeProviderBaseURL(for: providerID)
+        let apiKey = self.getAPIKey(for: providerID) ?? ""
+        return self.commandModeProviderFingerprint(baseURL: baseURL, apiKey: apiKey) == stored
+    }
+
+    private func commandModeProviderBaseURL(for providerID: String) -> String {
+        if let saved = self.savedProviders.first(where: { $0.id == providerID }) {
+            return saved.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if ModelRepository.shared.isBuiltIn(providerID) {
+            return ModelRepository.shared.defaultBaseURL(for: providerID).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return ""
+    }
+
+    private func commandModeProviderFingerprint(baseURL: String, apiKey: String) -> String? {
+        let trimmedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBase.isEmpty else { return nil }
+        let input = "\(trimmedBase)|\(trimmedKey)"
+        let digest = SHA256.hash(data: Data(input.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func isUnsupportedCommandModeModel(_ model: String) -> Bool {
+        let value = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if value.contains("embedding") || value.contains("rerank") || value.contains("moderation") {
+            return true
+        }
+        if value.hasPrefix("tts-") || value.hasPrefix("whisper-") || value.hasPrefix("dall-e") {
+            return true
+        }
+        return value == "davinci" || value == "curie" || value == "babbage" || value == "ada"
+    }
+
+    private func nonEmptyModel(_ model: String?) -> String? {
+        let trimmed = model?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private func providerScopedModel(_ model: String?, in models: [String]) -> String? {
+        guard let model = self.nonEmptyModel(model), models.contains(model) else { return nil }
+        return model
+    }
+}

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1853,14 +1853,6 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    var commandModeLinkedToGlobal: Bool {
-        get { self.defaults.bool(forKey: Keys.commandModeLinkedToGlobal) } // Default to false (let user opt-in, or true if preferred)
-        set {
-            objectWillChange.send()
-            self.defaults.set(newValue, forKey: Keys.commandModeLinkedToGlobal)
-        }
-    }
-
     // MARK: - Prompt Mode Settings (Transcribe with Prompt)
 
     var promptModeShortcutEnabled: Bool {

--- a/Sources/Fluid/Services/AppNavigationRouter.swift
+++ b/Sources/Fluid/Services/AppNavigationRouter.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum AppNavigationDestination {
+    case aiEnhancements
     case history
 }
 

--- a/Sources/Fluid/Services/CommandModeService.swift
+++ b/Sources/Fluid/Services/CommandModeService.swift
@@ -304,7 +304,7 @@ final class CommandModeService: ObservableObject {
     }
 
     /// Process user voice/text command
-    func processUserCommand(_ text: String) async {
+    func processUserCommand(_ text: String, notifyInvalidRequest: Bool = false) async {
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         self.isProcessing = true
@@ -321,7 +321,7 @@ final class CommandModeService: ObservableObject {
             NotchContentState.shared.setCommandProcessing(true)
         }
 
-        await self.processNextTurn()
+        await self.processNextTurn(notifyInvalidRequest: notifyInvalidRequest)
     }
 
     /// Process follow-up command from notch input
@@ -369,7 +369,7 @@ final class CommandModeService: ObservableObject {
 
     // MARK: - Agent Loop
 
-    private func processNextTurn() async {
+    private func processNextTurn(notifyInvalidRequest: Bool = false) async {
         if self.currentTurnCount >= self.maxTurns {
             let errorMsg = "Reached maximum steps limit. Please review the progress and continue if needed."
             self.conversationHistory.append(Message(
@@ -485,8 +485,16 @@ final class CommandModeService: ObservableObject {
             }
 
         } catch {
-            let errorMsg = "Error: \(error.localizedDescription)"
+            let errorMsg: String
+            if case LLMError.invalidRequest = error {
+                errorMsg = error.localizedDescription
+            } else {
+                errorMsg = "Error: \(error.localizedDescription)"
+            }
             DebugLogger.shared.error("Command mode failed: \(error.localizedDescription)", source: "CommandModeService")
+            if notifyInvalidRequest, case LLMError.invalidRequest = error {
+                NotificationService.showCommandModeFailure(error: errorMsg)
+            }
             self.conversationHistory.append(Message(
                 role: .assistant,
                 content: errorMsg,
@@ -707,9 +715,12 @@ final class CommandModeService: ObservableObject {
 
     private func callLLM() async throws -> LLMResponse {
         let settings = SettingsStore.shared
-        // Use Command Mode's independent provider/model settings
-        let providerID = settings.commandModeSelectedProviderID
-        let model = settings.commandModeSelectedModel ?? "gpt-4.1"
+        if let issue = settings.commandModeReadinessIssue {
+            throw LLMError.invalidRequest(issue)
+        }
+
+        let providerID = settings.effectiveCommandModeProviderID
+        let model = settings.effectiveCommandModeSelectedModel
         let apiKey = settings.getAPIKey(for: providerID) ?? ""
 
         let baseURL: String
@@ -990,9 +1001,17 @@ final class CommandModeService: ObservableObject {
             )
         }
 
+        if response.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            DebugLogger.shared.error(
+                "Command mode LLM returned empty content with no tool calls (model=\(model), provider=\(providerID))",
+                source: "CommandModeService"
+            )
+            throw LLMError.invalidResponse
+        }
+
         // Text response only
         return LLMResponse(
-            content: response.content.isEmpty ? "I couldn't understand that." : response.content,
+            content: response.content,
             thinking: finalThinking, // Display-only
             toolCall: nil
         )

--- a/Sources/Fluid/Services/LLMClient.swift
+++ b/Sources/Fluid/Services/LLMClient.swift
@@ -9,6 +9,7 @@ enum LLMError: Error, LocalizedError {
     case networkError(Error)
     case encodingError
     case timeout(TimeInterval)
+    case invalidRequest(String)
 
     var errorDescription: String? {
         switch self {
@@ -24,6 +25,8 @@ enum LLMError: Error, LocalizedError {
             return "Failed to encode request"
         case let .timeout(seconds):
             return "Request timed out after \(Int(seconds)) seconds"
+        case let .invalidRequest(message):
+            return message
         }
     }
 }
@@ -334,6 +337,7 @@ final class LLMClient {
         var thinkingBuffer: [String] = []
         var contentBuffer: [String] = []
         var tagDetectionBuffer = ""
+        var usesSeparateReasoningFields = false
 
         // Tool call accumulation
         var toolCallId: String?
@@ -376,6 +380,7 @@ final class LLMClient {
                 delta["thinking"] as? String
 
             if let reasoning = reasoningField {
+                usesSeparateReasoningFields = true
                 if state == .initial {
                     state = .inThinking
                     config.onThinkingStart?()
@@ -386,6 +391,16 @@ final class LLMClient {
 
             // Handle content with potential <think> tags
             if let content = delta["content"] as? String {
+                if usesSeparateReasoningFields {
+                    if state == .inThinking {
+                        state = .inContent
+                        config.onThinkingEnd?()
+                    }
+                    contentBuffer.append(content)
+                    config.onContentChunk?(content)
+                    continue
+                }
+
                 // If we were in thinking mode via a separate field (not tag-based),
                 // receiving "content" usually means the thinking phase is over.
                 if state == .inThinking && reasoningField == nil && tagDetectionBuffer.isEmpty {

--- a/Sources/Fluid/Services/NotificationService.swift
+++ b/Sources/Fluid/Services/NotificationService.swift
@@ -8,6 +8,7 @@ enum NotificationService {
 
     enum Kind {
         static let aiProcessingFallback = "aiProcessingFallback"
+        static let commandModeFailure = "commandModeFailure"
     }
 
     static func showAIProcessingFallback(error: String) {
@@ -40,6 +41,36 @@ enum NotificationService {
         }
     }
 
+    static func showCommandModeFailure(error: String) {
+        guard SettingsStore.shared.notifyAIProcessingFailures else { return }
+
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                self.deliverCommandModeFailure(error: error, using: center)
+            case .notDetermined:
+                center.requestAuthorization(options: [.alert, .sound]) { granted, requestError in
+                    if let requestError {
+                        DebugLogger.shared.warning(
+                            "Notification permission request failed: \(requestError.localizedDescription)",
+                            source: "NotificationService"
+                        )
+                    }
+                    guard granted else { return }
+                    self.deliverCommandModeFailure(error: error, using: center)
+                }
+            case .denied:
+                DebugLogger.shared.debug(
+                    "Skipping Command Mode notification because notification permission is denied",
+                    source: "NotificationService"
+                )
+            @unknown default:
+                break
+            }
+        }
+    }
+
     private static func deliverAIProcessingFallback(error: String, using center: UNUserNotificationCenter) {
         let content = UNMutableNotificationContent()
         content.title = "AI Enhancement failed"
@@ -58,6 +89,29 @@ enum NotificationService {
             if let addError {
                 DebugLogger.shared.warning(
                     "Failed to show AI fallback notification: \(addError.localizedDescription)",
+                    source: "NotificationService"
+                )
+            }
+        }
+    }
+
+    private static func deliverCommandModeFailure(error: String, using center: UNUserNotificationCenter) {
+        let content = UNMutableNotificationContent()
+        content.title = "Command Mode needs setup"
+        content.body = error
+        content.sound = nil
+        content.userInfo = [UserInfoKey.kind: Kind.commandModeFailure]
+
+        let request = UNNotificationRequest(
+            identifier: "command-mode-failure-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+
+        center.add(request) { addError in
+            if let addError {
+                DebugLogger.shared.warning(
+                    "Failed to show Command Mode notification: \(addError.localizedDescription)",
                     source: "NotificationService"
                 )
             }

--- a/Sources/Fluid/Views/CommandModeView.swift
+++ b/Sources/Fluid/Views/CommandModeView.swift
@@ -59,8 +59,14 @@ struct CommandModeView: View {
         .onChange(of: self.settings.commandModeSelectedProviderID) { _, _ in
             self.updateAvailableModels()
         }
-        .onExitCommand {
-            self.onClose?()
+        .onChange(of: self.settings.commandModeLinkedToGlobal) { _, _ in
+            self.updateAvailableModels()
+        }
+        .onChange(of: self.settings.selectedProviderID) { _, _ in
+            self.updateAvailableModels()
+        }
+        .onChange(of: self.settings.selectedModelByProvider) { _, _ in
+            self.updateAvailableModels()
         }
     }
 
@@ -283,21 +289,8 @@ struct CommandModeView: View {
                     }
 
                     if self.service.isProcessing {
-                        VStack(alignment: .leading, spacing: 8) {
-                            self.processingIndicator
-
-                            // Show thinking tokens in collapsible section (real-time)
-                            // Only show if setting is enabled AND there are thinking tokens
-                            if self.settings.showThinkingTokens && !self.service.streamingThinkingText.isEmpty {
-                                self.thinkingView
-                            }
-
-                            // Show streaming text in real-time
-                            if !self.service.streamingText.isEmpty {
-                                self.streamingTextView
-                            }
-                        }
-                        .id("processing")
+                        self.processingIndicator
+                            .id("processing")
                     }
 
                     Color.clear.frame(height: 1).id("bottom")
@@ -331,79 +324,29 @@ struct CommandModeView: View {
         }
     }
 
-    // MARK: - Thinking View (Cursor-style shimmer)
-
-    private var thinkingView: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header with shimmer effect - tap to expand/collapse
-            Button(action: { withAnimation(.easeInOut(duration: 0.2)) { self.isThinkingExpanded.toggle() } }) {
-                HStack(spacing: 8) {
-                    ThinkingShimmerLabel()
-
-                    Spacer()
-
-                    Image(systemName: self.isThinkingExpanded ? "chevron.up" : "chevron.down")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary.opacity(0.6))
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-            }
-            .buttonStyle(.plain)
-
-            // Expanded content
-            if self.isThinkingExpanded {
-                ScrollView(.vertical, showsIndicators: true) {
-                    Text(self.service.streamingThinkingText)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 12)
-                        .padding(.bottom, 10)
-                }
-                .frame(maxHeight: 200)
-            } else {
-                // Preview - first 150 chars
-                if !self.service.streamingThinkingText.isEmpty {
-                    Text(String(self.service.streamingThinkingText.prefix(150)) + (self.service.streamingThinkingText.count > 150 ? "..." : ""))
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary.opacity(0.7))
-                        .lineLimit(2)
-                        .padding(.horizontal, 12)
-                        .padding(.bottom, 8)
-                }
-            }
-        }
-        .background(self.theme.palette.cardBackground.opacity(0.9))
-        .cornerRadius(8)
-        .frame(maxWidth: 520, alignment: .leading)
-    }
-
     // MARK: - Processing Indicator (Minimal with Shimmer)
 
     private var processingIndicator: some View {
-        CommandShimmerText(text: self.currentStepLabel)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(self.theme.palette.cardBackground.opacity(0.9))
-            .cornerRadius(6)
-    }
+        VStack(alignment: .leading, spacing: 10) {
+            CommandShimmerText(text: "Thinking")
+                .padding(.horizontal, 12)
 
-    // MARK: - Streaming Text View (Real-time AI response)
-
-    private var streamingTextView: some View {
-        // Use fixedSize to prevent expensive re-layout on every update
-        Text(self.service.streamingText)
-            .font(.system(size: 13))
-            .foregroundStyle(.primary.opacity(0.9))
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: 520, alignment: .leading)
-            .background(self.theme.palette.contentBackground.opacity(0.9))
-            .cornerRadius(8)
-            .drawingGroup() // Flatten to bitmap for faster updates
-        // textSelection disabled during streaming - re-enabled in final message
+            if self.settings.showThinkingTokens && !self.service.streamingThinkingText.isEmpty {
+                ScrollView(.vertical, showsIndicators: true) {
+                    Text(self.service.streamingThinkingText)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 140)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 10)
+            }
+        }
+        .frame(maxWidth: 520, minHeight: 72, alignment: .leading)
+        .padding(.top, 8)
+        .padding(.bottom, 10)
     }
 
     private var currentStepLabel: String {
@@ -506,75 +449,160 @@ struct CommandModeView: View {
     // MARK: - Input Area
 
     private var inputArea: some View {
-        HStack(spacing: 8) {
-            // Provider Selector (compact, searchable)
-            SearchableProviderPicker(
-                builtInProviders: self.builtInProvidersList,
-                savedProviders: self.settings.savedProviders,
-                selectedProviderID: Binding(
-                    get: { self.settings.commandModeSelectedProviderID },
-                    set: { newValue in
-                        // Prevent selecting disabled Apple Intelligence
-                        if newValue == "apple-intelligence-disabled" || newValue == "apple-intelligence" {
-                            self.settings.commandModeSelectedProviderID = "openai"
-                        } else {
-                            self.settings.commandModeSelectedProviderID = newValue
-                        }
-                        self.updateAvailableModels()
+        VStack(alignment: .leading, spacing: 10) {
+            if let issue = self.settings.commandModeReadinessIssue {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    Text(issue)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+
+                    Spacer(minLength: 8)
+
+                    Button("AI Settings") {
+                        AppNavigationRouter.shared.request(.aiEnhancements)
                     }
-                )
-            )
-
-            // Model Selector (compact, searchable)
-            SearchableModelPicker(
-                models: self.availableModels,
-                selectedModel: Binding(
-                    get: { self.settings.commandModeSelectedModel ?? self.availableModels.first ?? "" },
-                    set: { self.settings.commandModeSelectedModel = $0 }
-                ),
-                onRefresh: nil,
-                isRefreshing: false
-            )
-
-            // Input field (flexible)
-            TextField("Type a command or ask a question...", text: self.$inputText)
-                .textFieldStyle(.roundedBorder)
-                .onSubmit {
-                    self.submitCommand()
+                    .font(.caption)
+                    .buttonStyle(.plain)
+                    .controlSize(.small)
                 }
-
-            Button(action: self.submitCommand) {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.title2)
+                .padding(.horizontal, 10)
+                .padding(.top, 2)
             }
-            .buttonStyle(.plain)
-            .disabled(self.inputText.isEmpty || self.service.isProcessing)
 
-            // Voice Input
-            Button(action: self.toggleRecording) {
-                Image(systemName: self.asr.isRunning ? "stop.circle.fill" : "mic.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(self.asr.isRunning ? Color.red : self.theme.palette.accent)
+            VStack(alignment: .leading, spacing: 14) {
+                TextField("Type a command or ask a question...", text: self.$inputText, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 16))
+                    .lineLimit(1...4)
+                    .onSubmit {
+                        self.submitCommand()
+                    }
+
+                HStack(spacing: 10) {
+                    Toggle("Sync", isOn: self.$settings.commandModeLinkedToGlobal)
+                        .toggleStyle(.checkbox)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .help("Use the same provider and model selected in AI Enhancement.")
+
+                    SearchableProviderPicker(
+                        builtInProviders: self.builtInProvidersList,
+                        savedProviders: self.settings.savedProviders,
+                        selectedProviderID: Binding(
+                            get: { self.settings.effectiveCommandModeProviderID },
+                            set: { newValue in
+                                guard !self.settings.commandModeLinkedToGlobal else { return }
+                                if newValue == "apple-intelligence-disabled" || newValue == "apple-intelligence" {
+                                    self.settings.commandModeSelectedProviderID = "openai"
+                                } else {
+                                    self.settings.commandModeSelectedProviderID = newValue
+                                }
+                                self.updateAvailableModels()
+                            }
+                        ),
+                        controlWidth: 140,
+                        controlHeight: 30
+                    )
+                    .disabled(self.settings.commandModeLinkedToGlobal)
+                    .opacity(self.settings.commandModeLinkedToGlobal ? 0.55 : 1)
+
+                    SearchableModelPicker(
+                        models: self.availableModels,
+                        selectedModel: Binding(
+                            get: { self.settings.effectiveCommandModeSelectedModel },
+                            set: { newValue in
+                                guard !self.settings.commandModeLinkedToGlobal else { return }
+                                self.settings.commandModeSelectedModel = newValue
+                            }
+                        ),
+                        onRefresh: nil,
+                        isRefreshing: false,
+                        selectionEnabled: !self.settings.commandModeLinkedToGlobal && !self.availableModels.isEmpty,
+                        controlWidth: 180,
+                        controlHeight: 30
+                    )
+                    .disabled(self.settings.commandModeLinkedToGlobal)
+
+                    Spacer(minLength: 12)
+
+                    Button(action: self.toggleRecording) {
+                        Image(systemName: self.asr.isRunning ? "stop.fill" : "mic")
+                            .font(.system(size: 15, weight: .semibold))
+                            .frame(width: 34, height: 34)
+                            .foregroundStyle(self.asr.isRunning ? Color.red : .secondary)
+                            .contentShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(self.service.isProcessing)
+                    .help(self.asr.isRunning ? "Stop voice command" : "Start voice command")
+
+                    Button(action: self.submitCommand) {
+                        Image(systemName: "arrow.up")
+                            .font(.system(size: 18, weight: .semibold))
+                            .frame(width: 34, height: 34)
+                            .foregroundStyle(self.canSubmitCommand ? Color.black : .secondary)
+                            .background(
+                                Circle()
+                                    .fill(self.canSubmitCommand ? Color.white.opacity(0.86) : self.theme.palette.cardBackground)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!self.canSubmitCommand)
+                    .help("Run command")
+                }
             }
-            .buttonStyle(.plain)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background(
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .fill(self.theme.palette.contentBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 28, style: .continuous)
+                            .stroke(self.theme.palette.cardBorder.opacity(0.55), lineWidth: 1)
+                    )
+            )
         }
-        .padding()
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
         .background(self.theme.palette.windowBackground)
     }
 
     // MARK: - Actions
 
+    private var canSubmitCommand: Bool {
+        !self.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !self.service.isProcessing &&
+            self.settings.commandModeReadinessIssue == nil
+    }
+
     private func toggleRecording() {
         if self.asr.isRunning {
-            Task { await self.asr.stop() }
+            Task {
+                let command = await self.asr.stop().trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !command.isEmpty else { return }
+                await MainActor.run {
+                    self.inputText = command
+                }
+                guard self.settings.commandModeReadinessIssue == nil else { return }
+                await self.service.processUserCommand(command)
+                await MainActor.run {
+                    self.inputText = ""
+                }
+            }
         } else {
             Task { await self.asr.start() }
         }
     }
 
     private func submitCommand() {
-        guard !self.inputText.isEmpty else { return }
-        let text = self.inputText
+        let text = self.inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        guard self.settings.commandModeReadinessIssue == nil else { return }
         self.inputText = ""
         Task {
             await self.service.processUserCommand(text)
@@ -582,30 +610,14 @@ struct CommandModeView: View {
     }
 
     private func updateAvailableModels() {
-        let currentProviderID = self.settings.commandModeSelectedProviderID
+        let currentProviderID = self.settings.effectiveCommandModeProviderID
         let currentModel = self.settings.commandModeSelectedModel ?? "gpt-4.1"
-
-        // Pull models from the shared pool configured in AI Settings
-        let possibleKeys = self.providerKeys(for: currentProviderID)
-        let storedList = possibleKeys.lazy
-            .compactMap { SettingsStore.shared.availableModelsByProvider[$0] }
-            .first { !$0.isEmpty }
-
-        if let stored = storedList {
-            self.availableModels = stored
-        } else {
-            self.availableModels = ModelRepository.shared.defaultModels(for: currentProviderID)
-        }
+        self.availableModels = self.settings.commandModeModels(for: currentProviderID)
 
         // If current model not in list, select first available
-        if !self.availableModels.contains(currentModel) {
+        if !self.settings.commandModeLinkedToGlobal, !self.availableModels.contains(currentModel) {
             self.settings.commandModeSelectedModel = self.availableModels.first ?? "gpt-4.1"
         }
-    }
-
-    /// Returns possible keys used to store models for a provider.
-    private func providerKeys(for providerID: String) -> [String] {
-        return ModelRepository.shared.providerKeys(for: providerID)
     }
 
     private var builtInProvidersList: [(id: String, name: String)] {
@@ -623,87 +635,32 @@ struct CommandModeView: View {
 struct CommandShimmerText: View {
     let text: String
 
-    @State private var shimmerPhase: CGFloat = 0
-
     var body: some View {
-        Text(self.text)
-            .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(
-                LinearGradient(
-                    colors: [
-                        Color.primary.opacity(0.4),
-                        Color.primary.opacity(0.4),
-                        Color.primary.opacity(0.8),
-                        Color.primary.opacity(0.4),
-                        Color.primary.opacity(0.4),
-                    ],
-                    startPoint: UnitPoint(x: self.shimmerPhase - 0.3, y: 0.5),
-                    endPoint: UnitPoint(x: self.shimmerPhase + 0.3, y: 0.5)
-                )
-            )
-            .onAppear {
-                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
-                    self.shimmerPhase = 1.3
-                }
-            }
-    }
-}
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+            let duration = 1.15
+            let progress = timeline.date.timeIntervalSinceReferenceDate
+                .truncatingRemainder(dividingBy: duration) / duration
+            let center = CGFloat(progress)
+            let leadingEdge = max(0, center - 0.18)
+            let trailingEdge = min(1, center + 0.18)
 
-// MARK: - Thinking Shimmer Label (Cursor-style sparkle)
-
-struct ThinkingShimmerLabel: View {
-    @State private var shimmerPhase: CGFloat = -0.5
-    @State private var sparkleOpacity: [Double] = [0.3, 0.5, 0.7, 0.4, 0.6]
-
-    var body: some View {
-        HStack(spacing: 6) {
-            // Sparkle dots with staggered animation
-            HStack(spacing: 2) {
-                ForEach(0..<3, id: \.self) { index in
-                    Circle()
-                        .fill(Color.primary.opacity(self.sparkleOpacity[index]))
-                        .frame(width: 4, height: 4)
-                }
-            }
-
-            // Shimmering "Think" text
-            Text("Think")
-                .font(.system(size: 12, weight: .medium))
+            Text(self.text)
+                .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(
                     LinearGradient(
                         stops: [
-                            .init(color: Color.primary.opacity(0.35), location: 0),
-                            .init(color: Color.primary.opacity(0.35), location: max(0, self.shimmerPhase - 0.15)),
-                            .init(color: Color.primary.opacity(0.85), location: self.shimmerPhase),
-                            .init(color: Color.primary.opacity(0.35), location: min(1, self.shimmerPhase + 0.15)),
-                            .init(color: Color.primary.opacity(0.35), location: 1),
+                            .init(color: Color.secondary.opacity(0.42), location: 0),
+                            .init(color: Color.secondary.opacity(0.42), location: leadingEdge),
+                            .init(color: Color.primary.opacity(0.98), location: center),
+                            .init(color: Color.secondary.opacity(0.42), location: trailingEdge),
+                            .init(color: Color.secondary.opacity(0.42), location: 1),
                         ],
                         startPoint: .leading,
                         endPoint: .trailing
                     )
                 )
         }
-        .onAppear {
-            // Shimmer animation - smooth left to right
-            withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
-                self.shimmerPhase = 1.5
-            }
-
-            // Sparkle animation - staggered twinkling
-            self.animateSparkles()
-        }
-    }
-
-    private func animateSparkles() {
-        // Create twinkling effect with staggered delays
-        for i in 0..<3 {
-            let delay = Double(i) * 0.15
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
-                    self.sparkleOpacity[i] = self.sparkleOpacity[i] > 0.5 ? 0.2 : 0.8
-                }
-            }
-        }
+        .accessibilityLabel(Text(self.text))
     }
 }
 
@@ -770,29 +727,23 @@ struct MessageBubble: View {
 
     private func thinkingSection(_ thinking: String) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header - tap to expand/collapse
             Button(action: { withAnimation(.easeInOut(duration: 0.2)) { self.isThinkingExpanded.toggle() } }) {
                 HStack(spacing: 6) {
-                    HStack(spacing: 2) {
-                        ForEach(0..<3, id: \.self) { _ in
-                            Circle()
-                                .fill(Color.primary.opacity(0.4))
-                                .frame(width: 3, height: 3)
-                        }
-                    }
-                    Text("Think")
+                    Text("Thinking")
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.secondary)
 
-                    Spacer()
-
-                    Text("\(thinking.count) chars")
-                        .font(.system(size: 9))
-                        .foregroundStyle(.tertiary)
+                    if self.isThinkingExpanded {
+                        Text("\(thinking.count) chars")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.tertiary)
+                    }
 
                     Image(systemName: self.isThinkingExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 9))
+                        .font(.system(size: 9, weight: .semibold))
                         .foregroundStyle(.tertiary)
+
+                    Spacer(minLength: 0)
                 }
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
@@ -811,18 +762,10 @@ struct MessageBubble: View {
                         .padding(.bottom, 8)
                 }
                 .frame(maxHeight: 150)
-            } else {
-                // Preview - first 80 chars
-                Text(String(thinking.prefix(80)) + (thinking.count > 80 ? "..." : ""))
-                    .font(.system(size: 10))
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
-                    .padding(.horizontal, 10)
-                    .padding(.bottom, 6)
             }
         }
-        .background(self.theme.palette.cardBackground.opacity(0.85))
-        .cornerRadius(6)
+        .background(self.theme.palette.cardBackground.opacity(0.55))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
     }
 
     // MARK: - Command Call View (Minimal)

--- a/Sources/Fluid/Views/RewriteModeView.swift
+++ b/Sources/Fluid/Views/RewriteModeView.swift
@@ -425,7 +425,7 @@ struct RewriteModeView: View {
             // Header with shimmer effect - tap to expand/collapse
             Button(action: { withAnimation(.easeInOut(duration: 0.2)) { self.isThinkingExpanded.toggle() } }) {
                 HStack(spacing: 8) {
-                    ThinkingShimmerLabel()
+                    CommandShimmerText(text: "Thinking")
 
                     Spacer()
 


### PR DESCRIPTION
## Description
Polishes Command Mode AI setup so it syncs with AI Enhancement by default, keeps inline provider/model controls, blocks unsupported provider/model states before requests, shows overlay voice notifications for setup errors, and improves the Thinking/reasoning UI.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- N/A

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.0 SDK build environment
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Release notes updated locally in `RELEASE_NOTES_1.5.14.md`; file is intentionally gitignored and not committed.
- Command Mode now refuses invalid/unsupported chat selections before sending, so users see the real provider/model issue instead of a misleading API fallback error.
- Overlay voice Command Mode shows the same setup error in the macOS notification and Command Mode history; active Command Mode submits stay in the in-app UI only.
- Empty model responses now surface as invalid responses instead of being replaced by the old fallback text.

## Screenshots / Video 
- Not included; UI was validated through local build/install.
