### PR TITLE
Improve Pill recording overlay (size, waveforms, glossy border, drop shadow)

### DIFF
--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -1757,22 +1757,22 @@ struct BottomOverlayView: View {
             switch size {
             case .pill:
                 return LayoutConstants(
-                    hPadding: 10,
-                    vPadding: 7,
-                    waveformWidth: 42,
-                    waveformHeight: 16,
+                    hPadding: 12,
+                    vPadding: 8,
+                    waveformWidth: 46,
+                    waveformHeight: 30,
                     iconSize: 18,
                     transFontSize: 10,
                     modeFontSize: 9,
-                    cornerRadius: 16,
+                    cornerRadius: 23,
                     barCount: 8,
-                    barWidth: 2.5,
-                    barSpacing: 2.0,
-                    minBarHeight: 3,
-                    maxBarHeight: 15,
-                    containerWidth: 88,
-                    overlayWidth: 88,
-                    overlayHeight: 32,
+                    barWidth: 3.0,
+                    barSpacing: 2.5,
+                    minBarHeight: 4,
+                    maxBarHeight: 28,
+                    containerWidth: 100,
+                    overlayWidth: 100,
+                    overlayHeight: 46,
                     previewBoxHeight: 0,
                     usesFixedCanvas: false,
                     showsTopControls: false,
@@ -1861,6 +1861,10 @@ struct BottomOverlayView: View {
 
     private var isCompactControls: Bool {
         self.settings.overlaySize == .medium
+    }
+
+    private var isPillSize: Bool {
+        self.settings.overlaySize == .pill
     }
 
     private var modeColor: Color {
@@ -2118,11 +2122,19 @@ struct BottomOverlayView: View {
     }
 
     private var overlayBorderTopOpacity: Double {
-        self.settings.overlaySize == .large ? 0.10 : 0.15
+        switch self.settings.overlaySize {
+        case .pill: return 0.22 // a touch crisper so the smaller pill reads clearly
+        case .large: return 0.10
+        default: return 0.15
+        }
     }
 
     private var overlayBorderBottomOpacity: Double {
-        self.settings.overlaySize == .large ? 0.05 : 0.08
+        switch self.settings.overlaySize {
+        case .pill: return 0.10
+        case .large: return 0.05
+        default: return 0.08
+        }
     }
 
     private var overlayAnimatedOffsetY: CGFloat {
@@ -2664,23 +2676,54 @@ struct BottomOverlayView: View {
             .frame(maxWidth: .infinity, alignment: .center)
             .background(
                 ZStack {
-                    // Solid pitch black background
+                    // Solid pitch black background, with a soft drop shadow so the pill lifts
+                    // off whatever is behind it (pill size only; outer padding reserves room).
                     RoundedRectangle(cornerRadius: self.layout.cornerRadius)
                         .fill(Color.black)
-
-                    // Inner border
-                    RoundedRectangle(cornerRadius: self.layout.cornerRadius)
-                        .strokeBorder(
-                            LinearGradient(
-                                colors: [
-                                    Color.white.opacity(self.overlayBorderTopOpacity),
-                                    Color.white.opacity(self.overlayBorderBottomOpacity),
-                                ],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            ),
-                            lineWidth: self.overlayBorderLineWidth
+                        .shadow(
+                            color: Color.black.opacity(self.isPillSize ? 0.45 : 0),
+                            radius: self.isPillSize ? 12 : 0,
+                            x: 0,
+                            y: self.isPillSize ? 5 : 0
                         )
+
+                    if self.isPillSize {
+                        // Glossy border: a bright highlight that slowly rotates around the edge.
+                        TimelineView(.animation) { timeline in
+                            let seconds = timeline.date.timeIntervalSinceReferenceDate
+                            let angle = (seconds.truncatingRemainder(dividingBy: 6.0) / 6.0) * 360.0
+                            RoundedRectangle(cornerRadius: self.layout.cornerRadius)
+                                .strokeBorder(
+                                    AngularGradient(
+                                        gradient: Gradient(stops: [
+                                            .init(color: .white.opacity(0.06), location: 0.00),
+                                            .init(color: .white.opacity(0.55), location: 0.13),
+                                            .init(color: .white.opacity(0.10), location: 0.30),
+                                            .init(color: .white.opacity(0.03), location: 0.55),
+                                            .init(color: .white.opacity(0.22), location: 0.80),
+                                            .init(color: .white.opacity(0.06), location: 1.00),
+                                        ]),
+                                        center: .center,
+                                        angle: .degrees(angle)
+                                    ),
+                                    lineWidth: 1.2
+                                )
+                        }
+                    } else {
+                        // Inner border
+                        RoundedRectangle(cornerRadius: self.layout.cornerRadius)
+                            .strokeBorder(
+                                LinearGradient(
+                                    colors: [
+                                        Color.white.opacity(self.overlayBorderTopOpacity),
+                                        Color.white.opacity(self.overlayBorderBottomOpacity),
+                                    ],
+                                    startPoint: .top,
+                                    endPoint: .bottom
+                                ),
+                                lineWidth: self.overlayBorderLineWidth
+                            )
+                    }
                 }
             )
             .frame(maxWidth: .infinity, alignment: .top)
@@ -2695,6 +2738,8 @@ struct BottomOverlayView: View {
             height: self.overlayFrameHeight,
             alignment: .top
         )
+        // Reserve space around the pill so its drop shadow isn't clipped by the (content-sized) window.
+        .padding(self.isPillSize ? 18 : 0)
         .frame(maxHeight: .infinity, alignment: .top)
         .scaleEffect(self.overlayAnimatedScale, anchor: .center)
         .offset(y: self.overlayAnimatedOffsetY)
@@ -2855,7 +2900,7 @@ struct BottomWaveformView: View {
 
     private var barFillColor: Color {
         if self.isPillStyle {
-            return Color.white.opacity(self.isProcessingVisualActive ? 0.28 : 0.62)
+            return Color.white.opacity(self.isProcessingVisualActive ? 0.32 : 0.88)
         }
         return self.color.opacity(self.isProcessingVisualActive ? 0.16 : 1.0)
     }
@@ -2977,7 +3022,8 @@ struct BottomWaveformView: View {
         let normalizedLevel = min(max(level, 0), 1)
         let denominator = max(1.0 - self.noiseThreshold, 0.001)
         let adjustedLevel = max(min((normalizedLevel - self.noiseThreshold) / denominator, 1.0), 0.0)
-        let amplifiedLevel = pow(adjustedLevel, 0.7)
+        // Lower exponent => normal speech pushes the bars higher (taller "waves" while talking).
+        let amplifiedLevel = pow(adjustedLevel, 0.55)
 
         withAnimation(.easeOut(duration: 0.08)) {
             for i in 0..<self.barCount {

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -2681,10 +2681,10 @@ struct BottomOverlayView: View {
                     RoundedRectangle(cornerRadius: self.layout.cornerRadius)
                         .fill(Color.black)
                         .shadow(
-                            color: Color.black.opacity(self.isPillSize ? 0.45 : 0),
-                            radius: self.isPillSize ? 12 : 0,
+                            color: Color.black.opacity(self.isPillSize ? 0.32 : 0),
+                            radius: self.isPillSize ? 10 : 0,
                             x: 0,
-                            y: self.isPillSize ? 5 : 0
+                            y: self.isPillSize ? 4 : 0
                         )
 
                     if self.isPillSize {
@@ -2739,7 +2739,7 @@ struct BottomOverlayView: View {
             alignment: .top
         )
         // Reserve space around the pill so its drop shadow isn't clipped by the (content-sized) window.
-        .padding(self.isPillSize ? 18 : 0)
+        .padding(self.isPillSize ? 26 : 0)
         .frame(maxHeight: .infinity, alignment: .top)
         .scaleEffect(self.overlayAnimatedScale, anchor: .center)
         .offset(y: self.overlayAnimatedOffsetY)


### PR DESCRIPTION
## Description
Visual polish for the bottom **Pill** recording overlay (the floating widget shown while dictating). The change is scoped to a single file, `Sources/Fluid/Views/BottomOverlayView.swift`:

- Taller pill with roomier proportions
- Larger, more legible waveform bars
- Glossy rotating gradient border
- Drop shadow for better separation from the background behind it
- Fixes a clipped drop shadow by adding padding around the pill and using a softer shadow

No behavior changes — recording, transcription, and device handling are untouched.

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- N/A

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [ ] Tested on macOS [version]
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Built locally: `sh build_incremental.sh`

## Notes
- Intentionally minimal: the diff touches only `BottomOverlayView.swift` (+76 / −30) and contains no logic changes.
- These overlay changes are already running in the author's local build.

## Screenshots / Video
_The change affects the Pill overlay shown during recording — screenshot/video to be added._

<img width="1645" height="993" alt="image" src="https://github.com/user-attachments/assets/37c0e398-b3fa-44e6-95a7-94d2a028bc63" />

<img width="247" height="118" alt="image" src="https://github.com/user-attachments/assets/510db706-fd14-485c-8190-637a0d5e2628" />
