### PR TITLE
Fix Command Mode AI provider errors

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore+CommandMode.swift
+++ b/Sources/Fluid/Persistence/SettingsStore+CommandMode.swift
@@ -19,17 +19,15 @@ extension SettingsStore {
     }
 
     var effectiveCommandModeProviderID: String {
-        if self.commandModeLinkedToGlobal,
-           let providerID = self.supportedCommandModeProviderID(self.selectedProviderID)
-        {
-            return providerID
+        if self.commandModeLinkedToGlobal {
+            return self.selectedProviderID.trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
         if let providerID = self.supportedCommandModeProviderID(self.commandModeSelectedProviderID) {
             return providerID
         }
 
-        return "openai"
+        return self.commandModeSelectedProviderID.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     var effectiveCommandModeSelectedModel: String {
@@ -92,7 +90,7 @@ extension SettingsStore {
         return trimmed
     }
 
-    private func isCommandModeProviderVerified(_ providerID: String) -> Bool {
+    func isCommandModeProviderVerified(_ providerID: String) -> Bool {
         let key = ModelRepository.shared.providerKey(for: providerID)
         guard let stored = self.verifiedProviderFingerprints[key] else { return false }
 

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2087,8 +2087,8 @@ final class SettingsStore: ObservableObject {
             return .openAIGPT5
         }
 
-        // OpenAI o1/o3 reasoning models
-        if modelLower.hasPrefix("o1") || modelLower.hasPrefix("o3") {
+        // OpenAI o-series reasoning models
+        if modelLower.hasPrefix("o1") || modelLower.hasPrefix("o3") || modelLower.hasPrefix("o4") {
             return .openAIO1
         }
 
@@ -2144,6 +2144,7 @@ final class SettingsStore: ObservableObject {
             modelLower.contains("gpt-5.") ||
             modelLower.hasPrefix("o1") ||
             modelLower.hasPrefix("o3") ||
+            modelLower.hasPrefix("o4") ||
             modelLower.contains("gpt-oss") ||
             modelLower.hasPrefix("openai/") ||
             (modelLower.contains("deepseek") && modelLower.contains("reasoner"))

--- a/Sources/Fluid/Services/LLMClient.swift
+++ b/Sources/Fluid/Services/LLMClient.swift
@@ -18,15 +18,38 @@ enum LLMError: Error, LocalizedError {
         case .invalidResponse:
             return "Invalid response from LLM"
         case let .httpError(code, message):
-            return "HTTP \(code): \(message)"
+            return "HTTP \(code): \(message.trimmingCharacters(in: .whitespacesAndNewlines))"
         case let .networkError(error):
-            return "Network error: \(error.localizedDescription)"
+            return Self.userFacingNetworkMessage(from: error)
         case .encodingError:
             return "Failed to encode request"
         case let .timeout(seconds):
             return "Request timed out after \(Int(seconds)) seconds"
         case let .invalidRequest(message):
             return message
+        }
+    }
+
+    private static func userFacingNetworkMessage(from error: Error) -> String {
+        guard let urlError = error as? URLError else {
+            return "Network error: \(error.localizedDescription)"
+        }
+
+        switch urlError.code {
+        case .notConnectedToInternet:
+            return "Network error: no internet connection."
+        case .timedOut:
+            return "Network error: request timed out."
+        case .cannotFindHost:
+            return "Network error: could not find API host."
+        case .cannotConnectToHost:
+            return "Network error: could not connect to API host."
+        case .networkConnectionLost:
+            return "Network error: connection dropped during the request."
+        case .secureConnectionFailed, .serverCertificateUntrusted, .serverCertificateHasBadDate, .serverCertificateNotYetValid:
+            return "Network error: TLS certificate validation failed."
+        default:
+            return "Network error: \(urlError.localizedDescription)"
         }
     }
 }
@@ -78,6 +101,13 @@ final class LLMClient {
             guard let value = arguments[key] as? String, !value.isEmpty else { return nil }
             return value
         }
+    }
+
+    private struct ResponsesToolCallAccumulator {
+        var id: String?
+        var callID: String?
+        var name: String?
+        var arguments: String = ""
     }
 
     // MARK: - Configuration
@@ -162,12 +192,15 @@ final class LLMClient {
         for attempt in 1...config.maxRetries {
             do {
                 if config.streaming {
+                    if self.isResponsesRequest(request) {
+                        return try await self.processResponsesStreaming(request: request, config: config)
+                    }
                     return try await self.processStreaming(request: request, config: config)
                 } else {
                     return try await self.processNonStreaming(request: request)
                 }
             } catch let error as URLError where self.isRetryableError(error) {
-                lastError = error
+                lastError = LLMError.networkError(error)
                 DebugLogger.shared.warning("LLMClient: Retry \(attempt)/\(config.maxRetries) due to \(error.code.rawValue)", source: "LLMClient")
                 if attempt < config.maxRetries {
                     // Exponential backoff
@@ -175,6 +208,8 @@ final class LLMClient {
                     try? await Task.sleep(nanoseconds: delayNs)
                     continue
                 }
+            } catch let error as URLError {
+                throw LLMError.networkError(error)
             } catch {
                 throw error // Non-retryable error
             }
@@ -195,21 +230,14 @@ final class LLMClient {
             throw LLMError.invalidURL
         }
 
-        let endpoint: String
-        if baseURL.contains("/chat/completions") ||
-            baseURL.contains("/api/chat") ||
-            baseURL.contains("/api/generate")
-        {
-            endpoint = baseURL
-        } else {
-            endpoint = self.appendingPath("chat/completions", to: baseURL)
-        }
+        let useResponsesAPI = self.shouldUseResponsesAPI(for: config, baseURL: baseURL)
+        let endpoint = self.endpoint(for: baseURL, useResponsesAPI: useResponsesAPI)
 
         guard let url = URL(string: endpoint) else {
             throw LLMError.invalidURL
         }
 
-        let body = self.buildChatCompletionsBody(config)
+        let body = useResponsesAPI ? self.buildResponsesBody(config) : self.buildChatCompletionsBody(config)
 
         // Serialize to JSON
         guard let jsonData = try? JSONSerialization.data(withJSONObject: body, options: []) else {
@@ -240,6 +268,46 @@ final class LLMClient {
 
     private func appendingPath(_ path: String, to baseURL: String) -> String {
         baseURL.hasSuffix("/") ? "\(baseURL)\(path)" : "\(baseURL)/\(path)"
+    }
+
+    private func endpoint(for baseURL: String, useResponsesAPI: Bool) -> String {
+        if useResponsesAPI {
+            if baseURL.contains("/responses") {
+                return baseURL
+            }
+            if baseURL.contains("/chat/completions") {
+                return baseURL.replacingOccurrences(of: "/chat/completions", with: "/responses")
+            }
+            return self.appendingPath("responses", to: baseURL)
+        }
+
+        if baseURL.contains("/chat/completions") ||
+            baseURL.contains("/api/chat") ||
+            baseURL.contains("/api/generate")
+        {
+            return baseURL
+        }
+        return self.appendingPath("chat/completions", to: baseURL)
+    }
+
+    private func shouldUseResponsesAPI(for config: Config, baseURL: String) -> Bool {
+        if baseURL.contains("/responses") {
+            return true
+        }
+
+        guard let url = URL(string: baseURL),
+              url.host?.lowercased() == "api.openai.com"
+        else { return false }
+
+        let modelLower = config.model.lowercased()
+        return modelLower.hasPrefix("gpt-5") ||
+            modelLower.hasPrefix("o1") ||
+            modelLower.hasPrefix("o3") ||
+            modelLower.hasPrefix("o4")
+    }
+
+    private func isResponsesRequest(_ request: URLRequest) -> Bool {
+        request.url?.path.contains("/responses") == true
     }
 
     private func buildChatCompletionsBody(_ config: Config) -> [String: Any] {
@@ -287,6 +355,114 @@ final class LLMClient {
         return body
     }
 
+    private func buildResponsesBody(_ config: Config) -> [String: Any] {
+        var body: [String: Any] = [
+            "model": config.model,
+            "input": self.responsesInput(from: config.messages),
+            "store": false,
+        ]
+
+        if config.streaming {
+            body["stream"] = true
+        }
+
+        if !config.tools.isEmpty {
+            body["tools"] = self.responsesTools(from: config.tools)
+            body["tool_choice"] = "auto"
+        }
+
+        if let tokens = config.maxTokens {
+            body["max_output_tokens"] = tokens
+        }
+
+        if let temp = config.temperature {
+            body["temperature"] = temp
+        }
+
+        for (key, value) in ThinkingParserFactory.getExtraParameters(for: config.model) {
+            self.addResponsesExtraParameter(name: key, value: value, to: &body)
+        }
+
+        for (key, value) in config.extraParameters {
+            self.addResponsesExtraParameter(name: key, value: value, to: &body)
+        }
+
+        return body
+    }
+
+    private func addResponsesExtraParameter(name: String, value: Any, to body: inout [String: Any]) {
+        if name == "reasoning_effort" {
+            body["reasoning"] = ["effort": value]
+        } else {
+            body[name] = value
+        }
+    }
+
+    private func responsesTools(from chatTools: [[String: Any]]) -> [[String: Any]] {
+        var tools: [[String: Any]] = []
+
+        for chatTool in chatTools {
+            guard chatTool["type"] as? String == "function",
+                  let function = chatTool["function"] as? [String: Any],
+                  let name = function["name"] as? String,
+                  let parameters = function["parameters"] as? [String: Any]
+            else { continue }
+
+            var tool: [String: Any] = [
+                "type": "function",
+                "name": name,
+                "parameters": parameters,
+                "strict": false,
+            ]
+            if let description = function["description"] as? String {
+                tool["description"] = description
+            }
+            tools.append(tool)
+        }
+
+        return tools
+    }
+
+    private func responsesInput(from messages: [[String: Any]]) -> [[String: Any]] {
+        var input: [[String: Any]] = []
+
+        for message in messages {
+            let role = message["role"] as? String ?? "user"
+
+            if role == "tool" {
+                input.append([
+                    "type": "function_call_output",
+                    "call_id": message["tool_call_id"] as? String ?? "call_unknown",
+                    "output": message["content"] as? String ?? "",
+                ])
+                continue
+            }
+
+            if let content = message["content"] as? String, !content.isEmpty {
+                input.append([
+                    "role": role,
+                    "content": content,
+                ])
+            }
+
+            guard let toolCalls = message["tool_calls"] as? [[String: Any]] else { continue }
+            for toolCall in toolCalls {
+                guard let function = toolCall["function"] as? [String: Any],
+                      let name = function["name"] as? String
+                else { continue }
+
+                input.append([
+                    "type": "function_call",
+                    "call_id": toolCall["id"] as? String ?? "call_\(UUID().uuidString.prefix(8))",
+                    "name": name,
+                    "arguments": function["arguments"] as? String ?? "{}",
+                ])
+            }
+        }
+
+        return input
+    }
+
     // MARK: - Non-Streaming Response
 
     private func processNonStreaming(request: URLRequest) async throws -> Response {
@@ -306,12 +482,119 @@ final class LLMClient {
             throw LLMError.invalidResponse
         }
 
+        if self.isResponsesRequest(request) {
+            return try self.parseResponsesResponse(json)
+        }
+
         guard let choices = json["choices"] as? [[String: Any]],
               let choice = choices.first,
               let message = choice["message"] as? [String: Any]
         else { throw LLMError.invalidResponse }
 
         return self.parseMessageResponse(message)
+    }
+
+    private func processResponsesStreaming(request: URLRequest, config: Config) async throws -> Response {
+        DebugLogger.shared.debug("LLMClient: Starting Responses streaming request to \(request.url?.absoluteString ?? "unknown")", source: "LLMClient")
+
+        let (bytes, response) = try await self.session.bytes(for: request)
+
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+            let errText = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+            throw LLMError.httpError(http.statusCode, errText)
+        }
+
+        var contentBuffer: [String] = []
+        var toolCallsByIndex: [Int: ResponsesToolCallAccumulator] = [:]
+
+        for try await rawLine in bytes.lines {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard line.hasPrefix("data:") else { continue }
+
+            var jsonString = String(line.dropFirst(5))
+            if jsonString.hasPrefix(" ") {
+                jsonString = String(jsonString.dropFirst(1))
+            }
+            if jsonString.trimmingCharacters(in: .whitespaces) == "[DONE]" {
+                continue
+            }
+
+            guard let jsonData = jsonString.data(using: .utf8),
+                  let event = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                  let type = event["type"] as? String
+            else {
+                continue
+            }
+
+            switch type {
+            case "response.output_text.delta":
+                if let delta = event["delta"] as? String {
+                    contentBuffer.append(delta)
+                    config.onContentChunk?(delta)
+                }
+            case "response.output_item.added", "response.output_item.done":
+                guard let item = event["item"] as? [String: Any],
+                      item["type"] as? String == "function_call"
+                else { continue }
+                let index = event["output_index"] as? Int ?? 0
+                var call = toolCallsByIndex[index] ?? ResponsesToolCallAccumulator()
+                call.id = item["id"] as? String ?? call.id
+                call.callID = item["call_id"] as? String ?? call.callID
+                call.name = item["name"] as? String ?? call.name
+                if let arguments = item["arguments"] as? String, !arguments.isEmpty {
+                    call.arguments = arguments
+                }
+                toolCallsByIndex[index] = call
+                if let name = call.name {
+                    config.onToolCallStart?(name)
+                }
+            case "response.function_call_arguments.delta":
+                let index = event["output_index"] as? Int ?? 0
+                var call = toolCallsByIndex[index] ?? ResponsesToolCallAccumulator()
+                call.arguments += event["delta"] as? String ?? ""
+                toolCallsByIndex[index] = call
+            case "response.function_call_arguments.done":
+                let index = event["output_index"] as? Int ?? 0
+                var call = toolCallsByIndex[index] ?? ResponsesToolCallAccumulator()
+                call.id = event["item_id"] as? String ?? call.id
+                call.callID = event["call_id"] as? String ?? call.callID
+                call.name = event["name"] as? String ?? call.name
+                call.arguments = event["arguments"] as? String ?? call.arguments
+                if let item = event["item"] as? [String: Any] {
+                    call.id = item["id"] as? String ?? call.id
+                    call.callID = item["call_id"] as? String ?? call.callID
+                    call.name = item["name"] as? String ?? call.name
+                    call.arguments = item["arguments"] as? String ?? call.arguments
+                }
+                toolCallsByIndex[index] = call
+            default:
+                continue
+            }
+        }
+
+        let toolCalls = toolCallsByIndex.keys.sorted().compactMap { index -> ToolCall? in
+            guard let call = toolCallsByIndex[index],
+                  let name = call.name,
+                  let argsData = call.arguments.data(using: .utf8),
+                  let args = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any]
+            else { return nil }
+
+            return ToolCall(
+                id: call.callID ?? call.id ?? "call_\(UUID().uuidString.prefix(8))",
+                name: name,
+                arguments: args
+            )
+        }
+
+        return Response(
+            thinking: nil,
+            content: contentBuffer.joined().trimmingCharacters(in: .whitespacesAndNewlines),
+            toolCalls: toolCalls
+        )
     }
 
     private func processStreaming(request: URLRequest, config: Config) async throws -> Response {
@@ -511,6 +794,54 @@ final class LLMClient {
     }
 
     // MARK: - Parse Non-Streaming Message
+
+    private func parseResponsesResponse(_ json: [String: Any]) throws -> Response {
+        guard let output = json["output"] as? [[String: Any]] else {
+            throw LLMError.invalidResponse
+        }
+
+        var contentParts: [String] = []
+        var parsedToolCalls: [ToolCall] = []
+
+        for item in output {
+            switch item["type"] as? String {
+            case "message":
+                guard let content = item["content"] as? [[String: Any]] else { continue }
+                for part in content {
+                    if part["type"] as? String == "output_text",
+                       let text = part["text"] as? String
+                    {
+                        contentParts.append(text)
+                    }
+                }
+            case "function_call":
+                guard let name = item["name"] as? String,
+                      let argsString = item["arguments"] as? String,
+                      let argsData = argsString.data(using: .utf8),
+                      let args = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any]
+                else { continue }
+
+                parsedToolCalls.append(
+                    ToolCall(
+                        id: item["call_id"] as? String ?? item["id"] as? String ?? "call_\(UUID().uuidString.prefix(8))",
+                        name: name,
+                        arguments: args
+                    )
+                )
+            default:
+                continue
+            }
+        }
+
+        let rawContent = contentParts.joined()
+        let (thinking, cleanedContent) = self.stripThinkingTags(rawContent)
+
+        return Response(
+            thinking: thinking.isEmpty ? nil : thinking,
+            content: cleanedContent.isEmpty ? rawContent.trimmingCharacters(in: .whitespacesAndNewlines) : cleanedContent,
+            toolCalls: parsedToolCalls
+        )
+    }
 
     private func parseMessageResponse(_ message: [String: Any]) -> Response {
         // Extract content

--- a/Sources/Fluid/Services/ModelRepository.swift
+++ b/Sources/Fluid/Services/ModelRepository.swift
@@ -274,15 +274,10 @@ final class ModelRepository {
             throw FetchError.networkError(details: errorDetails)
         }
 
-        // Check for HTTP errors with detailed messages
+        // Check for HTTP errors and preserve the provider body for the UI.
         if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
             let bodyString = String(data: data, encoding: .utf8) ?? "<unable to decode response body>"
-            let errorDetails = self.interpretHTTPError(
-                statusCode: httpResponse.statusCode,
-                providerID: providerID,
-                responseBody: bodyString,
-                endpoint: urlString
-            )
+            let errorDetails = self.rawHTTPErrorDetails(responseBody: bodyString)
             DebugLogger.shared.error(
                 "fetchModels: HTTP \(httpResponse.statusCode) for '\(providerID)': \(errorDetails)\nResponse body: \(bodyString.prefix(500))",
                 source: "ModelRepository"
@@ -335,32 +330,9 @@ final class ModelRepository {
         throw FetchError.invalidResponse(details: "Unknown response format. Top-level keys: [\(topLevelKeys)]. Expected 'data' or 'models'.")
     }
 
-    /// Provides detailed interpretation of HTTP errors
-    private func interpretHTTPError(statusCode: Int, providerID: String, responseBody: String, endpoint: String) -> String {
-        let providerName = self.displayName(for: providerID)
-
-        switch statusCode {
-        case 400:
-            return "Bad Request - The request format was invalid. Check if the base URL '\(endpoint)' is correct for \(providerName)."
-        case 401:
-            if responseBody.lowercased().contains("invalid") || responseBody.lowercased().contains("api key") || responseBody.lowercased().contains("authentication") {
-                return "Invalid API Key - The API key for \(providerName) appears to be incorrect or expired. Please verify your API key."
-            }
-            return "Unauthorized - API key is missing or invalid for \(providerName). Double-check your API key."
-        case 403:
-            if responseBody.lowercased().contains("permission") || responseBody.lowercased().contains("access") {
-                return "Forbidden - Your API key doesn't have permission to list models for \(providerName). Check your account permissions."
-            }
-            return "Forbidden - Access denied for \(providerName). Your API key may lack the required permissions."
-        case 404:
-            return "Not Found - The /models endpoint doesn't exist at '\(endpoint)'. This provider may not support model listing, or the base URL is incorrect."
-        case 429:
-            return "Rate Limited - Too many requests to \(providerName). Wait a moment and try again."
-        case 500, 502, 503:
-            return "\(providerName) server error (HTTP \(statusCode)). The service may be temporarily unavailable."
-        default:
-            return "HTTP \(statusCode) from \(providerName). Check your API key and base URL configuration."
-        }
+    private func rawHTTPErrorDetails(responseBody: String) -> String {
+        let trimmed = responseBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "<empty response body>" : trimmed
     }
 
     /// Provides detailed network error messages

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -55,6 +55,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     @Published var connectionStatus: AIConnectionStatus = .unknown
     @Published var connectionErrorMessage: String = ""
     @Published var connectionStatusByProvider: [String: AIConnectionStatus] = [:]
+    @Published var connectionErrorMessageByProvider: [String: String] = [:]
     @Published var fetchedModelsProviders: Set<String> = []
     @Published var editingAPIKeyProviders: Set<String> = []
 
@@ -254,6 +255,10 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.connectionStatusByProvider[providerID] ?? .unknown
     }
 
+    func connectionErrorMessage(for providerID: String) -> String {
+        self.connectionErrorMessageByProvider[providerID] ?? ""
+    }
+
     // MARK: - Provider Items Cache (for scroll performance)
 
     /// Refreshes the cached provider items. Call this when providers or connection status changes.
@@ -287,11 +292,28 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
     func updateConnectionStatus(_ status: AIConnectionStatus, for providerID: String) {
         self.connectionStatusByProvider[providerID] = status
+        if status != .failed {
+            self.clearConnectionError(for: providerID)
+        }
         if providerID == self.selectedProviderID {
             self.connectionStatus = status
         }
         // Refresh cached lists when verification status changes
         self.refreshProviderItems()
+    }
+
+    private func setConnectionError(_ message: String, for providerID: String) {
+        self.connectionErrorMessageByProvider[providerID] = message
+        if providerID == self.selectedProviderID {
+            self.connectionErrorMessage = message
+        }
+    }
+
+    private func clearConnectionError(for providerID: String) {
+        self.connectionErrorMessageByProvider.removeValue(forKey: providerID)
+        if providerID == self.selectedProviderID {
+            self.connectionErrorMessage = ""
+        }
     }
 
     func verifyAppleIntelligence() {
@@ -329,6 +351,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.selectedProviderID = providerID
         self.handleProviderChange(providerID)
         self.connectionStatus = self.connectionStatusByProvider[providerID] ?? .unknown
+        self.connectionErrorMessage = self.connectionErrorMessage(for: providerID)
         self.setEditingAPIKey(true, for: providerID)
     }
 
@@ -626,7 +649,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let baseURL = self.providerBaseURL(for: providerID)
         if self.hasProviderAPIKeyDraft(for: providerID), !self.saveProviderAPIKeys(invalidating: providerID) {
             self.updateConnectionStatus(.failed, for: providerID)
-            self.connectionErrorMessage = "Could not save API key to Keychain. Grant access and try again."
+            self.setConnectionError("Could not save API key to Keychain. Grant access and try again.", for: providerID)
             return
         }
         let apiKey = self.providerAPIKey(for: providerID)
@@ -637,7 +660,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         if baseURL.isEmpty {
             await MainActor.run {
                 self.updateConnectionStatus(.failed, for: providerID)
-                self.connectionErrorMessage = "Base URL is required for \(providerName)"
+                self.setConnectionError("Base URL is required for \(providerName)", for: providerID)
             }
             return
         }
@@ -645,7 +668,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         if !isLocal && apiKey.isEmpty {
             await MainActor.run {
                 self.updateConnectionStatus(.failed, for: providerID)
-                self.connectionErrorMessage = "API key is required for \(providerName). Enter your API key above."
+                self.setConnectionError("API key is required for \(providerName). Enter your API key above.", for: providerID)
             }
             return
         }
@@ -654,22 +677,30 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         guard !trimmedModel.isEmpty else {
             await MainActor.run {
                 self.updateConnectionStatus(.failed, for: providerID)
-                self.connectionErrorMessage = "Select a model before verifying. You may need to add a model manually for \(providerName)."
+                self.setConnectionError("Select a model before verifying. You may need to add a model manually for \(providerName).", for: providerID)
             }
             return
         }
+        let usesResponsesAPI = self.shouldVerifyWithResponsesAPI(baseURL: baseURL, model: trimmedModel)
 
         await MainActor.run {
             self.isTestingConnection = true
             self.updateConnectionStatus(.testing, for: providerID)
-            self.connectionErrorMessage = ""
         }
 
         // Build the endpoint URL
         let endpoint = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let fullURL: String
 
-        if isAnthropic {
+        if usesResponsesAPI {
+            if endpoint.contains("/responses") {
+                fullURL = endpoint
+            } else if endpoint.contains("/chat/completions") {
+                fullURL = endpoint.replacingOccurrences(of: "/chat/completions", with: "/responses")
+            } else {
+                fullURL = endpoint + "/responses"
+            }
+        } else if isAnthropic {
             // Anthropic uses /messages endpoint, not /chat/completions
             if endpoint.contains("/messages") {
                 fullURL = endpoint
@@ -684,14 +715,14 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
         // Debug logging
         DebugLogger.shared.debug(
-            "testAPIConnection: provider=\(providerID), model=\(trimmedModel), baseURL=\(endpoint), fullURL=\(fullURL), isAnthropic=\(isAnthropic)",
+            "testAPIConnection: provider=\(providerID), model=\(trimmedModel), baseURL=\(endpoint), fullURL=\(fullURL), isAnthropic=\(isAnthropic), usesResponsesAPI=\(usesResponsesAPI)",
             source: "AISettingsView"
         )
 
         guard let url = URL(string: fullURL) else {
             await MainActor.run {
                 self.updateConnectionStatus(.failed, for: providerID)
-                self.connectionErrorMessage = "Invalid Base URL format: '\(endpoint)' could not be parsed as a URL"
+                self.setConnectionError("Invalid Base URL format: '\(endpoint)' could not be parsed as a URL", for: providerID)
             }
             return
         }
@@ -717,7 +748,25 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let provKey = self.providerKey(for: providerID)
         let reasoningConfig = self.settings.getReasoningConfig(forModel: trimmedModel, provider: provKey)
 
-        if isAnthropic {
+        if usesResponsesAPI {
+            var dict: [String: Any] = [
+                "model": trimmedModel,
+                "input": "test",
+                "store": false,
+                "max_output_tokens": 50,
+            ]
+
+            if let config = reasoningConfig, config.isEnabled {
+                if config.parameterName == "reasoning_effort" {
+                    dict["reasoning"] = ["effort": config.parameterValue]
+                } else if config.parameterName == "enable_thinking" {
+                    dict[config.parameterName] = config.parameterValue == "true"
+                } else {
+                    dict[config.parameterName] = config.parameterValue
+                }
+            }
+            requestDict = dict
+        } else if isAnthropic {
             // Anthropic API format
             requestDict = [
                 "model": trimmedModel,
@@ -751,7 +800,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         guard let jsonData = try? JSONSerialization.data(withJSONObject: requestDict, options: []) else {
             await MainActor.run {
                 self.updateConnectionStatus(.failed, for: providerID)
-                self.connectionErrorMessage = "Internal error: Failed to create test request payload"
+                self.setConnectionError("Internal error: Failed to create test request payload", for: providerID)
             }
             return
         }
@@ -767,7 +816,6 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
                 if statusCode >= 200, statusCode < 300 {
                     await MainActor.run {
                         self.updateConnectionStatus(.success, for: providerID)
-                        self.connectionErrorMessage = ""
                         self.setEditingAPIKey(false, for: providerID)
                         self.storeVerificationFingerprint(for: providerID, baseURL: baseURL, apiKey: apiKey)
                     }
@@ -775,10 +823,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
                     // Parse error response for more details
                     let errorMessage = self.interpretVerificationError(
                         statusCode: statusCode,
-                        responseData: data,
-                        providerID: providerID,
-                        model: trimmedModel,
-                        endpoint: fullURL
+                        responseData: data
                     )
                     DebugLogger.shared.error(
                         "testAPIConnection failed: HTTP \(statusCode) for \(providerID), model=\(trimmedModel)\nError: \(errorMessage)\nResponse: \(String(data: data, encoding: .utf8)?.prefix(500) ?? "nil")",
@@ -786,13 +831,13 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
                     )
                     await MainActor.run {
                         self.updateConnectionStatus(.failed, for: providerID)
-                        self.connectionErrorMessage = errorMessage
+                        self.setConnectionError(errorMessage, for: providerID)
                     }
                 }
             } else {
                 await MainActor.run {
                     self.updateConnectionStatus(.failed, for: providerID)
-                    self.connectionErrorMessage = "Unexpected response type from server"
+                    self.setConnectionError("Unexpected response type from server", for: providerID)
                 }
             }
         } catch {
@@ -803,7 +848,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             )
             await MainActor.run {
                 self.updateConnectionStatus(.failed, for: providerID)
-                self.connectionErrorMessage = errorMessage
+                self.setConnectionError(errorMessage, for: providerID)
             }
         }
 
@@ -812,64 +857,31 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         }
     }
 
-    /// Interprets HTTP error responses with actionable guidance
-    private func interpretVerificationError(statusCode: Int, responseData: Data, providerID: String, model: String, endpoint: String) -> String {
-        let providerName = ModelRepository.shared.displayName(for: providerID)
-        let responseBody = String(data: responseData, encoding: .utf8)?.lowercased() ?? ""
+    /// Returns the provider's HTTP error body unchanged so setup errors match the real API response.
+    private func interpretVerificationError(statusCode: Int, responseData: Data) -> String {
+        let responseBody = String(data: responseData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        switch statusCode {
-        case 400:
-            // Check for specific error patterns in response
-            if responseBody.contains("model") {
-                return "Invalid model '\(model)' for \(providerName). Check if the model name is correct."
-            }
-            if responseBody.contains("messages") || responseBody.contains("content") {
-                return "Request format error for \(providerName). The API may have changed or the base URL is pointed at a different API."
-            }
-            return "Bad request (HTTP 400). Check that the base URL '\(endpoint)' is correct for \(providerName)."
-
-        case 401:
-            if responseBody.contains("invalid") || responseBody.contains("expired") {
-                return "Invalid API key for \(providerName). Please verify your API key is correct and not expired."
-            }
-            if responseBody.contains("missing") {
-                return "API key is missing. Enter your \(providerName) API key above."
-            }
-            return "Authentication failed (HTTP 401). Your \(providerName) API key may be invalid. Double-check the key."
-
-        case 403:
-            if responseBody.contains("permission") || responseBody.contains("access") {
-                return "Permission denied. Your \(providerName) API key may not have access to this model."
-            }
-            if responseBody.contains("region") || responseBody.contains("country") {
-                return "Access denied. \(providerName) may not be available in your region."
-            }
-            return "Forbidden (HTTP 403). Check your \(providerName) account permissions and subscription."
-
-        case 404:
-            if responseBody.contains("model") {
-                return "Model '\(model)' not found on \(providerName). Check if the model name is spelled correctly."
-            }
-            return "Endpoint not found (HTTP 404). The base URL '\(endpoint)' may be incorrect for \(providerName)."
-
-        case 422:
-            if responseBody.contains("model") {
-                return "Model '\(model)' is not valid for \(providerName). Try a different model."
-            }
-            return "Invalid request parameters for \(providerName). The model or configuration may be incorrect."
-
-        case 429:
-            return "Rate limited by \(providerName). Wait a moment and try again."
-
-        case 500, 502, 503:
-            return "\(providerName) server error (HTTP \(statusCode)). The service may be temporarily unavailable."
-
-        case 529:
-            return "\(providerName) is overloaded. Try again in a few moments."
-
-        default:
-            return "HTTP \(statusCode) from \(providerName). Check your API key, base URL, and model configuration."
+        if let responseBody, !responseBody.isEmpty {
+            return "HTTP \(statusCode): \(responseBody)"
         }
+        return "HTTP \(statusCode)"
+    }
+
+    private func shouldVerifyWithResponsesAPI(baseURL: String, model: String) -> Bool {
+        if baseURL.contains("/responses") {
+            return true
+        }
+
+        guard let url = URL(string: baseURL),
+              url.host?.lowercased() == "api.openai.com"
+        else { return false }
+
+        let modelLower = model.lowercased()
+        return modelLower.hasPrefix("gpt-5") ||
+            modelLower.hasPrefix("o1") ||
+            modelLower.hasPrefix("o3") ||
+            modelLower.hasPrefix("o4")
     }
 
     /// Interprets network errors with actionable guidance
@@ -1220,7 +1232,8 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         var fingerprints = self.settings.verifiedProviderFingerprints
         fingerprints[key] = fingerprint
         self.settings.verifiedProviderFingerprints = fingerprints
-        self.connectionStatusByProvider[providerID] = .success
+        self.updateConnectionStatus(.success, for: providerID)
+        self.clearConnectionError(for: providerID)
     }
 
     private func invalidateVerificationIfNeeded(for providerID: String) {
@@ -1232,6 +1245,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         if current != stored {
             self.settings.verifiedProviderFingerprints.removeValue(forKey: key)
             self.connectionStatusByProvider[providerID] = .unknown
+            self.clearConnectionError(for: providerID)
         }
     }
 
@@ -1239,6 +1253,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let key = self.providerKey(for: providerID)
         self.settings.verifiedProviderFingerprints.removeValue(forKey: key)
         self.connectionStatusByProvider[providerID] = .unknown
+        self.clearConnectionError(for: providerID)
     }
 
     private func refreshVerifiedProviders() {

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -471,6 +471,15 @@ extension AIEnhancementSettingsView {
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
 
+            if !isExpanded,
+               self.viewModel.connectionStatus(for: item.id) == .failed,
+               !self.viewModel.connectionErrorMessage(for: item.id).isEmpty
+            {
+                self.providerErrorPreview(self.viewModel.connectionErrorMessage(for: item.id), lineLimit: 2)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 10)
+            }
+
             if isExpanded {
                 Divider()
                     .background(self.theme.palette.separator.opacity(0.5))
@@ -904,6 +913,12 @@ extension AIEnhancementSettingsView {
                     self.reasoningConfigSection
                 }
 
+                if self.viewModel.connectionStatus(for: item.id) == .failed,
+                   !self.viewModel.connectionErrorMessage(for: item.id).isEmpty
+                {
+                    self.providerErrorPreview(self.viewModel.connectionErrorMessage(for: item.id), lineLimit: 8)
+                }
+
                 if let error = self.viewModel.fetchModelsError, !error.isEmpty {
                     HStack(spacing: 6) {
                         Image(systemName: "exclamationmark.triangle.fill")
@@ -967,6 +982,31 @@ extension AIEnhancementSettingsView {
                 }
             }
         })
+    }
+
+    private func providerErrorPreview(_ message: String, lineLimit: Int) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.red)
+                .padding(.top, 2)
+
+            Text(message)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(.red.opacity(0.9))
+                .lineLimit(lineLimit)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.red.opacity(0.11))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.red.opacity(0.18), lineWidth: 1)
+        )
     }
 
     private var customProviderButton: some View {

--- a/Sources/Fluid/Views/CommandModeView.swift
+++ b/Sources/Fluid/Views/CommandModeView.swift
@@ -491,17 +491,16 @@ struct CommandModeView: View {
                         .help("Use the same provider and model selected in AI Enhancement.")
 
                     SearchableProviderPicker(
-                        builtInProviders: self.builtInProvidersList,
-                        savedProviders: self.settings.savedProviders,
+                        builtInProviders: self.verifiedBuiltInProvidersList,
+                        savedProviders: self.verifiedSavedProviders,
                         selectedProviderID: Binding(
                             get: { self.settings.effectiveCommandModeProviderID },
                             set: { newValue in
                                 guard !self.settings.commandModeLinkedToGlobal else { return }
                                 if newValue == "apple-intelligence-disabled" || newValue == "apple-intelligence" {
-                                    self.settings.commandModeSelectedProviderID = "openai"
-                                } else {
-                                    self.settings.commandModeSelectedProviderID = newValue
+                                    return
                                 }
+                                self.settings.commandModeSelectedProviderID = newValue
                                 self.updateAvailableModels()
                             }
                         ),
@@ -627,6 +626,14 @@ struct CommandModeView: View {
             appleIntelligenceAvailable: false,
             appleIntelligenceDisabledReason: "No tools"
         )
+    }
+
+    private var verifiedBuiltInProvidersList: [(id: String, name: String)] {
+        self.builtInProvidersList.filter { self.settings.isCommandModeProviderVerified($0.id) }
+    }
+
+    private var verifiedSavedProviders: [SettingsStore.SavedProvider] {
+        self.settings.savedProviders.filter { self.settings.isCommandModeProviderVerified($0.id) }
     }
 }
 


### PR DESCRIPTION
## Description
Fixes Command Mode and AI enhancement provider errors by routing OpenAI reasoning models through the Responses API, preserving raw provider error bodies in the UI, and limiting Command Mode provider selection to verified chat providers without silently falling back.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to work differently)
- [ ] 📝 Documentation update

## Related Issues
- Closes #348

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.x
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- OpenAI `gpt-5*`/`o*` models now use `/v1/responses`; `reasoning_effort` is mapped to `reasoning.effort` for Responses requests.
- Command Mode no longer shows unverified providers in its picker and no longer maps invalid provider selections back to OpenAI.

## Screenshots / Video 
Not included; provider routing and error handling change only.
