### PR TITLE
Fix login startup hotkey initialization

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -25,7 +25,7 @@
 	<key>NSMicrophoneUsageDescription</key>
 	<string>FluidVoice needs microphone access to record your voice for speech-to-text transcription. Your audio is processed locally and never sent to external servers.</string>
 	<key>LSUIElement</key>
-	<true/>
+	<false/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>FluidVoice needs permission to control system events for managing launch at startup settings.</string>
 	<key>POSTHOG_API_KEY</key>

--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -12,6 +12,8 @@ import UserNotifications
 
 class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
     private var updateCheckTimer: Timer?
+    private var didRevealMainWindowOnLaunch = false
+    private var didRequestMainWindowReopen = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Bring up file logging + crash handlers immediately during launch.
@@ -47,9 +49,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         // Schedule periodic update checks every hour while app is running
         self.schedulePeriodicUpdateChecks()
 
-        // Bring the app to front on initial launch.
-        // Use a few delayed retries because SwiftUI window creation can lag app launch callbacks.
-        self.forceFrontOnLaunch()
+        // Login Items can launch hidden; reveal the real SwiftUI window so ContentView startup runs.
+        self.openMainWindowOnLaunch()
 
         // Note: App UI is designed with dark color scheme in mind
         // All gradients and effects are optimized for dark mode
@@ -65,15 +66,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         // Ensure dock-icon reopen always foregrounds FluidVoice.
         sender.activate(ignoringOtherApps: true)
-
-        if let mainWindow = sender.windows.first(where: { win in
-            guard win.level == .normal else { return false }
-            guard win.styleMask.contains(.titled) else { return false }
-            return win.title == "FluidVoice" || win.title.contains("FluidVoice")
-        }) {
-            mainWindow.orderFrontRegardless()
-            mainWindow.makeKeyAndOrderFront(nil)
-        }
+        self.bringMainWindowToFrontIfPresent()
 
         return true
     }
@@ -102,40 +95,70 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         completionHandler()
     }
 
-    private func forceFrontOnLaunch() {
-        // Login-item launches can take longer before SwiftUI's main window exists.
-        // Keep retrying while FluidVoice is still foregrounded, but stop if the user switches away.
-        for delay in [0.0, 0.12, 0.35, 1.0, 2.0, 4.0] {
+    private func openMainWindowOnLaunch() {
+        NSApp.setActivationPolicy(SettingsStore.shared.showInDock ? .regular : .accessory)
+
+        for delay in [0.1, 0.6, 1.2, 2.5, 4.0] {
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
                 guard let self else { return }
-                guard delay == 0.0 || self.shouldContinueLaunchForegroundRetry() else {
-                    DebugLogger.shared.debug("Skipped launch-front retry because another app is active", source: "AppDelegate")
+                guard self.didRevealMainWindowOnLaunch == false else { return }
+
+                NSApp.unhide(nil)
+                NSApp.activate(ignoringOtherApps: true)
+
+                if self.bringMainWindowToFrontIfPresent() {
+                    self.didRevealMainWindowOnLaunch = true
                     return
                 }
-                self.bringMainWindowToFront()
+
+                DebugLogger.shared.debug("Main window not ready during launch reveal retry", source: "AppDelegate")
+                if delay >= 0.6 {
+                    self.requestMainWindowReopenIfNeeded()
+                }
             }
         }
     }
 
-    private func shouldContinueLaunchForegroundRetry() -> Bool {
-        if NSApp.isActive { return true }
-        return NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier
+    private func requestMainWindowReopenIfNeeded() {
+        guard !self.didRequestMainWindowReopen else { return }
+        self.didRequestMainWindowReopen = true
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+
+        DebugLogger.shared.info("Requesting LaunchServices reopen to create SwiftUI main window", source: "AppDelegate")
+        NSWorkspace.shared.openApplication(at: Bundle.main.bundleURL, configuration: configuration) { _, error in
+            if let error {
+                DebugLogger.shared.error("LaunchServices reopen failed: \(error.localizedDescription)", source: "AppDelegate")
+            }
+        }
     }
 
     private func bringMainWindowToFront() {
+        NSApp.unhide(nil)
         NSApp.activate(ignoringOtherApps: true)
 
-        if let mainWindow = NSApp.windows.first(where: { win in
-            guard win.level == .normal else { return false }
-            guard win.styleMask.contains(.titled) else { return false }
-            return win.title == "FluidVoice" || win.title.contains("FluidVoice")
-        }) {
+        if !self.bringMainWindowToFrontIfPresent() {
+            DebugLogger.shared.debug("Main window not ready", source: "AppDelegate")
+        }
+    }
+
+    @discardableResult
+    private func bringMainWindowToFrontIfPresent() -> Bool {
+        if let mainWindow = NSApp.windows.first(where: self.isMainWindow) {
             mainWindow.orderFrontRegardless()
             mainWindow.makeKeyAndOrderFront(nil)
             DebugLogger.shared.debug("Brought main window to front", source: "AppDelegate")
-        } else {
-            DebugLogger.shared.debug("Main window not ready yet during launch-front retry", source: "AppDelegate")
+            return true
         }
+
+        return false
+    }
+
+    private func isMainWindow(_ window: NSWindow) -> Bool {
+        guard window.level == .normal else { return false }
+        guard window.styleMask.contains(.titled) else { return false }
+        return window.title == "FluidVoice" || window.title.contains("FluidVoice")
     }
 
     // MARK: - Periodic Update Checks

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -630,6 +630,7 @@ struct ContentView: View {
                 }
             }
         }
+        .toolbar(removing: .sidebarToggle)
         .overlay(alignment: .center) {}
         .alert(
             self.asr.errorTitle,

--- a/Sources/Fluid/Persistence/SettingsStore+LaunchAtStartup.swift
+++ b/Sources/Fluid/Persistence/SettingsStore+LaunchAtStartup.swift
@@ -1,0 +1,233 @@
+import Foundation
+#if os(macOS)
+import ServiceManagement
+#endif
+
+extension SettingsStore {
+    private static var launchAtStartupDefaults: UserDefaults {
+        UserDefaults.standard
+    }
+
+    func refreshLaunchAtStartupStatus(clearError: Bool = false, logMismatch: Bool = true) {
+        #if os(macOS)
+        let storedValue = Self.launchAtStartupDefaults.bool(forKey: LaunchAtStartupKeys.preference)
+        let systemState = self.currentLaunchAtStartupSystemState()
+        let systemEnabled = systemState.isEnabled
+
+        if logMismatch, storedValue != systemEnabled {
+            DebugLogger.shared.warning(
+                "Launch at startup preference mismatch. Stored: \(storedValue), actual: \(systemEnabled). Preferring macOS state.",
+                source: "SettingsStore"
+            )
+        }
+
+        Self.launchAtStartupDefaults.set(systemEnabled, forKey: LaunchAtStartupKeys.preference)
+
+        let nextErrorMessage = clearError ? nil : self.launchAtStartupErrorMessage
+        let nextStatusMessage = systemState.message
+        if self.launchAtStartupEnabled != systemEnabled ||
+            self.launchAtStartupStatusMessage != nextStatusMessage ||
+            self.launchAtStartupErrorMessage != nextErrorMessage
+        {
+            self.applyLaunchAtStartupStatus(
+                enabled: systemEnabled,
+                statusMessage: nextStatusMessage,
+                errorMessage: nextErrorMessage
+            )
+        }
+        #else
+        let unavailableMessage = "Launch at startup is only available on macOS."
+        let nextErrorMessage = clearError ? nil : self.launchAtStartupErrorMessage
+        if self.launchAtStartupEnabled ||
+            self.launchAtStartupStatusMessage != unavailableMessage ||
+            self.launchAtStartupErrorMessage != nextErrorMessage
+        {
+            self.applyLaunchAtStartupStatus(
+                enabled: false,
+                statusMessage: unavailableMessage,
+                errorMessage: nextErrorMessage
+            )
+        }
+        #endif
+    }
+
+    func setLaunchAtStartup(_ enabled: Bool) {
+        #if os(macOS)
+        let service = SMAppService.mainApp
+        let statusBeforeChange = self.currentLaunchAtStartupSystemState()
+
+        if statusBeforeChange.isEnabled == enabled {
+            if enabled == false {
+                self.cleanupLegacyCompatibilityLoginItemAfterDisable()
+            }
+            self.refreshLaunchAtStartupStatus(clearError: true, logMismatch: false)
+            return
+        }
+
+        do {
+            if enabled {
+                try service.register()
+                DebugLogger.shared.info("Requested registration for launch at startup", source: "SettingsStore")
+            } else {
+                try service.unregister()
+                self.cleanupLegacyCompatibilityLoginItemAfterDisable()
+                DebugLogger.shared.info("Requested unregistration from launch at startup", source: "SettingsStore")
+            }
+
+            self.refreshLaunchAtStartupStatus(clearError: true, logMismatch: false)
+
+            if self.launchAtStartupEnabled != enabled {
+                let mismatchMessage = enabled
+                    ? "macOS did not enable FluidVoice in Login Items. Check System Settings > General > Login Items."
+                    : "macOS still shows FluidVoice in Login Items. Check System Settings > General > Login Items."
+                self.applyLaunchAtStartupErrorMessage(mismatchMessage)
+                DebugLogger.shared.warning(mismatchMessage, source: "SettingsStore")
+            }
+        } catch {
+            DebugLogger.shared.error("Failed to update launch at startup: \(error)", source: "SettingsStore")
+            self.refreshLaunchAtStartupStatus(clearError: false, logMismatch: false)
+
+            let message = self.launchAtStartupFailureMessage(for: error, enabling: enabled)
+            if self.launchAtStartupErrorMessage != message {
+                self.applyLaunchAtStartupErrorMessage(message)
+            }
+        }
+        #else
+        let message = "Launch at startup is only available on macOS."
+        if self.launchAtStartupErrorMessage != message {
+            self.applyLaunchAtStartupErrorMessage(message)
+        }
+        #endif
+    }
+
+    #if os(macOS)
+    private func currentLaunchAtStartupSystemState() -> LaunchAtStartupSystemState {
+        let service = SMAppService.mainApp
+        switch service.status {
+        case .enabled:
+            return .enabled
+        case .requiresApproval:
+            return .requiresApproval
+        case .notFound:
+            return .disabled
+        case .notRegistered:
+            return .disabled
+        @unknown default:
+            return .disabled
+        }
+    }
+
+    private func launchAtStartupFailureMessage(for error: Error, enabling: Bool) -> String {
+        let nsError = error as NSError
+        let action = enabling ? "enable" : "disable"
+        let lowercasedDescription = nsError.localizedDescription.lowercased()
+
+        if lowercasedDescription.contains("developer") ||
+            lowercasedDescription.contains("sign") ||
+            lowercasedDescription.contains("entitlement")
+        {
+            return "FluidVoice could not \(action) launch at startup. This build may not be signed correctly for macOS Login Items."
+        }
+
+        if lowercasedDescription.contains("approval") ||
+            lowercasedDescription.contains("authorize")
+        {
+            return "macOS needs approval before FluidVoice can \(action) launch at startup. Check System Settings > General > Login Items."
+        }
+
+        return "FluidVoice could not \(action) launch at startup. macOS reported: \(nsError.localizedDescription)"
+    }
+
+    private func cleanupLegacyCompatibilityLoginItemAfterDisable() {
+        do {
+            try self.unregisterCompatibilityLoginItemIfNeeded()
+        } catch {
+            DebugLogger.shared.warning(
+                "Failed to remove legacy compatibility login item after disabling launch at startup: \(error)",
+                source: "SettingsStore"
+            )
+        }
+    }
+
+    private func unregisterCompatibilityLoginItemIfNeeded() throws {
+        guard Self.launchAtStartupDefaults.bool(forKey: LaunchAtStartupKeys.legacyCompatibilityItem) else { return }
+
+        let appName = self.compatibilityLoginItemName
+        let script = """
+        tell application "System Events"
+            if exists login item "\(self.appleScriptEscaped(appName))" then
+                delete login item "\(self.appleScriptEscaped(appName))"
+            end if
+        end tell
+        """
+
+        try self.runLaunchAtStartupAppleScript(script)
+        Self.launchAtStartupDefaults.set(false, forKey: LaunchAtStartupKeys.legacyCompatibilityItem)
+    }
+
+    private var compatibilityLoginItemName: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FluidVoice"
+    }
+
+    private func appleScriptEscaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private func runLaunchAtStartupAppleScript(_ source: String) throws {
+        var errorInfo: NSDictionary?
+        guard let script = NSAppleScript(source: source) else {
+            throw NSError(
+                domain: "FluidVoiceLaunchAtStartup",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not create launch at startup cleanup script."]
+            )
+        }
+
+        script.executeAndReturnError(&errorInfo)
+        if let errorInfo {
+            let message = errorInfo[NSAppleScript.errorMessage] as? String ?? "Unknown AppleScript error"
+            let number = errorInfo[NSAppleScript.errorNumber] as? Int ?? 2
+            throw NSError(
+                domain: "FluidVoiceLaunchAtStartup",
+                code: number,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
+    }
+    #endif
+}
+
+#if os(macOS)
+private enum LaunchAtStartupSystemState {
+    case enabled
+    case disabled
+    case requiresApproval
+
+    var isEnabled: Bool {
+        switch self {
+        case .enabled:
+            return true
+        case .disabled, .requiresApproval:
+            return false
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .enabled:
+            return "FluidVoice reflects the actual macOS login item state."
+        case .disabled:
+            return "FluidVoice reflects the actual macOS login item state. Unsigned or development builds may fail to enable this."
+        case .requiresApproval:
+            return "macOS requires approval for FluidVoice in Login Items before launch at startup becomes active."
+        }
+    }
+}
+#endif
+
+private enum LaunchAtStartupKeys {
+    static let preference = "LaunchAtStartup"
+    static let legacyCompatibilityItem = "LaunchAtStartupCompatibilityFallback"
+}

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1633,6 +1633,18 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    func applyLaunchAtStartupStatus(enabled: Bool, statusMessage: String, errorMessage: String?) {
+        objectWillChange.send()
+        self.launchAtStartupEnabled = enabled
+        self.launchAtStartupStatusMessage = statusMessage
+        self.launchAtStartupErrorMessage = errorMessage
+    }
+
+    func applyLaunchAtStartupErrorMessage(_ message: String?) {
+        objectWillChange.send()
+        self.launchAtStartupErrorMessage = message
+    }
+
     // MARK: - Initialization Methods
 
     func initializeAppSettings() {
@@ -2665,159 +2677,6 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    func refreshLaunchAtStartupStatus(clearError: Bool = false, logMismatch: Bool = true) {
-        #if os(macOS)
-        let persistedValue = self.defaults.bool(forKey: Keys.launchAtStartup)
-        let systemState = self.currentLaunchAtStartupSystemState()
-        let systemEnabled = systemState.isEnabled
-
-        if logMismatch, persistedValue != systemEnabled {
-            DebugLogger.shared.warning(
-                "Launch at startup preference mismatch. Stored: \(persistedValue), actual: \(systemEnabled). Preferring macOS state.",
-                source: "SettingsStore"
-            )
-        }
-
-        self.defaults.set(systemEnabled, forKey: Keys.launchAtStartup)
-
-        let nextErrorMessage = clearError ? nil : self.launchAtStartupErrorMessage
-        if self.launchAtStartupEnabled != systemEnabled ||
-            self.launchAtStartupStatusMessage != systemState.message ||
-            self.launchAtStartupErrorMessage != nextErrorMessage
-        {
-            objectWillChange.send()
-            self.launchAtStartupEnabled = systemEnabled
-            self.launchAtStartupStatusMessage = systemState.message
-            self.launchAtStartupErrorMessage = nextErrorMessage
-        }
-        #else
-        let unavailableMessage = "Launch at startup is only available on macOS."
-        let nextErrorMessage = clearError ? nil : self.launchAtStartupErrorMessage
-        if self.launchAtStartupEnabled ||
-            self.launchAtStartupStatusMessage != unavailableMessage ||
-            self.launchAtStartupErrorMessage != nextErrorMessage
-        {
-            objectWillChange.send()
-            self.launchAtStartupEnabled = false
-            self.launchAtStartupStatusMessage = unavailableMessage
-            self.launchAtStartupErrorMessage = nextErrorMessage
-        }
-        #endif
-    }
-
-    func setLaunchAtStartup(_ enabled: Bool) {
-        #if os(macOS)
-        let service = SMAppService.mainApp
-        let statusBeforeChange = self.currentLaunchAtStartupSystemState()
-
-        if statusBeforeChange.isEnabled == enabled {
-            self.refreshLaunchAtStartupStatus(clearError: true, logMismatch: false)
-            return
-        }
-
-        do {
-            if enabled {
-                try service.register()
-                DebugLogger.shared.info("Requested registration for launch at startup", source: "SettingsStore")
-            } else {
-                try service.unregister()
-                DebugLogger.shared.info("Requested unregistration from launch at startup", source: "SettingsStore")
-            }
-
-            self.refreshLaunchAtStartupStatus(clearError: true, logMismatch: false)
-
-            if self.launchAtStartupEnabled != enabled {
-                let fallbackMessage = enabled
-                    ? "macOS did not enable FluidVoice in Login Items. Unsigned or development builds may not support launch at startup."
-                    : "macOS still shows FluidVoice in Login Items. Check System Settings > General > Login Items."
-                objectWillChange.send()
-                self.launchAtStartupErrorMessage = fallbackMessage
-                DebugLogger.shared.warning(fallbackMessage, source: "SettingsStore")
-            }
-        } catch {
-            DebugLogger.shared.error("Failed to update launch at startup: \(error)", source: "SettingsStore")
-            self.refreshLaunchAtStartupStatus(clearError: false, logMismatch: false)
-
-            let message = self.launchAtStartupFailureMessage(for: error, enabling: enabled)
-            if self.launchAtStartupErrorMessage != message {
-                objectWillChange.send()
-                self.launchAtStartupErrorMessage = message
-            }
-        }
-        #else
-        let message = "Launch at startup is only available on macOS."
-        if self.launchAtStartupErrorMessage != message {
-            objectWillChange.send()
-            self.launchAtStartupErrorMessage = message
-        }
-        #endif
-    }
-
-    #if os(macOS)
-    private func currentLaunchAtStartupSystemState() -> LaunchAtStartupSystemState {
-        let service = SMAppService.mainApp
-        switch service.status {
-        case .enabled:
-            return .enabled
-        case .requiresApproval:
-            return .requiresApproval
-        case .notFound:
-            return .disabled
-        case .notRegistered:
-            return .disabled
-        @unknown default:
-            return .disabled
-        }
-    }
-
-    private func launchAtStartupFailureMessage(for error: Error, enabling: Bool) -> String {
-        let nsError = error as NSError
-        let action = enabling ? "enable" : "disable"
-        let lowercasedDescription = nsError.localizedDescription.lowercased()
-
-        if lowercasedDescription.contains("developer") ||
-            lowercasedDescription.contains("sign") ||
-            lowercasedDescription.contains("entitlement")
-        {
-            return "FluidVoice could not \(action) launch at startup. This build may not be signed correctly for macOS Login Items."
-        }
-
-        if lowercasedDescription.contains("approval") ||
-            lowercasedDescription.contains("authorize")
-        {
-            return "macOS needs approval before FluidVoice can \(action) launch at startup. Check System Settings > General > Login Items."
-        }
-
-        return "FluidVoice could not \(action) launch at startup. macOS reported: \(nsError.localizedDescription)"
-    }
-    #endif
-
-    private enum LaunchAtStartupSystemState {
-        case enabled
-        case disabled
-        case requiresApproval
-
-        var isEnabled: Bool {
-            switch self {
-            case .enabled:
-                return true
-            case .disabled, .requiresApproval:
-                return false
-            }
-        }
-
-        var message: String {
-            switch self {
-            case .enabled:
-                return "FluidVoice reflects the actual macOS login item state."
-            case .disabled:
-                return "FluidVoice reflects the actual macOS login item state. Unsigned or development builds may fail to enable this."
-            case .requiresApproval:
-                return "macOS requires approval for FluidVoice in Login Items before launch at startup becomes active."
-            }
-        }
-    }
-
     private func updateDockVisibility(_ visible: Bool) {
         #if os(macOS)
         // IMPORTANT: This is a simplified implementation for development
@@ -3615,7 +3474,6 @@ private extension SettingsStore {
         static let preferredOutputDeviceUID = "PreferredOutputDeviceUID"
         static let syncAudioDevicesWithSystem = "SyncAudioDevicesWithSystem"
         static let visualizerNoiseThreshold = "VisualizerNoiseThreshold"
-        static let launchAtStartup = "LaunchAtStartup"
         static let showInDock = "ShowInDock"
         static let accentColorOption = "AccentColorOption"
         static let enableTranscriptionSounds = "EnableTranscriptionSounds"

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -626,27 +626,29 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
         // Activate the app and bring it to the front
         NSApp.activate(ignoringOtherApps: true)
 
+        var mainWindows = NSApp.windows.filter(self.isFluidMainWindow)
+        if let hostedWindow,
+           mainWindows.contains(where: { $0 !== hostedWindow })
+        {
+            hostedWindow.close()
+            self.hostedWindow = nil
+            mainWindows = NSApp.windows.filter(self.isFluidMainWindow)
+        }
+
         // Find an existing *non-minimized* primary window.
         // Important: avoid programmatic deminiaturize() — it creates internal window transform animations
         // (NSWindowTransformAnimation) that have been unstable on macOS 26.x for this app.
-        if let window = hostedWindow, window.isReleasedWhenClosed == false {
+        if let window = mainWindows.first {
             self.ensureUsableMainWindow(window)
             window.animationBehavior = .none
             self.bringToFront(window)
-        } else if let window = NSApp.windows.first(where: { win in
-            // Only normal app windows (exclude overlays/panels/menus)
-            guard win.level == .normal else { return false }
-            guard win.styleMask.contains(.titled) else { return false }
-            guard win.canBecomeKey else { return false }
-            guard win.isMiniaturized == false else { return false }
-
-            // Prefer our main window title when present (both SwiftUI and our fallback window use this)
-            return win.title == "FluidVoice" || win.title.contains("FluidVoice")
-        }) {
+            if let hostedWindow, window !== hostedWindow {
+                self.hostedWindow = nil
+            }
+        } else if let window = hostedWindow, window.isReleasedWhenClosed == false {
             self.ensureUsableMainWindow(window)
             window.animationBehavior = .none
             self.bringToFront(window)
-            self.hostedWindow = window
         } else {
             // If there is no suitable window (or it's minimized), create a fresh one.
             self.createAndShowMainWindow()
@@ -657,6 +659,14 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
             NSApp.activate(ignoringOtherApps: true)
         }
+    }
+
+    private func isFluidMainWindow(_ window: NSWindow) -> Bool {
+        guard window.level == .normal else { return false }
+        guard window.styleMask.contains(.titled) else { return false }
+        guard window.canBecomeKey else { return false }
+        guard window.isMiniaturized == false else { return false }
+        return window.title == "FluidVoice" || window.title.contains("FluidVoice")
     }
 
     @objc private func openPreferences() {


### PR DESCRIPTION
## Description
Fixes launch-at-login startup so FluidVoice is treated as a visible app launch, creates one real SwiftUI main window when Login Items starts it hidden, and lets `ContentView` initialize shortcuts/runtime reliably.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #337
- Related to #349

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`
- [x] Verified login-style launch via `osascript`: one FluidVoice window, `ContentView` startup, `GlobalHotkeyManager` initialized, hotkey health true

## Notes
- Uses `SMAppService.mainApp` as the only current Login Items registration path.
- Legacy classic login-item cleanup is best-effort only when disabling startup.

## Screenshots / Video 
Not included; startup behavior was verified with logs and window count.