### PR TITLE
Media control modes (Off/Mute/Pause) during transcription + trailing-word fix

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		7C3236542EAAD608007E4CB6 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = 7C3236532EAAD608007E4CB6 /* MCP */; };
 		7C3697892ED70F9C005874CE /* DynamicNotchKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7C3697882ED70F9C005874CE /* DynamicNotchKit */; };
 		7C5AF14B2F15041600DE21B0 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */; };
+		B08CE3022F43300000078F5D /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
 		7CDB0A2F2F3C4D5600FB7CAD /* dictation_fixture.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */; };
@@ -45,6 +46,20 @@
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		B08CE3032F43300100078F5D /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				B08CE3022F43300000078F5D /* MediaRemoteAdapter in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		7C078D8C2E3B339200FB7CAC /* Frameworks */ = {
@@ -141,6 +156,7 @@
 				7C078D8B2E3B339200FB7CAC /* Sources */,
 				7C078D8C2E3B339200FB7CAC /* Frameworks */,
 				7C078D8D2E3B339200FB7CAC /* Resources */,
+				B08CE3032F43300100078F5D /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -62,6 +62,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let removeFillerWordsEnabled: Bool
     let gaavModeEnabled: Bool
     let pauseMediaDuringTranscription: Bool
+    let mediaTranscriptionMode: SettingsStore.MediaTranscriptionMode?
     let vocabularyBoostingEnabled: Bool
     let customDictionaryEntries: [SettingsStore.CustomDictionaryEntry]
     let selectedDictationPromptID: String?

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2310,6 +2310,7 @@ final class SettingsStore: ObservableObject {
             removeFillerWordsEnabled: self.removeFillerWordsEnabled,
             gaavModeEnabled: self.gaavModeEnabled,
             pauseMediaDuringTranscription: self.pauseMediaDuringTranscription,
+            mediaTranscriptionMode: self.mediaTranscriptionMode,
             vocabularyBoostingEnabled: self.vocabularyBoostingEnabled,
             customDictionaryEntries: self.customDictionaryEntries,
             selectedDictationPromptID: self.selectedDictationPromptID,
@@ -2384,6 +2385,9 @@ final class SettingsStore: ObservableObject {
         self.removeFillerWordsEnabled = payload.removeFillerWordsEnabled
         self.gaavModeEnabled = payload.gaavModeEnabled
         self.pauseMediaDuringTranscription = payload.pauseMediaDuringTranscription
+        if let mediaMode = payload.mediaTranscriptionMode {
+            self.mediaTranscriptionMode = mediaMode
+        }
         self.vocabularyBoostingEnabled = payload.vocabularyBoostingEnabled
         self.customDictionaryEntries = payload.customDictionaryEntries
 
@@ -2798,8 +2802,49 @@ final class SettingsStore: ObservableObject {
 
     // MARK: - Media Playback Control
 
-    /// When enabled, automatically pauses system media playback when transcription starts.
-    /// Only resumes if FluidVoice was the one that paused it.
+    /// How FluidVoice handles currently-playing media while transcription is active.
+    enum MediaTranscriptionMode: String, CaseIterable, Codable, Identifiable {
+        case off
+        case mute
+        case pause
+
+        var id: String { self.rawValue }
+
+        var displayName: String {
+            switch self {
+            case .off: return "Off"
+            case .mute: return "Mute"
+            case .pause: return "Pause"
+            }
+        }
+    }
+
+    /// How to control currently-playing media during transcription (off / mute / pause).
+    ///
+    /// Source of truth for the behavior. Kept in sync with the legacy
+    /// `pauseMediaDuringTranscription` boolean (true whenever this isn't `.off`) so older
+    /// reads and existing backups still reflect the enabled state; when the new key is
+    /// absent we seed the value from that boolean. In every production release the legacy
+    /// toggle PAUSED media, so `true` migrates to `.pause` to preserve existing users'
+    /// behavior (they must opt into `.mute` themselves).
+    var mediaTranscriptionMode: MediaTranscriptionMode {
+        get {
+            if let raw = self.defaults.string(forKey: Keys.mediaTranscriptionMode),
+               let mode = MediaTranscriptionMode(rawValue: raw) {
+                return mode
+            }
+            // Legacy `pauseMediaDuringTranscription == true` always meant "pause" in shipped builds.
+            return self.defaults.bool(forKey: Keys.pauseMediaDuringTranscription) ? .pause : .off
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue.rawValue, forKey: Keys.mediaTranscriptionMode)
+            self.defaults.set(newValue != .off, forKey: Keys.pauseMediaDuringTranscription)
+        }
+    }
+
+    /// Legacy enabled flag for media control during transcription. Retained for backup
+    /// compatibility; `mediaTranscriptionMode` is the source of truth for the behavior.
     var pauseMediaDuringTranscription: Bool {
         get { self.defaults.object(forKey: Keys.pauseMediaDuringTranscription) as? Bool ?? false }
         set {
@@ -3570,6 +3615,7 @@ private extension SettingsStore {
 
         /// Media Playback Control
         static let pauseMediaDuringTranscription = "PauseMediaDuringTranscription"
+        static let mediaTranscriptionMode = "MediaTranscriptionMode"
 
         /// Custom Dictation Prompt
         static let customDictationPrompt = "CustomDictationPrompt"

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -526,6 +526,11 @@ final class ASRService: ObservableObject {
     private let fastPreviewStopGraceMinimumCoverage = 0.72
     private let fastPreviewStopGraceTargetCoverage = 0.88
 
+    /// Keep capturing briefly after stop() is requested so trailing audio — often the last word,
+    /// still in flight from the audio engine when the hotkey is released — lands in the buffer
+    /// before we drain it. Without this, the final word gets cut off (most visible in full-final mode).
+    private let stopTailCaptureNanoseconds: UInt64 = 250_000_000
+
     /// What we did to system media for this recording session, so we can undo it
     /// correctly on stop (resume if we paused, restore volume if we muted).
     private enum ActiveMediaControl { case paused, muted }
@@ -938,6 +943,15 @@ final class ASRService: ObservableObject {
         self.activeMediaControl = nil // Reset for next session
 
         DebugLogger.shared.debug("📍 Preparing final transcription", source: "ASRService")
+
+        // Tail-capture grace: the audio engine delivers samples with some latency, and the hotkey
+        // is usually released right as the last word finishes. Keep recording (engine still running)
+        // for a brief moment so trailing audio lands in the buffer before we drain it — otherwise
+        // the final word is cut off. The fast-preview path has its own streaming grace below; this
+        // covers raw capture for every mode.
+        let bufferedBeforeTailGrace = self.audioBuffer.count
+        try? await Task.sleep(nanoseconds: self.stopTailCaptureNanoseconds)
+        self.benchmarkLog("stop_tail_grace waitedMs=\(Int(self.stopTailCaptureNanoseconds / 1_000_000)) addedSamples=\(self.audioBuffer.count - bufferedBeforeTailGrace)")
 
         DebugLogger.shared.debug("🚫 Setting audioCapturePipeline recording = false...", source: "ASRService")
         self.audioCapturePipeline.setRecordingEnabled(false)

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -526,9 +526,10 @@ final class ASRService: ObservableObject {
     private let fastPreviewStopGraceMinimumCoverage = 0.72
     private let fastPreviewStopGraceTargetCoverage = 0.88
 
-    /// Tracks whether we paused system media for this recording session.
-    /// Used to resume playback only if we were the ones who paused it.
-    private var didPauseMediaForThisSession: Bool = false
+    /// What we did to system media for this recording session, so we can undo it
+    /// correctly on stop (resume if we paused, restore volume if we muted).
+    private enum ActiveMediaControl { case paused, muted }
+    private var activeMediaControl: ActiveMediaControl?
 
     private var audioLevelSubject = PassthroughSubject<CGFloat, Never>()
     var audioLevelPublisher: AnyPublisher<CGFloat, Never> { self.audioLevelSubject.eraseToAnyPublisher() }
@@ -774,8 +775,8 @@ final class ASRService: ObservableObject {
             return
         }
 
-        // Reset media pause state for this session
-        self.didPauseMediaForThisSession = false
+        // Reset media control state for this session
+        self.activeMediaControl = nil
         self.audioRouteRecoveryTask?.cancel()
         self.audioRouteRecoveryTask = nil
         self.isRecoveringAudioRoute = false
@@ -819,13 +820,20 @@ final class ASRService: ObservableObject {
             try self.setupEngineTap()
             DebugLogger.shared.debug("✅ Engine tap setup complete", source: "ASRService")
 
-            // Pause system media AFTER successful audio setup but BEFORE setting isRunning
-            // This ensures we only pause media when we know recording will succeed
-            if SettingsStore.shared.pauseMediaDuringTranscription {
-                let didPause = await MediaPlaybackService.shared.pauseIfPlaying()
-                self.didPauseMediaForThisSession = didPause
-                if didPause {
-                    DebugLogger.shared.info("🎵 Paused system media for transcription", source: "ASRService")
+            // Control system media AFTER successful audio setup but BEFORE setting isRunning.
+            // This ensures we only act when we know recording will succeed.
+            switch SettingsStore.shared.mediaTranscriptionMode {
+            case .off:
+                break
+            case .mute:
+                if await MediaPlaybackService.shared.muteIfMediaPlaying() {
+                    self.activeMediaControl = .muted
+                    DebugLogger.shared.info("🔇 Muted system audio for transcription", source: "ASRService")
+                }
+            case .pause:
+                if await MediaPlaybackService.shared.pauseIfPlaying() {
+                    self.activeMediaControl = .paused
+                    DebugLogger.shared.info("⏸️ Paused system media for transcription", source: "ASRService")
                 }
             }
 
@@ -853,12 +861,9 @@ final class ASRService: ObservableObject {
         } catch {
             DebugLogger.shared.error("Failed to start ASR session: \(error)", source: "ASRService")
 
-            // Resume media if we paused it before the failure
-            if self.didPauseMediaForThisSession {
-                await MediaPlaybackService.shared.resumeIfWePaused(true)
-                self.didPauseMediaForThisSession = false
-                DebugLogger.shared.info("🎵 Resumed system media after start failure", source: "ASRService")
-            }
+            // Undo any media control we applied before the failure.
+            await self.restoreMediaControl(self.activeMediaControl)
+            self.activeMediaControl = nil
 
             // Provide user-friendly error feedback
             let errorMessage: String
@@ -928,9 +933,9 @@ final class ASRService: ObservableObject {
         self.audioRouteRecoveryTask = nil
         self.isRecoveringAudioRoute = false
 
-        // Capture media pause state before we reset it, for resuming at the end
-        let shouldResumeMedia = SettingsStore.shared.pauseMediaDuringTranscription && self.didPauseMediaForThisSession
-        self.didPauseMediaForThisSession = false // Reset for next session
+        // Capture what we did to media before resetting, so we can undo it at the end.
+        let mediaControlToRestore = self.activeMediaControl
+        self.activeMediaControl = nil // Reset for next session
 
         DebugLogger.shared.debug("📍 Preparing final transcription", source: "ASRService")
 
@@ -996,10 +1001,7 @@ final class ASRService: ObservableObject {
                 "Final ASR result | provider=\(self.transcriptionProvider.name) | samples=0 | textChars=0 | confidence=nil | reason=no_audio",
                 source: "ASRService"
             )
-            if shouldResumeMedia {
-                await MediaPlaybackService.shared.resumeIfWePaused(true)
-                DebugLogger.shared.info("🎵 Resumed system media after empty audio", source: "ASRService")
-            }
+            await self.restoreMediaControl(mediaControlToRestore)
             self.benchmarkLog("stop_end result=empty totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) reason=no_audio")
             return ""
         }
@@ -1034,11 +1036,7 @@ final class ASRService: ObservableObject {
 
             guard provider.isReady else {
                 DebugLogger.shared.error("Transcription provider is not ready", source: "ASRService")
-                // Resume media playback if we paused it
-                if shouldResumeMedia {
-                    await MediaPlaybackService.shared.resumeIfWePaused(true)
-                    DebugLogger.shared.info("🎵 Resumed system media after provider not ready", source: "ASRService")
-                }
+                await self.restoreMediaControl(mediaControlToRestore)
                 self.benchmarkLog("stop_end result=empty totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) reason=provider_not_ready")
                 return ""
             }
@@ -1091,11 +1089,7 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.debug("After post-processing: '\(cleanedText)'", source: "ASRService")
             self.benchmarkLog("stop_end result=success totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) recordingAgeMs=\(self.elapsedMilliseconds(since: self.benchmarkRecordingStartedAt)) cleanedChars=\(cleanedText.count)")
 
-            // Resume media playback if we paused it
-            if shouldResumeMedia {
-                await MediaPlaybackService.shared.resumeIfWePaused(true)
-                DebugLogger.shared.info("🎵 Resumed system media after transcription", source: "ASRService")
-            }
+            await self.restoreMediaControl(mediaControlToRestore)
 
             return cleanedText
         } catch {
@@ -1120,11 +1114,7 @@ final class ASRService: ObservableObject {
             // (e.g., accidental hotkey press) and would disrupt the user's workflow.
             // Errors are logged for debugging purposes.
 
-            // Resume media playback if we paused it
-            if shouldResumeMedia {
-                await MediaPlaybackService.shared.resumeIfWePaused(true)
-                DebugLogger.shared.info("🎵 Resumed system media after transcription failure", source: "ASRService")
-            }
+            await self.restoreMediaControl(mediaControlToRestore)
 
             self.benchmarkLog("stop_end result=error totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) error=\(error.localizedDescription)")
             return ""
@@ -1139,9 +1129,9 @@ final class ASRService: ObservableObject {
         self.audioRouteRecoveryTask = nil
         self.isRecoveringAudioRoute = false
 
-        // Capture media pause state before we reset it, for resuming at the end
-        let shouldResumeMedia = SettingsStore.shared.pauseMediaDuringTranscription && self.didPauseMediaForThisSession
-        self.didPauseMediaForThisSession = false // Reset for next session
+        // Capture what we did to media before resetting, so we can undo it at the end.
+        let mediaControlToRestore = self.activeMediaControl
+        self.activeMediaControl = nil // Reset for next session
 
         DebugLogger.shared.info("🛑 Stopping recording - releasing audio devices", source: "ASRService")
 
@@ -1183,10 +1173,19 @@ final class ASRService: ObservableObject {
         self.lastStreamingChunkFailureAnalyticsAt = nil
         self.refreshWordBoostStatus()
 
-        // Resume media playback if we paused it
-        if shouldResumeMedia {
+        await self.restoreMediaControl(mediaControlToRestore)
+    }
+
+    /// Undoes whatever media control we applied for this session: resume if we paused,
+    /// restore the volume if we muted. No-op if we didn't touch media.
+    private func restoreMediaControl(_ control: ActiveMediaControl?) async {
+        switch control {
+        case .paused:
             await MediaPlaybackService.shared.resumeIfWePaused(true)
-            DebugLogger.shared.info("🎵 Resumed system media after stopping without transcription", source: "ASRService")
+        case .muted:
+            await MediaPlaybackService.shared.unmuteIfWeMuted(true)
+        case .none:
+            break
         }
     }
 

--- a/Sources/Fluid/Services/AudioDeviceService.swift
+++ b/Sources/Fluid/Services/AudioDeviceService.swift
@@ -115,6 +115,131 @@ enum AudioDevice {
         return self.listAllDevices().first { $0.uid == uid }?.id
     }
 
+    // MARK: - Output Mute
+
+    /// Captures how the default output device was muted, so it can be restored exactly.
+    struct OutputMuteToken {
+        let deviceID: AudioObjectID
+        let restore: Restore
+        let methodDescription: String
+
+        enum Restore {
+            case muteProperty(previous: UInt32)
+            case masterVolume(previous: Float)
+            case channelVolumes([UInt32: Float])
+        }
+    }
+
+    /// Mutes the current default output device using the most reliable method it supports.
+    ///
+    /// Tries, in order: the device Mute property (works on Bluetooth / HDMI / aggregate devices
+    /// that don't expose a settable master volume scalar — e.g. AirPods, Sony WH-1000XM4,
+    /// external displays), then the master volume scalar, then per-channel volume scalars.
+    ///
+    /// - Returns: a token to pass to ``restoreOutput(_:)``, or `nil` if the device can't be muted in software.
+    static func muteDefaultOutput() -> OutputMuteToken? {
+        guard let device = getDefaultOutputDevice() else { return nil }
+        let id = device.id
+
+        // 1. Device Mute property — most broadly supported, including Bluetooth.
+        if let previous = self.getUInt32(id, kAudioDevicePropertyMute, kAudioObjectPropertyElementMain),
+           self.setUInt32(id, kAudioDevicePropertyMute, kAudioObjectPropertyElementMain, 1) {
+            return OutputMuteToken(deviceID: id, restore: .muteProperty(previous: previous), methodDescription: "mute property")
+        }
+
+        // 2. Master volume scalar on the main element.
+        if let previous = self.getScalarVolume(id, kAudioObjectPropertyElementMain),
+           self.setScalarVolume(id, kAudioObjectPropertyElementMain, 0) {
+            return OutputMuteToken(deviceID: id, restore: .masterVolume(previous: previous), methodDescription: "master volume (was \(previous))")
+        }
+
+        // 3. Per-channel volume scalars (many devices only expose channels 1/2, not a main element).
+        var saved: [UInt32: Float] = [:]
+        for channel in UInt32(1) ... UInt32(8) {
+            if let previous = self.getScalarVolume(id, channel), self.setScalarVolume(id, channel, 0) {
+                saved[channel] = previous
+            }
+        }
+        if !saved.isEmpty {
+            return OutputMuteToken(deviceID: id, restore: .channelVolumes(saved), methodDescription: "per-channel volume (\(saved.count) ch)")
+        }
+
+        return nil
+    }
+
+    /// Restores whatever ``muteDefaultOutput()`` changed, targeting the same device it muted.
+    static func restoreOutput(_ token: OutputMuteToken) {
+        switch token.restore {
+        case let .muteProperty(previous):
+            _ = self.setUInt32(token.deviceID, kAudioDevicePropertyMute, kAudioObjectPropertyElementMain, previous)
+        case let .masterVolume(previous):
+            _ = self.setScalarVolume(token.deviceID, kAudioObjectPropertyElementMain, previous)
+        case let .channelVolumes(channels):
+            for (channel, value) in channels {
+                _ = self.setScalarVolume(token.deviceID, channel, value)
+            }
+        }
+    }
+
+    // MARK: Low-level property helpers
+
+    private static func getScalarVolume(_ deviceID: AudioObjectID, _ element: AudioObjectPropertyElement) -> Float? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: element
+        )
+        guard AudioObjectHasProperty(deviceID, &address) else { return nil }
+        var value: Float32 = 0
+        var size = UInt32(MemoryLayout<Float32>.size)
+        return AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &value) == noErr ? value : nil
+    }
+
+    @discardableResult
+    private static func setScalarVolume(_ deviceID: AudioObjectID, _ element: AudioObjectPropertyElement, _ value: Float) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: element
+        )
+        guard self.isSettable(deviceID, &address) else { return false }
+        var clamped = min(max(value, 0.0), 1.0)
+        let size = UInt32(MemoryLayout<Float32>.size)
+        return AudioObjectSetPropertyData(deviceID, &address, 0, nil, size, &clamped) == noErr
+    }
+
+    private static func getUInt32(_ deviceID: AudioObjectID, _ selector: AudioObjectPropertySelector, _ element: AudioObjectPropertyElement) -> UInt32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: element
+        )
+        guard AudioObjectHasProperty(deviceID, &address) else { return nil }
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &value) == noErr ? value : nil
+    }
+
+    @discardableResult
+    private static func setUInt32(_ deviceID: AudioObjectID, _ selector: AudioObjectPropertySelector, _ element: AudioObjectPropertyElement, _ value: UInt32) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: element
+        )
+        guard self.isSettable(deviceID, &address) else { return false }
+        var mutableValue = value
+        let size = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectSetPropertyData(deviceID, &address, 0, nil, size, &mutableValue) == noErr
+    }
+
+    private static func isSettable(_ deviceID: AudioObjectID, _ address: inout AudioObjectPropertyAddress) -> Bool {
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+        var settable: DarwinBoolean = false
+        guard AudioObjectIsPropertySettable(deviceID, &address, &settable) == noErr else { return false }
+        return settable.boolValue
+    }
+
     private static func getDefaultDeviceId(selector: AudioObjectPropertySelector) -> AudioObjectID? {
         var address = AudioObjectPropertyAddress(
             mSelector: selector,

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -4,16 +4,24 @@ import MediaRemoteAdapter
 #endif
 
 /// Service that wraps MediaRemoteAdapter's MediaController to provide
-/// controlled pause/resume functionality during transcription.
+/// controlled muting during transcription.
 ///
-/// This service ensures we only pause media if it's currently playing,
-/// and only resume if we were the ones who paused it.
+/// Instead of pausing playback, this service mutes the system output volume
+/// while transcription is active (only if media is actually playing) and
+/// restores the previous volume afterwards. This keeps media playing in the
+/// background so it picks up exactly where it was, just silenced.
+///
+/// It only mutes if media is currently playing, and only restores the volume
+/// if we were the ones who muted it.
 @MainActor
 final class MediaPlaybackService {
     static let shared = MediaPlaybackService()
 
     #if arch(arm64)
     private let mediaController = MediaController()
+
+    /// What we changed to mute the output device, used to restore it exactly later.
+    private var outputMuteToken: AudioDevice.OutputMuteToken?
     #endif
 
     private init() {}
@@ -21,16 +29,122 @@ final class MediaPlaybackService {
     // MARK: - Public API
 
     #if arch(arm64)
-    /// Pauses system media playback if something is currently playing.
+    /// Mutes the default output device if media is currently playing.
     ///
-    /// - Returns: `true` if we successfully paused playback, `false` if nothing was playing
-    ///   or if we couldn't determine playback state.
+    /// What was changed is stored so it can be restored via ``unmuteIfWeMuted(_:)``.
+    ///
+    /// - Returns: `true` if we muted the output, `false` if nothing was playing,
+    ///   the playback state couldn't be determined, or the device couldn't be muted.
+    func muteIfMediaPlaying() async -> Bool {
+        let isPlaying = await self.isMediaPlaying()
+
+        guard isPlaying else {
+            DebugLogger.shared.debug(
+                "MediaPlaybackService: Media is not playing, nothing to mute",
+                source: "MediaPlaybackService"
+            )
+            return false
+        }
+
+        // Mute the default output device using whatever method it supports (mute property,
+        // master volume, or per-channel). Bluetooth / HDMI devices often don't expose a
+        // settable master volume scalar, so a plain volume-to-zero isn't enough on its own.
+        guard let token = AudioDevice.muteDefaultOutput() else {
+            DebugLogger.shared.warning(
+                "MediaPlaybackService: Could not mute the output device, skipping mute",
+                source: "MediaPlaybackService"
+            )
+            return false
+        }
+
+        self.outputMuteToken = token
+        DebugLogger.shared.info(
+            "MediaPlaybackService: Media is playing, muted output via \(token.methodDescription)",
+            source: "MediaPlaybackService"
+        )
+        return true
+    }
+
+    /// Restores the output device we muted, but only if we were the ones who muted it.
+    ///
+    /// - Parameter weMuted: `true` if ``muteIfMediaPlaying()`` returned `true` for this session.
+    func unmuteIfWeMuted(_ weMuted: Bool) async {
+        guard weMuted else {
+            DebugLogger.shared.debug(
+                "MediaPlaybackService: We didn't mute, not restoring volume",
+                source: "MediaPlaybackService"
+            )
+            return
+        }
+
+        guard let token = self.outputMuteToken else {
+            DebugLogger.shared.debug(
+                "MediaPlaybackService: No stored mute state to restore",
+                source: "MediaPlaybackService"
+            )
+            return
+        }
+
+        AudioDevice.restoreOutput(token)
+        self.outputMuteToken = nil
+        DebugLogger.shared.info(
+            "MediaPlaybackService: Restored output (\(token.methodDescription))",
+            source: "MediaPlaybackService"
+        )
+    }
+
+    /// Pauses system media playback if media is currently playing.
+    ///
+    /// - Returns: `true` if we sent a pause command, `false` if nothing was playing
+    ///   or the playback state couldn't be determined.
+    func pauseIfPlaying() async -> Bool {
+        let isPlaying = await self.isMediaPlaying()
+
+        guard isPlaying else {
+            DebugLogger.shared.debug(
+                "MediaPlaybackService: Media is not playing, nothing to pause",
+                source: "MediaPlaybackService"
+            )
+            return false
+        }
+
+        self.mediaController.pause()
+        DebugLogger.shared.info(
+            "MediaPlaybackService: Media is playing, sent pause command",
+            source: "MediaPlaybackService"
+        )
+        return true
+    }
+
+    /// Resumes media playback, but only if we were the ones who paused it.
+    ///
+    /// - Parameter wePaused: `true` if ``pauseIfPlaying()`` returned `true` for this session.
+    func resumeIfWePaused(_ wePaused: Bool) async {
+        guard wePaused else {
+            DebugLogger.shared.debug(
+                "MediaPlaybackService: We didn't pause media, not resuming",
+                source: "MediaPlaybackService"
+            )
+            return
+        }
+
+        // Use an explicit play() command — never toggle.
+        self.mediaController.play()
+        DebugLogger.shared.info(
+            "MediaPlaybackService: Resumed media playback (we paused it)",
+            source: "MediaPlaybackService"
+        )
+    }
+
+    // MARK: - Private
+
+    /// Determines whether system media is currently playing.
     ///
     /// - Note: Uses a local one-shot gate to protect against `MediaRemoteAdapter`
     ///   firing the `getTrackInfo` callback more than once, which would otherwise
     ///   crash with `EXC_BREAKPOINT` (SIGTRAP) due to double-resume of a
     ///   `CheckedContinuation`.
-    func pauseIfPlaying() async -> Bool {
+    private func isMediaPlaying() async -> Bool {
         return await withCheckedContinuation { continuation in
             let resumeLock = NSLock()
             var didResume = false
@@ -47,7 +161,7 @@ final class MediaPlaybackService {
 
                 guard shouldResume else {
                     DebugLogger.shared.warning(
-                        "MediaPlaybackService: Suppressed duplicate resume (MediaRemoteAdapter callback fired more than once)",
+                        "MediaPlaybackService: Suppressed duplicate callback (MediaRemoteAdapter callback fired more than once)",
                         source: "MediaPlaybackService"
                     )
                     return
@@ -56,16 +170,11 @@ final class MediaPlaybackService {
                 continuation.resume(returning: value)
             }
 
-            self.mediaController.getTrackInfo { [weak self] trackInfo in
-                guard let self = self else {
-                    resumeOnce(false)
-                    return
-                }
-
+            self.mediaController.getTrackInfo { trackInfo in
                 // If no track info is available, nothing is playing
                 guard let trackInfo = trackInfo else {
                     DebugLogger.shared.debug(
-                        "MediaPlaybackService: No track info available, nothing to pause",
+                        "MediaPlaybackService: No track info available, nothing is playing",
                         source: "MediaPlaybackService"
                     )
                     resumeOnce(false)
@@ -82,7 +191,6 @@ final class MediaPlaybackService {
                     isPlaying = (trackInfo.payload.playbackRate ?? 0.0) > 0.0
                 }
 
-                // Log what we found
                 DebugLogger.shared.debug(
                     """
                     MediaPlaybackService: Track info received
@@ -96,46 +204,24 @@ final class MediaPlaybackService {
                     source: "MediaPlaybackService"
                 )
 
-                if isPlaying {
-                    DebugLogger.shared.info(
-                        "MediaPlaybackService: Media is playing, sending pause command",
-                        source: "MediaPlaybackService"
-                    )
-                    self.mediaController.pause()
-                    resumeOnce(true)
-                } else {
-                    DebugLogger.shared.debug(
-                        "MediaPlaybackService: Media is not playing, no action needed",
-                        source: "MediaPlaybackService"
-                    )
-                    resumeOnce(false)
-                }
+                resumeOnce(isPlaying)
             }
         }
     }
-
-    /// Resumes media playback only if we were the ones who paused it.
-    ///
-    /// - Parameter wePaused: `true` if `pauseIfPlaying()` returned `true` for this session.
-    func resumeIfWePaused(_ wePaused: Bool) async {
-        guard wePaused else {
-            DebugLogger.shared.debug(
-                "MediaPlaybackService: We didn't pause media, not resuming",
-                source: "MediaPlaybackService"
-            )
-            return
-        }
-
-        DebugLogger.shared.info(
-            "MediaPlaybackService: Resuming media playback (we paused it)",
-            source: "MediaPlaybackService"
-        )
-
-        // Use explicit play() command - never toggle
-        self.mediaController.play()
-    }
     #else
     // Intel Mac stub - media control not available
+    func muteIfMediaPlaying() async -> Bool {
+        DebugLogger.shared.debug(
+            "MediaPlaybackService: Not available on Intel Macs",
+            source: "MediaPlaybackService"
+        )
+        return false
+    }
+
+    func unmuteIfWeMuted(_ weMuted: Bool) async {
+        // No-op on Intel
+    }
+
     func pauseIfPlaying() async -> Bool {
         DebugLogger.shared.debug(
             "MediaPlaybackService: Not available on Intel Macs",

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -850,14 +850,28 @@ struct SettingsView: View {
                                     )
                                     Divider().opacity(0.2)
 
-                                    self.optionToggleRow(
-                                        title: "Pause Media During Transcription",
-                                        description: "Automatically pause currently playing audio/video when transcription starts. Resumes only if FluidVoice paused it.",
-                                        isOn: Binding(
-                                            get: { SettingsStore.shared.pauseMediaDuringTranscription },
-                                            set: { SettingsStore.shared.pauseMediaDuringTranscription = $0 }
-                                        )
-                                    )
+                                    HStack(alignment: .center) {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text("Media During Transcription")
+                                                .font(.body)
+                                            Text("When transcribing with media playing, mute or pause it, then restore it afterwards. Mute silences system audio; Pause stops playback. Choose Off to disable.")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+
+                                        Spacer()
+
+                                        Picker("", selection: Binding(
+                                            get: { SettingsStore.shared.mediaTranscriptionMode },
+                                            set: { SettingsStore.shared.mediaTranscriptionMode = $0 }
+                                        )) {
+                                            ForEach(SettingsStore.MediaTranscriptionMode.allCases) { mode in
+                                                Text(mode.displayName).tag(mode)
+                                            }
+                                        }
+                                        .pickerStyle(.menu)
+                                        .frame(width: 170, alignment: .trailing)
+                                    }
                                     Divider().opacity(0.2)
 
                                     self.optionToggleRow(


### PR DESCRIPTION
## Summary
Replaces the single "Pause Media During Transcription" toggle with a 3-way **Off / Mute / Pause** control, adds Bluetooth-robust output muting, fixes the last spoken word being cut off at stop, and embeds `MediaRemoteAdapter.framework` so the app launches.

## Changes
- Added option Off / Mute / Pause for Media. (I like using "Mute" because is more fluent...).
- Fixed isssue: After i finish the speaking and press the command to close the widget i added a delay of 250ms to stop the audio input after that 250ms... If i didn't do that sometimes it doesn't capture the last word....

Others things made by Opus 4.8:
- **Build:** Fluid.xcodeproj/project.pbxproj - i think these was for making the build run.

## Notes
- No code-signing / `DEVELOPMENT_TEAM` changes.
- Behavior-preserving migration for existing users.

---
P.s. Feel free to edit / delete the code from this PR ;)
