### PR TITLE
Fix OpenRouter API key saving

### DIFF
--- a/Sources/Fluid/Persistence/KeychainService.swift
+++ b/Sources/Fluid/Persistence/KeychainService.swift
@@ -71,7 +71,6 @@ final class KeychainService {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecReturnAttributes as String: true,
-            kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitAll,
         ]
 
@@ -83,8 +82,22 @@ final class KeychainService {
             guard let attributesArray = items as? [[String: Any]] else { return [:] }
             for attributes in attributesArray {
                 guard let providerID = attributes[kSecAttrAccount as String] as? String,
-                      providerID != account,
-                      let data = attributes[kSecValueData as String] as? Data,
+                      providerID != account
+                else {
+                    continue
+                }
+
+                var dataQuery = self.legacyQuery(for: providerID)
+                dataQuery[kSecReturnData as String] = true
+                dataQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+
+                var dataItem: CFTypeRef?
+                let dataStatus = SecItemCopyMatching(dataQuery as CFDictionary, &dataItem)
+                guard dataStatus == errSecSuccess else {
+                    if dataStatus == errSecItemNotFound { continue }
+                    throw KeychainServiceError.unhandled(dataStatus)
+                }
+                guard let data = dataItem as? Data,
                       let key = String(data: data, encoding: .utf8)
                 else {
                     continue
@@ -149,7 +162,6 @@ final class KeychainService {
         let data = try JSONEncoder().encode(keys)
 
         var attributes = self.aggregatedQuery()
-        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
         attributes[kSecValueData as String] = data
 
         let status = SecItemAdd(attributes as CFDictionary, nil)

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1173,8 +1173,19 @@ final class SettingsStore: ObservableObject {
         get { (try? self.keychain.fetchAllKeys()) ?? [:] }
         set {
             objectWillChange.send()
-            self.persistProviderAPIKeys(newValue)
+            do {
+                _ = try self.saveProviderAPIKeys(newValue)
+            } catch {
+                self.logProviderAPIKeyPersistenceFailure(error)
+            }
         }
+    }
+
+    @discardableResult
+    func saveProviderAPIKeys(_ values: [String: String]) throws -> [String: String] {
+        let trimmed = self.sanitizeAPIKeys(values)
+        try self.keychain.storeAllKeys(trimmed)
+        return try self.keychain.fetchAllKeys()
     }
 
     /// Securely retrieve API key for a provider, handling custom prefix logic
@@ -2391,16 +2402,11 @@ final class SettingsStore: ObservableObject {
 
     // MARK: - Private Methods
 
-    private func persistProviderAPIKeys(_ values: [String: String]) {
-        let trimmed = self.sanitizeAPIKeys(values)
-        do {
-            try self.keychain.storeAllKeys(trimmed)
-        } catch {
-            DebugLogger.shared.error(
-                "Failed to persist provider API keys: \(error.localizedDescription)",
-                source: "SettingsStore"
-            )
-        }
+    private func logProviderAPIKeyPersistenceFailure(_ error: Error) {
+        DebugLogger.shared.error(
+            "Failed to persist provider API keys: \(error.localizedDescription)",
+            source: "SettingsStore"
+        )
     }
 
     private func migrateTranscriptionStartSoundIfNeeded() {
@@ -2434,7 +2440,11 @@ final class SettingsStore: ObservableObject {
         }
 
         if didMutate {
-            self.persistProviderAPIKeys(merged)
+            do {
+                _ = try self.saveProviderAPIKeys(merged)
+            } catch {
+                self.logProviderAPIKeyPersistenceFailure(error)
+            }
         }
     }
 

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -71,6 +71,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     @Published var newProviderModels: String = ""
     @Published var editProviderName: String = ""
     @Published var editProviderBaseURL: String = ""
+    @Published var editProviderApiKey: String = ""
 
     // Keychain State
     @Published var showKeychainPermissionAlert: Bool = false
@@ -227,6 +228,18 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         return self.providerAPIKeys[key] ?? self.providerAPIKeys[providerID] ?? ""
     }
 
+    func updateProviderAPIKey(_ apiKey: String, for providerID: String, persistEmptyValue: Bool = false) {
+        let key = self.providerKey(for: providerID)
+        let hadDraft = self.providerAPIKeys[key] != nil || self.providerAPIKeys[providerID] != nil
+        self.providerAPIKeys[key] = apiKey
+        if key != providerID {
+            self.providerAPIKeys.removeValue(forKey: providerID)
+        }
+        if persistEmptyValue, hadDraft, apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            _ = self.saveProviderAPIKeys(invalidating: providerID)
+        }
+    }
+
     func providerDisplayName(for providerID: String) -> String {
         switch providerID {
         case "openai": return "OpenAI"
@@ -319,9 +332,23 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.setEditingAPIKey(true, for: providerID)
     }
 
-    func saveProviderAPIKeys() {
-        self.settings.providerAPIKeys = self.providerAPIKeys
-        self.invalidateVerificationIfNeeded(for: self.selectedProviderID)
+    @discardableResult
+    func saveProviderAPIKeys(invalidating providerID: String? = nil) -> Bool {
+        let expected = self.sanitizedAPIKeys(self.providerAPIKeys)
+        let invalidationTarget = providerID ?? self.selectedProviderID
+        do {
+            let persisted = try self.settings.saveProviderAPIKeys(self.providerAPIKeys)
+            guard persisted == expected else {
+                throw ProviderAPIKeySaveError.readbackMismatch
+            }
+            self.providerAPIKeys = persisted
+            self.invalidateVerificationIfNeeded(for: invalidationTarget)
+            return true
+        } catch {
+            self.invalidateVerificationIfNeeded(for: invalidationTarget)
+            self.showKeychainPersistenceFailure(error)
+            return false
+        }
     }
 
     func createDraftProvider(named name: String) -> String? {
@@ -450,14 +477,29 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         case denied(OSStatus)
     }
 
+    private enum ProviderAPIKeySaveError: LocalizedError {
+        case readbackMismatch
+
+        var errorDescription: String? {
+            "Saved API key could not be read back from Keychain."
+        }
+    }
+
     func handleAPIKeyButtonTapped() {
+        guard self.ensureKeychainAccessForAPIKeyEdit() else { return }
+        self.newProviderApiKey = self.providerAPIKey(for: self.selectedProviderID)
+        self.showAPIKeyEditor = true
+    }
+
+    @discardableResult
+    func ensureKeychainAccessForAPIKeyEdit() -> Bool {
         switch self.probeKeychainAccess() {
         case .granted:
-            self.newProviderApiKey = self.providerAPIKey(for: self.selectedProviderID)
-            self.showAPIKeyEditor = true
+            return true
         case let .denied(status):
             self.keychainPermissionMessage = self.keychainPermissionExplanation(for: status)
             self.showKeychainPermissionAlert = true
+            return false
         }
     }
 
@@ -481,7 +523,6 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             return .granted
         case errSecItemNotFound:
             var addQuery = query
-            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
             addQuery[kSecValueData as String] = (try? JSONEncoder().encode([String: String]())) ?? Data()
 
             let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
@@ -511,6 +552,44 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         }
         message += "\n\nClick \"Always Allow\" when the Keychain prompt appears, or open Keychain Access > login > Passwords, locate the FluidVoice entry, and grant access."
         return message
+    }
+
+    private func keychainPersistenceExplanation(for error: Error) -> String {
+        var message = "FluidVoice could not save the API key to your macOS Keychain, so this provider was not verified."
+        if let keychainError = error as? KeychainServiceError {
+            switch keychainError {
+            case .invalidData:
+                message += "\n\nmacOS returned unreadable Keychain data."
+            case let .unhandled(status):
+                if let detail = SecCopyErrorMessageString(status, nil) as String? {
+                    message += "\n\nmacOS reported: \(detail) (\(status))"
+                } else {
+                    message += "\n\nmacOS reported Keychain status \(status)."
+                }
+            }
+        } else {
+            message += "\n\n\(error.localizedDescription)"
+        }
+        message += "\n\nClick \"Always Allow\" when the Keychain prompt appears, or open Keychain Access > login > Passwords, locate the FluidVoice entry, and grant access."
+        return message
+    }
+
+    private func showKeychainPersistenceFailure(_ error: Error) {
+        self.keychainPermissionMessage = self.keychainPersistenceExplanation(for: error)
+        self.showKeychainPermissionAlert = true
+    }
+
+    private func sanitizedAPIKeys(_ values: [String: String]) -> [String: String] {
+        values.reduce(into: [String: String]()) { partialResult, pair in
+            let sanitizedValue = pair.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard sanitizedValue.isEmpty == false else { return }
+            partialResult[pair.key] = sanitizedValue
+        }
+    }
+
+    private func hasProviderAPIKeyDraft(for providerID: String) -> Bool {
+        let key = self.providerKey(for: providerID)
+        return self.providerAPIKeys[key] != nil || self.providerAPIKeys[providerID] != nil
     }
 
     func presentKeychainAccessAlert(message: String) {
@@ -544,8 +623,13 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
         let providerID = self.selectedProviderID
         let providerName = ModelRepository.shared.displayName(for: providerID)
-        let apiKey = self.providerAPIKey(for: providerID)
         let baseURL = self.providerBaseURL(for: providerID)
+        if self.hasProviderAPIKeyDraft(for: providerID), !self.saveProviderAPIKeys(invalidating: providerID) {
+            self.updateConnectionStatus(.failed, for: providerID)
+            self.connectionErrorMessage = "Could not save API key to Keychain. Grant access and try again."
+            return
+        }
+        let apiKey = self.providerAPIKey(for: providerID)
         let isLocal = self.isLocalEndpoint(baseURL)
         let isAnthropic = providerID == "anthropic" || baseURL.contains("anthropic.com")
 
@@ -851,6 +935,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         if ModelRepository.shared.isBuiltIn(self.selectedProviderID) {
             self.editProviderName = ModelRepository.shared.displayName(for: self.selectedProviderID)
             self.editProviderBaseURL = self.openAIBaseURL // Use current URL (may have been customized)
+            self.editProviderApiKey = self.providerAPIKey(for: self.selectedProviderID)
             self.showingEditProvider = true
             return
         }
@@ -858,8 +943,27 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         if let provider = savedProviders.first(where: { $0.id == selectedProviderID }) {
             self.editProviderName = provider.name
             self.editProviderBaseURL = provider.baseURL
+            self.editProviderApiKey = self.providerAPIKey(for: self.selectedProviderID)
             self.showingEditProvider = true
         }
+    }
+
+    func clearEditProviderDraft() {
+        self.showingEditProvider = false
+        self.editProviderName = ""
+        self.editProviderBaseURL = ""
+        self.editProviderApiKey = ""
+    }
+
+    @discardableResult
+    func saveEditedProviderAPIKey() -> Bool {
+        let previousAPIKeys = self.providerAPIKeys
+        self.updateProviderAPIKey(self.editProviderApiKey, for: self.selectedProviderID)
+        guard self.saveProviderAPIKeys(invalidating: self.selectedProviderID) else {
+            self.providerAPIKeys = previousAPIKeys
+            return false
+        }
+        return true
     }
 
     func deleteCurrentProvider() {
@@ -891,8 +995,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         if ModelRepository.shared.isBuiltIn(self.selectedProviderID) {
             self.openAIBaseURL = base
             self.updateCurrentProvider()
-            self.showingEditProvider = false
-            self.editProviderName = ""; self.editProviderBaseURL = ""
+            self.clearEditProviderDraft()
             self.invalidateVerification(for: self.selectedProviderID)
             return
         }
@@ -906,8 +1009,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             self.openAIBaseURL = base
             self.updateCurrentProvider()
         }
-        self.showingEditProvider = false
-        self.editProviderName = ""; self.editProviderBaseURL = ""
+        self.clearEditProviderDraft()
         self.invalidateVerification(for: self.selectedProviderID)
     }
 
@@ -947,7 +1049,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
         let baseURL = self.openAIBaseURL
         let key = self.providerKey(for: self.selectedProviderID)
-        let apiKey = self.providerAPIKeys[key] ?? self.providerAPIKeys[self.selectedProviderID]
+        let shouldPersistKey = self.hasProviderAPIKeyDraft(for: self.selectedProviderID)
+        if shouldPersistKey, !self.saveProviderAPIKeys(invalidating: self.selectedProviderID) {
+            self.fetchModelsError = "Could not save API key to Keychain. Grant access and try again."
+            return
+        }
+        let apiKey = self.providerAPIKey(for: self.selectedProviderID)
 
         do {
             let models = try await ModelRepository.shared.fetchModels(
@@ -1010,7 +1117,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     func fetchModels(for providerID: String) async {
         let baseURL = self.providerBaseURL(for: providerID)
         let key = self.providerKey(for: providerID)
-        let apiKey = self.providerAPIKeys[key] ?? self.providerAPIKeys[providerID]
+        let shouldPersistKey = self.hasProviderAPIKeyDraft(for: providerID)
 
         self.refreshingProviderID = providerID
         self.isFetchingModels = true
@@ -1019,6 +1126,13 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             self.isFetchingModels = false
             self.refreshingProviderID = nil
         }
+
+        if shouldPersistKey, !self.saveProviderAPIKeys(invalidating: providerID) {
+            self.fetchModelsError = "Could not save API key to Keychain. Grant access and try again."
+            return
+        }
+
+        let apiKey = self.providerAPIKey(for: providerID)
 
         do {
             let models = try await ModelRepository.shared.fetchModels(
@@ -1215,15 +1329,24 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let models: [String] = []
 
         let newProvider = SettingsStore.SavedProvider(name: name, baseURL: base, models: models)
+        let key = self.providerKey(for: newProvider.id)
+        if !api.isEmpty {
+            var updatedAPIKeys = self.providerAPIKeys
+            updatedAPIKeys[key] = api
+            let previousAPIKeys = self.providerAPIKeys
+            self.providerAPIKeys = updatedAPIKeys
+            guard self.saveProviderAPIKeys(invalidating: newProvider.id) else {
+                self.providerAPIKeys = previousAPIKeys
+                return
+            }
+        }
+
         self.savedProviders.removeAll { $0.name.lowercased() == name.lowercased() }
         self.savedProviders.append(newProvider)
         self.saveSavedProviders()
 
-        let key = self.providerKey(for: newProvider.id)
-        self.providerAPIKeys[key] = api
         self.availableModelsByProvider[key] = models
         self.selectedModelByProvider[key] = models.first ?? self.selectedModel
-        self.settings.providerAPIKeys = self.providerAPIKeys
         self.settings.availableModelsByProvider = self.availableModelsByProvider
         self.settings.selectedModelByProvider = self.selectedModelByProvider
 

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -541,9 +541,7 @@ extension AIEnhancementSettingsView {
         }
         if self.expandedProviderID == providerID {
             self.expandedProviderID = nil
-            self.viewModel.showingEditProvider = false
-            self.viewModel.editProviderName = ""
-            self.viewModel.editProviderBaseURL = ""
+            self.viewModel.clearEditProviderDraft()
             self.viewModel.setEditingAPIKey(false, for: providerID)
         } else {
             self.expandedProviderID = providerID
@@ -751,7 +749,7 @@ extension AIEnhancementSettingsView {
         let isCustom = !ModelRepository.shared.isBuiltIn(item.id)
         let baseURL = self.viewModel.openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let isLocal = self.viewModel.isLocalEndpoint(baseURL)
-        let apiKeyValue = self.viewModel.providerAPIKeys[providerKey] ?? ""
+        let apiKeyValue = self.viewModel.providerAPIKey(for: item.id)
         let hasAPIKey = !apiKeyValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let models = self.viewModel.availableModelsByProvider[providerKey] ?? []
         let hasModels = !models.isEmpty
@@ -761,8 +759,8 @@ extension AIEnhancementSettingsView {
         let canVerify = hasModels && !self.viewModel.selectedModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && canFetchModels
         let isVerified = self.viewModel.connectionStatus(for: item.id) == .success
         let apiKeyBinding = Binding(
-            get: { self.viewModel.providerAPIKeys[providerKey] ?? "" },
-            set: { self.viewModel.providerAPIKeys[providerKey] = $0 }
+            get: { self.viewModel.providerAPIKey(for: item.id) },
+            set: { self.viewModel.updateProviderAPIKey($0, for: item.id, persistEmptyValue: true) }
         )
         let nameBinding = Binding(
             get: { self.viewModel.savedProviders.first(where: { $0.id == item.id })?.name ?? "" },
@@ -854,6 +852,9 @@ extension AIEnhancementSettingsView {
                             .textFieldStyle(.roundedBorder)
                             .font(.system(size: 13))
                             .frame(maxWidth: 200)
+                            .onTapGesture {
+                                self.viewModel.ensureKeychainAccessForAPIKeyEdit()
+                            }
                         if let websiteInfo = ModelRepository.shared.providerWebsiteURL(for: item.id),
                            let url = URL(string: websiteInfo.url)
                         {
@@ -887,7 +888,6 @@ extension AIEnhancementSettingsView {
                         models: models,
                         selectedModel: self.modelBinding(for: item.id),
                         onRefresh: {
-                            self.viewModel.saveProviderAPIKeys()
                             Task { await self.viewModel.fetchModelsForCurrentProvider() }
                         },
                         isRefreshing: isRefreshing,
@@ -922,7 +922,6 @@ extension AIEnhancementSettingsView {
 
                 if canVerify {
                     Button(action: {
-                        self.viewModel.saveProviderAPIKeys()
                         Task { await self.viewModel.testAPIConnection() }
                     }) {
                         HStack(spacing: 6) {
@@ -1040,7 +1039,7 @@ extension AIEnhancementSettingsView {
         let isRefreshing = self.viewModel.isFetchingModels && self.viewModel.selectedProviderID == item.id
         let baseURL = self.providerBaseURL(for: item).trimmingCharacters(in: .whitespacesAndNewlines)
         let isLocal = self.viewModel.isLocalEndpoint(baseURL)
-        let apiKeyValue = self.viewModel.providerAPIKeys[providerKey] ?? ""
+        let apiKeyValue = self.viewModel.providerAPIKey(for: item.id)
         let hasAPIKey = !apiKeyValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let canFetchModels = isLocal ? !baseURL.isEmpty : (hasAPIKey && !baseURL.isEmpty)
         let hasModels = !models.isEmpty
@@ -1092,9 +1091,7 @@ extension AIEnhancementSettingsView {
                 Button("Edit") {
                     self.activateProvider(item.id)
                     if isEditing {
-                        self.viewModel.showingEditProvider = false
-                        self.viewModel.editProviderName = ""
-                        self.viewModel.editProviderBaseURL = ""
+                        self.viewModel.clearEditProviderDraft()
                         self.viewModel.setEditingAPIKey(false, for: item.id)
                     } else {
                         self.viewModel.startEditingProvider()
@@ -1344,11 +1341,10 @@ extension AIEnhancementSettingsView {
     }
 
     var editProviderSection: some View {
-        let providerKey = self.viewModel.providerKey(for: self.viewModel.selectedProviderID)
         let isBuiltIn = ModelRepository.shared.isBuiltIn(self.viewModel.selectedProviderID)
         let apiKeyBinding = Binding(
-            get: { self.viewModel.providerAPIKeys[providerKey] ?? "" },
-            set: { self.viewModel.providerAPIKeys[providerKey] = $0 }
+            get: { self.viewModel.editProviderApiKey },
+            set: { self.viewModel.editProviderApiKey = $0 }
         )
         let isVerified = self.viewModel.connectionStatus(for: self.viewModel.selectedProviderID) == .success
 
@@ -1410,6 +1406,9 @@ extension AIEnhancementSettingsView {
                             .textFieldStyle(.roundedBorder)
                             .font(.system(size: 13))
                             .frame(maxWidth: 200)
+                            .onTapGesture {
+                                self.viewModel.ensureKeychainAccessForAPIKeyEdit()
+                            }
                         if let websiteInfo = ModelRepository.shared.providerWebsiteURL(for: self.viewModel.selectedProviderID),
                            let url = URL(string: websiteInfo.url)
                         {
@@ -1436,11 +1435,11 @@ extension AIEnhancementSettingsView {
 
             HStack(spacing: 10) {
                 Button(action: {
-                    self.viewModel.saveProviderAPIKeys()
+                    guard self.viewModel.saveEditedProviderAPIKey() else { return }
                     if !isBuiltIn {
                         self.viewModel.saveEditedProvider()
                     } else {
-                        self.viewModel.showingEditProvider = false
+                        self.viewModel.clearEditProviderDraft()
                     }
                 }) {
                     HStack(spacing: 6) {
@@ -1455,9 +1454,7 @@ extension AIEnhancementSettingsView {
                         self.viewModel.editProviderBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty))
 
                 Button("Cancel") {
-                    self.viewModel.showingEditProvider = false
-                    self.viewModel.editProviderName = ""
-                    self.viewModel.editProviderBaseURL = ""
+                    self.viewModel.clearEditProviderDraft()
                 }
                 .buttonStyle(CompactButtonStyle())
             }
@@ -1466,7 +1463,7 @@ extension AIEnhancementSettingsView {
                 if isVerified {
                     Button("Reset Verification") {
                         self.viewModel.resetVerification(for: self.viewModel.selectedProviderID)
-                        self.viewModel.showingEditProvider = false
+                        self.viewModel.clearEditProviderDraft()
                     }
                     .buttonStyle(CompactButtonStyle(foreground: .red, borderColor: .red.opacity(0.6)))
                 }
@@ -1474,7 +1471,7 @@ extension AIEnhancementSettingsView {
                 if !isBuiltIn {
                     Button(role: .destructive) {
                         self.viewModel.deleteCurrentProvider()
-                        self.viewModel.showingEditProvider = false
+                        self.viewModel.clearEditProviderDraft()
                         self.expandedProviderID = nil
                     } label: {
                         HStack(spacing: 6) {
@@ -1842,15 +1839,17 @@ extension AIEnhancementSettingsView {
                 .font(.headline)
             SecureField("API Key (optional for local endpoints)", text: self.$viewModel.newProviderApiKey)
                 .textFieldStyle(.roundedBorder).frame(width: 300)
+                .onTapGesture {
+                    self.viewModel.ensureKeychainAccessForAPIKeyEdit()
+                }
             HStack(spacing: 12) {
                 Button("Cancel") { self.viewModel.showAPIKeyEditor = false }
                     .buttonStyle(CompactButtonStyle())
                     .frame(minWidth: AISettingsLayout.actionMinWidth, minHeight: AISettingsLayout.controlHeight)
                 Button("OK") {
                     let trimmedKey = self.viewModel.newProviderApiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let providerKey = self.viewModel.providerKey(for: self.viewModel.selectedProviderID)
-                    self.viewModel.providerAPIKeys[providerKey] = trimmedKey
-                    self.viewModel.saveProviderAPIKeys()
+                    self.viewModel.updateProviderAPIKey(trimmedKey, for: self.viewModel.selectedProviderID)
+                    guard self.viewModel.saveProviderAPIKeys() else { return }
                     if self.viewModel.connectionStatus != .unknown {
                         self.viewModel.connectionStatus = .unknown
                         self.viewModel.connectionErrorMessage = ""
@@ -1904,6 +1903,9 @@ extension AIEnhancementSettingsView {
                     SecureField("Enter API key", text: self.$viewModel.newProviderApiKey)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(size: 13))
+                        .onTapGesture {
+                            self.viewModel.ensureKeychainAccessForAPIKeyEdit()
+                        }
                 }
             }
 

--- a/Sources/Fluid/UI/AISettingsView+AdvancedSettings.swift
+++ b/Sources/Fluid/UI/AISettingsView+AdvancedSettings.swift
@@ -880,8 +880,7 @@ extension AIEnhancementSettingsView {
     }
 
     private func canFetchModels(for providerID: String) -> Bool {
-        let key = self.viewModel.providerKey(for: providerID)
-        let apiKey = self.viewModel.providerAPIKeys[key] ?? ""
+        let apiKey = self.viewModel.providerAPIKey(for: providerID)
         let hasAPIKey = !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
         let baseURL: String


### PR DESCRIPTION
## Description
Fixes provider API key persistence so FluidVoice no longer silently loses keys when Keychain save/readback fails or legacy Keychain entries need migration. Adds user-visible Keychain failure handling and blocks provider fetch/verify when the key could not be saved.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #328

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources/`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`
- [x] Ran macOS test target with heavy Whisper E2E skipped
- [x] Verified real OpenRouter key save, provider verification, app relaunch, and persisted active provider state

## Notes
- Keychain reads from Terminal can prompt for the user password; FV itself can still save/read its own Keychain item normally.

## Screenshots / Video
Not included.