### PR TITLE
Add SenseVoice speech model option

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -589,9 +589,9 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		7C078DA32E3B386A00FB7CAC /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/altic-dev/FluidAudio.git";
+			repositoryURL = "https://github.com/jayrodge/FluidAudio.git";
 			requirement = {
-				branch = "B/cohere-coreml-asr";
+				branch = "add-sensevoice-coreml-for-fluidvoice";
 				kind = branch;
 			};
 		};

--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -608,7 +608,7 @@
 			repositoryURL = "https://github.com/modelcontextprotocol/swift-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.10.2;
+				minimumVersion = 0.12.1;
 			};
 		};
 		7C3697872ED70F9C005874CE /* XCRemoteSwiftPackageReference "DynamicNotchKit" */ = {

--- a/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -31,10 +31,10 @@
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/altic-dev/FluidAudio.git",
+      "location" : "https://github.com/jayrodge/FluidAudio.git",
       "state" : {
-        "branch" : "B/cohere-coreml-asr",
-        "revision" : "72625bbccf9f6c797a540a1f1cb66a4cb60753eb"
+        "branch" : "add-sensevoice-coreml-for-fluidvoice",
+        "revision" : "6c722f8fa71248ea753311620f257aa7657fff24"
       }
     },
     {

--- a/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "98186d72302f89f0ba2f7e7af3fb034d3d75340965f566935f17fd7196e69e57",
+  "originHash" : "d7e140ce2c475ae2639740b8ec9ca2ff9804c41b3c73d6b43011119fdbad17b1",
   "pins" : [
     {
       "identity" : "appupdater",
@@ -83,6 +83,15 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -128,12 +137,21 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "c0407a0b52677cb395d824cac2879b963075ba8c",
-        "version" : "0.10.2"
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "05ea74bc26b0fcf88ae5bb3d58eee58199def2b550e5fd4a7f5b5c58bddb7b77",
+  "originHash" : "2573eafa06ec8b5beb07df650ac1591969041be985f51c6da67fc14d21281ae2",
   "pins" : [
     {
       "identity" : "appupdater",
@@ -31,10 +31,10 @@
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/altic-dev/FluidAudio.git",
+      "location" : "https://github.com/jayrodge/FluidAudio.git",
       "state" : {
-        "branch" : "B/cohere-coreml-asr",
-        "revision" : "72625bbccf9f6c797a540a1f1cb66a4cb60753eb"
+        "branch" : "add-sensevoice-coreml-for-fluidvoice",
+        "revision" : "6c722f8fa71248ea753311620f257aa7657fff24"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "05ea74bc26b0fcf88ae5bb3d58eee58199def2b550e5fd4a7f5b5c58bddb7b77",
   "pins" : [
     {
       "identity" : "appupdater",
@@ -16,6 +17,15 @@
       "state" : {
         "branch" : "main",
         "revision" : "708f31da5319436c64059ee7ae566953407063d7"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -64,12 +74,48 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
       }
     },
     {
@@ -82,12 +128,30 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "573e5c9036c2f136b3a8a071da8e8907322403d0",
-        "version" : "1.1.6"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
       }
     },
     {
@@ -107,7 +171,16 @@
         "revision" : "200046c93f6d5d78a6d72bfd9c0b27a95e9c0a2b",
         "version" : "1.2.0"
       }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/mxcl/AppUpdater.git", from: "1.0.0"),
-        .package(url: "https://github.com/altic-dev/FluidAudio.git", branch: "B/cohere-coreml-asr"),
+        .package(url: "https://github.com/jayrodge/FluidAudio.git", branch: "add-sensevoice-coreml-for-fluidvoice"),
         .package(url: "https://github.com/mxcl/PromiseKit", from: "6.0.0"),
         .package(url: "https://github.com/altic-dev/DynamicNotchKit.git", branch: "main"),
         .package(url: "https://github.com/exPHAT/SwiftWhisper.git", branch: "master"),

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ https://github.com/user-attachments/assets/c57ef6d5-f0a1-4a3f-a121-637533442c24
 | Parakeet TDT v3 | Fast default multilingual dictation | [25 languages](#parakeet-tdt-v3-languages) | ~500 MB | Apple Silicon |
 | Parakeet TDT v2 | Fastest English-only dictation | [English only](#parakeet-tdt-v2-languages) | ~500 MB | Apple Silicon |
 | Cohere Transcribe | High-accuracy multilingual dictation | [14 languages](#cohere-transcribe-languages) | ~1.4 GB | Apple Silicon |
-| SenseVoice Small | Compact local transcription with emotion/audio event tags via sherpa-onnx | Mandarin, Cantonese, English, Japanese, Korean | ~230 MB | Apple Silicon |
+| SenseVoice Small | Compact English-only local transcription with emotion/audio event tags via sherpa-onnx | English only | ~230 MB | Apple Silicon |
 | Apple Speech | Zero-download native macOS speech recognition | [System languages](#apple-speech-languages) | Built-in | Apple Silicon + Intel |
 | Whisper Tiny / Base / Small / Medium / Large | Broad compatibility, including Intel Macs | [99 languages](#whisper-language-support) | ~75 MB to ~2.9 GB | Apple Silicon + Intel |
 
 Notes:
 Nemotron Speech 3.5 Ultra Fast Low Latency is the newest Apple Silicon option for streaming-capable multilingual dictation. Nemotron 3.5 Multilingual is slower but tuned for higher accuracy. Parakeet Flash is the best pick when you want English words to appear live with the lowest latency. Whisper remains the fallback for Intel Macs and the widest language coverage.
 
-SenseVoice uses the sherpa-onnx SenseVoice Small int8 model. Install `sherpa-onnx-offline` or set the `SenseVoiceSherpaOnnxExecutablePath` macOS default to your sherpa-onnx executable path before using it for dictation.
+SenseVoice uses the sherpa-onnx SenseVoice Small int8 model and is forced to English mode in FluidVoice. Install `sherpa-onnx-offline` or set the `SenseVoiceSherpaOnnxExecutablePath` macOS default to your sherpa-onnx executable path before using it for dictation.
 
 ### Parakeet Flash Languages
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FluidVoice
 
-[![Supported Models](https://img.shields.io/badge/Models-Nemotron%20Speech%203.5%20%7C%20Parakeet%20Flash%20%7C%20Parakeet%20v3%20%26%20v2%20%7C%20Cohere%20%7C%20Apple%20Speech%20%7C%20Whisper-blue)](https://huggingface.co/nvidia/parakeet_realtime_eou_120m-v1)
+[![Supported Models](https://img.shields.io/badge/Models-Nemotron%20Speech%203.5%20%7C%20Parakeet%20Flash%20%7C%20Parakeet%20v3%20%26%20v2%20%7C%20Cohere%20%7C%20SenseVoice%20%7C%20Apple%20Speech%20%7C%20Whisper-blue)](https://huggingface.co/nvidia/parakeet_realtime_eou_120m-v1)
 
 Fully open source voice-to-text dictation app for macOS with AI enhancement.
 
@@ -17,7 +17,7 @@ Fully open source voice-to-text dictation app for macOS with AI enhancement.
 
 - Added **NVIDIA Nemotron Speech 3.5** support on day 0, including **Nemotron 3.5 Multilingual** and **Nemotron Speech 3.5 Ultra Fast Low Latency** for Apple Silicon
 - FluidVoice is one of the first dictation apps to support **Nemotron Speech 3.5 streaming-capable transcription** in a native macOS workflow
-- Expanded the voice engine lineup with **Nemotron, Parakeet Flash, Parakeet v3/v2, Cohere, Apple Speech, and Whisper**
+- Expanded the voice engine lineup with **Nemotron, Parakeet Flash, Parakeet v3/v2, Cohere, SenseVoice, Apple Speech, and Whisper**
 
 ## Star History
 
@@ -59,7 +59,7 @@ https://github.com/user-attachments/assets/c57ef6d5-f0a1-4a3f-a121-637533442c24
 
 ## Features
 - **Live Preview Mode**: Real-time transcription preview in overlay
-- **Multiple Speech Models**: Nemotron Speech 3.5, Parakeet Flash, Parakeet TDT v3 & v2, Cohere Transcribe, Apple Speech, and Whisper
+- **Multiple Speech Models**: Nemotron Speech 3.5, Parakeet Flash, Parakeet TDT v3 & v2, Cohere Transcribe, SenseVoice, Apple Speech, and Whisper
 - **Real-time transcription** with extremely low latency
 - **AI enhancement** with OpenAI, Groq, and custom providers
 - **Global hotkey** for instant voice capture
@@ -78,11 +78,14 @@ https://github.com/user-attachments/assets/c57ef6d5-f0a1-4a3f-a121-637533442c24
 | Parakeet TDT v3 | Fast default multilingual dictation | [25 languages](#parakeet-tdt-v3-languages) | ~500 MB | Apple Silicon |
 | Parakeet TDT v2 | Fastest English-only dictation | [English only](#parakeet-tdt-v2-languages) | ~500 MB | Apple Silicon |
 | Cohere Transcribe | High-accuracy multilingual dictation | [14 languages](#cohere-transcribe-languages) | ~1.4 GB | Apple Silicon |
+| SenseVoice Small | Compact local transcription with emotion/audio event tags via sherpa-onnx | Mandarin, Cantonese, English, Japanese, Korean | ~230 MB | Apple Silicon |
 | Apple Speech | Zero-download native macOS speech recognition | [System languages](#apple-speech-languages) | Built-in | Apple Silicon + Intel |
 | Whisper Tiny / Base / Small / Medium / Large | Broad compatibility, including Intel Macs | [99 languages](#whisper-language-support) | ~75 MB to ~2.9 GB | Apple Silicon + Intel |
 
 Notes:
 Nemotron Speech 3.5 Ultra Fast Low Latency is the newest Apple Silicon option for streaming-capable multilingual dictation. Nemotron 3.5 Multilingual is slower but tuned for higher accuracy. Parakeet Flash is the best pick when you want English words to appear live with the lowest latency. Whisper remains the fallback for Intel Macs and the widest language coverage.
+
+SenseVoice uses the sherpa-onnx SenseVoice Small int8 model. Install `sherpa-onnx-offline` or set the `SenseVoiceSherpaOnnxExecutablePath` macOS default to your sherpa-onnx executable path before using it for dictation.
 
 ### Parakeet Flash Languages
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ https://github.com/user-attachments/assets/c57ef6d5-f0a1-4a3f-a121-637533442c24
 | Parakeet TDT v3 | Fast default multilingual dictation | [25 languages](#parakeet-tdt-v3-languages) | ~500 MB | Apple Silicon |
 | Parakeet TDT v2 | Fastest English-only dictation | [English only](#parakeet-tdt-v2-languages) | ~500 MB | Apple Silicon |
 | Cohere Transcribe | High-accuracy multilingual dictation | [14 languages](#cohere-transcribe-languages) | ~1.4 GB | Apple Silicon |
-| SenseVoice Small | Compact English-only local transcription with emotion/audio event tags via sherpa-onnx | English only | ~230 MB | Apple Silicon |
+| SenseVoice Small | Compact English-only local transcription through FluidAudio CoreML | English only | ~230 MB | Apple Silicon |
 | Apple Speech | Zero-download native macOS speech recognition | [System languages](#apple-speech-languages) | Built-in | Apple Silicon + Intel |
 | Whisper Tiny / Base / Small / Medium / Large | Broad compatibility, including Intel Macs | [99 languages](#whisper-language-support) | ~75 MB to ~2.9 GB | Apple Silicon + Intel |
 
 Notes:
 Nemotron Speech 3.5 Ultra Fast Low Latency is the newest Apple Silicon option for streaming-capable multilingual dictation. Nemotron 3.5 Multilingual is slower but tuned for higher accuracy. Parakeet Flash is the best pick when you want English words to appear live with the lowest latency. Whisper remains the fallback for Intel Macs and the widest language coverage.
 
-SenseVoice uses the sherpa-onnx SenseVoice Small int8 model and is forced to English mode in FluidVoice. Install `sherpa-onnx-offline` or set the `SenseVoiceSherpaOnnxExecutablePath` macOS default to your sherpa-onnx executable path before using it for dictation.
+SenseVoice uses the FluidAudio SenseVoice Small int8 CoreML model and is forced to English mode in FluidVoice.
 
 ### Parakeet Flash Languages
 

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -3105,7 +3105,7 @@ final class SettingsStore: ObservableObject {
             case .cohereTranscribeSixBit:
                 return "High-accuracy multilingual transcription. Select the language manually before dictation for best results."
             case .senseVoiceSmall:
-                return "Compact non-autoregressive English transcription through sherpa-onnx with emotion and audio event tags."
+                return "Compact non-autoregressive English transcription through FluidAudio CoreML on Apple Silicon."
             case .nemotronOffline:
                 return "Slower but more accurate NVIDIA Nemotron 3.5 transcription. Supports 40 language-locales with auto or manual language selection."
             case .nemotronStreaming:
@@ -3399,14 +3399,15 @@ final class SettingsStore: ObservableObject {
                 }
                 return spec.validateArtifacts(at: directory)
             case .senseVoiceSmall:
-                let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
-                    .appendingPathComponent("sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17", isDirectory: true)
-                return directory.map { url in
-                    [
-                        "model.int8.onnx",
-                        "tokens.txt",
-                    ].allSatisfy { FileManager.default.fileExists(atPath: url.appendingPathComponent($0).path) }
-                } ?? false
+                #if canImport(FluidAudio)
+                let directory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+                    .appendingPathComponent("FluidAudio", isDirectory: true)
+                    .appendingPathComponent("Models", isDirectory: true)
+                    .appendingPathComponent(Repo.senseVoiceSmall.folderName, isDirectory: true)
+                return directory.map { SenseVoiceModels.modelsExist(at: $0, precision: .int8) } ?? false
+                #else
+                return false
+                #endif
             case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
                 let hint: String
                 switch self {

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2882,6 +2882,7 @@ final class SettingsStore: ObservableObject {
         case parakeetRealtime = "parakeet-realtime"
         case qwen3Asr = "qwen3-asr"
         case cohereTranscribeSixBit = "cohere-transcribe-6bit"
+        case senseVoiceSmall = "sensevoice-small"
         case nemotronOffline = "nemotron-3.5-offline"
         case nemotronStreaming = "nemotron-3.5-streaming"
         case nemotronStreaming320 = "nemotron-3.5-streaming-320"
@@ -2913,6 +2914,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return "Parakeet Flash (Beta)"
             case .qwen3Asr: return "Qwen3 ASR (Beta)"
             case .cohereTranscribeSixBit: return "Cohere Transcribe"
+            case .senseVoiceSmall: return "SenseVoice Small"
             case .nemotronOffline: return "Nemotron 3.5 Multilingual"
             case .nemotronStreaming: return "Nemotron Speech 3.5 - Ultra Fast Low Latency"
             case .nemotronStreaming320: return "Nemotron Speech 3.5 - Ultra Fast Low Latency"
@@ -2935,6 +2937,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return "English Only (Live Streaming)"
             case .qwen3Asr: return "30 Languages"
             case .cohereTranscribeSixBit: return "14 Languages (Select Manually)"
+            case .senseVoiceSmall: return "ZH, EN, JA, KO, Cantonese"
             case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320: return "Around 40 Languages"
             case .appleSpeech: return "System Languages"
             case .appleSpeechAnalyzer: return "EN, ES, FR, DE, IT, JA, KO, PT, ZH"
@@ -2950,6 +2953,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return "~250 MB"
             case .qwen3Asr: return "~2.0 GB"
             case .cohereTranscribeSixBit: return "~1.4 GB"
+            case .senseVoiceSmall: return "~230 MB"
             case .nemotronOffline: return "~530 MB"
             case .nemotronStreaming: return "~670 MB"
             case .nemotronStreaming320: return "~670 MB"
@@ -2966,14 +2970,14 @@ final class SettingsStore: ObservableObject {
 
         var requiresAppleSilicon: Bool {
             switch self {
-            case .parakeetTDT, .parakeetTDTv2, .parakeetRealtime, .qwen3Asr, .cohereTranscribeSixBit, .nemotronOffline, .nemotronStreaming, .nemotronStreaming320: return true
+            case .parakeetTDT, .parakeetTDTv2, .parakeetRealtime, .qwen3Asr, .cohereTranscribeSixBit, .senseVoiceSmall, .nemotronOffline, .nemotronStreaming, .nemotronStreaming320: return true
             default: return false
             }
         }
 
         var isWhisperModel: Bool {
             switch self {
-            case .parakeetTDT, .parakeetTDTv2, .parakeetRealtime, .qwen3Asr, .cohereTranscribeSixBit, .nemotronOffline, .nemotronStreaming, .nemotronStreaming320, .appleSpeech, .appleSpeechAnalyzer: return false
+            case .parakeetTDT, .parakeetTDTv2, .parakeetRealtime, .qwen3Asr, .cohereTranscribeSixBit, .senseVoiceSmall, .nemotronOffline, .nemotronStreaming, .nemotronStreaming320, .appleSpeech, .appleSpeechAnalyzer: return false
             default: return true
             }
         }
@@ -3017,7 +3021,7 @@ final class SettingsStore: ObservableObject {
         /// Requires macOS 15 or later.
         var requiresMacOS15: Bool {
             switch self {
-            case .qwen3Asr, .cohereTranscribeSixBit: return true
+            case .qwen3Asr, .cohereTranscribeSixBit, .senseVoiceSmall: return true
             default: return false
             }
         }
@@ -3069,6 +3073,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return "Flash Dictation"
             case .qwen3Asr: return "Qwen3 - Multilingual"
             case .cohereTranscribeSixBit: return "Cohere - High Accuracy"
+            case .senseVoiceSmall: return "SenseVoice - Fast Local"
             case .nemotronOffline: return "Nemotron 3.5 Multilingual"
             case .nemotronStreaming: return "Nemotron Speech 3.5 - Ultra Fast Low Latency"
             case .nemotronStreaming320: return "Nemotron Speech 3.5 - Ultra Fast Low Latency"
@@ -3099,6 +3104,8 @@ final class SettingsStore: ObservableObject {
                 return "Qwen3 multilingual ASR via FluidAudio. Higher quality, heavier memory footprint."
             case .cohereTranscribeSixBit:
                 return "High-accuracy multilingual transcription. Select the language manually before dictation for best results."
+            case .senseVoiceSmall:
+                return "Compact non-autoregressive local transcription through sherpa-onnx. Supports Chinese, English, Japanese, Korean, and Cantonese with emotion and audio event tags."
             case .nemotronOffline:
                 return "Slower but more accurate NVIDIA Nemotron 3.5 transcription. Supports 40 language-locales with auto or manual language selection."
             case .nemotronStreaming:
@@ -3133,6 +3140,8 @@ final class SettingsStore: ObservableObject {
                 return 8.0
             case .cohereTranscribeSixBit:
                 return 8.0
+            case .senseVoiceSmall:
+                return 4.0
             case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
                 return 8.0
             case .appleSpeech, .appleSpeechAnalyzer:
@@ -3176,6 +3185,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return 5
             case .qwen3Asr: return 3
             case .cohereTranscribeSixBit: return 3
+            case .senseVoiceSmall: return 5
             case .nemotronOffline: return 3
             case .nemotronStreaming, .nemotronStreaming320: return 4
             case .appleSpeech: return 4
@@ -3197,6 +3207,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return 4
             case .qwen3Asr: return 4
             case .cohereTranscribeSixBit: return 5
+            case .senseVoiceSmall: return 4
             case .nemotronOffline: return 5
             case .nemotronStreaming, .nemotronStreaming320: return 4
             case .appleSpeech: return 4
@@ -3218,6 +3229,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return 1.0
             case .qwen3Asr: return 0.45
             case .cohereTranscribeSixBit: return 0.85
+            case .senseVoiceSmall: return 1.0
             case .nemotronOffline: return 0.85
             case .nemotronStreaming, .nemotronStreaming320: return 1.0
             case .appleSpeech: return 0.60
@@ -3239,6 +3251,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return 0.75
             case .qwen3Asr: return 0.90
             case .cohereTranscribeSixBit: return 0.98
+            case .senseVoiceSmall: return 0.86
             case .nemotronOffline: return 0.90
             case .nemotronStreaming, .nemotronStreaming320: return 0.85
             case .appleSpeech: return 0.60
@@ -3260,6 +3273,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return "Beta"
             case .qwen3Asr: return "Beta"
             case .cohereTranscribeSixBit: return "New"
+            case .senseVoiceSmall: return "New"
             case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320: return "New + Beta"
             case .appleSpeechAnalyzer: return "New"
             default: return nil
@@ -3269,7 +3283,7 @@ final class SettingsStore: ObservableObject {
         /// Optimization level for Apple Silicon (for display)
         var appleSiliconOptimized: Bool {
             switch self {
-            case .parakeetTDT, .parakeetTDTv2, .parakeetRealtime, .qwen3Asr, .cohereTranscribeSixBit, .nemotronOffline, .nemotronStreaming, .nemotronStreaming320, .appleSpeechAnalyzer:
+            case .parakeetTDT, .parakeetTDTv2, .parakeetRealtime, .qwen3Asr, .cohereTranscribeSixBit, .senseVoiceSmall, .nemotronOffline, .nemotronStreaming, .nemotronStreaming320, .appleSpeechAnalyzer:
                 return true
             default:
                 return false
@@ -3280,7 +3294,7 @@ final class SettingsStore: ObservableObject {
         /// Large Whisper models are too slow for streaming, so they only do final transcription on stop.
         var supportsStreaming: Bool {
             switch self {
-            case .qwen3Asr, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
+            case .qwen3Asr, .senseVoiceSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
                 return false // Too slow for real-time chunk processing
             default:
                 return true // All other models support streaming
@@ -3297,6 +3311,8 @@ final class SettingsStore: ObservableObject {
                 return 0.32
             case .cohereTranscribeSixBit:
                 return 1.0
+            case .senseVoiceSmall:
+                return 1.2
             default:
                 return 0.6
             }
@@ -3312,6 +3328,8 @@ final class SettingsStore: ObservableObject {
                 return 0.64
             case .cohereTranscribeSixBit:
                 return 1.5
+            case .senseVoiceSmall:
+                return 1.0
             default:
                 return 1.0
             }
@@ -3324,6 +3342,7 @@ final class SettingsStore: ObservableObject {
             case openai = "OpenAI"
             case qwen = "Qwen"
             case cohere = "Cohere"
+            case senseVoice = "SenseVoice"
         }
 
         /// Which provider this model belongs to
@@ -3337,6 +3356,8 @@ final class SettingsStore: ObservableObject {
                 return .qwen
             case .cohereTranscribeSixBit:
                 return .cohere
+            case .senseVoiceSmall:
+                return .senseVoice
             case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
                 return .openai
             }
@@ -3377,6 +3398,15 @@ final class SettingsStore: ObservableObject {
                     return false
                 }
                 return spec.validateArtifacts(at: directory)
+            case .senseVoiceSmall:
+                let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
+                    .appendingPathComponent("sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17", isDirectory: true)
+                return directory.map { url in
+                    [
+                        "model.int8.onnx",
+                        "tokens.txt",
+                    ].allSatisfy { FileManager.default.fileExists(atPath: url.appendingPathComponent($0).path) }
+                } ?? false
             case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
                 let hint: String
                 switch self {
@@ -3432,6 +3462,8 @@ final class SettingsStore: ObservableObject {
                 return "Qwen"
             case .cohereTranscribeSixBit:
                 return "Cohere"
+            case .senseVoiceSmall:
+                return "SenseVoice"
             case .appleSpeech, .appleSpeechAnalyzer:
                 return "Apple"
             case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
@@ -3456,6 +3488,8 @@ final class SettingsStore: ObservableObject {
                 return "#E67E22"
             case .cohereTranscribeSixBit:
                 return "#FA6B3C"
+            case .senseVoiceSmall:
+                return "#2563EB"
             case .appleSpeech, .appleSpeechAnalyzer:
                 return "#A2AAAD" // Apple Gray
             case .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
@@ -3761,6 +3795,8 @@ extension SettingsStore.SpeechModel {
             return "EN"
         case .cohereTranscribeSixBit:
             return "AR, DE, EL, EN, ES, FR, IT, JA, KO, NL, PL, PT, VI, ZH"
+        case .senseVoiceSmall:
+            return "ZH, EN, JA, KO, YUE"
         case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
             return "40 language-locales"
         case .appleSpeechAnalyzer:
@@ -3778,6 +3814,8 @@ extension SettingsStore.SpeechModel {
             """
         case .cohereTranscribeSixBit:
             return "Arabic, German, Greek, English, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Portuguese, Vietnamese, and Mandarin Chinese"
+        case .senseVoiceSmall:
+            return "Mandarin Chinese, English, Japanese, Korean, and Cantonese"
         case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
             return "Spanish, Italian, Portuguese, Hindi, Korean, English, German, French, Russian, Turkish, Vietnamese, Dutch, Japanese, Arabic, " +
                 "Ukrainian; Polish, Norwegian Bokmal, Finnish, Mandarin, Czech, Bulgarian, Slovak, Swedish, Croatian, Romanian, Estonian, " +

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2914,7 +2914,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return "Parakeet Flash (Beta)"
             case .qwen3Asr: return "Qwen3 ASR (Beta)"
             case .cohereTranscribeSixBit: return "Cohere Transcribe"
-            case .senseVoiceSmall: return "SenseVoice Small"
+            case .senseVoiceSmall: return "SenseVoice Small (English)"
             case .nemotronOffline: return "Nemotron 3.5 Multilingual"
             case .nemotronStreaming: return "Nemotron Speech 3.5 - Ultra Fast Low Latency"
             case .nemotronStreaming320: return "Nemotron Speech 3.5 - Ultra Fast Low Latency"
@@ -2937,7 +2937,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return "English Only (Live Streaming)"
             case .qwen3Asr: return "30 Languages"
             case .cohereTranscribeSixBit: return "14 Languages (Select Manually)"
-            case .senseVoiceSmall: return "ZH, EN, JA, KO, Cantonese"
+            case .senseVoiceSmall: return "English Only"
             case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320: return "Around 40 Languages"
             case .appleSpeech: return "System Languages"
             case .appleSpeechAnalyzer: return "EN, ES, FR, DE, IT, JA, KO, PT, ZH"
@@ -3073,7 +3073,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetRealtime: return "Flash Dictation"
             case .qwen3Asr: return "Qwen3 - Multilingual"
             case .cohereTranscribeSixBit: return "Cohere - High Accuracy"
-            case .senseVoiceSmall: return "SenseVoice - Fast Local"
+            case .senseVoiceSmall: return "SenseVoice - English"
             case .nemotronOffline: return "Nemotron 3.5 Multilingual"
             case .nemotronStreaming: return "Nemotron Speech 3.5 - Ultra Fast Low Latency"
             case .nemotronStreaming320: return "Nemotron Speech 3.5 - Ultra Fast Low Latency"
@@ -3105,7 +3105,7 @@ final class SettingsStore: ObservableObject {
             case .cohereTranscribeSixBit:
                 return "High-accuracy multilingual transcription. Select the language manually before dictation for best results."
             case .senseVoiceSmall:
-                return "Compact non-autoregressive local transcription through sherpa-onnx. Supports Chinese, English, Japanese, Korean, and Cantonese with emotion and audio event tags."
+                return "Compact non-autoregressive English transcription through sherpa-onnx with emotion and audio event tags."
             case .nemotronOffline:
                 return "Slower but more accurate NVIDIA Nemotron 3.5 transcription. Supports 40 language-locales with auto or manual language selection."
             case .nemotronStreaming:
@@ -3796,7 +3796,7 @@ extension SettingsStore.SpeechModel {
         case .cohereTranscribeSixBit:
             return "AR, DE, EL, EN, ES, FR, IT, JA, KO, NL, PL, PT, VI, ZH"
         case .senseVoiceSmall:
-            return "ZH, EN, JA, KO, YUE"
+            return "EN"
         case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
             return "40 language-locales"
         case .appleSpeechAnalyzer:
@@ -3815,7 +3815,7 @@ extension SettingsStore.SpeechModel {
         case .cohereTranscribeSixBit:
             return "Arabic, German, Greek, English, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Portuguese, Vietnamese, and Mandarin Chinese"
         case .senseVoiceSmall:
-            return "Mandarin Chinese, English, Japanese, Korean, and Cantonese"
+            return "English"
         case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
             return "Spanish, Italian, Portuguese, Hindi, Korean, English, German, French, Russian, Turkish, Vietnamese, Dutch, Japanese, Arabic, " +
                 "Ukrainian; Polish, Norwegian Bokmal, Finnish, Mandarin, Czech, Bulgarian, Slovak, Swedish, Croatian, Romanian, Estonian, " +

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -139,6 +139,7 @@ final class ASRService: ObservableObject {
     private var fluidAudioProvider: FluidAudioProvider?
     private var parakeetRealtimeProvider: ParakeetRealtimeProvider?
     private var externalCoreMLProvider: ExternalCoreMLTranscriptionProvider?
+    private var senseVoiceProvider: SenseVoiceProvider?
     private var nemotronProviders: [NemotronProvider.Mode: NemotronProvider] = [:]
     private var whisperProvider: WhisperProvider?
     private var appleSpeechProvider: AppleSpeechProvider?
@@ -171,6 +172,8 @@ final class ASRService: ObservableObject {
             return self.getParakeetRealtimeProvider()
         case .cohereTranscribeSixBit:
             return self.getExternalCoreMLProvider()
+        case .senseVoiceSmall:
+            return self.getSenseVoiceProvider()
         case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
             return self.getNemotronProvider(mode: model.nemotronProviderMode)
         case .qwen3Asr:
@@ -212,6 +215,16 @@ final class ASRService: ObservableObject {
         let provider = ExternalCoreMLTranscriptionProvider()
         self.externalCoreMLProvider = provider
         DebugLogger.shared.info("ASRService: Created external CoreML provider", source: "ASRService")
+        return provider
+    }
+
+    private func getSenseVoiceProvider() -> SenseVoiceProvider {
+        if let existing = senseVoiceProvider {
+            return existing
+        }
+        let provider = SenseVoiceProvider()
+        self.senseVoiceProvider = provider
+        DebugLogger.shared.info("ASRService: Created SenseVoice provider", source: "ASRService")
         return provider
     }
 
@@ -372,6 +385,8 @@ final class ASRService: ObservableObject {
             return ParakeetRealtimeProvider()
         case .cohereTranscribeSixBit:
             return ExternalCoreMLTranscriptionProvider(modelOverride: model)
+        case .senseVoiceSmall:
+            return SenseVoiceProvider()
         case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
             return NemotronProvider(mode: model.nemotronProviderMode)
         case .qwen3Asr:
@@ -450,6 +465,7 @@ final class ASRService: ObservableObject {
         self.fluidAudioProvider = nil
         self.parakeetRealtimeProvider = nil
         self.externalCoreMLProvider = nil
+        self.senseVoiceProvider = nil
         self.whisperProvider = nil
         self.appleSpeechProvider = nil
         self._appleSpeechAnalyzerProvider = nil

--- a/Sources/Fluid/Services/SenseVoiceProvider.swift
+++ b/Sources/Fluid/Services/SenseVoiceProvider.swift
@@ -1,49 +1,65 @@
 import Foundation
 
+#if arch(arm64)
+import FluidAudio
+
+private actor SenseVoiceProgressSink {
+    private let handler: ((Double) -> Void)?
+
+    init(handler: ((Double) -> Void)?) {
+        self.handler = handler
+    }
+
+    func emit(_ progress: Double) {
+        self.handler?(progress)
+    }
+}
+
 final class SenseVoiceProvider: TranscriptionProvider {
     let name = "SenseVoice"
     var isAvailable: Bool { true }
     private(set) var isReady = false
-    var prefersNativeFileTranscription: Bool { true }
 
-    private struct SenseVoiceCLIResult: Decodable {
-        let text: String
-        let emotion: String?
-        let event: String?
-    }
-
-    private enum Constants {
-        static let folderName = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17"
-        static let archiveName = "\(folderName).tar.bz2"
-        static let archiveURL = URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
-        static let modelFile = "model.int8.onnx"
-        static let tokensFile = "tokens.txt"
-        static let executableDefaultsKey = "SenseVoiceSherpaOnnxExecutablePath"
-    }
-
-    private var cacheDirectory: URL? {
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
-            .appendingPathComponent(Constants.folderName, isDirectory: true)
-    }
+    private let precision: SenseVoiceEncoderPrecision = .int8
+    private let language: Int32 = SenseVoiceConfig.englishLanguage
+    private let maxSamplesPerPass = 96 * SenseVoiceConfig.sampleRate
+    private var manager: SenseVoiceManager?
 
     func prepare(progressHandler: ((Double) -> Void)? = nil) async throws {
         guard self.isReady == false else { return }
-        guard let directory = self.cacheDirectory else {
-            throw Self.makeError("Unable to resolve a cache directory for SenseVoice.")
-        }
 
-        if self.modelsExistOnDisk() {
-            progressHandler?(1.0)
-            self.isReady = true
-            return
-        }
+        let progressSink = SenseVoiceProgressSink(handler: progressHandler)
+        await progressSink.emit(0.05)
+        let progressTicker = Task(priority: .utility) {
+            var stagedProgress = 0.05
+            let stageCap = 0.82
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                if Task.isCancelled { break }
+                if stagedProgress >= stageCap { continue }
 
-        try await self.downloadAndExtractModel(to: directory, progressHandler: progressHandler)
-        guard self.modelsExistOnDisk() else {
-            throw Self.makeError("SenseVoice model files are incomplete after download.")
+                let remaining = stageCap - stagedProgress
+                let step = max(0.008, remaining * 0.12)
+                stagedProgress = min(stageCap, stagedProgress + step)
+                await progressSink.emit(stagedProgress)
+            }
         }
+        defer { progressTicker.cancel() }
+
+        let manager = try await SenseVoiceManager.load(
+            precision: self.precision,
+            language: self.language,
+            progressHandler: { progress in
+                Task {
+                    await progressSink.emit(min(0.88, progress.fractionCompleted * 0.88))
+                }
+            }
+        )
+
+        progressTicker.cancel()
+        self.manager = manager
         self.isReady = true
-        progressHandler?(1.0)
+        await progressSink.emit(1.0)
     }
 
     func transcribe(_ samples: [Float]) async throws -> ASRTranscriptionResult {
@@ -51,254 +67,99 @@ final class SenseVoiceProvider: TranscriptionProvider {
     }
 
     func transcribeStreaming(_ samples: [Float]) async throws -> ASRTranscriptionResult {
-        guard samples.count >= 16_000 else {
+        guard samples.count >= SenseVoiceConfig.sampleRate else {
             return ASRTranscriptionResult(text: "", confidence: 0)
         }
-        let previewSamples = samples.count > 160_000 ? Array(samples.suffix(160_000)) : samples
-        return try await self.transcribeFinal(previewSamples)
+        return try await self.transcribeChunked(samples)
     }
 
     func transcribeFinal(_ samples: [Float]) async throws -> ASRTranscriptionResult {
-        guard samples.isEmpty == false else {
-            return ASRTranscriptionResult(text: "", confidence: 0)
-        }
-        guard self.modelsExistOnDisk(), let directory = self.cacheDirectory else {
-            throw Self.makeError("SenseVoice model is not downloaded.")
-        }
-        let executableURL = try Self.resolveSherpaExecutable()
-        let wavURL = try Self.writeTemporaryWAV(samples: samples)
-        defer { try? FileManager.default.removeItem(at: wavURL) }
-
-        let result = try Self.runSherpa(
-            executableURL: executableURL,
-            modelDirectory: directory,
-            wavURL: wavURL
-        )
-        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return ASRTranscriptionResult(text: text, confidence: text.isEmpty ? 0 : 1)
+        try await self.transcribeChunked(samples)
     }
 
     func transcribeFile(at fileURL: URL) async throws -> ASRTranscriptionResult {
-        guard self.modelsExistOnDisk(), let directory = self.cacheDirectory else {
-            throw Self.makeError("SenseVoice model is not downloaded.")
-        }
-        let executableURL = try Self.resolveSherpaExecutable()
-        let result = try Self.runSherpa(
-            executableURL: executableURL,
-            modelDirectory: directory,
-            wavURL: fileURL
-        )
-        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return ASRTranscriptionResult(text: text, confidence: text.isEmpty ? 0 : 1)
+        let converter = AudioConverter(sampleRate: Double(SenseVoiceConfig.sampleRate))
+        let samples = try converter.resampleAudioFile(fileURL)
+        return try await self.transcribeChunked(samples)
     }
 
     func modelsExistOnDisk() -> Bool {
-        guard let directory = self.cacheDirectory else { return false }
-        return [
-            Constants.modelFile,
-            Constants.tokensFile,
-        ].allSatisfy { entry in
-            FileManager.default.fileExists(atPath: directory.appendingPathComponent(entry).path)
-        }
+        guard let directory = Self.cacheDirectory else { return false }
+        return SenseVoiceModels.modelsExist(at: directory, precision: self.precision)
     }
 
     func clearCache() async throws {
-        if let directory = self.cacheDirectory,
-           FileManager.default.fileExists(atPath: directory.path)
-        {
-            try FileManager.default.removeItem(at: directory)
-        }
+        self.manager = nil
         self.isReady = false
+        guard let directory = Self.cacheDirectory,
+              FileManager.default.fileExists(atPath: directory.path)
+        else {
+            return
+        }
+        try FileManager.default.removeItem(at: directory)
     }
 
-    private func downloadAndExtractModel(to directory: URL, progressHandler: ((Double) -> Void)?) async throws {
-        let parent = directory.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-        let archiveURL = parent.appendingPathComponent(Constants.archiveName, isDirectory: false)
-        defer { try? FileManager.default.removeItem(at: archiveURL) }
-
-        let delegate = DownloadProgressDelegate { progress in
-            progressHandler?(progress * 0.85)
+    private func transcribeChunked(_ samples: [Float]) async throws -> ASRTranscriptionResult {
+        guard samples.isEmpty == false else {
+            return ASRTranscriptionResult(text: "", confidence: 0)
         }
-        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        let task = session.downloadTask(with: Constants.archiveURL)
+        guard let manager = self.manager else {
+            throw Self.makeError("SenseVoice model is not initialized.")
+        }
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            delegate.onFinish = { temporaryURL, response in
-                do {
-                    if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
-                        throw Self.makeError("SenseVoice download failed with HTTP \(http.statusCode).")
-                    }
-                    if FileManager.default.fileExists(atPath: archiveURL.path) {
-                        try FileManager.default.removeItem(at: archiveURL)
-                    }
-                    try FileManager.default.moveItem(at: temporaryURL, to: archiveURL)
-                    continuation.resume()
-                } catch {
-                    continuation.resume(throwing: error)
-                }
+        if samples.count <= self.maxSamplesPerPass {
+            let text = try await manager.transcribe(audio: samples)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return ASRTranscriptionResult(text: text, confidence: text.isEmpty ? 0 : 1)
+        }
+
+        var transcriptions: [String] = []
+        var offset = 0
+        while offset < samples.count {
+            let end = min(offset + self.maxSamplesPerPass, samples.count)
+            let chunkText = try await manager.transcribe(audio: Array(samples[offset..<end]))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if chunkText.isEmpty == false {
+                transcriptions.append(chunkText)
             }
-            delegate.onError = { error in
-                continuation.resume(throwing: error)
-            }
-            task.resume()
+            offset = end
         }
 
-        if FileManager.default.fileExists(atPath: directory.path) {
-            try FileManager.default.removeItem(at: directory)
-        }
-        progressHandler?(0.9)
-        try Self.extractArchive(archiveURL, into: parent)
-        progressHandler?(0.98)
+        let text = transcriptions.joined(separator: " ")
+        return ASRTranscriptionResult(text: text, confidence: text.isEmpty ? 0 : 1)
     }
 
-    private static func extractArchive(_ archiveURL: URL, into directory: URL) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
-        process.arguments = ["xjf", archiveURL.path, "-C", directory.path]
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            throw Self.makeError("Failed to extract SenseVoice model archive.")
-        }
-    }
-
-    private static func resolveSherpaExecutable() throws -> URL {
-        if let explicitPath = UserDefaults.standard.string(forKey: Constants.executableDefaultsKey)?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            explicitPath.isEmpty == false,
-            FileManager.default.isExecutableFile(atPath: explicitPath)
-        {
-            return URL(fileURLWithPath: explicitPath)
-        }
-
-        let candidates = [
-            "/opt/homebrew/bin/sherpa-onnx-offline",
-            "/usr/local/bin/sherpa-onnx-offline",
-            "/usr/bin/sherpa-onnx-offline",
-        ]
-        if let match = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
-            return URL(fileURLWithPath: match)
-        }
-
-        throw Self.makeError(
-            "SenseVoice requires sherpa-onnx-offline. Install sherpa-onnx or set the \(Constants.executableDefaultsKey) default to the executable path."
-        )
-    }
-
-    private static func runSherpa(
-        executableURL: URL,
-        modelDirectory: URL,
-        wavURL: URL
-    ) throws -> SenseVoiceCLIResult {
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = [
-            "--tokens=\(modelDirectory.appendingPathComponent(Constants.tokensFile).path)",
-            "--sense-voice-model=\(modelDirectory.appendingPathComponent(Constants.modelFile).path)",
-            "--sense-voice-language=en",
-            "--num-threads=2",
-            "--sense-voice-use-itn=1",
-            "--debug=0",
-            wavURL.path,
-        ]
-
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-
-        try process.run()
-        process.waitUntilExit()
-
-        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let errorOutput = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-
-        guard process.terminationStatus == 0 else {
-            let message = errorOutput.isEmpty ? output : errorOutput
-            throw Self.makeError("SenseVoice transcription failed: \(message)")
-        }
-
-        for line in output.components(separatedBy: .newlines).reversed() {
-            guard line.contains("\"text\""), let data = line.data(using: .utf8) else { continue }
-            if let decoded = try? JSONDecoder().decode(SenseVoiceCLIResult.self, from: data) {
-                return decoded
-            }
-        }
-
-        throw Self.makeError("SenseVoice did not return a parseable transcription result.")
-    }
-
-    private static func writeTemporaryWAV(samples: [Float]) throws -> URL {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("sensevoice-\(UUID().uuidString).wav", isDirectory: false)
-        var data = Data()
-        let pcm = samples.map { sample -> Int16 in
-            let clamped = max(-1.0, min(1.0, sample))
-            return Int16(clamped * Float(Int16.max))
-        }
-        let dataBytes = UInt32(pcm.count * MemoryLayout<Int16>.size)
-
-        data.append(contentsOf: "RIFF".utf8)
-        data.append(UInt32(36 + dataBytes).littleEndianData)
-        data.append(contentsOf: "WAVEfmt ".utf8)
-        data.append(UInt32(16).littleEndianData)
-        data.append(UInt16(1).littleEndianData)
-        data.append(UInt16(1).littleEndianData)
-        data.append(UInt32(16_000).littleEndianData)
-        data.append(UInt32(16_000 * 2).littleEndianData)
-        data.append(UInt16(2).littleEndianData)
-        data.append(UInt16(16).littleEndianData)
-        data.append(contentsOf: "data".utf8)
-        data.append(dataBytes.littleEndianData)
-        pcm.withUnsafeBufferPointer { buffer in
-            let rawBuffer = UnsafeRawBufferPointer(buffer)
-            if let baseAddress = rawBuffer.baseAddress {
-                data.append(Data(bytes: baseAddress, count: rawBuffer.count))
-            }
-        }
-        try data.write(to: url, options: .atomic)
-        return url
+    private static var cacheDirectory: URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent(Repo.senseVoiceSmall.folderName, isDirectory: true)
     }
 
     private static func makeError(_ description: String) -> NSError {
         NSError(domain: "SenseVoiceProvider", code: -1, userInfo: [NSLocalizedDescriptionKey: description])
     }
+}
+#else
+final class SenseVoiceProvider: TranscriptionProvider {
+    let name = "SenseVoice"
+    var isAvailable: Bool { false }
+    var isReady: Bool { false }
 
-    private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate {
-        private let onProgress: ((Double) -> Void)?
-        var onFinish: ((URL, URLResponse) -> Void)?
-        var onError: ((Error) -> Void)?
+    func prepare(progressHandler: ((Double) -> Void)?) async throws {
+        throw NSError(
+            domain: "SenseVoiceProvider",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "SenseVoice requires Apple Silicon."]
+        )
+    }
 
-        init(onProgress: ((Double) -> Void)?) {
-            self.onProgress = onProgress
-        }
-
-        func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-            guard let response = downloadTask.response else { return }
-            self.onFinish?(location, response)
-        }
-
-        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-            if let error { self.onError?(error) }
-        }
-
-        func urlSession(
-            _ session: URLSession,
-            downloadTask: URLSessionDownloadTask,
-            didWriteData bytesWritten: Int64,
-            totalBytesWritten: Int64,
-            totalBytesExpectedToWrite: Int64
-        ) {
-            guard totalBytesExpectedToWrite > 0 else { return }
-            self.onProgress?(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
-        }
+    func transcribe(_ samples: [Float]) async throws -> ASRTranscriptionResult {
+        throw NSError(
+            domain: "SenseVoiceProvider",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "SenseVoice requires Apple Silicon."]
+        )
     }
 }
-
-private extension FixedWidthInteger {
-    var littleEndianData: Data {
-        var value = self.littleEndian
-        return Data(bytes: &value, count: MemoryLayout<Self>.size)
-    }
-}
+#endif

--- a/Sources/Fluid/Services/SenseVoiceProvider.swift
+++ b/Sources/Fluid/Services/SenseVoiceProvider.swift
@@ -1,0 +1,303 @@
+import Foundation
+
+final class SenseVoiceProvider: TranscriptionProvider {
+    let name = "SenseVoice"
+    var isAvailable: Bool { true }
+    private(set) var isReady = false
+    var prefersNativeFileTranscription: Bool { true }
+
+    private struct SenseVoiceCLIResult: Decodable {
+        let text: String
+        let emotion: String?
+        let event: String?
+    }
+
+    private enum Constants {
+        static let folderName = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17"
+        static let archiveName = "\(folderName).tar.bz2"
+        static let archiveURL = URL(string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(archiveName)")!
+        static let modelFile = "model.int8.onnx"
+        static let tokensFile = "tokens.txt"
+        static let executableDefaultsKey = "SenseVoiceSherpaOnnxExecutablePath"
+    }
+
+    private var cacheDirectory: URL? {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
+            .appendingPathComponent(Constants.folderName, isDirectory: true)
+    }
+
+    func prepare(progressHandler: ((Double) -> Void)? = nil) async throws {
+        guard self.isReady == false else { return }
+        guard let directory = self.cacheDirectory else {
+            throw Self.makeError("Unable to resolve a cache directory for SenseVoice.")
+        }
+
+        if self.modelsExistOnDisk() {
+            progressHandler?(1.0)
+            self.isReady = true
+            return
+        }
+
+        try await self.downloadAndExtractModel(to: directory, progressHandler: progressHandler)
+        guard self.modelsExistOnDisk() else {
+            throw Self.makeError("SenseVoice model files are incomplete after download.")
+        }
+        self.isReady = true
+        progressHandler?(1.0)
+    }
+
+    func transcribe(_ samples: [Float]) async throws -> ASRTranscriptionResult {
+        try await self.transcribeFinal(samples)
+    }
+
+    func transcribeStreaming(_ samples: [Float]) async throws -> ASRTranscriptionResult {
+        guard samples.count >= 16_000 else {
+            return ASRTranscriptionResult(text: "", confidence: 0)
+        }
+        let previewSamples = samples.count > 160_000 ? Array(samples.suffix(160_000)) : samples
+        return try await self.transcribeFinal(previewSamples)
+    }
+
+    func transcribeFinal(_ samples: [Float]) async throws -> ASRTranscriptionResult {
+        guard samples.isEmpty == false else {
+            return ASRTranscriptionResult(text: "", confidence: 0)
+        }
+        guard self.modelsExistOnDisk(), let directory = self.cacheDirectory else {
+            throw Self.makeError("SenseVoice model is not downloaded.")
+        }
+        let executableURL = try Self.resolveSherpaExecutable()
+        let wavURL = try Self.writeTemporaryWAV(samples: samples)
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+
+        let result = try Self.runSherpa(
+            executableURL: executableURL,
+            modelDirectory: directory,
+            wavURL: wavURL
+        )
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ASRTranscriptionResult(text: text, confidence: text.isEmpty ? 0 : 1)
+    }
+
+    func transcribeFile(at fileURL: URL) async throws -> ASRTranscriptionResult {
+        guard self.modelsExistOnDisk(), let directory = self.cacheDirectory else {
+            throw Self.makeError("SenseVoice model is not downloaded.")
+        }
+        let executableURL = try Self.resolveSherpaExecutable()
+        let result = try Self.runSherpa(
+            executableURL: executableURL,
+            modelDirectory: directory,
+            wavURL: fileURL
+        )
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ASRTranscriptionResult(text: text, confidence: text.isEmpty ? 0 : 1)
+    }
+
+    func modelsExistOnDisk() -> Bool {
+        guard let directory = self.cacheDirectory else { return false }
+        return [
+            Constants.modelFile,
+            Constants.tokensFile,
+        ].allSatisfy { entry in
+            FileManager.default.fileExists(atPath: directory.appendingPathComponent(entry).path)
+        }
+    }
+
+    func clearCache() async throws {
+        if let directory = self.cacheDirectory,
+           FileManager.default.fileExists(atPath: directory.path)
+        {
+            try FileManager.default.removeItem(at: directory)
+        }
+        self.isReady = false
+    }
+
+    private func downloadAndExtractModel(to directory: URL, progressHandler: ((Double) -> Void)?) async throws {
+        let parent = directory.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        let archiveURL = parent.appendingPathComponent(Constants.archiveName, isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: archiveURL) }
+
+        let delegate = DownloadProgressDelegate { progress in
+            progressHandler?(progress * 0.85)
+        }
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let task = session.downloadTask(with: Constants.archiveURL)
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            delegate.onFinish = { temporaryURL, response in
+                do {
+                    if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+                        throw Self.makeError("SenseVoice download failed with HTTP \(http.statusCode).")
+                    }
+                    if FileManager.default.fileExists(atPath: archiveURL.path) {
+                        try FileManager.default.removeItem(at: archiveURL)
+                    }
+                    try FileManager.default.moveItem(at: temporaryURL, to: archiveURL)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+            delegate.onError = { error in
+                continuation.resume(throwing: error)
+            }
+            task.resume()
+        }
+
+        if FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.removeItem(at: directory)
+        }
+        progressHandler?(0.9)
+        try Self.extractArchive(archiveURL, into: parent)
+        progressHandler?(0.98)
+    }
+
+    private static func extractArchive(_ archiveURL: URL, into directory: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = ["xjf", archiveURL.path, "-C", directory.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw Self.makeError("Failed to extract SenseVoice model archive.")
+        }
+    }
+
+    private static func resolveSherpaExecutable() throws -> URL {
+        if let explicitPath = UserDefaults.standard.string(forKey: Constants.executableDefaultsKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            explicitPath.isEmpty == false,
+            FileManager.default.isExecutableFile(atPath: explicitPath)
+        {
+            return URL(fileURLWithPath: explicitPath)
+        }
+
+        let candidates = [
+            "/opt/homebrew/bin/sherpa-onnx-offline",
+            "/usr/local/bin/sherpa-onnx-offline",
+            "/usr/bin/sherpa-onnx-offline",
+        ]
+        if let match = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return URL(fileURLWithPath: match)
+        }
+
+        throw Self.makeError(
+            "SenseVoice requires sherpa-onnx-offline. Install sherpa-onnx or set the \(Constants.executableDefaultsKey) default to the executable path."
+        )
+    }
+
+    private static func runSherpa(
+        executableURL: URL,
+        modelDirectory: URL,
+        wavURL: URL
+    ) throws -> SenseVoiceCLIResult {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = [
+            "--tokens=\(modelDirectory.appendingPathComponent(Constants.tokensFile).path)",
+            "--sense-voice-model=\(modelDirectory.appendingPathComponent(Constants.modelFile).path)",
+            "--num-threads=2",
+            "--sense-voice-use-itn=1",
+            "--debug=0",
+            wavURL.path,
+        ]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let errorOutput = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            let message = errorOutput.isEmpty ? output : errorOutput
+            throw Self.makeError("SenseVoice transcription failed: \(message)")
+        }
+
+        for line in output.components(separatedBy: .newlines).reversed() {
+            guard line.contains("\"text\""), let data = line.data(using: .utf8) else { continue }
+            if let decoded = try? JSONDecoder().decode(SenseVoiceCLIResult.self, from: data) {
+                return decoded
+            }
+        }
+
+        throw Self.makeError("SenseVoice did not return a parseable transcription result.")
+    }
+
+    private static func writeTemporaryWAV(samples: [Float]) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sensevoice-\(UUID().uuidString).wav", isDirectory: false)
+        var data = Data()
+        let pcm = samples.map { sample -> Int16 in
+            let clamped = max(-1.0, min(1.0, sample))
+            return Int16(clamped * Float(Int16.max))
+        }
+        let dataBytes = UInt32(pcm.count * MemoryLayout<Int16>.size)
+
+        data.append(contentsOf: "RIFF".utf8)
+        data.append(UInt32(36 + dataBytes).littleEndianData)
+        data.append(contentsOf: "WAVEfmt ".utf8)
+        data.append(UInt32(16).littleEndianData)
+        data.append(UInt16(1).littleEndianData)
+        data.append(UInt16(1).littleEndianData)
+        data.append(UInt32(16_000).littleEndianData)
+        data.append(UInt32(16_000 * 2).littleEndianData)
+        data.append(UInt16(2).littleEndianData)
+        data.append(UInt16(16).littleEndianData)
+        data.append(contentsOf: "data".utf8)
+        data.append(dataBytes.littleEndianData)
+        pcm.withUnsafeBufferPointer { buffer in
+            let rawBuffer = UnsafeRawBufferPointer(buffer)
+            if let baseAddress = rawBuffer.baseAddress {
+                data.append(Data(bytes: baseAddress, count: rawBuffer.count))
+            }
+        }
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private static func makeError(_ description: String) -> NSError {
+        NSError(domain: "SenseVoiceProvider", code: -1, userInfo: [NSLocalizedDescriptionKey: description])
+    }
+
+    private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate {
+        private let onProgress: ((Double) -> Void)?
+        var onFinish: ((URL, URLResponse) -> Void)?
+        var onError: ((Error) -> Void)?
+
+        init(onProgress: ((Double) -> Void)?) {
+            self.onProgress = onProgress
+        }
+
+        func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+            guard let response = downloadTask.response else { return }
+            self.onFinish?(location, response)
+        }
+
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+            if let error { self.onError?(error) }
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            downloadTask: URLSessionDownloadTask,
+            didWriteData bytesWritten: Int64,
+            totalBytesWritten: Int64,
+            totalBytesExpectedToWrite: Int64
+        ) {
+            guard totalBytesExpectedToWrite > 0 else { return }
+            self.onProgress?(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+        }
+    }
+}
+
+private extension FixedWidthInteger {
+    var littleEndianData: Data {
+        var value = self.littleEndian
+        return Data(bytes: &value, count: MemoryLayout<Self>.size)
+    }
+}

--- a/Sources/Fluid/Services/SenseVoiceProvider.swift
+++ b/Sources/Fluid/Services/SenseVoiceProvider.swift
@@ -196,6 +196,7 @@ final class SenseVoiceProvider: TranscriptionProvider {
         process.arguments = [
             "--tokens=\(modelDirectory.appendingPathComponent(Constants.tokensFile).path)",
             "--sense-voice-model=\(modelDirectory.appendingPathComponent(Constants.modelFile).path)",
+            "--sense-voice-language=en",
             "--num-threads=2",
             "--sense-voice-use-itn=1",
             "--debug=0",

--- a/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
@@ -210,7 +210,7 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
         case .cohereTranscribeSixBit:
             return "Cohere Transcribe downloads a CoreML pipeline from Hugging Face and caches it locally. Select the language manually before dictation. Best on Apple Silicon with 8GB+ RAM."
         case .senseVoiceSmall:
-            return "SenseVoice downloads the compact int8 sherpa-onnx model locally and runs it in English mode. Install sherpa-onnx or set SenseVoiceSherpaOnnxExecutablePath before dictation."
+            return "SenseVoice downloads the compact int8 FluidAudio CoreML model locally and runs it in English mode on Apple Silicon."
         case .nemotronOffline:
             return "Nemotron 3.5 Multilingual is slower but more accurate. Supports around 40 languages with auto or manual language selection. Best on Apple Silicon with 8GB+ RAM."
         case .nemotronStreaming, .nemotronStreaming320:

--- a/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
@@ -68,6 +68,8 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
             models = models.filter { $0.provider == .apple }
         case .cohere:
             models = models.filter { $0.provider == .cohere }
+        case .senseVoice:
+            models = models.filter { $0.provider == .senseVoice }
         case .openai:
             models = models.filter { $0.provider == .openai }
         }
@@ -207,6 +209,8 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
             return "Qwen3 ASR is a multilingual FluidAudio model with strong quality, but higher memory usage. Requires macOS 15+."
         case .cohereTranscribeSixBit:
             return "Cohere Transcribe downloads a CoreML pipeline from Hugging Face and caches it locally. Select the language manually before dictation. Best on Apple Silicon with 8GB+ RAM."
+        case .senseVoiceSmall:
+            return "SenseVoice downloads the compact int8 sherpa-onnx model locally. Transcription uses sherpa-onnx-offline, so install sherpa-onnx or set SenseVoiceSherpaOnnxExecutablePath before dictation."
         case .nemotronOffline:
             return "Nemotron 3.5 Multilingual is slower but more accurate. Supports around 40 languages with auto or manual language selection. Best on Apple Silicon with 8GB+ RAM."
         case .nemotronStreaming, .nemotronStreaming320:

--- a/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
@@ -210,7 +210,7 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
         case .cohereTranscribeSixBit:
             return "Cohere Transcribe downloads a CoreML pipeline from Hugging Face and caches it locally. Select the language manually before dictation. Best on Apple Silicon with 8GB+ RAM."
         case .senseVoiceSmall:
-            return "SenseVoice downloads the compact int8 sherpa-onnx model locally. Transcription uses sherpa-onnx-offline, so install sherpa-onnx or set SenseVoiceSherpaOnnxExecutablePath before dictation."
+            return "SenseVoice downloads the compact int8 sherpa-onnx model locally and runs it in English mode. Install sherpa-onnx or set SenseVoiceSherpaOnnxExecutablePath before dictation."
         case .nemotronOffline:
             return "Nemotron 3.5 Multilingual is slower but more accurate. Supports around 40 languages with auto or manual language selection. Best on Apple Silicon with 8GB+ RAM."
         case .nemotronStreaming, .nemotronStreaming320:

--- a/Sources/Fluid/UI/AISettingsView.swift
+++ b/Sources/Fluid/UI/AISettingsView.swift
@@ -59,6 +59,7 @@ enum SpeechProviderFilter: String, CaseIterable, Identifiable {
     case nvidia = "NVIDIA"
     case apple = "Apple"
     case cohere = "Cohere"
+    case senseVoice = "SenseVoice"
     case openai = "OpenAI"
 
     var id: String { self.rawValue }


### PR DESCRIPTION
## Summary
- rework SenseVoice to use FluidAudio/CoreML instead of the sherpa-onnx-offline CLI
- keep SenseVoice English-only in FluidVoice and run the int8 CoreML encoder through FluidAudio on Apple Silicon
- remove the external CLI requirement, temporary WAV writes for sample transcription, ONNX archive download/extract flow, and sherpa setup docs
- add a focused FluidAudio companion branch dependency with SenseVoice CoreML support

## Companion dependency PR
- FluidAudio: https://github.com/altic-dev/FluidAudio/pull/1
- FluidVoice currently points at jayrodge/FluidAudio:add-sensevoice-coreml-for-fluidvoice so this PR can build before the companion FluidAudio branch is merged upstream.

## Verification
- swift build in the FluidAudio companion branch
- swift package resolve in FluidVoice
- xcodebuild -project Fluid.xcodeproj -scheme Fluid -configuration Debug -derivedDataPath /private/tmp/fluidvoice-derived CODE_SIGNING_ALLOWED=NO build -quiet

## Notes
- SenseVoice remains a batch/non-autoregressive model here, not a true live streaming engine.
- The implementation is now CoreML via FluidAudio, not ONNX via an external process.