### PR TITLE
fix(deps): revert FluidAudio pin

### DIFF
--- a/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/altic-dev/FluidAudio.git",
       "state" : {
         "branch" : "B/cohere-coreml-asr",
-        "revision" : "cdb826639722d01e2f642306d484c71f40113e1a"
+        "revision" : "ba6e4359fbb0d00b63e789354acc3f005641cfe4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/altic-dev/FluidAudio.git",
       "state" : {
         "branch" : "B/cohere-coreml-asr",
-        "revision" : "cdb826639722d01e2f642306d484c71f40113e1a"
+        "revision" : "ba6e4359fbb0d00b63e789354acc3f005641cfe4"
       }
     },
     {


### PR DESCRIPTION
## Description
Reverts the accidental FluidAudio package pin bump from PR #339. The final fast dictation implementation does not use the newer FluidAudio sliding-window changes, so this keeps the dependency locked to the prior revision.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- None

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.0 SDK build environment
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Only changes the two `Package.resolved` FluidAudio revisions back from `cdb8266` to `ba6e435`.
- Release notes intentionally not updated for this cleanup-only dependency correction.

## Screenshots / Video 
Not applicable; dependency lockfile cleanup only.
