### PR TITLE
Fix Command Mode model fallback

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore+CommandMode.swift
+++ b/Sources/Fluid/Persistence/SettingsStore+CommandMode.swift
@@ -40,13 +40,15 @@ extension SettingsStore {
            self.supportedCommandModeProviderID(self.selectedProviderID) == providerID
         {
             let key = ModelRepository.shared.providerKey(for: providerID)
-            return self.nonEmptyModel(self.selectedModelByProvider[key])
+            return self.providerScopedModel(self.selectedModelByProvider[key], in: models)
                 ?? self.providerScopedModel(self.selectedModel, in: models)
                 ?? models.first
-                ?? "gpt-4.1"
+                ?? ""
         }
 
-        return self.nonEmptyModel(self.commandModeSelectedModel) ?? models.first ?? "gpt-4.1"
+        return self.providerScopedModel(self.commandModeSelectedModel, in: models)
+            ?? models.first
+            ?? ""
     }
 
     var commandModeReadinessIssue: String? {

--- a/Sources/Fluid/Views/CommandModeView.swift
+++ b/Sources/Fluid/Views/CommandModeView.swift
@@ -611,12 +611,12 @@ struct CommandModeView: View {
 
     private func updateAvailableModels() {
         let currentProviderID = self.settings.effectiveCommandModeProviderID
-        let currentModel = self.settings.commandModeSelectedModel ?? "gpt-4.1"
+        let currentModel = self.settings.commandModeSelectedModel ?? ""
         self.availableModels = self.settings.commandModeModels(for: currentProviderID)
 
         // If current model not in list, select first available
         if !self.settings.commandModeLinkedToGlobal, !self.availableModels.contains(currentModel) {
-            self.settings.commandModeSelectedModel = self.availableModels.first ?? "gpt-4.1"
+            self.settings.commandModeSelectedModel = self.availableModels.first
         }
     }
 


### PR DESCRIPTION
## Description
Prevents Command Mode from falling back to `gpt-4.1` for local/custom providers with no valid model list. Missing models now stay empty so the existing setup guard blocks safely.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- N/A

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.3
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- Release note kept local.

## Screenshots / Video
N/A