### PR TITLE
Prepare for Fluid Provider, added API suppport for FV, store audio wav files for each transcription in history option and more

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+- Be brief and clear. Keep first issue summaries to 5 lines max.
+- For macOS app code, optimize for low resource usage and multiple OS versions.
+- Ask Barath when a decision is genuinely unclear.
+- Build FluidVoice with `sh build_incremental.sh`.
+- Before commit-ready code, run `swiftformat --config .swiftformat Sources` and `swiftlint --strict --config .swiftlint.yml Sources/`.
+- After committing, update the relevant `RELEASE_NOTES_*.md` version section.
+- Ask which release-notes version to use before editing release notes.
+- Keep `RELEASE_NOTES_*.md` files local and uncommitted.

--- a/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "98186d72302f89f0ba2f7e7af3fb034d3d75340965f566935f17fd7196e69e57",
+  "originHash" : "d7e140ce2c475ae2639740b8ec9ca2ff9804c41b3c73d6b43011119fdbad17b1",
   "pins" : [
     {
       "identity" : "appupdater",

--- a/Info.plist
+++ b/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleVersion</key>
-		<string>11</string>
+		<string>12</string>
 	<key>CFBundleShortVersionString</key>
-		<string>1.5.15</string>
+		<string>1.6.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -23,6 +23,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         // Initialize app settings (dock visibility, etc.)
         SettingsStore.shared.initializeAppSettings()
+        LocalAPIServer.shared.start()
 
         // Record first-open synchronously before async analytics bootstrap so
         // onboarding initialization is deterministic on brand-new installs.
@@ -58,6 +59,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     func applicationWillTerminate(_ notification: Notification) {
         DebugLogger.shared.info("Application will terminate", source: "AppDelegate")
+        LocalAPIServer.shared.stop()
         // Clean up the update check timer
         self.updateCheckTimer?.invalidate()
         self.updateCheckTimer = nil

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -138,6 +138,7 @@ struct ContentView: View {
     @State private var promptModeOverrideText: String? // System prompt text to use when in prompt mode
     @State private var activeDictationShortcutSlot: SettingsStore.DictationShortcutSlot? = nil
     @State private var activeRecordingMode: ActiveRecordingMode = .none
+    @State private var pendingAIReprocessText: String? = nil
     @State private var activeShortcutRecordingTarget: ShortcutRecordingTarget? = nil
     @State private var currentRecordingModifierKeyCodes: Set<UInt16> = []
     @State private var pendingModifierKeyCodes: Set<UInt16> = []
@@ -2038,7 +2039,10 @@ struct ContentView: View {
         }
         let shouldShowAIProcessingFailure = shouldPersistOutputs && aiFallbackReason != nil
         if shouldShowAIProcessingFailure {
+            self.pendingAIReprocessText = transcribedText
             NotchContentState.shared.showAIProcessingFailure()
+        } else {
+            self.pendingAIReprocessText = nil
         }
 
         // When FluidVoice itself is frontmost, the bound editor already receives `finalText`.
@@ -2172,7 +2176,17 @@ struct ContentView: View {
         return .normal
     }
 
-    private func reprocessLastDictationFromHistory() {
+    private func reprocessLastDictation() {
+        if let pendingText = self.pendingAIReprocessText?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !pendingText.isEmpty
+        {
+            DebugLogger.shared.info("Actions: Reprocessing pending failed dictation", source: "ContentView")
+            Task { @MainActor in
+                await self.reprocessDictationText(pendingText)
+            }
+            return
+        }
+
         guard let last = TranscriptionHistoryStore.shared.entries.first else {
             DebugLogger.shared.info("Actions: Reprocess requested but history is empty", source: "ContentView")
             return
@@ -2326,7 +2340,10 @@ struct ContentView: View {
             )
         }
         if aiFallbackReason != nil {
+            self.pendingAIReprocessText = transcribedText
             NotchContentState.shared.showAIProcessingFailure()
+        } else {
+            self.pendingAIReprocessText = nil
         }
 
         if SettingsStore.shared.copyTranscriptionToClipboard {
@@ -2658,7 +2675,7 @@ struct ContentView: View {
             self.handleLiveOverlayModeSwitch(mode)
         }
         NotchContentState.shared.onReprocessLastRequested = {
-            self.reprocessLastDictationFromHistory()
+            self.reprocessLastDictation()
         }
         NotchContentState.shared.onCopyLastRequested = {
             self.copyLastDictationFromHistory()

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1572,9 +1572,50 @@ struct ContentView: View {
 
         DebugLogger.shared.debug("processTextWithAI using provider=\(derivedCurrentProvider), model=\(derivedSelectedModel)", source: "ContentView")
 
+        let appInfo = self.recordingAppInfo ?? self.getCurrentAppInfo()
+        let isDictationCall = overrideSystemPrompt != nil || dictationSlot != nil
+        let isPrivateAIProvider = currentSelectedProviderID == PrivateAIProviderFeature.shared.providerID ||
+            derivedCurrentProvider == PrivateAIProviderFeature.shared.providerID ||
+            derivedCurrentProvider == "custom:\(PrivateAIProviderFeature.shared.providerID)"
+        let usePrivateAIProvider = overrideSystemPrompt == nil &&
+            isDictationCall &&
+            (isPrivateAIProvider || PrivateAIIntegrationService.shouldHandleDictation(model: derivedSelectedModel))
+
+        if usePrivateAIProvider {
+            if self.shouldTracePromptProcessing {
+                self.logDictationPromptTrace("Private AI Provider task", value: "dictationEnhancement")
+                self.logDictationPromptTrace("Input transcription (Q)", value: inputText)
+                self.logDictationPromptTrace("Selected context text", value: "<none (dictation mode)>")
+            }
+
+            let apiKey = storedProviderAPIKeys[derivedCurrentProvider] ?? storedProviderAPIKeys[currentSelectedProviderID] ?? ""
+            let response = try await PrivateAIIntegrationService.shared.enhanceDictation(
+                inputText,
+                runtime: PrivateAIIntegrationService.RuntimeConfiguration(
+                    selectedProviderID: currentSelectedProviderID,
+                    providerKey: derivedCurrentProvider,
+                    baseURL: derivedBaseURL,
+                    model: derivedSelectedModel,
+                    apiKey: apiKey,
+                    localModelPath: PrivateAIIntegrationService.configuredLocalModelPath,
+                    usesStablePromptPrefixKVCache: SettingsStore.shared.privateAIPrefixKVCacheEnabled
+                ),
+                context: PrivateAIIntegrationService.AppContext(
+                    appName: appInfo.name,
+                    bundleID: appInfo.bundleId,
+                    windowTitle: appInfo.windowTitle,
+                    appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+                )
+            )
+
+            if self.shouldTracePromptProcessing {
+                self.logDictationPromptTrace("Model answer (A)", value: response.outputText)
+            }
+            return response.outputText
+        }
+
         // Resolve the effective prompt once so every provider path honors
         // transient overrides such as "Transcribe with Prompt".
-        let appInfo = self.recordingAppInfo ?? self.getCurrentAppInfo()
         let promptText: String = {
             let override = overrideSystemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if !override.isEmpty { return override }
@@ -1586,8 +1627,6 @@ struct ContentView: View {
         // the transcript after a blank line). Non-dictation callers — the AI
         // chat tab specifically — keep the legacy two-message layout where
         // the prompt is the system turn and the input is the user turn.
-        let isDictationCall = overrideSystemPrompt != nil || dictationSlot != nil
-
         let systemPrompt: String
         let userMessageContent: String
         if isDictationCall {
@@ -1801,6 +1840,7 @@ struct ContentView: View {
         // Stop the ASR service and wait for transcription to complete
         // The processing indicator will stay visible during this phase
         let transcribedText = await asr.stop()
+        let audioSnapshot = self.asr.consumeLastCompletedAudioSnapshot()
         DebugLogger.shared.info(
             "Stop transcription result | chars=\(transcribedText.count) | empty=\(transcribedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)",
             source: "ContentView"
@@ -1978,13 +2018,27 @@ struct ContentView: View {
 
         // Save to transcription history (transcription mode only, if enabled)
         if shouldPersistOutputs, SettingsStore.shared.saveTranscriptionHistory {
+            let historyEntryID = UUID()
+            let historyTimestamp = Date()
             TranscriptionHistoryStore.shared.addEntry(
+                id: historyEntryID,
+                timestamp: historyTimestamp,
                 rawText: transcribedText,
                 processedText: finalText,
                 appName: appInfo.name,
                 windowTitle: appInfo.windowTitle,
                 aiProcessingError: aiFallbackReason
             )
+            self.persistDictationAudioIfNeeded(
+                audioSnapshot,
+                entryID: historyEntryID,
+                timestamp: historyTimestamp,
+                model: transcriptionModelInfo.model
+            )
+        }
+        let shouldShowAIProcessingFailure = shouldPersistOutputs && aiFallbackReason != nil
+        if shouldShowAIProcessingFailure {
+            NotchContentState.shared.showAIProcessingFailure()
         }
 
         // When FluidVoice itself is frontmost, the bound editor already receives `finalText`.
@@ -2047,7 +2101,9 @@ struct ContentView: View {
                 aiProvider: modelInfo.provider
             )
 
-            NotchOverlayManager.shared.hide()
+            if !shouldShowAIProcessingFailure {
+                NotchOverlayManager.shared.hide()
+            }
         } else if shouldPersistOutputs,
                   SettingsStore.shared.copyTranscriptionToClipboard == false,
                   SettingsStore.shared.saveTranscriptionHistory
@@ -2061,8 +2117,46 @@ struct ContentView: View {
             )
         }
 
-        if !didTypeExternally {
+        if !didTypeExternally, !shouldShowAIProcessingFailure {
             NotchOverlayManager.shared.hide()
+        }
+    }
+
+    private func persistDictationAudioIfNeeded(
+        _ snapshot: DictationAudioSnapshot?,
+        entryID: UUID,
+        timestamp: Date,
+        model: String
+    ) {
+        guard SettingsStore.shared.saveTranscriptionHistory,
+              SettingsStore.shared.saveAudioWithTranscriptionHistory,
+              let snapshot = snapshot
+        else {
+            return
+        }
+
+        Task.detached(priority: .utility) {
+            let result: (metadata: DictationAudioMetadata?, error: String?) = {
+                do {
+                    let metadata = try DictationAudioHistoryStore.shared.save(
+                        snapshot: snapshot,
+                        entryID: entryID,
+                        timestamp: timestamp,
+                        model: model
+                    )
+                    return (metadata, nil)
+                } catch {
+                    return (nil, error.localizedDescription)
+                }
+            }()
+
+            await MainActor.run {
+                if let metadata = result.metadata {
+                    TranscriptionHistoryStore.shared.attachAudio(metadata, to: entryID)
+                } else if let error = result.error {
+                    DebugLogger.shared.error("Failed to save dictation audio: \(error)", source: "ContentView")
+                }
+            }
         }
     }
 
@@ -2202,7 +2296,10 @@ struct ContentView: View {
         let shouldUseAI = DictationAIPostProcessingGate.isConfigured(for: .primary, appBundleID: appInfo.bundleId)
         if shouldUseAI {
             do {
-                finalText = try await self.processTextWithAI(transcribedText)
+                finalText = try await self.processTextWithAI(
+                    transcribedText,
+                    dictationSlot: .primary
+                )
             } catch {
                 DebugLogger.shared.error(
                     "AI reprocess failed, falling back to raw transcription: \(error.localizedDescription)",
@@ -2227,6 +2324,9 @@ struct ContentView: View {
                 windowTitle: appInfo.windowTitle,
                 aiProcessingError: aiFallbackReason
             )
+        }
+        if aiFallbackReason != nil {
+            NotchContentState.shared.showAIProcessingFailure()
         }
 
         if SettingsStore.shared.copyTranscriptionToClipboard {
@@ -2573,6 +2673,15 @@ struct ContentView: View {
             _ = self.handleCancelShortcut()
         }
         NotchContentState.shared.onDictationPromptSelectionRequested = { selection in
+            let privateAIAvailable = PrivateAIProviderPromptFormat.isAvailable()
+            switch selection {
+            case .off:
+                break
+            case .privateAI:
+                guard privateAIAvailable else { return }
+            case .default, .profile:
+                guard !privateAIAvailable else { return }
+            }
             let slot = self.activeDictationShortcutSlot ?? .primary
             SettingsStore.shared.setDictationPromptSelection(selection, for: slot)
             self.applyDictationShortcutSelectionContext(for: slot)
@@ -2929,6 +3038,10 @@ extension ContentView {
             self.promptModeOverrideText = nil
             NotchContentState.shared.promptModeOverrideProfileName = nil
             NotchContentState.shared.promptModeOverrideProfileID = nil
+        case .privateAI:
+            self.promptModeOverrideText = nil
+            NotchContentState.shared.promptModeOverrideProfileName = PrivateAIProviderFeature.displayName
+            NotchContentState.shared.promptModeOverrideProfileID = PrivateAIProviderPromptFormat.promptSelectionID
         case let .profile(profileID):
             guard let profile = settings.selectedDictationPromptProfile(for: slot) ?? settings.dictationPromptProfiles.first(where: {
                 $0.id == profileID && $0.mode.normalized == .dictate

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -12,6 +12,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let selectedModelByProvider: [String: String]
     let savedProviders: [SettingsStore.SavedProvider]
     let modelReasoningConfigs: [String: SettingsStore.ModelReasoningConfig]
+    let privateAIPrefixKVCacheEnabled: Bool?
     let selectedSpeechModel: SettingsStore.SpeechModel
     let selectedCohereLanguage: SettingsStore.CohereLanguage
     let selectedNemotronLanguage: SettingsStore.NemotronLanguage?
@@ -57,6 +58,8 @@ struct SettingsBackupPayload: Codable, Equatable {
     let transcriptionPreviewCharLimit: Int
     let userTypingWPM: Int
     let saveTranscriptionHistory: Bool
+    let saveAudioWithTranscriptionHistory: Bool?
+    let audioHistoryBudgetGB: Double?
     let notifyAIProcessingFailures: Bool?
     let weekendsDontBreakStreak: Bool
     let fillerWords: [String]
@@ -125,9 +128,10 @@ final class BackupService {
     func decode(_ data: Data) throws -> AppBackupDocument {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
+        let migratedData = Self.dataByMigratingLegacyPrivateAIKeys(in: data) ?? data
 
         do {
-            let document = try decoder.decode(AppBackupDocument.self, from: data)
+            let document = try decoder.decode(AppBackupDocument.self, from: migratedData)
             try self.validate(document)
             return document
         } catch let error as BackupServiceError {
@@ -158,6 +162,24 @@ final class BackupService {
         guard document.schemaVersion.major == BackupFileVersion.current.major else {
             throw BackupServiceError.unsupportedSchemaVersion(document.schemaVersion)
         }
+    }
+
+    private static func dataByMigratingLegacyPrivateAIKeys(in data: Data) -> Data? {
+        guard var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var settings = root["settings"] as? [String: Any],
+              settings["privateAIPrefixKVCacheEnabled"] == nil
+        else {
+            return nil
+        }
+
+        let legacyPrefixCacheKey = ["fluid", "Int", "elligence", "PrefixKVCacheEnabled"].joined()
+        guard let legacyValue = settings[legacyPrefixCacheKey] else {
+            return nil
+        }
+
+        settings["privateAIPrefixKVCacheEnabled"] = legacyValue
+        root["settings"] = settings
+        return try? JSONSerialization.data(withJSONObject: root)
     }
 }
 

--- a/Sources/Fluid/Persistence/DictationAudioHistoryStore.swift
+++ b/Sources/Fluid/Persistence/DictationAudioHistoryStore.swift
@@ -74,7 +74,7 @@ final nonisolated class DictationAudioHistoryStore: @unchecked Sendable {
 
     func audioFileURL(for entry: TranscriptionHistoryEntry) -> URL? {
         guard let audio = entry.audio else { return nil }
-        return try? self.audioDirectory(createIfNeeded: false).appendingPathComponent(audio.fileName, isDirectory: false)
+        return self.audioFileURL(fileName: audio.fileName, createIfNeeded: false)
     }
 
     func audioFileExists(for entry: TranscriptionHistoryEntry) -> Bool {
@@ -84,7 +84,7 @@ final nonisolated class DictationAudioHistoryStore: @unchecked Sendable {
 
     @discardableResult
     func deleteAudio(fileName: String) -> Int64 {
-        guard let url = try? self.audioDirectory(createIfNeeded: false).appendingPathComponent(fileName, isDirectory: false) else {
+        guard let url = self.audioFileURL(fileName: fileName, createIfNeeded: false) else {
             return 0
         }
 
@@ -259,6 +259,31 @@ final nonisolated class DictationAudioHistoryStore: @unchecked Sendable {
             try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
         }
         return directory
+    }
+
+    private func audioFileURL(fileName: String, createIfNeeded: Bool) -> URL? {
+        guard let safeFileName = self.safeAudioFileName(fileName),
+              let directory = try? self.audioDirectory(createIfNeeded: createIfNeeded)
+        else {
+            return nil
+        }
+        return directory.appendingPathComponent(safeFileName, isDirectory: false)
+    }
+
+    private func safeAudioFileName(_ fileName: String) -> String? {
+        let trimmed = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let lastPathComponent = URL(fileURLWithPath: trimmed).lastPathComponent
+        guard trimmed == lastPathComponent,
+              lastPathComponent != ".",
+              lastPathComponent != "..",
+              URL(fileURLWithPath: lastPathComponent).pathExtension.lowercased() == "wav"
+        else {
+            return nil
+        }
+
+        return lastPathComponent
     }
 
     private func audioFileName(entryID: UUID, timestamp: Date) -> String {

--- a/Sources/Fluid/Persistence/DictationAudioHistoryStore.swift
+++ b/Sources/Fluid/Persistence/DictationAudioHistoryStore.swift
@@ -82,11 +82,51 @@ final nonisolated class DictationAudioHistoryStore: @unchecked Sendable {
         return self.fileManager.fileExists(atPath: url.path)
     }
 
-    func deleteAudio(fileName: String) {
+    @discardableResult
+    func deleteAudio(fileName: String) -> Int64 {
         guard let url = try? self.audioDirectory(createIfNeeded: false).appendingPathComponent(fileName, isDirectory: false) else {
-            return
+            return 0
         }
-        try? self.fileManager.removeItem(at: url)
+
+        return self.deleteAudioFile(at: url) ?? 0
+    }
+
+    func deleteUnreferencedAudioFiles(referencedFileNames: Set<String>) -> (fileCount: Int, byteCount: Int64) {
+        guard let directory = try? self.audioDirectory(createIfNeeded: false),
+              self.fileManager.fileExists(atPath: directory.path)
+        else {
+            return (0, 0)
+        }
+
+        let files = (try? self.fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        var fileCount = 0
+        var byteCount: Int64 = 0
+        for file in files where file.pathExtension.lowercased() == "wav" && !referencedFileNames.contains(file.lastPathComponent) {
+            guard let removedBytes = self.deleteAudioFile(at: file) else { continue }
+            fileCount += 1
+            byteCount += removedBytes
+        }
+
+        return (fileCount, byteCount)
+    }
+
+    private func deleteAudioFile(at url: URL) -> Int64? {
+        guard self.fileManager.fileExists(atPath: url.path) else {
+            return nil
+        }
+
+        let fileSize = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize).map(Int64.init) ?? 0
+        do {
+            try self.fileManager.removeItem(at: url)
+            return fileSize
+        } catch {
+            return nil
+        }
     }
 
     func deleteAllAudioFiles() {

--- a/Sources/Fluid/Persistence/DictationAudioHistoryStore.swift
+++ b/Sources/Fluid/Persistence/DictationAudioHistoryStore.swift
@@ -1,0 +1,332 @@
+import Foundation
+
+struct DictationAudioSnapshot: Sendable {
+    let samples: [Float]
+    let sampleRate: Int
+    let channels: Int
+
+    var durationMilliseconds: Int {
+        guard self.sampleRate > 0, self.channels > 0 else { return 0 }
+        let frames = Double(self.samples.count) / Double(self.channels)
+        return Int((frames / Double(self.sampleRate) * 1000).rounded())
+    }
+}
+
+struct DictationAudioMetadata: Codable, Equatable, Sendable {
+    let fileName: String
+    let durationMilliseconds: Int
+    let byteCount: Int
+    let sampleRate: Int
+    let channels: Int
+    let model: String?
+}
+
+enum DictationAudioHistoryError: LocalizedError {
+    case applicationSupportUnavailable
+    case audioMissing
+    case noAudioEntries
+    case zipFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .applicationSupportUnavailable:
+            return "Could not access Application Support."
+        case .audioMissing:
+            return "Saved audio is missing."
+        case .noAudioEntries:
+            return "No saved dictation audio is available to export."
+        case let .zipFailed(message):
+            return "Could not create export zip. \(message)"
+        }
+    }
+}
+
+final nonisolated class DictationAudioHistoryStore: @unchecked Sendable {
+    static let shared = DictationAudioHistoryStore()
+
+    private let appSupportFolder = "FluidVoice"
+    private let audioFolder = "DictationAudioHistory"
+    private let fileManager = FileManager.default
+
+    private init() {}
+
+    func save(
+        snapshot: DictationAudioSnapshot,
+        entryID: UUID,
+        timestamp: Date,
+        model: String?
+    ) throws -> DictationAudioMetadata {
+        let directory = try self.audioDirectory()
+        let fileName = self.audioFileName(entryID: entryID, timestamp: timestamp)
+        let url = directory.appendingPathComponent(fileName, isDirectory: false)
+        let data = Self.wavData(from: snapshot)
+        try data.write(to: url, options: .atomic)
+
+        return DictationAudioMetadata(
+            fileName: fileName,
+            durationMilliseconds: snapshot.durationMilliseconds,
+            byteCount: data.count,
+            sampleRate: snapshot.sampleRate,
+            channels: snapshot.channels,
+            model: model
+        )
+    }
+
+    func audioFileURL(for entry: TranscriptionHistoryEntry) -> URL? {
+        guard let audio = entry.audio else { return nil }
+        return try? self.audioDirectory(createIfNeeded: false).appendingPathComponent(audio.fileName, isDirectory: false)
+    }
+
+    func audioFileExists(for entry: TranscriptionHistoryEntry) -> Bool {
+        guard let url = self.audioFileURL(for: entry) else { return false }
+        return self.fileManager.fileExists(atPath: url.path)
+    }
+
+    func deleteAudio(fileName: String) {
+        guard let url = try? self.audioDirectory(createIfNeeded: false).appendingPathComponent(fileName, isDirectory: false) else {
+            return
+        }
+        try? self.fileManager.removeItem(at: url)
+    }
+
+    func deleteAllAudioFiles() {
+        guard let directory = try? self.audioDirectory(createIfNeeded: false),
+              self.fileManager.fileExists(atPath: directory.path)
+        else {
+            return
+        }
+        let files = (try? self.fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)) ?? []
+        for file in files where file.pathExtension.lowercased() == "wav" {
+            try? self.fileManager.removeItem(at: file)
+        }
+    }
+
+    func audioUsageBytes() -> Int64 {
+        guard let directory = try? self.audioDirectory(createIfNeeded: false),
+              let files = try? self.fileManager.contentsOfDirectory(
+                  at: directory,
+                  includingPropertiesForKeys: [.fileSizeKey],
+                  options: [.skipsHiddenFiles]
+              )
+        else {
+            return 0
+        }
+
+        return files.reduce(Int64(0)) { total, url in
+            guard url.pathExtension.lowercased() == "wav",
+                  let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+                  let size = values.fileSize
+            else {
+                return total
+            }
+            return total + Int64(size)
+        }
+    }
+
+    func exportAudioArchive(entries: [TranscriptionHistoryEntry], to destinationURL: URL) throws {
+        try self.exportArchive(entries: entries, to: destinationURL)
+    }
+
+    func exportPair(entry: TranscriptionHistoryEntry, to destinationURL: URL) throws {
+        try self.exportArchive(entries: [entry], to: destinationURL)
+    }
+
+    func suggestedAudioExportFilename(for date: Date = Date()) -> String {
+        "FluidVoice_Audio_\(Self.fileTimestampFormatter.string(from: date)).zip"
+    }
+
+    func suggestedPairExportFilename(for entry: TranscriptionHistoryEntry) -> String {
+        "FluidVoice_Pair_\(Self.fileTimestampFormatter.string(from: entry.timestamp))_\(entry.id.uuidString.prefix(8)).zip"
+    }
+
+    static func formattedGigabytes(_ bytes: Int64) -> String {
+        let gb = Double(bytes) / 1_073_741_824.0
+        if gb < 0.1 {
+            return String(format: "%.2f GB", gb)
+        }
+        return String(format: "%.1f GB", gb)
+    }
+
+    static func bytes(forGigabytes gigabytes: Double) -> Int64 {
+        Int64((gigabytes * 1_073_741_824.0).rounded())
+    }
+
+    private func exportArchive(entries: [TranscriptionHistoryEntry], to destinationURL: URL) throws {
+        let exportEntries = entries.filter { self.audioFileExists(for: $0) }
+        guard !exportEntries.isEmpty else { throw DictationAudioHistoryError.noAudioEntries }
+
+        let staging = self.fileManager.temporaryDirectory
+            .appendingPathComponent("fluidvoice-audio-\(UUID().uuidString)", isDirectory: true)
+        let audioDirectory = staging.appendingPathComponent("audio", isDirectory: true)
+
+        try self.fileManager.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+        defer { try? self.fileManager.removeItem(at: staging) }
+
+        var manifestLines: [String] = []
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        for entry in exportEntries.sorted(by: { $0.timestamp < $1.timestamp }) {
+            guard let sourceURL = self.audioFileURL(for: entry),
+                  let audio = entry.audio
+            else {
+                continue
+            }
+
+            let exportFileName = "\(Self.fileTimestampFormatter.string(from: entry.timestamp))_\(entry.id.uuidString.prefix(8)).wav"
+            let relativeAudioPath = "audio/\(exportFileName)"
+            try self.fileManager.copyItem(
+                at: sourceURL,
+                to: audioDirectory.appendingPathComponent(exportFileName, isDirectory: false)
+            )
+
+            let row = AudioManifestRow(
+                audio: relativeAudioPath,
+                text: entry.rawText,
+                rawTranscript: entry.rawText,
+                finalTranscript: entry.processedText,
+                timestamp: Self.isoFormatter.string(from: entry.timestamp),
+                durationMilliseconds: audio.durationMilliseconds,
+                sampleRate: audio.sampleRate,
+                channels: audio.channels,
+                app: entry.appName,
+                model: audio.model ?? ""
+            )
+            let data = try encoder.encode(row)
+            if let line = String(data: data, encoding: .utf8) {
+                manifestLines.append(line)
+            }
+        }
+
+        guard !manifestLines.isEmpty else { throw DictationAudioHistoryError.noAudioEntries }
+        let manifestURL = staging.appendingPathComponent("manifest.jsonl", isDirectory: false)
+        try (manifestLines.joined(separator: "\n") + "\n").write(to: manifestURL, atomically: true, encoding: .utf8)
+
+        if self.fileManager.fileExists(atPath: destinationURL.path) {
+            try self.fileManager.removeItem(at: destinationURL)
+        }
+        try self.zip(stagingDirectory: staging, destinationURL: destinationURL)
+    }
+
+    private func audioDirectory(createIfNeeded: Bool = true) throws -> URL {
+        guard let base = self.fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            throw DictationAudioHistoryError.applicationSupportUnavailable
+        }
+        let directory = base
+            .appendingPathComponent(self.appSupportFolder, isDirectory: true)
+            .appendingPathComponent(self.audioFolder, isDirectory: true)
+        if createIfNeeded {
+            try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        return directory
+    }
+
+    private func audioFileName(entryID: UUID, timestamp: Date) -> String {
+        "\(Self.fileTimestampFormatter.string(from: timestamp))_\(entryID.uuidString.prefix(8)).wav"
+    }
+
+    private func zip(stagingDirectory: URL, destinationURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.arguments = ["-qr", destinationURL.path, "manifest.jsonl", "audio"]
+        process.currentDirectoryURL = stagingDirectory
+
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8) ?? ""
+            throw DictationAudioHistoryError.zipFailed(message)
+        }
+    }
+
+    private static func wavData(from snapshot: DictationAudioSnapshot) -> Data {
+        let bitsPerSample = 16
+        let bytesPerSample = bitsPerSample / 8
+        let dataByteCount = snapshot.samples.count * bytesPerSample
+        let byteRate = snapshot.sampleRate * snapshot.channels * bytesPerSample
+        let blockAlign = snapshot.channels * bytesPerSample
+
+        var data = Data()
+        data.reserveCapacity(44 + dataByteCount)
+        data.append(contentsOf: Array("RIFF".utf8))
+        Self.appendUInt32LE(UInt32(36 + dataByteCount), to: &data)
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        Self.appendUInt32LE(16, to: &data)
+        Self.appendUInt16LE(1, to: &data)
+        Self.appendUInt16LE(UInt16(snapshot.channels), to: &data)
+        Self.appendUInt32LE(UInt32(snapshot.sampleRate), to: &data)
+        Self.appendUInt32LE(UInt32(byteRate), to: &data)
+        Self.appendUInt16LE(UInt16(blockAlign), to: &data)
+        Self.appendUInt16LE(UInt16(bitsPerSample), to: &data)
+        data.append(contentsOf: Array("data".utf8))
+        Self.appendUInt32LE(UInt32(dataByteCount), to: &data)
+
+        for sample in snapshot.samples {
+            let clamped = max(-1.0, min(1.0, sample))
+            let scaled = Int16((clamped * Float(Int16.max)).rounded())
+            Self.appendInt16LE(scaled, to: &data)
+        }
+        return data
+    }
+
+    private static func appendUInt16LE(_ value: UInt16, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func appendUInt32LE(_ value: UInt32, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func appendInt16LE(_ value: Int16, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static let fileTimestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss'Z'"
+        return formatter
+    }()
+
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}
+
+private struct AudioManifestRow: Encodable {
+    let audio: String
+    let text: String
+    let rawTranscript: String
+    let finalTranscript: String
+    let timestamp: String
+    let durationMilliseconds: Int
+    let sampleRate: Int
+    let channels: Int
+    let app: String
+    let model: String
+
+    enum CodingKeys: String, CodingKey {
+        case audio
+        case text
+        case rawTranscript = "raw_transcript"
+        case finalTranscript = "final_transcript"
+        case timestamp
+        case durationMilliseconds = "duration_ms"
+        case sampleRate = "sample_rate"
+        case channels
+        case app
+        case model
+    }
+}

--- a/Sources/Fluid/Persistence/SettingsStore+NemotronLanguage.swift
+++ b/Sources/Fluid/Persistence/SettingsStore+NemotronLanguage.swift
@@ -20,6 +20,7 @@ extension SettingsStore {
             try container.encode(self.rawValue)
         }
 
+        static let auto = Self(rawValue: "auto")
         static let english = Self(rawValue: "en")
 
         static let allCases: [Self] = [
@@ -46,6 +47,18 @@ extension SettingsStore {
                 return "\(localized) (\(self.rawValue))"
             }
             return self.rawValue
+        }
+
+        var compactDisplayName: String {
+            switch self.rawValue {
+            case "auto": return "Auto"
+            case "hi": return "Hindi"
+            case "en": return "English"
+            default:
+                return self.displayName
+                    .components(separatedBy: " (")
+                    .first ?? self.displayName
+            }
         }
 
         private static let displayNames: [String: String] = [

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import FluidAudio
 #endif
 
-// swiftlint:disable type_body_length
+// swiftlint:disable file_length type_body_length
 final class SettingsStore: ObservableObject {
     static let shared = SettingsStore()
     static let transcriptionPreviewCharLimitRange: ClosedRange<Int> = 50...800
@@ -105,8 +105,7 @@ final class SettingsStore: ObservableObject {
     }
 
     enum DictationPromptSelection: Equatable {
-        case off
-        case `default`
+        case off, `default`, privateAI
         case profile(String)
     }
 
@@ -311,27 +310,29 @@ final class SettingsStore: ObservableObject {
     }
 
     func dictationPromptSelection(for slot: DictationShortcutSlot) -> DictationPromptSelection {
-        if self.isDictationPromptOff(for: slot) {
-            return .off
-        }
+        if self.isDictationPromptOff(for: slot) { return .off }
+        if PrivateAIProviderPromptFormat.isAvailable(settings: self) { return .privateAI }
         if let promptID = self.selectedDictationPromptID(for: slot) {
+            if promptID == PrivateAIProviderPromptFormat.promptSelectionID {
+                return PrivateAIProviderPromptFormat.isAvailable(settings: self) ? .privateAI : .default
+            }
             return .profile(promptID)
         }
         return .default
     }
 
     func setDictationPromptSelection(_ selection: DictationPromptSelection, for slot: DictationShortcutSlot) {
+        let selectedID: String?
         switch selection {
-        case .off:
-            self.setDictationPromptOff(true, for: slot)
-            self.setSelectedDictationPromptID(nil, for: slot)
-        case .default:
-            self.setDictationPromptOff(false, for: slot)
-            self.setSelectedDictationPromptID(nil, for: slot)
+        case .off, .default:
+            selectedID = nil
+        case .privateAI:
+            selectedID = PrivateAIProviderPromptFormat.promptSelectionID
         case let .profile(promptID):
-            self.setDictationPromptOff(false, for: slot)
-            self.setSelectedDictationPromptID(promptID, for: slot)
+            selectedID = promptID
         }
+        self.setDictationPromptOff(selection == .off, for: slot)
+        self.setSelectedDictationPromptID(selectedID, for: slot)
     }
 
     /// Convenience: currently selected profile, or nil if Default/invalid selection.
@@ -387,6 +388,8 @@ final class SettingsStore: ObservableObject {
     func selectedPromptID(for mode: PromptMode) -> String? {
         switch mode.normalized {
         case .dictate:
+            if self.selectedDictationPromptID == PrivateAIProviderPromptFormat.promptSelectionID,
+               !PrivateAIProviderPromptFormat.isAvailable(settings: self) { return nil }
             return self.selectedDictationPromptID
         case .edit:
             return self.selectedEditPromptID
@@ -438,7 +441,7 @@ final class SettingsStore: ObservableObject {
 
     func resolvedDictationPromptProfile(for slot: DictationShortcutSlot, appBundleID: String?) -> DictationPromptProfile? {
         switch self.dictationPromptSelection(for: slot) {
-        case .off:
+        case .off, .privateAI:
             return nil
         case let .profile(promptID):
             return self.dictationPromptProfiles.first(where: { $0.id == promptID && $0.mode.normalized == .dictate })
@@ -452,6 +455,7 @@ final class SettingsStore: ObservableObject {
     }
 
     func isAppDictationPromptBindingActive(for slot: DictationShortcutSlot, appBundleID: String?) -> Bool {
+        guard !PrivateAIProviderPromptFormat.isAvailable(settings: self) else { return false }
         guard self.dictationPromptSelection(for: slot) == .default else { return false }
         return self.hasAppPromptBinding(for: .dictate, appBundleID: appBundleID)
     }
@@ -466,6 +470,7 @@ final class SettingsStore: ObservableObject {
                 return name.isEmpty ? "Untitled" : name
             }
             return "Default"
+        case .privateAI: return PrivateAIProviderFeature.displayName
         case let .profile(promptID):
             guard let profile = self.dictationPromptProfiles.first(where: { $0.id == promptID && $0.mode.normalized == .dictate }) else {
                 return "Default"
@@ -924,7 +929,7 @@ final class SettingsStore: ObservableObject {
         switch self.dictationPromptSelection(for: slot) {
         case .off:
             return ""
-        case .default:
+        case .default, .privateAI:
             return self.effectivePromptBody(for: .dictate, appBundleID: appBundleID)
         case let .profile(promptID):
             guard let profile = self.dictationPromptProfiles.first(where: { $0.id == promptID && $0.mode.normalized == .dictate }) else {
@@ -945,7 +950,7 @@ final class SettingsStore: ObservableObject {
         }
 
         switch self.dictationPromptSelection(for: slot) {
-        case .off, .default:
+        case .off, .default, .privateAI:
             return self.effectiveSystemPrompt(for: .dictate, appBundleID: appBundleID)
         case let .profile(promptID):
             guard let profile = self.dictationPromptProfiles.first(where: { $0.id == promptID && $0.mode.normalized == .dictate }) else {
@@ -1109,11 +1114,11 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    var fluid1InterestCaptured: Bool {
-        get { self.defaults.bool(forKey: Keys.fluid1InterestCaptured) }
+    var privateAIInterestCaptured: Bool {
+        get { self.defaults.bool(forKey: Keys.privateAIInterestCaptured) }
         set {
             objectWillChange.send()
-            self.defaults.set(newValue, forKey: Keys.fluid1InterestCaptured)
+            self.defaults.set(newValue, forKey: Keys.privateAIInterestCaptured)
         }
     }
 
@@ -1200,10 +1205,19 @@ final class SettingsStore: ObservableObject {
     }
 
     var selectedProviderID: String {
-        get { self.defaults.string(forKey: Keys.selectedProviderID) ?? "openai" }
+        get { self.availableSelectedProviderID(for: self.defaults.string(forKey: Keys.selectedProviderID)) }
         set {
             objectWillChange.send()
-            self.defaults.set(newValue, forKey: Keys.selectedProviderID)
+            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            self.defaults.set(trimmed.isEmpty ? "openai" : trimmed, forKey: Keys.selectedProviderID)
+        }
+    }
+
+    var privateAIPrefixKVCacheEnabled: Bool {
+        get { self.defaults.object(forKey: PrivateAIProviderFeature.shared.prefixCacheDefaultsKey) as? Bool ?? true }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: PrivateAIProviderFeature.shared.prefixCacheDefaultsKey)
         }
     }
 
@@ -2242,6 +2256,33 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Stores actual microphone audio locally alongside dictation history.
+    var saveAudioWithTranscriptionHistory: Bool {
+        get {
+            let value = self.defaults.object(forKey: Keys.saveAudioWithTranscriptionHistory)
+            return value as? Bool ?? false
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.saveAudioWithTranscriptionHistory)
+        }
+    }
+
+    var audioHistoryBudgetGB: Double {
+        get {
+            let value = self.defaults.double(forKey: Keys.audioHistoryBudgetGB)
+            return value > 0 ? max(0.1, value) : 4.0
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(max(0.1, newValue), forKey: Keys.audioHistoryBudgetGB)
+        }
+    }
+
+    var audioHistoryBudgetBytes: Int64 {
+        DictationAudioHistoryStore.bytes(forGigabytes: self.audioHistoryBudgetGB)
+    }
+
     /// Whether to show a native notification when AI post-processing fails and raw text is used
     var notifyAIProcessingFailures: Bool {
         get {
@@ -2260,6 +2301,7 @@ final class SettingsStore: ObservableObject {
             selectedModelByProvider: self.selectedModelByProvider,
             savedProviders: self.savedProviders,
             modelReasoningConfigs: self.modelReasoningConfigs,
+            privateAIPrefixKVCacheEnabled: self.privateAIPrefixKVCacheEnabled,
             selectedSpeechModel: self.selectedSpeechModel,
             selectedCohereLanguage: self.selectedCohereLanguage,
             selectedNemotronLanguage: self.selectedNemotronLanguage,
@@ -2305,6 +2347,8 @@ final class SettingsStore: ObservableObject {
             transcriptionPreviewCharLimit: self.transcriptionPreviewCharLimit,
             userTypingWPM: self.userTypingWPM,
             saveTranscriptionHistory: self.saveTranscriptionHistory,
+            saveAudioWithTranscriptionHistory: self.saveAudioWithTranscriptionHistory,
+            audioHistoryBudgetGB: self.audioHistoryBudgetGB,
             notifyAIProcessingFailures: self.notifyAIProcessingFailures,
             weekendsDontBreakStreak: self.weekendsDontBreakStreak,
             fillerWords: self.fillerWords,
@@ -2336,6 +2380,9 @@ final class SettingsStore: ObservableObject {
         self.selectedProviderID = payload.selectedProviderID
         self.selectedModelByProvider = payload.selectedModelByProvider
         self.modelReasoningConfigs = payload.modelReasoningConfigs
+        if let privateAIPrefixKVCacheEnabled = payload.privateAIPrefixKVCacheEnabled {
+            self.privateAIPrefixKVCacheEnabled = privateAIPrefixKVCacheEnabled
+        }
         self.selectedSpeechModel = payload.selectedSpeechModel
         self.selectedCohereLanguage = payload.selectedCohereLanguage
         if let selectedNemotronLanguage = payload.selectedNemotronLanguage {
@@ -2380,6 +2427,12 @@ final class SettingsStore: ObservableObject {
         self.transcriptionPreviewCharLimit = payload.transcriptionPreviewCharLimit
         self.userTypingWPM = payload.userTypingWPM
         self.saveTranscriptionHistory = payload.saveTranscriptionHistory
+        if let saveAudioWithTranscriptionHistory = payload.saveAudioWithTranscriptionHistory {
+            self.saveAudioWithTranscriptionHistory = saveAudioWithTranscriptionHistory
+        }
+        if let audioHistoryBudgetGB = payload.audioHistoryBudgetGB {
+            self.audioHistoryBudgetGB = audioHistoryBudgetGB
+        }
         if let notifyAIProcessingFailures = payload.notifyAIProcessingFailures {
             self.notifyAIProcessingFailures = notifyAIProcessingFailures
         }
@@ -2534,6 +2587,18 @@ final class SettingsStore: ObservableObject {
                 didChangeProfiles = true
             }
         }
+        normalizedProfiles.removeAll { profile in
+            let name = profile.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let prompt = Self.stripBasePrompt(for: profile.mode, from: profile.prompt)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let isLegacyPlaceholder = profile.mode.normalized == .dictate &&
+                name.caseInsensitiveCompare("Blocked") == .orderedSame &&
+                prompt.caseInsensitiveCompare("Blocked prompt") == .orderedSame
+            if isLegacyPlaceholder {
+                didChangeProfiles = true
+            }
+            return isLegacyPlaceholder
+        }
         if didChangeProfiles {
             self.dictationPromptProfiles = normalizedProfiles
         }
@@ -2682,6 +2747,20 @@ final class SettingsStore: ObservableObject {
             return providerID
         }
         return "custom:\(providerID)"
+    }
+
+    private func availableSelectedProviderID(for rawValue: String?) -> String {
+        let trimmed = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let providerID = trimmed.isEmpty ? "openai" : trimmed
+        if ModelRepository.shared.isBuiltIn(providerID) { return providerID }
+
+        let savedProviderID = providerID.hasPrefix("custom:") ?
+            String(providerID.dropFirst("custom:".count)) : providerID
+        if self.savedProviders.contains(where: { $0.id == savedProviderID }) {
+            return savedProviderID
+        }
+
+        return "openai"
     }
 
     private func sanitizeAPIKeys(_ values: [String: String]) -> [String: String] {
@@ -3539,17 +3618,19 @@ private extension SettingsStore {
         static let selectedAIModel = "SelectedAIModel"
         static let selectedModelByProvider = "SelectedModelByProvider"
         static let selectedProviderID = "SelectedProviderID"
+        static let privateAIPrefixKVCacheEnabled = "PrivateAIProviderPrefixKVCacheEnabled"
         static let providerAPIKeys = "ProviderAPIKeys"
         static let providerAPIKeyIdentifiers = "ProviderAPIKeyIdentifiers"
         static let savedProviders = "SavedProviders"
         static let verifiedProviderFingerprints = "VerifiedProviderFingerprints"
         static let shareAnonymousAnalytics = "ShareAnonymousAnalytics"
-        static let fluid1InterestCaptured = "Fluid1InterestCaptured"
+        static let privateAIInterestCaptured = "PrivateAIProviderInterestCaptured"
         static let hotkeyShortcutKey = "HotkeyShortcutKey"
         static let preferredInputDeviceUID = "PreferredInputDeviceUID"
         static let preferredOutputDeviceUID = "PreferredOutputDeviceUID"
         static let syncAudioDevicesWithSystem = "SyncAudioDevicesWithSystem"
         static let visualizerNoiseThreshold = "VisualizerNoiseThreshold"
+        static let launchAtStartup = "LaunchAtStartup"
         static let showInDock = "ShowInDock"
         static let accentColorOption = "AccentColorOption"
         static let enableTranscriptionSounds = "EnableTranscriptionSounds"
@@ -3603,6 +3684,8 @@ private extension SettingsStore {
         // Stats Keys
         static let userTypingWPM = "UserTypingWPM"
         static let saveTranscriptionHistory = "SaveTranscriptionHistory"
+        static let saveAudioWithTranscriptionHistory = "SaveAudioWithTranscriptionHistory"
+        static let audioHistoryBudgetGB = "AudioHistoryBudgetGB"
         static let notifyAIProcessingFailures = "NotifyAIProcessingFailures"
 
         // Filler Words

--- a/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
+++ b/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
@@ -309,11 +309,19 @@ final class TranscriptionHistoryStore: ObservableObject {
         guard currentBytes > budgetBytes else { return 0 }
 
         var updatedEntries = self.entries
+        let referencedFileNames = Set(updatedEntries.compactMap { $0.audio?.fileName })
+        let orphanedAudio = DictationAudioHistoryStore.shared.deleteUnreferencedAudioFiles(referencedFileNames: referencedFileNames)
+        if orphanedAudio.fileCount > 0 {
+            currentBytes = max(0, currentBytes - orphanedAudio.byteCount)
+            DebugLogger.shared.info("Pruned orphaned dictation audio (\(orphanedAudio.fileCount) files)", source: "TranscriptionHistoryStore")
+        }
+        guard currentBytes > budgetBytes else { return 0 }
+
         var prunedCount = 0
         for index in updatedEntries.indices.reversed() {
             guard let audio = updatedEntries[index].audio else { continue }
-            DictationAudioHistoryStore.shared.deleteAudio(fileName: audio.fileName)
-            currentBytes -= Int64(audio.byteCount)
+            let removedBytes = DictationAudioHistoryStore.shared.deleteAudio(fileName: audio.fileName)
+            currentBytes = max(0, currentBytes - removedBytes)
             updatedEntries[index] = updatedEntries[index].replacingAudio(nil)
             prunedCount += 1
             if currentBytes <= budgetBytes {

--- a/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
+++ b/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
@@ -23,6 +23,7 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
     /// back to typing the raw transcription. The string carries the error
     /// message for display / debugging.
     let aiProcessingError: String?
+    let audio: DictationAudioMetadata?
 
     init(
         id: UUID = UUID(),
@@ -31,7 +32,8 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         processedText: String,
         appName: String,
         windowTitle: String,
-        aiProcessingError: String? = nil
+        aiProcessingError: String? = nil,
+        audio: DictationAudioMetadata? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -42,6 +44,31 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         self.characterCount = processedText.count
         self.wasAIProcessed = rawText != processedText
         self.aiProcessingError = aiProcessingError
+        self.audio = audio
+    }
+
+    private init(
+        id: UUID,
+        timestamp: Date,
+        rawText: String,
+        processedText: String,
+        appName: String,
+        windowTitle: String,
+        characterCount: Int,
+        wasAIProcessed: Bool,
+        aiProcessingError: String?,
+        audio: DictationAudioMetadata?
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.rawText = rawText
+        self.processedText = processedText
+        self.appName = appName
+        self.windowTitle = windowTitle
+        self.characterCount = characterCount
+        self.wasAIProcessed = wasAIProcessed
+        self.aiProcessingError = aiProcessingError
+        self.audio = audio
     }
 
     init(from decoder: Decoder) throws {
@@ -55,11 +82,12 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         self.characterCount = try container.decode(Int.self, forKey: .characterCount)
         self.wasAIProcessed = try container.decode(Bool.self, forKey: .wasAIProcessed)
         self.aiProcessingError = try container.decodeIfPresent(String.self, forKey: .aiProcessingError)
+        self.audio = try container.decodeIfPresent(DictationAudioMetadata.self, forKey: .audio)
     }
 
     private enum CodingKeys: String, CodingKey {
         case id, timestamp, rawText, processedText, appName, windowTitle
-        case characterCount, wasAIProcessed, aiProcessingError
+        case characterCount, wasAIProcessed, aiProcessingError, audio
     }
 
     /// Preview text for list display (first 80 chars)
@@ -84,6 +112,25 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: self.timestamp)
+    }
+
+    var hasAudioMetadata: Bool {
+        self.audio != nil
+    }
+
+    func replacingAudio(_ audio: DictationAudioMetadata?) -> TranscriptionHistoryEntry {
+        TranscriptionHistoryEntry(
+            id: self.id,
+            timestamp: self.timestamp,
+            rawText: self.rawText,
+            processedText: self.processedText,
+            appName: self.appName,
+            windowTitle: self.windowTitle,
+            characterCount: self.characterCount,
+            wasAIProcessed: self.wasAIProcessed,
+            aiProcessingError: self.aiProcessingError,
+            audio: audio
+        )
     }
 }
 
@@ -116,33 +163,45 @@ final class TranscriptionHistoryStore: ObservableObject {
 
     /// Add a new transcription entry
     func addEntry(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
         rawText: String,
         processedText: String,
         appName: String,
         windowTitle: String,
-        aiProcessingError: String? = nil
+        aiProcessingError: String? = nil,
+        audio: DictationAudioMetadata? = nil
     ) {
         // Skip empty transcriptions
         guard !processedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         let entry = TranscriptionHistoryEntry(
+            id: id,
+            timestamp: timestamp,
             rawText: rawText,
             processedText: processedText,
             appName: appName,
             windowTitle: windowTitle,
-            aiProcessingError: aiProcessingError
+            aiProcessingError: aiProcessingError,
+            audio: audio
         )
 
         // Insert at beginning (newest first)
         self.entries.insert(entry, at: 0)
 
         self.saveEntries()
+        if audio != nil {
+            self.pruneAudioToBudget()
+        }
 
         DebugLogger.shared.debug("Added transcription to history (total: \(self.entries.count))", source: "TranscriptionHistoryStore")
     }
 
     /// Delete a specific entry
     func deleteEntry(id: UUID) {
+        if let audio = self.entries.first(where: { $0.id == id })?.audio {
+            DictationAudioHistoryStore.shared.deleteAudio(fileName: audio.fileName)
+        }
         self.entries.removeAll { $0.id == id }
 
         // Clear selection if deleted
@@ -155,6 +214,11 @@ final class TranscriptionHistoryStore: ObservableObject {
 
     /// Delete multiple entries
     func deleteEntries(ids: Set<UUID>) {
+        for entry in self.entries where ids.contains(entry.id) {
+            if let audio = entry.audio {
+                DictationAudioHistoryStore.shared.deleteAudio(fileName: audio.fileName)
+            }
+        }
         self.entries.removeAll { ids.contains($0.id) }
 
         if let selected = selectedEntryID, ids.contains(selected) {
@@ -166,6 +230,7 @@ final class TranscriptionHistoryStore: ObservableObject {
 
     /// Clear all history
     func clearAllHistory() {
+        DictationAudioHistoryStore.shared.deleteAllAudioFiles()
         self.entries.removeAll()
         self.selectedEntryID = nil
         self.saveEntries()
@@ -211,6 +276,57 @@ final class TranscriptionHistoryStore: ObservableObject {
         self.entries = payload.sorted { $0.timestamp > $1.timestamp }
         self.selectedEntryID = self.entries.first?.id
         self.saveEntries()
+    }
+
+    func attachAudio(_ audio: DictationAudioMetadata, to entryID: UUID) {
+        guard let index = self.entries.firstIndex(where: { $0.id == entryID }) else {
+            DictationAudioHistoryStore.shared.deleteAudio(fileName: audio.fileName)
+            return
+        }
+        self.entries[index] = self.entries[index].replacingAudio(audio)
+        self.saveEntries()
+        self.pruneAudioToBudget()
+    }
+
+    @discardableResult
+    func deleteAllSavedAudio() -> Int {
+        let removedCount = self.entries.filter { $0.audio != nil }.count
+        DictationAudioHistoryStore.shared.deleteAllAudioFiles()
+        self.entries = self.entries.map { $0.replacingAudio(nil) }
+        self.saveEntries()
+        DebugLogger.shared.info("Deleted saved dictation audio (\(removedCount) entries)", source: "TranscriptionHistoryStore")
+        return removedCount
+    }
+
+    @discardableResult
+    func pruneAudioToBudget() -> Int {
+        let budgetBytes = SettingsStore.shared.audioHistoryBudgetBytes
+        guard budgetBytes > 0 else {
+            return self.deleteAllSavedAudio()
+        }
+
+        var currentBytes = DictationAudioHistoryStore.shared.audioUsageBytes()
+        guard currentBytes > budgetBytes else { return 0 }
+
+        var updatedEntries = self.entries
+        var prunedCount = 0
+        for index in updatedEntries.indices.reversed() {
+            guard let audio = updatedEntries[index].audio else { continue }
+            DictationAudioHistoryStore.shared.deleteAudio(fileName: audio.fileName)
+            currentBytes -= Int64(audio.byteCount)
+            updatedEntries[index] = updatedEntries[index].replacingAudio(nil)
+            prunedCount += 1
+            if currentBytes <= budgetBytes {
+                break
+            }
+        }
+
+        if prunedCount > 0 {
+            self.entries = updatedEntries
+            self.saveEntries()
+            DebugLogger.shared.info("Pruned saved dictation audio (\(prunedCount) entries)", source: "TranscriptionHistoryStore")
+        }
+        return prunedCount
     }
 
     // MARK: - Private Methods

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1203,6 +1203,8 @@ final class ASRService: ObservableObject {
             )
         }
 
+        let estimatedSamples = try LocalAPIAudioDecoder.validateDurationWithinLimit(for: fileURL)
+
         try await self.ensureAsrReady()
         let provider = self.transcriptionProvider
         guard provider.isReady else {
@@ -1213,7 +1215,6 @@ final class ASRService: ObservableObject {
             )
         }
 
-        let estimatedSamples = Self.estimatedMono16kSampleCount(for: fileURL)
         guard provider.prefersNativeFileTranscription else {
             let samples = try LocalAPIAudioDecoder.samples(from: fileURL)
             let result = try await self.transcribeSamplesForAPI(samples)
@@ -1232,16 +1233,6 @@ final class ASRService: ObservableObject {
         let cleanedText = ASRService.applyCustomDictionary(ASRService.removeFillerWords(result.text))
         self.recordWordBoostHitIfAny(transcribedText: cleanedText)
         return (ASRTranscriptionResult(text: cleanedText, confidence: result.confidence), estimatedSamples)
-    }
-
-    private static func estimatedMono16kSampleCount(for fileURL: URL) -> Int {
-        guard
-            let file = try? AVAudioFile(forReading: fileURL),
-            file.processingFormat.sampleRate > 0
-        else {
-            return 0
-        }
-        return Int((Double(file.length) * 16_000.0 / file.processingFormat.sampleRate).rounded())
     }
 
     func stopWithoutTranscription() async {

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -58,6 +58,7 @@ private actor ModelDownloadRegistry {
     }
 }
 
+// swiftlint:disable type_body_length
 /// A comprehensive speech recognition service that handles real-time audio transcription.
 ///
 /// This service manages the entire ASR (Automatic Speech Recognition) pipeline including:
@@ -504,6 +505,7 @@ final class ASRService: ObservableObject {
     // Thread-safe buffer to prevent "Array mutation while enumerating" and memory corruption crashes
     // during long sessions where reallocation occurs frequently.
     private let audioBuffer = ThreadSafeAudioBuffer()
+    private var lastCompletedAudioSnapshot: DictationAudioSnapshot?
 
     // Streaming transcription state (no VAD)
     private var streamingTask: Task<Void, Never>?
@@ -540,11 +542,20 @@ final class ASRService: ObservableObject {
     var audioLevelPublisher: AnyPublisher<CGFloat, Never> { self.audioLevelSubject.eraseToAnyPublisher() }
     private var lastAudioLevelSentAt: TimeInterval = 0
 
+    func consumeLastCompletedAudioSnapshot() -> DictationAudioSnapshot? {
+        let snapshot = self.lastCompletedAudioSnapshot
+        self.lastCompletedAudioSnapshot = nil
+        return snapshot
+    }
+
     private var streamingChunkDurationSeconds: Double {
-        if SettingsStore.shared.parakeetFinalizationMode == .tokenTimedChunkMerge {
+        let selectedModel = SettingsStore.shared.selectedSpeechModel
+        if selectedModel == .parakeetTDT || selectedModel == .parakeetTDTv2,
+           SettingsStore.shared.parakeetFinalizationMode == .tokenTimedChunkMerge
+        {
             return 0.4
         }
-        return SettingsStore.shared.selectedSpeechModel.streamingPreviewIntervalSeconds
+        return selectedModel.streamingPreviewIntervalSeconds
     }
 
     private var minimumStreamingPreviewSamples: Int {
@@ -921,6 +932,7 @@ final class ASRService: ObservableObject {
     /// Check debug logs for detailed error information.
     func stop() async -> String {
         DebugLogger.shared.info("🛑 STOP() called - beginning shutdown sequence", source: "ASRService")
+        self.lastCompletedAudioSnapshot = nil
         let stopStartedAt = Date().timeIntervalSince1970
         self.benchmarkLog("stop_start ageMs=\(self.elapsedMilliseconds(since: self.benchmarkRecordingStartedAt)) bufferedSamples=\(self.audioBuffer.count)")
 
@@ -990,6 +1002,7 @@ final class ASRService: ObservableObject {
         // Thread-safe copy of recorded audio
         var pcm = self.audioBuffer.getAll()
         self.audioBuffer.clear()
+        let capturedPCM = pcm
         self.benchmarkLog("stop_audio_drained samples=\(pcm.count) audioMs=\(Int((Double(pcm.count) / 16_000.0 * 1000).rounded()))")
 
         // Drop recordings with no audio at all — nothing to transcribe.
@@ -1096,6 +1109,16 @@ final class ASRService: ObservableObject {
             self.recordWordBoostHitIfAny(transcribedText: cleanedText)
             DebugLogger.shared.debug("After post-processing: '\(cleanedText)'", source: "ASRService")
             self.benchmarkLog("stop_end result=success totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) recordingAgeMs=\(self.elapsedMilliseconds(since: self.benchmarkRecordingStartedAt)) cleanedChars=\(cleanedText.count)")
+            if SettingsStore.shared.saveTranscriptionHistory,
+               SettingsStore.shared.saveAudioWithTranscriptionHistory,
+               !capturedPCM.isEmpty
+            {
+                self.lastCompletedAudioSnapshot = DictationAudioSnapshot(
+                    samples: capturedPCM,
+                    sampleRate: 16_000,
+                    channels: 1
+                )
+            }
 
             // Resume media playback if we paused it
             if shouldResumeMedia {
@@ -1135,6 +1158,90 @@ final class ASRService: ObservableObject {
             self.benchmarkLog("stop_end result=error totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) error=\(error.localizedDescription)")
             return ""
         }
+    }
+
+    func transcribeSamplesForAPI(_ inputSamples: [Float]) async throws -> ASRTranscriptionResult {
+        var samples = inputSamples
+        guard !samples.isEmpty else {
+            return ASRTranscriptionResult(text: "", confidence: 0)
+        }
+
+        let minSamples = 16_000
+        if samples.count < minSamples {
+            samples.append(contentsOf: repeatElement(0.0, count: minSamples - samples.count))
+        }
+
+        try await self.ensureAsrReady()
+        guard self.transcriptionProvider.isReady else {
+            throw NSError(
+                domain: "ASRService",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Transcription provider is not ready."]
+            )
+        }
+
+        let result = try await transcriptionExecutor.run { [provider = self.transcriptionProvider] in
+            try await provider.transcribeFinal(samples)
+        }
+
+        if !self.hasCompletedFirstTranscription {
+            self.hasCompletedFirstTranscription = true
+            self.isLoadingModel = false
+        }
+
+        let cleanedText = ASRService.applyCustomDictionary(ASRService.removeFillerWords(result.text))
+        self.recordWordBoostHitIfAny(transcribedText: cleanedText)
+        return ASRTranscriptionResult(text: cleanedText, confidence: result.confidence)
+    }
+
+    func transcribeFileForAPI(_ fileURL: URL) async throws -> (result: ASRTranscriptionResult, sampleCount: Int) {
+        guard FileManager.default.isReadableFile(atPath: fileURL.path) else {
+            throw NSError(
+                domain: "ASRService",
+                code: -3,
+                userInfo: [NSLocalizedDescriptionKey: "Audio file is not readable."]
+            )
+        }
+
+        try await self.ensureAsrReady()
+        let provider = self.transcriptionProvider
+        guard provider.isReady else {
+            throw NSError(
+                domain: "ASRService",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Transcription provider is not ready."]
+            )
+        }
+
+        let estimatedSamples = Self.estimatedMono16kSampleCount(for: fileURL)
+        guard provider.prefersNativeFileTranscription else {
+            let samples = try LocalAPIAudioDecoder.samples(from: fileURL)
+            let result = try await self.transcribeSamplesForAPI(samples)
+            return (result, samples.count)
+        }
+
+        let result = try await transcriptionExecutor.run { [provider] in
+            try await provider.transcribeFile(at: fileURL)
+        }
+
+        if !self.hasCompletedFirstTranscription {
+            self.hasCompletedFirstTranscription = true
+            self.isLoadingModel = false
+        }
+
+        let cleanedText = ASRService.applyCustomDictionary(ASRService.removeFillerWords(result.text))
+        self.recordWordBoostHitIfAny(transcribedText: cleanedText)
+        return (ASRTranscriptionResult(text: cleanedText, confidence: result.confidence), estimatedSamples)
+    }
+
+    private static func estimatedMono16kSampleCount(for fileURL: URL) -> Int {
+        guard
+            let file = try? AVAudioFile(forReading: fileURL),
+            file.processingFormat.sampleRate > 0
+        else {
+            return 0
+        }
+        return Int((Double(file.length) * 16_000.0 / file.processingFormat.sampleRate).rounded())
     }
 
     func stopWithoutTranscription() async {
@@ -2789,6 +2896,8 @@ final class ASRService: ObservableObject {
         return result
     }
 }
+
+// swiftlint:enable type_body_length
 
 private extension SettingsStore.SpeechModel {
     var nemotronProviderMode: NemotronProvider.Mode {

--- a/Sources/Fluid/Services/DictationAIPostProcessingGate.swift
+++ b/Sources/Fluid/Services/DictationAIPostProcessingGate.swift
@@ -13,6 +13,12 @@ enum DictationAIPostProcessingGate {
     static func isConfigured(for slot: SettingsStore.DictationShortcutSlot, appBundleID: String? = nil) -> Bool {
         let settings = SettingsStore.shared
         guard settings.dictationPromptSelection(for: slot) != .off else { return false }
+        if PrivateAIProviderPromptFormat.isAvailable(settings: settings) {
+            if PrivateAIIntegrationService.isLocalRuntimeConfigured {
+                return true
+            }
+            return self.isProviderConfigured()
+        }
         if let appBundleID,
            settings.promptRoutingScope(for: .dictate) == .selectedAppsOnly,
            !settings.hasAppPromptBinding(for: .dictate, appBundleID: appBundleID)

--- a/Sources/Fluid/Services/DictationAIPostProcessingGate.swift
+++ b/Sources/Fluid/Services/DictationAIPostProcessingGate.swift
@@ -14,10 +14,7 @@ enum DictationAIPostProcessingGate {
         let settings = SettingsStore.shared
         guard settings.dictationPromptSelection(for: slot) != .off else { return false }
         if PrivateAIProviderPromptFormat.isAvailable(settings: settings) {
-            if PrivateAIIntegrationService.isLocalRuntimeConfigured {
-                return true
-            }
-            return self.isProviderConfigured()
+            return self.isPrivateProviderConfigured(settings: settings)
         }
         if let appBundleID,
            settings.promptRoutingScope(for: .dictate) == .selectedAppsOnly,
@@ -74,6 +71,17 @@ enum DictationAIPostProcessingGate {
         let input = "\(trimmedBase)|\(trimmedKey)"
         let digest = SHA256.hash(data: Data(input.utf8))
         return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func isPrivateProviderConfigured(settings: SettingsStore) -> Bool {
+        guard PrivateAIIntegrationService.isLocalRuntimeConfigured else { return false }
+
+        let providerID = PrivateAIProviderFeature.shared.providerID
+        let key = self.providerKey(for: providerID)
+        let modelID = settings.selectedModelByProvider[key] ?? PrivateAIIntegrationService.configuredModelID
+        guard !modelID.isEmpty else { return false }
+
+        return settings.verifiedProviderFingerprints[key] == PrivateAIProviderFeature.verificationFingerprint(for: modelID)
     }
 
     static func isLocalEndpoint(_ urlString: String) -> Bool {

--- a/Sources/Fluid/Services/DictationPostProcessingService.swift
+++ b/Sources/Fluid/Services/DictationPostProcessingService.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+@MainActor
+final class DictationPostProcessingService {
+    static let shared = DictationPostProcessingService()
+
+    private init() {}
+
+    struct Result {
+        let text: String
+        let providerID: String
+        let model: String
+    }
+
+    private struct ResolvedProvider {
+        let providerID: String
+        let providerKey: String
+        let baseURL: String
+        let model: String
+        let apiKey: String
+    }
+
+    func process(_ inputText: String, dictationSlot: SettingsStore.DictationShortcutSlot = .primary) async throws -> Result {
+        let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return Result(text: "", providerID: SettingsStore.shared.selectedProviderID, model: "")
+        }
+
+        let settings = SettingsStore.shared
+        let resolved = self.resolveProvider(settings: settings)
+        DebugLogger.shared.debug(
+            "DictationPostProcessingService using provider=\(resolved.providerKey), model=\(resolved.model)",
+            source: "DictationPostProcessingService"
+        )
+
+        let isPrivateAIProvider = resolved.providerID == PrivateAIProviderFeature.shared.providerID ||
+            resolved.providerKey == PrivateAIProviderFeature.shared.providerID ||
+            resolved.providerKey == "custom:\(PrivateAIProviderFeature.shared.providerID)"
+
+        if isPrivateAIProvider || PrivateAIIntegrationService.shouldHandleDictation(model: resolved.model) {
+            let response = try await PrivateAIIntegrationService.shared.enhanceDictation(
+                trimmed,
+                runtime: PrivateAIIntegrationService.RuntimeConfiguration(
+                    selectedProviderID: resolved.providerID,
+                    providerKey: resolved.providerKey,
+                    baseURL: resolved.baseURL,
+                    model: resolved.model,
+                    apiKey: resolved.apiKey,
+                    localModelPath: PrivateAIIntegrationService.configuredLocalModelPath,
+                    usesStablePromptPrefixKVCache: settings.privateAIPrefixKVCacheEnabled
+                ),
+                context: PrivateAIIntegrationService.AppContext(
+                    appName: "",
+                    bundleID: "",
+                    windowTitle: "",
+                    appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+                )
+            )
+            return Result(
+                text: ASRService.applyGAAVFormatting(response.outputText),
+                providerID: resolved.providerID,
+                model: resolved.model
+            )
+        }
+
+        let promptText = settings.effectiveDictationSystemPrompt(for: dictationSlot, appBundleID: nil)
+        let systemPrompt = ""
+        let userMessageContent = SettingsStore.renderDictationUserMessage(
+            promptText: promptText,
+            transcript: trimmed
+        )
+
+        if resolved.providerID == "apple-intelligence" {
+            #if canImport(FoundationModels)
+            if #available(macOS 26.0, *) {
+                let provider = AppleIntelligenceProvider()
+                let output = try await provider.process(systemPrompt: systemPrompt, userText: userMessageContent)
+                guard !output.isEmpty else { throw AIProcessingError.emptyResponse }
+                return Result(text: ASRService.applyGAAVFormatting(output), providerID: resolved.providerID, model: resolved.model)
+            }
+            #endif
+            return Result(text: trimmed, providerID: resolved.providerID, model: resolved.model)
+        }
+
+        let isLocal = ModelRepository.shared.isLocalEndpoint(resolved.baseURL)
+        if !isLocal, resolved.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw AIProcessingError.missingAPIKey(provider: resolved.providerKey)
+        }
+
+        var extraParams: [String: Any] = [:]
+        if let config = settings.getReasoningConfig(forModel: resolved.model, provider: resolved.providerKey), config.isEnabled {
+            extraParams[config.parameterName] = config.parameterName == "enable_thinking"
+                ? (config.parameterValue == "true")
+                : config.parameterValue
+        }
+
+        var messages: [[String: Any]] = []
+        if !systemPrompt.isEmpty {
+            messages.append(["role": "system", "content": systemPrompt])
+        }
+        messages.append(["role": "user", "content": userMessageContent])
+
+        var config = LLMClient.Config(
+            messages: messages,
+            model: resolved.model,
+            baseURL: resolved.baseURL,
+            apiKey: resolved.apiKey,
+            streaming: false,
+            tools: [],
+            temperature: settings.isTemperatureUnsupported(resolved.model) ? nil : 0.2,
+            extraParameters: extraParams
+        )
+        config.timeoutSeconds = 120
+
+        let response = try await LLMClient.shared.call(config)
+        guard !response.content.isEmpty else {
+            throw AIProcessingError.emptyResponse
+        }
+        return Result(
+            text: ASRService.applyGAAVFormatting(response.content),
+            providerID: resolved.providerID,
+            model: resolved.model
+        )
+    }
+
+    private func resolveProvider(settings: SettingsStore) -> ResolvedProvider {
+        let providerID = settings.selectedProviderID
+        let selectedModels = settings.selectedModelByProvider
+        let providerKeys = settings.providerAPIKeys
+
+        if let saved = settings.savedProviders.first(where: { $0.id == providerID }) {
+            let key = "custom:\(saved.id)"
+            return ResolvedProvider(
+                providerID: providerID,
+                providerKey: key,
+                baseURL: saved.baseURL,
+                model: selectedModels[key] ?? saved.models.first ?? "",
+                apiKey: providerKeys[key] ?? providerKeys[providerID] ?? ""
+            )
+        }
+
+        if ModelRepository.shared.isBuiltIn(providerID) {
+            return ResolvedProvider(
+                providerID: providerID,
+                providerKey: providerID,
+                baseURL: ModelRepository.shared.defaultBaseURL(for: providerID),
+                model: selectedModels[providerID] ?? ModelRepository.shared.defaultModels(for: providerID).first ?? "",
+                apiKey: providerKeys[providerID] ?? ""
+            )
+        }
+
+        return ResolvedProvider(
+            providerID: providerID,
+            providerKey: providerID,
+            baseURL: "",
+            model: selectedModels[providerID] ?? "",
+            apiKey: providerKeys[providerID] ?? ""
+        )
+    }
+}

--- a/Sources/Fluid/Services/FluidAudioProvider.swift
+++ b/Sources/Fluid/Services/FluidAudioProvider.swift
@@ -42,7 +42,6 @@ final class FluidAudioProvider: TranscriptionProvider {
     /// Used for downloading specific models without changing the active selection.
     var modelOverride: SettingsStore.SpeechModel?
     private let configureWordBoosting: Bool
-
     init(modelOverride: SettingsStore.SpeechModel? = nil, configureWordBoosting: Bool = true) {
         self.modelOverride = modelOverride
         self.configureWordBoosting = configureWordBoosting

--- a/Sources/Fluid/Services/LocalAPI/DictionaryAPIController.swift
+++ b/Sources/Fluid/Services/LocalAPI/DictionaryAPIController.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+struct DictionaryAPIController: LocalAPIRouteHandler {
+    struct ReplacementEntry: Codable {
+        let id: UUID?
+        let triggers: [String]
+        let replacement: String
+    }
+
+    struct ReplacementListResponse: Encodable {
+        let count: Int
+        let items: [ReplacementEntry]
+    }
+
+    struct ReplacementWriteRequest: Decodable {
+        let mode: WriteMode
+        let entries: [ReplacementEntry]
+        let hasEntries: Bool
+        let singleEntry: ReplacementEntry?
+
+        enum CodingKeys: String, CodingKey {
+            case mode
+            case entries
+            case triggers
+            case replacement
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.mode = try container.decodeIfPresent(WriteMode.self, forKey: .mode) ?? .append
+            self.entries = try container.decodeIfPresent([ReplacementEntry].self, forKey: .entries) ?? []
+            self.hasEntries = container.contains(.entries)
+
+            let triggers = try container.decodeIfPresent([String].self, forKey: .triggers) ?? []
+            let replacement = try container.decodeIfPresent(String.self, forKey: .replacement)
+            if let replacement, !triggers.isEmpty {
+                self.singleEntry = ReplacementEntry(id: nil, triggers: triggers, replacement: replacement)
+            } else {
+                self.singleEntry = nil
+            }
+        }
+    }
+
+    struct CustomWordEntry: Codable {
+        let text: String
+        let weight: Float?
+        let aliases: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case text
+            case weight
+            case aliases
+        }
+
+        init(text: String, weight: Float?, aliases: [String] = []) {
+            self.text = text
+            self.weight = weight
+            self.aliases = aliases
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.text = try container.decode(String.self, forKey: .text)
+            self.weight = try container.decodeIfPresent(Float.self, forKey: .weight)
+            self.aliases = try container.decodeIfPresent([String].self, forKey: .aliases) ?? []
+        }
+    }
+
+    struct CustomWordsResponse: Encodable {
+        let count: Int
+        let items: [CustomWordEntry]
+    }
+
+    struct CustomWordsWriteRequest: Decodable {
+        let mode: WriteMode
+        let entries: [CustomWordEntry]
+        let hasEntries: Bool
+        let singleEntry: CustomWordEntry?
+
+        enum CodingKeys: String, CodingKey {
+            case mode
+            case entries
+            case text
+            case weight
+            case aliases
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.mode = try container.decodeIfPresent(WriteMode.self, forKey: .mode) ?? .append
+            self.entries = try container.decodeIfPresent([CustomWordEntry].self, forKey: .entries) ?? []
+            self.hasEntries = container.contains(.entries)
+
+            if let text = try container.decodeIfPresent(String.self, forKey: .text) {
+                let weight = try container.decodeIfPresent(Float.self, forKey: .weight)
+                let aliases = try container.decodeIfPresent([String].self, forKey: .aliases) ?? []
+                self.singleEntry = CustomWordEntry(text: text, weight: weight, aliases: aliases)
+            } else {
+                self.singleEntry = nil
+            }
+        }
+    }
+
+    enum WriteMode: String, Decodable {
+        case append
+        case replace
+    }
+
+    func handle(_ request: LocalAPI.Request) async -> LocalAPI.Response {
+        switch (request.method, request.path) {
+        case ("GET", "/v1/dictionary/replacements"):
+            return self.getReplacements()
+        case ("POST", "/v1/dictionary/replacements"):
+            return self.writeReplacements(request)
+        case ("GET", "/v1/dictionary/custom-words"):
+            return self.getCustomWords()
+        case ("POST", "/v1/dictionary/custom-words"):
+            return self.writeCustomWords(request)
+        default:
+            return LocalAPI.error("Route not found.", status: 404)
+        }
+    }
+
+    private func getReplacements() -> LocalAPI.Response {
+        let entries = SettingsStore.shared.customDictionaryEntries.map(Self.apiEntry(from:))
+        return LocalAPI.json(ReplacementListResponse(count: entries.count, items: entries))
+    }
+
+    private func writeReplacements(_ request: LocalAPI.Request) -> LocalAPI.Response {
+        do {
+            let payload = try LocalAPI.decoder.decode(ReplacementWriteRequest.self, from: request.body)
+            let incoming = try self.replacementEntries(from: payload)
+
+            var stored = payload.mode == .replace ? [] : SettingsStore.shared.customDictionaryEntries
+            for entry in incoming {
+                let normalized = Self.storeEntry(from: entry)
+                guard !normalized.triggers.isEmpty,
+                      !normalized.replacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                else {
+                    continue
+                }
+
+                stored.removeAll { existing in
+                    if let id = entry.id, existing.id == id { return true }
+                    return existing.replacement.caseInsensitiveCompare(normalized.replacement) == .orderedSame
+                }
+                stored.append(normalized)
+            }
+
+            SettingsStore.shared.customDictionaryEntries = stored
+            ASRService.invalidateDictionaryCache()
+            NotificationCenter.default.post(name: .parakeetVocabularyDidChange, object: nil)
+            return self.getReplacements()
+        } catch {
+            return LocalAPI.error("Invalid replacement payload: \(error.localizedDescription)", status: 400)
+        }
+    }
+
+    private func getCustomWords() -> LocalAPI.Response {
+        do {
+            let entries = try ParakeetVocabularyStore.shared.loadUserBoostTerms().map(Self.apiEntry(from:))
+            return LocalAPI.json(CustomWordsResponse(count: entries.count, items: entries))
+        } catch {
+            return LocalAPI.error("Failed to load custom words: \(error.localizedDescription)", status: 500)
+        }
+    }
+
+    private func writeCustomWords(_ request: LocalAPI.Request) -> LocalAPI.Response {
+        do {
+            let payload = try LocalAPI.decoder.decode(CustomWordsWriteRequest.self, from: request.body)
+            let incoming = try self.customWordEntries(from: payload)
+
+            var stored = payload.mode == .replace ? [] : try ParakeetVocabularyStore.shared.loadUserBoostTerms()
+            for entry in incoming {
+                let normalized = Self.storeEntry(from: entry)
+                guard !normalized.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+                stored.removeAll { $0.text.caseInsensitiveCompare(normalized.text) == .orderedSame }
+                stored.append(normalized)
+            }
+
+            try ParakeetVocabularyStore.shared.saveUserBoostTerms(stored)
+            NotificationCenter.default.post(name: .parakeetVocabularyDidChange, object: nil)
+            return self.getCustomWords()
+        } catch {
+            return LocalAPI.error("Invalid custom words payload: \(error.localizedDescription)", status: 400)
+        }
+    }
+
+    private func replacementEntries(from payload: ReplacementWriteRequest) throws -> [ReplacementEntry] {
+        if payload.hasEntries {
+            return payload.entries
+        }
+        if let singleEntry = payload.singleEntry {
+            return [singleEntry]
+        }
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [], debugDescription: "Expected entries or triggers/replacement.")
+        )
+    }
+
+    private func customWordEntries(from payload: CustomWordsWriteRequest) throws -> [CustomWordEntry] {
+        if payload.hasEntries {
+            return payload.entries
+        }
+        if let singleEntry = payload.singleEntry {
+            return [singleEntry]
+        }
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [], debugDescription: "Expected entries or text.")
+        )
+    }
+
+    private static func apiEntry(from entry: SettingsStore.CustomDictionaryEntry) -> ReplacementEntry {
+        ReplacementEntry(id: entry.id, triggers: entry.triggers, replacement: entry.replacement)
+    }
+
+    private static func storeEntry(from entry: ReplacementEntry) -> SettingsStore.CustomDictionaryEntry {
+        if let id = entry.id {
+            return SettingsStore.CustomDictionaryEntry(id: id, triggers: entry.triggers, replacement: entry.replacement)
+        }
+        return SettingsStore.CustomDictionaryEntry(triggers: entry.triggers, replacement: entry.replacement)
+    }
+
+    private static func apiEntry(from term: ParakeetVocabularyStore.VocabularyConfig.Term) -> CustomWordEntry {
+        CustomWordEntry(text: term.text, weight: term.weight, aliases: term.aliases)
+    }
+
+    private static func storeEntry(from entry: CustomWordEntry) -> ParakeetVocabularyStore.VocabularyConfig.Term {
+        ParakeetVocabularyStore.VocabularyConfig.Term(
+            text: entry.text,
+            weight: entry.weight,
+            aliases: entry.aliases
+        )
+    }
+}

--- a/Sources/Fluid/Services/LocalAPI/HistoryAPIController.swift
+++ b/Sources/Fluid/Services/LocalAPI/HistoryAPIController.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct HistoryAPIController: LocalAPIRouteHandler {
+    struct HistoryResponse: Encodable {
+        let count: Int
+        let items: [HistoryItem]
+    }
+
+    struct HistoryItem: Encodable {
+        let id: UUID
+        let timestamp: Date
+        let originalText: String
+        let finalText: String
+        let rawText: String
+        let processedText: String
+        let appName: String
+        let windowTitle: String
+        let characterCount: Int
+        let wasAIProcessed: Bool
+        let aiProcessingError: String?
+    }
+
+    func handle(_ request: LocalAPI.Request) async -> LocalAPI.Response {
+        guard request.method == "GET" else {
+            return LocalAPI.error("Method not allowed.", status: 405)
+        }
+
+        let limit = LocalAPI.boundedLimit(from: request)
+        let items = TranscriptionHistoryStore.shared.entries
+            .prefix(limit)
+            .map { entry in
+                HistoryItem(
+                    id: entry.id,
+                    timestamp: entry.timestamp,
+                    originalText: entry.rawText,
+                    finalText: entry.processedText,
+                    rawText: entry.rawText,
+                    processedText: entry.processedText,
+                    appName: entry.appName,
+                    windowTitle: entry.windowTitle,
+                    characterCount: entry.characterCount,
+                    wasAIProcessed: entry.wasAIProcessed,
+                    aiProcessingError: entry.aiProcessingError
+                )
+            }
+
+        return LocalAPI.json(HistoryResponse(count: items.count, items: Array(items)))
+    }
+}

--- a/Sources/Fluid/Services/LocalAPI/InferenceAPIController.swift
+++ b/Sources/Fluid/Services/LocalAPI/InferenceAPIController.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+@MainActor
+final class InferenceAPIController: LocalAPIRouteHandler {
+    struct TranscribeJSONRequest: Decodable {
+        let path: String?
+        let audioBase64: String?
+        let filename: String?
+    }
+
+    struct TextRequest: Decodable {
+        let text: String
+    }
+
+    struct TranscribeResponse: Encodable {
+        let text: String
+        let confidence: Float
+        let sampleCount: Int
+        let provider: String
+    }
+
+    struct PostprocessResponse: Encodable {
+        let text: String
+        let provider: String
+        let model: String
+    }
+
+    func handle(_ request: LocalAPI.Request) async -> LocalAPI.Response {
+        guard request.method == "POST" else {
+            return LocalAPI.error("Method not allowed.", status: 405)
+        }
+
+        switch request.path {
+        case "/v1/transcribe":
+            return await self.transcribe(request)
+        case "/v1/postprocess":
+            return await self.postprocess(request)
+        default:
+            return LocalAPI.error("Route not found.", status: 404)
+        }
+    }
+
+    private func transcribe(_ request: LocalAPI.Request) async -> LocalAPI.Response {
+        do {
+            if let fileURL = try self.decodeFilePath(from: request) {
+                let apiResult = try await AppServices.shared.asr.transcribeFileForAPI(fileURL)
+                return LocalAPI.json(
+                    TranscribeResponse(
+                        text: apiResult.result.text,
+                        confidence: apiResult.result.confidence,
+                        sampleCount: apiResult.sampleCount,
+                        provider: SettingsStore.shared.selectedSpeechModel.displayName
+                    )
+                )
+            }
+
+            let samples = try self.decodeAudioSamples(from: request)
+            let result = try await AppServices.shared.asr.transcribeSamplesForAPI(samples)
+            return LocalAPI.json(
+                TranscribeResponse(
+                    text: result.text,
+                    confidence: result.confidence,
+                    sampleCount: samples.count,
+                    provider: SettingsStore.shared.selectedSpeechModel.displayName
+                )
+            )
+        } catch {
+            return LocalAPI.error(error.localizedDescription, status: 400)
+        }
+    }
+
+    private func decodeFilePath(from request: LocalAPI.Request) throws -> URL? {
+        guard self.isJSON(request) else { return nil }
+        let payload: TranscribeJSONRequest
+        do {
+            payload = try LocalAPI.decoder.decode(TranscribeJSONRequest.self, from: request.body)
+        } catch {
+            throw NSError(domain: "InferenceAPIController", code: -3, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON audio payload."])
+        }
+
+        guard let path = payload.path, !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path)
+    }
+
+    private func postprocess(_ request: LocalAPI.Request) async -> LocalAPI.Response {
+        do {
+            let text = try self.decodeText(from: request)
+            let result = try await DictationPostProcessingService.shared.process(text)
+            return LocalAPI.json(
+                PostprocessResponse(
+                    text: result.text,
+                    provider: result.providerID,
+                    model: result.model
+                )
+            )
+        } catch {
+            return LocalAPI.error(error.localizedDescription, status: 400)
+        }
+    }
+
+    private func decodeAudioSamples(from request: LocalAPI.Request) throws -> [Float] {
+        if self.isJSON(request) {
+            let payload: TranscribeJSONRequest
+            do {
+                payload = try LocalAPI.decoder.decode(TranscribeJSONRequest.self, from: request.body)
+            } catch {
+                throw NSError(domain: "InferenceAPIController", code: -3, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON audio payload."])
+            }
+
+            if let path = payload.path, !path.isEmpty {
+                return try LocalAPIAudioDecoder.samples(from: URL(fileURLWithPath: path))
+            }
+
+            if let audioBase64 = payload.audioBase64,
+               let data = Data(base64Encoded: audioBase64)
+            {
+                return try LocalAPIAudioDecoder.samples(
+                    fromAudioData: data,
+                    suggestedExtension: payload.filename.flatMap { URL(fileURLWithPath: $0).pathExtension } ?? "wav"
+                )
+            }
+
+            throw NSError(domain: "InferenceAPIController", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing audio path or audioBase64."])
+        }
+
+        guard !request.body.isEmpty else {
+            throw NSError(domain: "InferenceAPIController", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing audio body."])
+        }
+
+        let filename = request.headers["x-filename"] ?? "audio.wav"
+        return try LocalAPIAudioDecoder.samples(
+            fromAudioData: request.body,
+            suggestedExtension: URL(fileURLWithPath: filename).pathExtension
+        )
+    }
+
+    private func decodeText(from request: LocalAPI.Request) throws -> String {
+        if self.isJSON(request) {
+            let payload: TextRequest
+            do {
+                payload = try LocalAPI.decoder.decode(TextRequest.self, from: request.body)
+            } catch {
+                throw NSError(domain: "InferenceAPIController", code: -4, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON text payload."])
+            }
+            return payload.text
+        }
+
+        guard let text = String(data: request.body, encoding: .utf8) else {
+            throw NSError(domain: "InferenceAPIController", code: -2, userInfo: [NSLocalizedDescriptionKey: "Text body must be UTF-8."])
+        }
+        return text
+    }
+
+    private func isJSON(_ request: LocalAPI.Request) -> Bool {
+        request.headers["content-type"]?.lowercased().contains("application/json") == true
+    }
+}

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIAudioDecoder.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIAudioDecoder.swift
@@ -3,7 +3,7 @@ import Foundation
 
 enum LocalAPIAudioDecoder {
     static let sampleRate: Double = 16_000
-    private static let maxDurationSeconds: Double = 300
+    static let maxDurationSeconds: Double = 300
 
     static func samples(from fileURL: URL) throws -> [Float] {
         let file = try AVAudioFile(forReading: fileURL)
@@ -33,6 +33,25 @@ enum LocalAPIAudioDecoder {
         try data.write(to: url, options: .atomic)
         defer { try? FileManager.default.removeItem(at: url) }
         return try self.samples(from: url)
+    }
+
+    static func validateDurationWithinLimit(for fileURL: URL) throws -> Int {
+        let file = try AVAudioFile(forReading: fileURL)
+        let sourceFormat = file.processingFormat
+        guard sourceFormat.sampleRate > 0 else {
+            throw NSError(domain: "LocalAPIAudioDecoder", code: -6, userInfo: [NSLocalizedDescriptionKey: "Audio file has an invalid sample rate."])
+        }
+
+        let maxFrames = AVAudioFramePosition(sourceFormat.sampleRate * self.maxDurationSeconds)
+        guard file.length <= maxFrames else {
+            throw NSError(
+                domain: "LocalAPIAudioDecoder",
+                code: -5,
+                userInfo: [NSLocalizedDescriptionKey: "Audio file exceeds the \(Int(self.maxDurationSeconds)) second API limit."]
+            )
+        }
+
+        return Int((Double(file.length) * self.sampleRate / sourceFormat.sampleRate).rounded())
     }
 
     private static func convertToMono16k(_ sourceBuffer: AVAudioPCMBuffer) throws -> [Float] {

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIAudioDecoder.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIAudioDecoder.swift
@@ -1,0 +1,82 @@
+import AVFoundation
+import Foundation
+
+enum LocalAPIAudioDecoder {
+    static let sampleRate: Double = 16_000
+    private static let maxDurationSeconds: Double = 300
+
+    static func samples(from fileURL: URL) throws -> [Float] {
+        let file = try AVAudioFile(forReading: fileURL)
+        let sourceFormat = file.processingFormat
+        let maxFrames = AVAudioFramePosition(sourceFormat.sampleRate * self.maxDurationSeconds)
+        let framesToRead = min(file.length, maxFrames)
+        guard framesToRead > 0 else { return [] }
+
+        guard let sourceBuffer = AVAudioPCMBuffer(
+            pcmFormat: sourceFormat,
+            frameCapacity: AVAudioFrameCount(framesToRead)
+        ) else {
+            throw NSError(domain: "LocalAPIAudioDecoder", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unable to allocate audio buffer."])
+        }
+
+        try file.read(into: sourceBuffer, frameCount: AVAudioFrameCount(framesToRead))
+        return try self.convertToMono16k(sourceBuffer)
+    }
+
+    static func samples(fromAudioData data: Data, suggestedExtension: String) throws -> [Float] {
+        let ext = suggestedExtension.trimmingCharacters(in: CharacterSet(charactersIn: ". \n\t")).isEmpty
+            ? "wav"
+            : suggestedExtension.trimmingCharacters(in: CharacterSet(charactersIn: ". \n\t"))
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fluidvoice-api-\(UUID().uuidString)")
+            .appendingPathExtension(ext)
+        try data.write(to: url, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: url) }
+        return try self.samples(from: url)
+    }
+
+    private static func convertToMono16k(_ sourceBuffer: AVAudioPCMBuffer) throws -> [Float] {
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: self.sampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw NSError(domain: "LocalAPIAudioDecoder", code: -4, userInfo: [NSLocalizedDescriptionKey: "Unable to create target audio format."])
+        }
+
+        guard sourceBuffer.format != targetFormat else {
+            guard let channel = sourceBuffer.floatChannelData?[0] else { return [] }
+            return Array(UnsafeBufferPointer(start: channel, count: Int(sourceBuffer.frameLength)))
+        }
+
+        guard let converter = AVAudioConverter(from: sourceBuffer.format, to: targetFormat) else {
+            throw NSError(domain: "LocalAPIAudioDecoder", code: -2, userInfo: [NSLocalizedDescriptionKey: "Unable to convert audio to 16 kHz mono."])
+        }
+
+        let ratio = self.sampleRate / sourceBuffer.format.sampleRate
+        let capacity = AVAudioFrameCount((Double(sourceBuffer.frameLength) * ratio).rounded(.up)) + 1024
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else {
+            throw NSError(domain: "LocalAPIAudioDecoder", code: -3, userInfo: [NSLocalizedDescriptionKey: "Unable to allocate converted audio buffer."])
+        }
+
+        var consumedInput = false
+        var conversionError: NSError?
+        converter.convert(to: outputBuffer, error: &conversionError) { _, status in
+            if consumedInput {
+                status.pointee = .noDataNow
+                return nil
+            }
+            consumedInput = true
+            status.pointee = .haveData
+            return sourceBuffer
+        }
+
+        if let conversionError {
+            throw conversionError
+        }
+
+        guard let channel = outputBuffer.floatChannelData?[0] else { return [] }
+        return Array(UnsafeBufferPointer(start: channel, count: Int(outputBuffer.frameLength)))
+    }
+}

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIModels.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIModels.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+enum LocalAPI {
+    static let defaultPort: UInt16 = 47_733
+    static let maxRequestBytes = 25 * 1024 * 1024
+
+    struct Configuration {
+        let enabled: Bool
+        let port: UInt16
+
+        static var current: Configuration {
+            let defaults = UserDefaults.standard
+            let enabled: Bool
+            if defaults.object(forKey: "LocalAPIEnabled") == nil {
+                enabled = true
+            } else {
+                enabled = defaults.bool(forKey: "LocalAPIEnabled")
+            }
+
+            let rawPort = defaults.integer(forKey: "LocalAPIPort")
+            let port = rawPort > 0 && rawPort <= Int(UInt16.max) ? UInt16(rawPort) : LocalAPI.defaultPort
+            return Configuration(enabled: enabled, port: port)
+        }
+    }
+
+    struct Request {
+        let method: String
+        let path: String
+        let query: [String: String]
+        let headers: [String: String]
+        let body: Data
+    }
+
+    struct Response {
+        let status: Int
+        let headers: [String: String]
+        let body: Data
+
+        init(status: Int, headers: [String: String] = [:], body: Data = Data()) {
+            self.status = status
+            self.headers = headers
+            self.body = body
+        }
+    }
+
+    struct ErrorBody: Encodable {
+        let error: String
+    }
+
+    static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    static func json<T: Encodable>(_ value: T, status: Int = 200) -> Response {
+        do {
+            let body = try Self.encoder.encode(value)
+            return Response(
+                status: status,
+                headers: ["Content-Type": "application/json; charset=utf-8"],
+                body: body
+            )
+        } catch {
+            return Self.error("Failed to encode response.", status: 500)
+        }
+    }
+
+    static func empty(status: Int = 204) -> Response {
+        Response(status: status)
+    }
+
+    static func error(_ message: String, status: Int) -> Response {
+        let body = (try? Self.encoder.encode(ErrorBody(error: message))) ?? Data()
+        return Response(
+            status: status,
+            headers: ["Content-Type": "application/json; charset=utf-8"],
+            body: body
+        )
+    }
+
+    static func boundedLimit(from request: Request, default defaultValue: Int = 100, maximum: Int = 1000) -> Int {
+        guard let raw = request.query["limit"], let value = Int(raw) else {
+            return defaultValue
+        }
+        return max(1, min(value, maximum))
+    }
+}
+
+@MainActor
+protocol LocalAPIRouteHandler {
+    func handle(_ request: LocalAPI.Request) async -> LocalAPI.Response
+}

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIModels.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIModels.swift
@@ -12,7 +12,7 @@ enum LocalAPI {
             let defaults = UserDefaults.standard
             let enabled: Bool
             if defaults.object(forKey: "LocalAPIEnabled") == nil {
-                enabled = true
+                enabled = false
             } else {
                 enabled = defaults.bool(forKey: "LocalAPIEnabled")
             }

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIRouter.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIRouter.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+final class LocalAPIRouter {
+    private struct RouteKey: Hashable {
+        let method: String
+        let path: String
+    }
+
+    private var routes: [RouteKey: LocalAPIRouteHandler] = [:]
+
+    init() {
+        self.register(method: "GET", path: "/v1/health", handler: HealthController())
+
+        let history = HistoryAPIController()
+        self.register(method: "GET", path: "/v1/history", handler: history)
+
+        let dictionary = DictionaryAPIController()
+        self.register(method: "GET", path: "/v1/dictionary/replacements", handler: dictionary)
+        self.register(method: "POST", path: "/v1/dictionary/replacements", handler: dictionary)
+        self.register(method: "GET", path: "/v1/dictionary/custom-words", handler: dictionary)
+        self.register(method: "POST", path: "/v1/dictionary/custom-words", handler: dictionary)
+
+        let inference = InferenceAPIController()
+        self.register(method: "POST", path: "/v1/transcribe", handler: inference)
+        self.register(method: "POST", path: "/v1/postprocess", handler: inference)
+    }
+
+    func register(method: String, path: String, handler: LocalAPIRouteHandler) {
+        let key = RouteKey(method: method.uppercased(), path: path)
+        self.routes[key] = handler
+    }
+
+    func route(_ request: LocalAPI.Request) async -> LocalAPI.Response {
+        let key = RouteKey(method: request.method.uppercased(), path: request.path)
+        guard let handler = self.routes[key] else {
+            if self.routes.keys.contains(where: { $0.path == request.path }) {
+                return LocalAPI.error("Method not allowed.", status: 405)
+            }
+            return LocalAPI.error("Route not found.", status: 404)
+        }
+        return await handler.handle(request)
+    }
+}
+
+private struct HealthController: LocalAPIRouteHandler {
+    struct Body: Encodable {
+        let status: String
+        let version: String
+    }
+
+    func handle(_ request: LocalAPI.Request) async -> LocalAPI.Response {
+        guard request.method == "GET" else {
+            return LocalAPI.error("Method not allowed.", status: 405)
+        }
+
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        return LocalAPI.json(Body(status: "ok", version: version))
+    }
+}

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIServer.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIServer.swift
@@ -1,0 +1,261 @@
+import Foundation
+import Network
+
+@MainActor
+final class LocalAPIServer {
+    static let shared = LocalAPIServer()
+
+    private let router = LocalAPIRouter()
+    private let queue = DispatchQueue(label: "fluidvoice.local-api", qos: .utility)
+    private var listener: NWListener?
+    private var activeConnections: [ObjectIdentifier: LocalAPIConnectionHandler] = [:]
+    private(set) var port: UInt16 = LocalAPI.defaultPort
+
+    private init() {}
+
+    func start() {
+        let config = LocalAPI.Configuration.current
+        guard config.enabled else {
+            DebugLogger.shared.info("Local API disabled", source: "LocalAPIServer")
+            return
+        }
+
+        if self.listener != nil {
+            return
+        }
+
+        do {
+            guard let port = NWEndpoint.Port(rawValue: config.port) else {
+                DebugLogger.shared.error("Local API invalid port", source: "LocalAPIServer")
+                return
+            }
+
+            let parameters = NWParameters.tcp
+
+            let listener = try NWListener(using: parameters, on: port)
+            listener.newConnectionHandler = { [weak self] connection in
+                guard Self.isLoopback(connection.endpoint) else {
+                    connection.cancel()
+                    return
+                }
+
+                Task { @MainActor [weak self] in
+                    guard let self else {
+                        connection.cancel()
+                        return
+                    }
+
+                    let handler = LocalAPIConnectionHandler(connection: connection, router: self.router)
+                    let id = ObjectIdentifier(handler)
+                    handler.onClose = { [weak self] in
+                        Task { @MainActor in
+                            self?.activeConnections[id] = nil
+                        }
+                    }
+                    self.activeConnections[id] = handler
+                    handler.start(on: self.queue)
+                }
+            }
+            listener.stateUpdateHandler = { state in
+                Task { @MainActor in
+                    self.handleState(state)
+                }
+            }
+
+            self.port = config.port
+            self.listener = listener
+            listener.start(queue: self.queue)
+        } catch {
+            DebugLogger.shared.error("Local API failed to start: \(error.localizedDescription)", source: "LocalAPIServer")
+        }
+    }
+
+    func stop() {
+        for handler in self.activeConnections.values {
+            handler.cancel()
+        }
+        self.activeConnections.removeAll()
+        self.listener?.cancel()
+        self.listener = nil
+    }
+
+    private func handleState(_ state: NWListener.State) {
+        switch state {
+        case .ready:
+            DebugLogger.shared.info("Local API listening on http://127.0.0.1:\(self.port)", source: "LocalAPIServer")
+        case let .failed(error):
+            DebugLogger.shared.error("Local API listener failed: \(error.localizedDescription)", source: "LocalAPIServer")
+            self.listener?.cancel()
+            self.listener = nil
+        case .cancelled:
+            self.listener = nil
+        default:
+            break
+        }
+    }
+
+    private nonisolated static func isLoopback(_ endpoint: NWEndpoint) -> Bool {
+        guard case let .hostPort(host, _) = endpoint else { return false }
+
+        switch host {
+        case let .name(name, _):
+            return name.caseInsensitiveCompare("localhost") == .orderedSame
+        case let .ipv4(address):
+            return "\(address)" == "127.0.0.1"
+        case let .ipv6(address):
+            return "\(address)" == "::1"
+        @unknown default:
+            return false
+        }
+    }
+}
+
+@MainActor
+private final class LocalAPIConnectionHandler {
+    private let connection: NWConnection
+    private let router: LocalAPIRouter
+    private var buffer = Data()
+    private var isClosed = false
+    var onClose: (() -> Void)?
+
+    init(connection: NWConnection, router: LocalAPIRouter) {
+        self.connection = connection
+        self.router = router
+    }
+
+    func start(on queue: DispatchQueue) {
+        self.connection.start(queue: queue)
+        self.receive()
+    }
+
+    func cancel() {
+        self.close()
+    }
+
+    private func receive() {
+        self.connection.receive(minimumIncompleteLength: 1, maximumLength: 16_384) { [weak self] data, _, isComplete, error in
+            Task { @MainActor in
+                guard let self else { return }
+                if error != nil || isComplete {
+                    self.close()
+                    return
+                }
+
+                if let data {
+                    self.buffer.append(data)
+                }
+
+                guard self.buffer.count <= LocalAPI.maxRequestBytes else {
+                    self.send(LocalAPI.error("Request too large.", status: 413))
+                    return
+                }
+
+                if let request = self.parseRequestIfComplete() {
+                    let response = await self.router.route(request)
+                    self.send(response)
+                } else {
+                    self.receive()
+                }
+            }
+        }
+    }
+
+    private func send(_ response: LocalAPI.Response) {
+        let body = response.body
+        var headers = response.headers
+        headers["Content-Length"] = "\(body.count)"
+        headers["Connection"] = "close"
+
+        let statusLine = "HTTP/1.1 \(response.status) \(Self.reasonPhrase(for: response.status))\r\n"
+        let headerLines = headers
+            .map { "\($0.key): \($0.value)\r\n" }
+            .sorted()
+            .joined()
+        var data = Data((statusLine + headerLines + "\r\n").utf8)
+        data.append(body)
+
+        self.connection.send(content: data, completion: .contentProcessed { [connection] _ in
+            connection.cancel()
+            Task { @MainActor [weak self] in
+                self?.close()
+            }
+        })
+    }
+
+    private func close() {
+        guard !self.isClosed else { return }
+        self.isClosed = true
+        self.connection.cancel()
+        self.onClose?()
+    }
+
+    private func parseRequestIfComplete() -> LocalAPI.Request? {
+        guard let headerEnd = self.buffer.range(of: Data("\r\n\r\n".utf8)) else {
+            return nil
+        }
+
+        let headerData = self.buffer[..<headerEnd.lowerBound]
+        guard let headerText = String(data: headerData, encoding: .utf8) else {
+            return LocalAPI.Request(method: "", path: "", query: [:], headers: [:], body: Data())
+        }
+
+        let lines = headerText.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else { return nil }
+        let parts = requestLine.split(separator: " ", maxSplits: 2).map(String.init)
+        guard parts.count >= 2 else {
+            return LocalAPI.Request(method: "", path: "", query: [:], headers: [:], body: Data())
+        }
+
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() {
+            guard let separator = line.firstIndex(of: ":") else { continue }
+            let key = line[..<separator].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            headers[key] = value
+        }
+
+        let contentLength = Int(headers["content-length"] ?? "0") ?? 0
+        let bodyStart = headerEnd.upperBound
+        guard self.buffer.count >= bodyStart + contentLength else {
+            return nil
+        }
+
+        let body = Data(self.buffer[bodyStart..<(bodyStart + contentLength)])
+        let parsedTarget = Self.parseTarget(parts[1])
+        return LocalAPI.Request(
+            method: parts[0].uppercased(),
+            path: parsedTarget.path,
+            query: parsedTarget.query,
+            headers: headers,
+            body: body
+        )
+    }
+
+    private static func parseTarget(_ target: String) -> (path: String, query: [String: String]) {
+        let base = target.hasPrefix("http") ? target : "http://127.0.0.1\(target)"
+        guard let components = URLComponents(string: base) else {
+            return (target, [:])
+        }
+
+        var query: [String: String] = [:]
+        for item in components.queryItems ?? [] {
+            guard !item.name.isEmpty else { continue }
+            query[item.name] = item.value ?? ""
+        }
+
+        return (components.path.isEmpty ? "/" : components.path, query)
+    }
+
+    private static func reasonPhrase(for status: Int) -> String {
+        switch status {
+        case 200: return "OK"
+        case 204: return "No Content"
+        case 400: return "Bad Request"
+        case 404: return "Not Found"
+        case 405: return "Method Not Allowed"
+        case 413: return "Payload Too Large"
+        case 500: return "Internal Server Error"
+        default: return "OK"
+        }
+    }
+}

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIServer.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIServer.swift
@@ -150,10 +150,13 @@ private final class LocalAPIConnectionHandler {
                     return
                 }
 
-                if let request = self.parseRequestIfComplete() {
+                switch self.parseRequestIfComplete() {
+                case let .request(request):
                     let response = await self.router.route(request)
                     self.send(response)
-                } else {
+                case let .failure(response):
+                    self.send(response)
+                case .incomplete:
                     self.receive()
                 }
             }
@@ -189,21 +192,27 @@ private final class LocalAPIConnectionHandler {
         self.onClose?()
     }
 
-    private func parseRequestIfComplete() -> LocalAPI.Request? {
+    private enum ParsedRequest {
+        case incomplete
+        case request(LocalAPI.Request)
+        case failure(LocalAPI.Response)
+    }
+
+    private func parseRequestIfComplete() -> ParsedRequest {
         guard let headerEnd = self.buffer.range(of: Data("\r\n\r\n".utf8)) else {
-            return nil
+            return .incomplete
         }
 
         let headerData = self.buffer[..<headerEnd.lowerBound]
         guard let headerText = String(data: headerData, encoding: .utf8) else {
-            return LocalAPI.Request(method: "", path: "", query: [:], headers: [:], body: Data())
+            return .failure(LocalAPI.error("Malformed request.", status: 400))
         }
 
         let lines = headerText.components(separatedBy: "\r\n")
-        guard let requestLine = lines.first else { return nil }
+        guard let requestLine = lines.first else { return .incomplete }
         let parts = requestLine.split(separator: " ", maxSplits: 2).map(String.init)
         guard parts.count >= 2 else {
-            return LocalAPI.Request(method: "", path: "", query: [:], headers: [:], body: Data())
+            return .failure(LocalAPI.error("Malformed request.", status: 400))
         }
 
         var headers: [String: String] = [:]
@@ -214,21 +223,37 @@ private final class LocalAPIConnectionHandler {
             headers[key] = value
         }
 
-        let contentLength = Int(headers["content-length"] ?? "0") ?? 0
-        let bodyStart = headerEnd.upperBound
-        guard self.buffer.count >= bodyStart + contentLength else {
-            return nil
+        let contentLength: Int
+        if let rawContentLength = headers["content-length"] {
+            guard let parsedContentLength = Int(rawContentLength), parsedContentLength >= 0 else {
+                return .failure(LocalAPI.error("Invalid Content-Length.", status: 400))
+            }
+            guard parsedContentLength <= LocalAPI.maxRequestBytes else {
+                return .failure(LocalAPI.error("Request too large.", status: 413))
+            }
+            contentLength = parsedContentLength
+        } else {
+            contentLength = 0
         }
 
-        let body = Data(self.buffer[bodyStart..<(bodyStart + contentLength)])
+        let bodyStart = headerEnd.upperBound
+        let requestEnd = bodyStart + contentLength
+        guard requestEnd <= LocalAPI.maxRequestBytes else {
+            return .failure(LocalAPI.error("Request too large.", status: 413))
+        }
+        guard self.buffer.count >= requestEnd else {
+            return .incomplete
+        }
+
+        let body = Data(self.buffer[bodyStart..<requestEnd])
         let parsedTarget = Self.parseTarget(parts[1])
-        return LocalAPI.Request(
+        return .request(LocalAPI.Request(
             method: parts[0].uppercased(),
             path: parsedTarget.path,
             query: parsedTarget.query,
             headers: headers,
             body: body
-        )
+        ))
     }
 
     private static func parseTarget(_ target: String) -> (path: String, query: [String: String]) {

--- a/Sources/Fluid/Services/ModelRepository.swift
+++ b/Sources/Fluid/Services/ModelRepository.swift
@@ -15,16 +15,24 @@ final class ModelRepository {
     private init() {}
 
     /// All built-in provider IDs (not including custom/saved providers)
-    static let builtInProviderIDs = [
-        "fluid-1", "openai", "anthropic", "xai", "groq", "cerebras", "google", "openrouter", "ollama", "lmstudio", "apple-intelligence",
-    ]
+    static var builtInProviderIDs: [String] {
+        var providers = [
+            "openai", "anthropic", "xai", "groq", "cerebras", "google", "openrouter", "ollama", "lmstudio", "apple-intelligence",
+        ]
+        if PrivateFeatures.privateAIProvider {
+            providers.insert(PrivateAIProviderFeature.shared.providerID, at: 0)
+        }
+        return providers
+    }
 
     /// Returns the default models for a given provider ID.
     /// This is used when the user has not added any custom models for that provider.
     func defaultModels(for providerID: String) -> [String] {
+        if PrivateFeatures.privateAIProvider, providerID == PrivateAIProviderFeature.shared.providerID {
+            return PrivateAIProviderFeature.shared.modelIDs()
+        }
+
         switch providerID {
-        case "fluid-1":
-            return ["fluid-1-preview"]
         case "openai":
             return ["gpt-4.1"]
         case "anthropic":
@@ -78,8 +86,11 @@ final class ModelRepository {
 
     /// Returns the display name for a provider ID
     func displayName(for providerID: String) -> String {
+        if PrivateFeatures.privateAIProvider, providerID == PrivateAIProviderFeature.shared.providerID {
+            return PrivateAIProviderFeature.shared.providerName
+        }
+
         switch providerID {
-        case "fluid-1": return "Fluid-1"
         case "openai": return "OpenAI"
         case "anthropic": return "Anthropic"
         case "xai": return "xAI"
@@ -151,7 +162,6 @@ final class ModelRepository {
         appleIntelligenceDisabledReason: String? = nil
     ) -> [(id: String, name: String)] {
         var list: [(id: String, name: String)] = [
-            ("fluid-1", "Fluid-1"),
             ("openai", "OpenAI"),
             ("anthropic", "Anthropic"),
             ("xai", "xAI"),
@@ -162,6 +172,10 @@ final class ModelRepository {
             ("ollama", "Ollama"),
             ("lmstudio", "LM Studio"),
         ]
+
+        if PrivateFeatures.privateAIProvider {
+            list.insert((PrivateAIProviderFeature.shared.providerID, PrivateAIProviderFeature.shared.providerName), at: 0)
+        }
 
         if includeAppleIntelligence {
             if appleIntelligenceAvailable {
@@ -229,6 +243,10 @@ final class ModelRepository {
     ///   - apiKey: Optional API key for authentication
     /// - Returns: Array of model IDs sorted alphabetically
     func fetchModels(for providerID: String, baseURL: String, apiKey: String?) async throws -> [String] {
+        if PrivateFeatures.privateAIProvider, providerID == PrivateAIProviderFeature.shared.providerID {
+            return PrivateAIProviderFeature.shared.modelIDs()
+        }
+
         let isAnthropic = providerID == "anthropic" || baseURL.contains("anthropic.com")
 
         // Construct the models endpoint URL

--- a/Sources/Fluid/Services/PrivateAIIntegrationService.swift
+++ b/Sources/Fluid/Services/PrivateAIIntegrationService.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+actor PrivateAIIntegrationService {
+    static let shared = PrivateAIIntegrationService()
+
+    static var selectedModelDefaultsKey: String {
+        PrivateAIProviderFeature.shared.selectedModelDefaultsKey
+    }
+
+    static var localModelPathDefaultsKey: String {
+        PrivateAIProviderFeature.shared.localModelPathDefaultsKey
+    }
+
+    struct RuntimeConfiguration: Sendable, Equatable {
+        let selectedProviderID: String
+        let providerKey: String
+        let baseURL: String
+        let model: String
+        let apiKey: String
+        let localModelPath: String?
+        let usesStablePromptPrefixKVCache: Bool
+    }
+
+    struct AppContext: Sendable, Equatable {
+        let appName: String
+        let bundleID: String
+        let windowTitle: String
+        let appVersion: String?
+    }
+
+    struct EnhancementResult: Sendable, Equatable {
+        let outputText: String
+        let backendKind: String?
+        let latencyMilliseconds: Int?
+    }
+
+    struct LoadedModelState: Sendable, Equatable {
+        let modelID: String
+        let state: PrivateAIRuntimeState
+        let message: String?
+    }
+
+    private init() {}
+
+    private nonisolated static var provider: any PrivateAIIntegrationProviding {
+        PrivateAIProviderFeature.shared.isAvailable
+            ? PrivateAIProviderRegistry.integration
+            : UnavailableAIIntegrationShim.shared
+    }
+
+    nonisolated static var configuredModelID: String {
+        provider.configuredModelID
+    }
+
+    nonisolated static var selectedModel: PrivateAIRegisteredModel {
+        provider.selectedModel
+    }
+
+    nonisolated static var configuredLocalModelPath: String? {
+        provider.configuredLocalModelPath
+    }
+
+    nonisolated static var modelDirectoryURL: URL {
+        provider.modelDirectoryURL
+    }
+
+    nonisolated static func expectedLocalModelURL(for model: PrivateAIRegisteredModel) -> URL {
+        self.provider.expectedLocalModelURL(for: model)
+    }
+
+    nonisolated static func localModelPath(for model: PrivateAIRegisteredModel) -> String? {
+        self.provider.localModelPath(for: model)
+    }
+
+    nonisolated static func isModelInstalled(_ model: PrivateAIRegisteredModel) -> Bool {
+        self.provider.isModelInstalled(model)
+    }
+
+    nonisolated static func prepareModel(
+        _ model: PrivateAIRegisteredModel,
+        progressHandler: PrivateAIModelDownloadProgressHandler? = nil
+    ) async throws -> URL {
+        try await self.provider.prepareModel(model, progressHandler: progressHandler)
+    }
+
+    nonisolated static var isLocalRuntimeConfigured: Bool {
+        provider.isLocalRuntimeConfigured
+    }
+
+    nonisolated static func shouldHandleDictation(model: String) -> Bool {
+        self.provider.shouldHandleDictation(model: model)
+    }
+
+    func status(for runtime: RuntimeConfiguration) async -> PrivateAIStatus {
+        await Self.provider.status(for: runtime)
+    }
+
+    func loadedModelState() async -> LoadedModelState? {
+        await Self.provider.loadedModelState()
+    }
+
+    func loadModel(_ model: PrivateAIRegisteredModel) async throws -> PrivateAIStatus {
+        try await Self.provider.loadModel(model)
+    }
+
+    func unloadCachedRuntime(reason: String = "manual") async {
+        await Self.provider.unloadCachedRuntime(reason: reason)
+    }
+
+    func enhanceDictation(
+        _ inputText: String,
+        runtime: RuntimeConfiguration,
+        context: AppContext
+    ) async throws -> EnhancementResult {
+        try await Self.provider.enhanceDictation(inputText, runtime: runtime, context: context)
+    }
+}
+
+private struct UnavailableAIIntegrationShim: PrivateAIIntegrationProviding {
+    static let shared = UnavailableAIIntegrationShim()
+
+    var configuredModelID: String { PrivateAIModelRegistry.defaultModelID }
+    var selectedModel: PrivateAIRegisteredModel { PrivateAIModelRegistry.defaultModel }
+    var configuredLocalModelPath: String? { nil }
+    var modelDirectoryURL: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("FluidVoice", isDirectory: true)
+            .appendingPathComponent(PrivateAIProviderFeature.shared.modelDirectoryName, isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("FluidVoice", isDirectory: true)
+            .appendingPathComponent(PrivateAIProviderFeature.shared.modelDirectoryName, isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    var isLocalRuntimeConfigured: Bool { false }
+
+    func expectedLocalModelURL(for model: PrivateAIRegisteredModel) -> URL {
+        PrivateAIModelRegistry.localModelURL(for: model, directoryURL: self.modelDirectoryURL)
+    }
+
+    func localModelPath(for _: PrivateAIRegisteredModel) -> String? { nil }
+    func isModelInstalled(_: PrivateAIRegisteredModel) -> Bool { false }
+
+    func prepareModel(
+        _: PrivateAIRegisteredModel,
+        progressHandler _: PrivateAIModelDownloadProgressHandler?
+    ) async throws -> URL {
+        throw PrivateAIUnavailableError()
+    }
+
+    func shouldHandleDictation(model _: String) -> Bool { false }
+
+    func status(for _: PrivateAIIntegrationService.RuntimeConfiguration) async -> PrivateAIStatus {
+        PrivateAIStatus(
+            state: .unavailable,
+            message: PrivateAIUnavailableError().errorDescription
+        )
+    }
+
+    func loadedModelState() async -> PrivateAIIntegrationService.LoadedModelState? { nil }
+
+    func loadModel(_: PrivateAIRegisteredModel) async throws -> PrivateAIStatus {
+        throw PrivateAIUnavailableError()
+    }
+
+    func unloadCachedRuntime(reason _: String) async {}
+
+    func enhanceDictation(
+        _ inputText: String,
+        runtime _: PrivateAIIntegrationService.RuntimeConfiguration,
+        context _: PrivateAIIntegrationService.AppContext
+    ) async throws -> PrivateAIIntegrationService.EnhancementResult {
+        PrivateAIIntegrationService.EnhancementResult(
+            outputText: inputText,
+            backendKind: nil,
+            latencyMilliseconds: nil
+        )
+    }
+}

--- a/Sources/Fluid/Services/PrivateAIProvider.swift
+++ b/Sources/Fluid/Services/PrivateAIProvider.swift
@@ -1,0 +1,287 @@
+import Foundation
+
+struct PrivateAIModelArtifact: Sendable, Codable, Hashable {
+    var identifier: String
+    var filename: String
+    var downloadURL: URL?
+    var sha256: String?
+    var byteCount: Int64?
+    var version: String?
+}
+
+struct PrivateAIModelDownloadProgress: Sendable, Equatable {
+    var bytesWritten: Int64
+    var totalBytesWritten: Int64
+    var totalBytesExpected: Int64?
+
+    var fractionCompleted: Double? {
+        guard let totalBytesExpected, totalBytesExpected > 0 else { return nil }
+        return min(1, max(0, Double(self.totalBytesWritten) / Double(totalBytesExpected)))
+    }
+}
+
+typealias PrivateAIModelDownloadProgressHandler = @Sendable (PrivateAIModelDownloadProgress) async -> Void
+
+struct PrivateAIRegisteredModel: Sendable, Codable, Hashable, Identifiable {
+    var id: String { self.artifact.identifier }
+    var displayName: String
+    var detail: String
+    var isEnabled: Bool
+    var parameterCount: String
+    var recommendedMemoryGB: Int?
+    var artifact: PrivateAIModelArtifact
+
+    var canDownload: Bool {
+        self.artifact.downloadURL != nil && self.artifact.sha256?.isEmpty == false
+    }
+}
+
+enum PrivateAIRuntimeState: String, Sendable, Codable, Hashable {
+    case unavailable
+    case missingModel
+    case configured
+    case loading
+    case ready
+    case failed
+}
+
+struct PrivateAIStatus: Sendable, Codable, Equatable {
+    var state: PrivateAIRuntimeState
+    var message: String?
+}
+
+struct PrivateAIUnavailableError: LocalizedError {
+    var errorDescription: String? {
+        "Private AI provider is not available in this build."
+    }
+}
+
+protocol PrivateAIProviderFeatureProviding: Sendable {
+    var isAvailable: Bool { get }
+    var providerID: String { get }
+    var providerName: String { get }
+    var promptSelectionID: String { get }
+    var defaultModelID: String { get }
+    var selectedModelDefaultsKey: String { get }
+    var localModelPathDefaultsKey: String { get }
+    var prefixCacheDefaultsKey: String { get }
+    var modelDirectoryName: String { get }
+
+    func modelIDs() -> [String]
+    func model(id: String) -> PrivateAIRegisteredModel?
+    func canonicalModelID(for value: String) -> String?
+    func isKnownModelID(_ value: String) -> Bool
+    func matches(model: String) -> Bool
+    func localModelURL(for model: PrivateAIRegisteredModel, directoryURL: URL) -> URL
+}
+
+extension PrivateAIProviderFeatureProviding {
+    func matches(model: String) -> Bool {
+        guard self.isAvailable else { return false }
+
+        let normalized = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if self.isKnownModelID(normalized) {
+            return true
+        }
+
+        let normalizedProviderID = self.providerID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return !normalizedProviderID.isEmpty && normalized == normalizedProviderID
+    }
+
+    func localModelURL(for model: PrivateAIRegisteredModel, directoryURL: URL) -> URL {
+        directoryURL.appendingPathComponent(model.artifact.filename)
+    }
+}
+
+protocol PrivateAIIntegrationProviding: Sendable {
+    var configuredModelID: String { get }
+    var selectedModel: PrivateAIRegisteredModel { get }
+    var configuredLocalModelPath: String? { get }
+    var modelDirectoryURL: URL { get }
+    var isLocalRuntimeConfigured: Bool { get }
+
+    func expectedLocalModelURL(for model: PrivateAIRegisteredModel) -> URL
+    func localModelPath(for model: PrivateAIRegisteredModel) -> String?
+    func isModelInstalled(_ model: PrivateAIRegisteredModel) -> Bool
+    func prepareModel(
+        _ model: PrivateAIRegisteredModel,
+        progressHandler: PrivateAIModelDownloadProgressHandler?
+    ) async throws -> URL
+    func shouldHandleDictation(model: String) -> Bool
+    func status(for runtime: PrivateAIIntegrationService.RuntimeConfiguration) async -> PrivateAIStatus
+    func loadedModelState() async -> PrivateAIIntegrationService.LoadedModelState?
+    func loadModel(_ model: PrivateAIRegisteredModel) async throws -> PrivateAIStatus
+    func unloadCachedRuntime(reason: String) async
+    func enhanceDictation(
+        _ inputText: String,
+        runtime: PrivateAIIntegrationService.RuntimeConfiguration,
+        context: PrivateAIIntegrationService.AppContext
+    ) async throws -> PrivateAIIntegrationService.EnhancementResult
+}
+
+extension PrivateAIIntegrationProviding {
+    func prepareModel(_ model: PrivateAIRegisteredModel) async throws -> URL {
+        try await self.prepareModel(model, progressHandler: nil)
+    }
+}
+
+enum PrivateAIProviderRegistry {
+    nonisolated(unsafe) static var feature: any PrivateAIProviderFeatureProviding = UnavailablePrivateAIProviderFeature()
+    nonisolated(unsafe) static var integration: any PrivateAIIntegrationProviding = UnavailablePrivateAIIntegrationProvider()
+}
+
+private enum PrivateAIProviderBootstrap {
+    static let installOnce: Void = {
+        #if PRIVATE_AI_PROVIDER
+        PrivateAIProviderBridge.install()
+        #endif
+    }()
+
+    static func installIfAvailable() {
+        _ = self.installOnce
+    }
+}
+
+enum PrivateAIProviderFeature {
+    nonisolated static var shared: any PrivateAIProviderFeatureProviding {
+        PrivateAIProviderBootstrap.installIfAvailable()
+        return PrivateAIProviderRegistry.feature
+    }
+
+    nonisolated static var displayName: String {
+        let name = self.shared.providerName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? "Private AI Provider" : name
+    }
+}
+
+enum PrivateFeatures {
+    static var privateAIProvider: Bool {
+        PrivateAIProviderFeature.shared.isAvailable
+    }
+}
+
+enum PrivateAIModelRegistry {
+    nonisolated static var defaultModelID: String {
+        PrivateAIProviderFeature.shared.defaultModelID
+    }
+
+    nonisolated static var defaultModel: PrivateAIRegisteredModel {
+        if let model = model(id: defaultModelID) {
+            return model
+        }
+        return PrivateAIRegisteredModel.unavailable
+    }
+
+    nonisolated static func model(id: String) -> PrivateAIRegisteredModel? {
+        PrivateAIProviderFeature.shared.model(id: id)
+    }
+
+    nonisolated static func canonicalModelID(for value: String) -> String? {
+        PrivateAIProviderFeature.shared.canonicalModelID(for: value)
+    }
+
+    nonisolated static func modelIDs(includeDisabled _: Bool = false) -> [String] {
+        PrivateAIProviderFeature.shared.modelIDs()
+    }
+
+    nonisolated static func localModelURL(for model: PrivateAIRegisteredModel, directoryURL: URL) -> URL {
+        PrivateAIProviderFeature.shared.localModelURL(for: model, directoryURL: directoryURL)
+    }
+}
+
+extension PrivateAIRegisteredModel {
+    static let unavailable = PrivateAIRegisteredModel(
+        displayName: "",
+        detail: "",
+        isEnabled: false,
+        parameterCount: "",
+        recommendedMemoryGB: nil,
+        artifact: PrivateAIModelArtifact(
+            identifier: "",
+            filename: "",
+            downloadURL: nil,
+            sha256: nil,
+            byteCount: nil,
+            version: nil
+        )
+    )
+}
+
+private struct UnavailablePrivateAIProviderFeature: PrivateAIProviderFeatureProviding {
+    let isAvailable = false
+    let providerID = "__private_ai_provider__"
+    let providerName = ""
+    let promptSelectionID = "__PRIVATE_AI_PROVIDER__"
+    let defaultModelID = ""
+    let selectedModelDefaultsKey = "PrivateAIProviderSelectedModelID"
+    let localModelPathDefaultsKey = "PrivateAIProviderLocalModelPath"
+    let prefixCacheDefaultsKey = "PrivateAIProviderPrefixKVCacheEnabled"
+    let modelDirectoryName = "PrivateAIProvider"
+
+    func modelIDs() -> [String] { [] }
+    func model(id _: String) -> PrivateAIRegisteredModel? { nil }
+    func canonicalModelID(for _: String) -> String? { nil }
+    func isKnownModelID(_: String) -> Bool { false }
+}
+
+private struct UnavailablePrivateAIIntegrationProvider: PrivateAIIntegrationProviding {
+    var configuredModelID: String { PrivateAIModelRegistry.defaultModelID }
+    var selectedModel: PrivateAIRegisteredModel { PrivateAIModelRegistry.defaultModel }
+    var configuredLocalModelPath: String? { nil }
+    var modelDirectoryURL: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("FluidVoice", isDirectory: true)
+            .appendingPathComponent(PrivateAIProviderFeature.shared.modelDirectoryName, isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("FluidVoice", isDirectory: true)
+            .appendingPathComponent(PrivateAIProviderFeature.shared.modelDirectoryName, isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    var isLocalRuntimeConfigured: Bool { false }
+
+    func expectedLocalModelURL(for model: PrivateAIRegisteredModel) -> URL {
+        PrivateAIModelRegistry.localModelURL(for: model, directoryURL: self.modelDirectoryURL)
+    }
+
+    func localModelPath(for _: PrivateAIRegisteredModel) -> String? { nil }
+    func isModelInstalled(_: PrivateAIRegisteredModel) -> Bool { false }
+
+    func prepareModel(
+        _: PrivateAIRegisteredModel,
+        progressHandler _: PrivateAIModelDownloadProgressHandler?
+    ) async throws -> URL {
+        throw PrivateAIUnavailableError()
+    }
+
+    func shouldHandleDictation(model _: String) -> Bool { false }
+
+    func status(for _: PrivateAIIntegrationService.RuntimeConfiguration) async -> PrivateAIStatus {
+        PrivateAIStatus(
+            state: .unavailable,
+            message: PrivateAIUnavailableError().errorDescription
+        )
+    }
+
+    func loadedModelState() async -> PrivateAIIntegrationService.LoadedModelState? { nil }
+
+    func loadModel(_: PrivateAIRegisteredModel) async throws -> PrivateAIStatus {
+        throw PrivateAIUnavailableError()
+    }
+
+    func unloadCachedRuntime(reason _: String) async {}
+
+    func enhanceDictation(
+        _ inputText: String,
+        runtime _: PrivateAIIntegrationService.RuntimeConfiguration,
+        context _: PrivateAIIntegrationService.AppContext
+    ) async throws -> PrivateAIIntegrationService.EnhancementResult {
+        PrivateAIIntegrationService.EnhancementResult(
+            outputText: inputText,
+            backendKind: nil,
+            latencyMilliseconds: nil
+        )
+    }
+}

--- a/Sources/Fluid/Services/PrivateAIProvider.swift
+++ b/Sources/Fluid/Services/PrivateAIProvider.swift
@@ -152,6 +152,10 @@ enum PrivateAIProviderFeature {
         let name = self.shared.providerName.trimmingCharacters(in: .whitespacesAndNewlines)
         return name.isEmpty ? "Private AI Provider" : name
     }
+
+    nonisolated static func verificationFingerprint(for modelID: String) -> String {
+        "private-ai-provider|\(modelID)"
+    }
 }
 
 enum PrivateFeatures {

--- a/Sources/Fluid/Services/PrivateAIProviderPromptFormat.swift
+++ b/Sources/Fluid/Services/PrivateAIProviderPromptFormat.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum PrivateAIProviderPromptFormat {
+    static var promptSelectionID: String {
+        PrivateAIProviderFeature.shared.promptSelectionID
+    }
+
+    nonisolated static func matches(model: String) -> Bool {
+        PrivateAIProviderFeature.shared.matches(model: model)
+    }
+
+    static func isAvailable(settings: SettingsStore = .shared) -> Bool {
+        self.matches(model: self.selectedDictationModel(settings: settings))
+    }
+
+    private static func selectedDictationModel(settings: SettingsStore) -> String {
+        let providerID = settings.selectedProviderID
+        let selectedModelByProvider = settings.selectedModelByProvider
+
+        if let saved = settings.savedProviders.first(where: { $0.id == providerID }) {
+            let key = "custom:\(saved.id)"
+            return selectedModelByProvider[key] ?? saved.models.first ?? ""
+        }
+
+        if ModelRepository.shared.isBuiltIn(providerID) {
+            return selectedModelByProvider[providerID] ?? ModelRepository.shared.defaultModels(for: providerID).first ?? ""
+        }
+
+        return selectedModelByProvider[providerID] ?? ""
+    }
+}

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsView.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsView.swift
@@ -1,5 +1,49 @@
 import SwiftUI
 
+enum PrivateAIModelLoadState: Equatable {
+    case idle
+    case downloading(modelID: String, progress: Double?)
+    case loading(modelID: String)
+    case loaded(modelID: String, latencyMilliseconds: Int?)
+    case failed(modelID: String, message: String)
+
+    func isLoading(_ modelID: String) -> Bool {
+        if case .loading(modelID) = self { return true }
+        return false
+    }
+
+    func isDownloading(_ modelID: String) -> Bool {
+        if case .downloading(modelID, _) = self { return true }
+        return false
+    }
+
+    func isLoaded(_ modelID: String) -> Bool {
+        if case .loaded(modelID, _) = self { return true }
+        return false
+    }
+
+    func latencyMilliseconds(for modelID: String) -> Int? {
+        if case let .loaded(loadedModelID, latencyMilliseconds) = self, loadedModelID == modelID {
+            return latencyMilliseconds
+        }
+        return nil
+    }
+
+    func failureMessage(for modelID: String) -> String? {
+        if case let .failed(failedModelID, message) = self, failedModelID == modelID {
+            return message
+        }
+        return nil
+    }
+
+    func downloadProgress(for modelID: String) -> Double? {
+        if case let .downloading(downloadingModelID, progress) = self, downloadingModelID == modelID {
+            return progress
+        }
+        return nil
+    }
+}
+
 struct AIEnhancementSettingsView: View {
     @ObservedObject var viewModel: AIEnhancementSettingsViewModel
     @ObservedObject var settings: SettingsStore
@@ -7,9 +51,8 @@ struct AIEnhancementSettingsView: View {
     let theme: AppTheme
     @State var expandedProviderID: String? = nil
     @State var providerSearchText: String = ""
-    @State var fluid1InterestEmail: String = ""
-    @State var fluid1InterestErrorMessage: String = ""
-    @State var fluid1InterestIsSubmitting: Bool = false
+    @State var privateAISelectedModelID: String = PrivateAIIntegrationService.configuredModelID
+    @State var privateAILoadState: PrivateAIModelLoadState = .idle
     @State var hoveredPromptCardKey: String? = nil
     @State var selectedPromptMode: SettingsStore.PromptMode = .dictate
     @State var hoveredPromptModeKey: String? = nil
@@ -20,6 +63,8 @@ struct AIEnhancementSettingsView: View {
         self.aiConfigurationCard
             .onAppear {
                 self.viewModel.onAppear()
+                self.privateAISelectedModelID = PrivateAIIntegrationService.configuredModelID
+                self.refreshPrivateAILoadState()
             }
             .onChange(of: self.viewModel.connectionStatus) { oldValue, newValue in
                 if oldValue == .success && newValue != .success {

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -1298,7 +1298,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     }
 
     private func privateAIFingerprint(for modelID: String) -> String {
-        "private-ai-provider|\(modelID)"
+        PrivateAIProviderFeature.verificationFingerprint(for: modelID)
     }
 
     private func privateAIErrorMessage(for error: Error) -> String {

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -182,6 +182,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         }
         self.selectedModelByProvider = normalizedSel
         self.settings.selectedModelByProvider = normalizedSel
+        self.normalizePrivateAIModels()
 
         // Determine initial model list AND set baseURL BEFORE calling updateCurrentProvider
         if let saved = savedProviders.first(where: { $0.id == selectedProviderID }) {
@@ -242,6 +243,10 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     }
 
     func providerDisplayName(for providerID: String) -> String {
+        if PrivateFeatures.privateAIProvider, providerID == PrivateAIProviderFeature.shared.providerID {
+            return ModelRepository.shared.displayName(for: providerID)
+        }
+
         switch providerID {
         case "openai": return "OpenAI"
         case "groq": return "Groq"
@@ -249,6 +254,21 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         default:
             return self.savedProviders.first(where: { $0.id == providerID })?.name ?? providerID.capitalized
         }
+    }
+
+    private func normalizePrivateAIModels() {
+        guard PrivateFeatures.privateAIProvider else { return }
+
+        let key = self.providerKey(for: PrivateAIProviderFeature.shared.providerID)
+        let models = PrivateAIModelRegistry.modelIDs()
+        let current = self.selectedModelByProvider[key] ?? ""
+        let selected = PrivateAIModelRegistry.model(id: current)?.id ?? PrivateAIIntegrationService.configuredModelID
+
+        self.availableModelsByProvider[key] = models
+        self.selectedModelByProvider[key] = selected
+        self.settings.availableModelsByProvider = self.availableModelsByProvider
+        self.settings.selectedModelByProvider = self.selectedModelByProvider
+        UserDefaults.standard.set(selected, forKey: PrivateAIIntegrationService.selectedModelDefaultsKey)
     }
 
     func connectionStatus(for providerID: String) -> AIConnectionStatus {
@@ -321,6 +341,57 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let key = self.providerKey(for: providerID)
         self.settings.verifiedProviderFingerprints[key] = "apple-intelligence"
         self.updateConnectionStatus(.success, for: providerID)
+    }
+
+    func verifyPrivateAIProvider(model: PrivateAIRegisteredModel) async -> Bool {
+        let providerID = PrivateAIProviderFeature.shared.providerID
+        let key = self.providerKey(for: providerID)
+        guard !self.isTestingConnection else { return false }
+
+        self.isTestingConnection = true
+        self.updateConnectionStatus(.testing, for: providerID)
+        self.connectionErrorMessage = ""
+
+        defer {
+            self.isTestingConnection = false
+        }
+
+        guard PrivateAIIntegrationService.isModelInstalled(model) else {
+            self.updateConnectionStatus(.failed, for: providerID)
+            self.connectionErrorMessage = "\(model.displayName) is not installed."
+            return false
+        }
+
+        do {
+            let status = try await PrivateAIIntegrationService.shared.loadModel(model)
+            switch status.state {
+            case .ready:
+                var fingerprints = self.settings.verifiedProviderFingerprints
+                fingerprints[key] = self.privateAIFingerprint(for: model.id)
+                self.settings.verifiedProviderFingerprints = fingerprints
+                self.selectedModelByProvider[key] = model.id
+                self.settings.selectedModelByProvider = self.selectedModelByProvider
+                self.updateConnectionStatus(.success, for: providerID)
+                self.connectionErrorMessage = ""
+                DebugLogger.shared.info(
+                    "Private AI Provider verification succeeded for \(model.id)",
+                    source: "AISettingsView"
+                )
+                return true
+            default:
+                self.updateConnectionStatus(.failed, for: providerID)
+                self.connectionErrorMessage = status.message ?? "\(model.displayName) did not report ready."
+                return false
+            }
+        } catch {
+            self.updateConnectionStatus(.failed, for: providerID)
+            self.connectionErrorMessage = self.privateAIErrorMessage(for: error)
+            DebugLogger.shared.error(
+                "Private AI Provider verification failed for \(model.id): \(self.connectionErrorMessage)",
+                source: "AISettingsView"
+            )
+            return false
+        }
     }
 
     func resetVerification(for providerID: String) {
@@ -1226,6 +1297,19 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
+    private func privateAIFingerprint(for modelID: String) -> String {
+        "private-ai-provider|\(modelID)"
+    }
+
+    private func privateAIErrorMessage(for error: Error) -> String {
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription
+        {
+            return description
+        }
+        return String(describing: error)
+    }
+
     private func storeVerificationFingerprint(for providerID: String, baseURL: String, apiKey: String) {
         guard let fingerprint = self.fingerprint(baseURL: baseURL, apiKey: apiKey) else { return }
         let key = self.providerKey(for: providerID)
@@ -1263,6 +1347,15 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             let key = self.providerKey(for: providerID)
             if providerID == "apple-intelligence" {
                 if self.settings.verifiedProviderFingerprints[key] == "apple-intelligence" {
+                    statuses[providerID] = .success
+                } else if statuses[providerID] == .success {
+                    statuses[providerID] = .unknown
+                }
+                continue
+            }
+            if providerID == PrivateAIProviderFeature.shared.providerID {
+                let selected = self.selectedModelByProvider[key] ?? PrivateAIIntegrationService.configuredModelID
+                if self.settings.verifiedProviderFingerprints[key] == self.privateAIFingerprint(for: selected) {
                     statuses[providerID] = .success
                 } else if statuses[providerID] == .success {
                     statuses[providerID] = .unknown
@@ -1673,7 +1766,26 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     }
 
     func isPrimaryDictationPromptSelectionOff() -> Bool {
-        self.settings.isDictationPromptOff
+        return self.settings.isDictationPromptOff
+    }
+
+    func isPrivateAIPromptAvailable() -> Bool {
+        PrivateAIProviderPromptFormat.isAvailable(settings: self.settings)
+    }
+
+    func isPrivateAIModelSelected() -> Bool {
+        PrivateAIProviderPromptFormat.isAvailable(settings: self.settings)
+    }
+
+    func isPrivateAIPromptSelected() -> Bool {
+        self.settings.dictationPromptSelection == .privateAI
+    }
+
+    func selectPrivateAIPromptIfAvailable() {
+        guard self.isPrivateAIPromptAvailable() else { return }
+        self.settings.setDictationPromptSelection(.privateAI)
+        self.selectedDictationPromptID = self.settings.selectedDictationPromptID
+        self.isDictationPromptOff = self.settings.isDictationPromptOff
     }
 
     func selectPrimaryDictationPromptOff() {
@@ -1763,7 +1875,11 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
     func setSelectedPromptID(_ id: String?, for mode: SettingsStore.PromptMode) {
         if mode.normalized == .dictate {
-            if let id {
+            if self.isPrivateAIModelSelected() {
+                if id == nil {
+                    self.settings.setDictationPromptSelection(.privateAI)
+                }
+            } else if let id {
                 self.settings.setDictationPromptSelection(.profile(id))
             } else {
                 self.settings.setDictationPromptSelection(.default)

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -319,7 +319,7 @@ extension AIEnhancementSettingsView {
                     }
                     .padding(4)
                 }
-                .onChange(of: self.expandedProviderID) { newID in
+                .onChange(of: self.expandedProviderID) { _, newID in
                     if let id = newID {
                         withAnimation(.easeInOut(duration: 0.3)) {
                             proxy.scrollTo(id, anchor: .top)
@@ -395,6 +395,14 @@ extension AIEnhancementSettingsView {
         let isBuiltIn: Bool
     }
 
+    private struct PrivateAIProviderModelStatus {
+        let title: String
+        let detail: String
+        let icon: String
+        let detailIcon: String
+        let color: Color
+    }
+
     // Use cached provider items from ViewModel for scroll performance
     private var verifiedProviderItems: [ProviderItem] {
         self.viewModel.cachedVerifiedProviderItems.map {
@@ -410,13 +418,13 @@ extension AIEnhancementSettingsView {
 
     private func providerCard(_ item: ProviderItem) -> some View {
         let isAppleDisabled = item.id == "apple-intelligence-disabled"
-        let isFluidInterest = item.id == "fluid-1"
+        let isPrivateAIProvider = item.id == PrivateAIProviderFeature.shared.providerID
         let isComingSoon = isAppleDisabled
         let isExpanded = self.expandedProviderID == item.id && !isAppleDisabled
         let status = self.providerStatus(for: item)
         let borderColor = isExpanded
             ? self.theme.palette.accent.opacity(0.5)
-            : (isFluidInterest ? self.theme.palette.accent.opacity(0.3) : self.theme.palette.cardBorder.opacity(0.3))
+            : self.theme.palette.cardBorder.opacity(0.3)
         let statusView = HStack(spacing: 5) {
             if !status.icon.isEmpty {
                 Image(systemName: status.icon)
@@ -438,21 +446,7 @@ extension AIEnhancementSettingsView {
                             .font(.system(size: 14, weight: .semibold))
                             .foregroundStyle(isComingSoon ? self.theme.palette.accent : self.theme.palette.primaryText)
 
-                        if isFluidInterest {
-                            statusView
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 3)
-                                .background(
-                                    Capsule()
-                                        .fill(self.theme.palette.accent.opacity(0.12))
-                                        .overlay(
-                                            Capsule()
-                                                .stroke(self.theme.palette.accent.opacity(0.3), lineWidth: 1)
-                                        )
-                                )
-                        } else {
-                            statusView
-                        }
+                        statusView
                     }
 
                     Spacer()
@@ -485,8 +479,8 @@ extension AIEnhancementSettingsView {
                     .background(self.theme.palette.separator.opacity(0.5))
                     .padding(.horizontal, 14)
 
-                if isFluidInterest {
-                    self.fluid1InterestSection
+                if isPrivateAIProvider {
+                    self.privateAIRuntimeSection
                         .padding(14)
                         .padding(.top, 4)
                 } else {
@@ -509,13 +503,6 @@ extension AIEnhancementSettingsView {
     }
 
     private func providerStatus(for item: ProviderItem) -> (text: String, color: Color, icon: String) {
-        if item.id == "fluid-1" {
-            let hasInterest = self.settings.fluid1InterestCaptured
-            if hasInterest {
-                return ("Thanks · Coming soon", self.theme.palette.accent, "checkmark.circle.fill")
-            }
-            return ("Early access · Tap to join", self.theme.palette.accent, "hand.tap")
-        }
         if item.id == "apple-intelligence-disabled" {
             return ("Unavailable", .secondary, "lock.slash")
         }
@@ -539,15 +526,6 @@ extension AIEnhancementSettingsView {
     }
 
     private func toggleProviderExpansion(_ providerID: String) {
-        if providerID == "fluid-1" {
-            if self.expandedProviderID == providerID {
-                self.expandedProviderID = nil
-            } else {
-                self.expandedProviderID = providerID
-                self.fluid1InterestErrorMessage = ""
-            }
-            return
-        }
         if self.expandedProviderID == providerID {
             self.expandedProviderID = nil
             self.viewModel.clearEditProviderDraft()
@@ -558,175 +536,520 @@ extension AIEnhancementSettingsView {
         }
     }
 
-    private var fluid1InterestSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            let hasInterest = self.settings.fluid1InterestCaptured
-            if hasInterest {
-                HStack(spacing: 8) {
-                    Image(systemName: "checkmark.seal.fill")
-                        .font(.system(size: 13))
-                        .foregroundStyle(self.theme.palette.accent)
-                    Text("Thank you — coming soon")
-                        .font(.system(size: 13, weight: .semibold))
-                }
+    private var privateAIRuntimeSection: some View {
+        let model = self.selectedPrivateAIModel
+        let status = self.privateAIModelStatus(for: model)
+        let isInstalled = PrivateAIIntegrationService.isModelInstalled(model)
+        let isDownloading = self.privateAILoadState.isDownloading(model.id)
+        let downloadProgress = self.privateAILoadState.downloadProgress(for: model.id)
+        let isLoading = self.privateAILoadState.isLoading(model.id)
+        let isLoaded = self.privateAILoadState.isLoaded(model.id)
+        let hasLoadFailure = self.privateAILoadState.failureMessage(for: model.id) != nil
+        let isTesting = self.viewModel.isTestingConnection && self.viewModel.selectedProviderID == PrivateAIProviderFeature.shared.providerID
+        let isBusy = isDownloading || isLoading || isTesting
+        let canVerify = isInstalled && !self.privateAISelectedModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-                Text("We saved your interest in Fluid-1, our private on-device model. We'll notify you when it's ready.")
-                    .font(.caption)
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Text("Model")
+                    .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
-            } else {
-                HStack(spacing: 8) {
-                    Image(systemName: "envelope.fill")
-                        .font(.system(size: 13))
-                        .foregroundStyle(self.theme.palette.accent)
-                    Text("Join Fluid-1 early access")
-                        .font(.system(size: 13, weight: .semibold))
-                }
+                    .frame(width: 50, alignment: .leading)
 
-                Text("Share your email to get notified when our private on-device model is ready.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Email")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.secondary)
-                    TextField("you@example.com", text: self.$fluid1InterestEmail)
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(size: 13))
-                        .onChange(of: self.fluid1InterestEmail) { _, _ in
-                            if !self.fluid1InterestErrorMessage.isEmpty {
-                                self.fluid1InterestErrorMessage = ""
-                            }
+                SearchableModelPicker(
+                    models: PrivateAIModelRegistry.modelIDs(),
+                    selectedModel: self.privateAIModelBinding,
+                    onRefresh: {
+                        await MainActor.run {
+                            self.refreshPrivateAIProviderModels()
                         }
-                }
+                    },
+                    isRefreshing: false,
+                    refreshEnabled: true,
+                    selectionEnabled: !isBusy,
+                    controlWidth: 180,
+                    controlHeight: 30
+                )
 
-                HStack(spacing: 10) {
-                    Button(action: { self.submitFluid1Interest() }) {
-                        HStack(spacing: 6) {
-                            if self.fluid1InterestIsSubmitting {
-                                ProgressView()
-                                    .controlSize(.small)
-                                    .fixedSize()
-                            } else {
-                                Image(systemName: "paperplane.fill")
-                                    .font(.system(size: 11))
-                            }
-                            Text("Join early access")
-                                .font(.system(size: 12, weight: .medium))
+                Button(action: { self.loadPrivateAIModel(model) }) {
+                    if isLoading {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .fixedSize()
+                    } else {
+                        Image(systemName: "memorychip")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                }
+                .buttonStyle(CompactButtonStyle(foreground: isLoaded ? Color.fluidGreen : nil))
+                .frame(width: 28, height: 28)
+                .disabled(!isInstalled || isBusy)
+                .help("Load selected model")
+
+                Button(action: { self.unloadPrivateAIModel() }) {
+                    Image(systemName: "eject")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(CompactButtonStyle())
+                .frame(width: 28, height: 28)
+                .disabled(isBusy || !isLoaded)
+                .help("Unload selected model")
+
+                Button(action: { self.revealPrivateAIModelFolder() }) {
+                    Image(systemName: "folder")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(CompactButtonStyle())
+                .frame(width: 28, height: 28)
+                .help("Open models folder")
+
+                if !isInstalled {
+                    Button(action: { self.downloadPrivateAIModel(model) }) {
+                        if isDownloading {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .fixedSize()
+                        } else {
+                            Image(systemName: "arrow.down.circle")
+                                .font(.system(size: 12, weight: .semibold))
                         }
                     }
-                    .buttonStyle(GlassButtonStyle(height: AISettingsLayout.controlHeight))
-                    .disabled(self.fluid1InterestIsSubmitting)
-                }
-
-                if !self.fluid1InterestErrorMessage.isEmpty {
-                    Text(self.fluid1InterestErrorMessage)
-                        .font(.caption)
-                        .foregroundStyle(.red)
+                    .buttonStyle(CompactButtonStyle())
+                    .frame(width: 28, height: 28)
+                    .disabled(!model.canDownload || isBusy)
+                    .help(model.canDownload ? "Download this model" : "Download URL is not configured yet")
                 }
             }
-        }
-        .padding(12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(self.theme.palette.accent.opacity(0.08))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .stroke(self.theme.palette.accent.opacity(0.25), lineWidth: 1)
+
+            if isDownloading || isLoading || isLoaded || hasLoadFailure || !isInstalled {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        Image(systemName: status.detailIcon)
+                            .font(.caption)
+                        Text(status.detail)
+                            .font(.caption)
+                            .lineLimit(2)
+                    }
+
+                    if let downloadProgress {
+                        ProgressView(value: downloadProgress)
+                            .controlSize(.mini)
+                            .frame(maxWidth: 260)
+                            .tint(status.color)
+                    }
+                }
+                .foregroundStyle(status.color)
+            }
+
+            self.privateAIPrefixCacheRow(isBusy: isBusy)
+
+            if self.viewModel.connectionStatus(for: PrivateAIProviderFeature.shared.providerID) == .failed,
+               !self.viewModel.connectionErrorMessage.isEmpty
+            {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                    Text(self.viewModel.connectionErrorMessage)
+                        .font(.caption)
+                }
+                .foregroundStyle(.red)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.red.opacity(0.1))
                 )
+            }
+
+            if canVerify {
+                Button(action: { self.verifyPrivateAIConnection(model) }) {
+                    HStack(spacing: 6) {
+                        if isTesting {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .fixedSize()
+                        } else {
+                            Image(systemName: "checkmark.shield")
+                                .font(.system(size: 12))
+                        }
+                        Text(isTesting ? "Verifying..." : "Verify Connection")
+                            .font(.system(size: 13, weight: .semibold))
+                    }
+                }
+                .buttonStyle(AccentButtonStyle(compact: true))
+                .disabled(isBusy)
+            } else if model.canDownload {
+                Button(action: { self.downloadPrivateAIModel(model) }) {
+                    HStack(spacing: 6) {
+                        if isDownloading {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .fixedSize()
+                        } else {
+                            Image(systemName: "arrow.down.circle")
+                                .font(.system(size: 12))
+                        }
+                        Text(isDownloading ? Self.downloadButtonText(progress: downloadProgress) : "Download & Verify")
+                            .font(.system(size: 13, weight: .semibold))
+                    }
+                }
+                .buttonStyle(AccentButtonStyle(compact: true))
+                .disabled(isBusy)
+            } else {
+                HStack(spacing: 6) {
+                    Image(systemName: "info.circle")
+                        .font(.caption)
+                    Text("Install the selected model to enable verification")
+                        .font(.caption)
+                }
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func privateAIPrefixCacheRow(isBusy: Bool) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "bolt.horizontal.circle")
+                .font(.caption)
+                .foregroundStyle(self.theme.palette.accent)
+                .frame(width: 16)
+
+            Toggle("Prefix cache", isOn: self.privateAIPrefixCacheBinding)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .font(.caption)
+                .disabled(isBusy)
+                .help("Reuse the stable Fluid prompt KV cache for faster local dictation enhancement.")
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var privateAIPrefixCacheBinding: Binding<Bool> {
+        Binding(
+            get: { self.settings.privateAIPrefixKVCacheEnabled },
+            set: { enabled in
+                guard self.settings.privateAIPrefixKVCacheEnabled != enabled else { return }
+                self.settings.privateAIPrefixKVCacheEnabled = enabled
+                self.privateAILoadState = .idle
+                Task { @MainActor in
+                    await PrivateAIIntegrationService.shared.unloadCachedRuntime(
+                        reason: enabled ? "prefix cache enabled" : "prefix cache disabled"
+                    )
+                    self.viewModel.refreshProviderItems()
+                }
+            }
         )
     }
 
-    private func submitFluid1Interest() {
-        guard !self.settings.fluid1InterestCaptured else { return }
-        let email = self.fluid1InterestEmail.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !email.isEmpty else {
-            self.fluid1InterestErrorMessage = "Enter your email to join early access."
-            return
-        }
-        guard self.isValidEmail(email) else {
-            self.fluid1InterestErrorMessage = "Enter a valid email address."
-            return
-        }
-        self.fluid1InterestErrorMessage = ""
-        self.fluid1InterestIsSubmitting = true
+    private var privateAIModelBinding: Binding<String> {
+        Binding(
+            get: { self.privateAISelectedModelID },
+            set: { self.persistPrivateAIModelSelection($0) }
+        )
+    }
 
-        Task {
-            let success = await self.sendFluid1Interest(email: email)
-            await MainActor.run {
-                self.fluid1InterestIsSubmitting = false
-                if success {
-                    self.settings.fluid1InterestCaptured = true
-                    self.fluid1InterestEmail = ""
-                } else {
-                    self.fluid1InterestErrorMessage = "We couldn't save your interest. Please try again."
+    private func refreshPrivateAIProviderModels() {
+        let providerKey = self.viewModel.providerKey(for: PrivateAIProviderFeature.shared.providerID)
+        let models = PrivateAIModelRegistry.modelIDs()
+        let selected = PrivateAIModelRegistry.canonicalModelID(for: self.privateAISelectedModelID) ?? PrivateAIModelRegistry.defaultModel.id
+
+        self.privateAISelectedModelID = selected
+        self.viewModel.availableModelsByProvider[providerKey] = models
+        self.viewModel.selectedModelByProvider[providerKey] = selected
+        self.viewModel.settings.availableModelsByProvider = self.viewModel.availableModelsByProvider
+        self.viewModel.settings.selectedModelByProvider = self.viewModel.selectedModelByProvider
+
+        if self.viewModel.selectedProviderID == PrivateAIProviderFeature.shared.providerID {
+            self.viewModel.availableModels = models
+            self.viewModel.selectedModel = selected
+        }
+
+        self.refreshPrivateAILoadState()
+        self.viewModel.refreshProviderItems()
+    }
+
+    private func downloadPrivateAIModel(_ model: PrivateAIRegisteredModel) {
+        guard model.canDownload else {
+            self.privateAILoadState = .failed(modelID: model.id, message: "Download URL is not configured yet.")
+            return
+        }
+
+        guard !self.privateAILoadState.isDownloading(model.id) else { return }
+
+        self.privateAILoadState = .downloading(modelID: model.id, progress: nil)
+        Task { @MainActor in
+            do {
+                DebugLogger.shared.info(
+                    "Private provider download button pressed model=\(model.id)",
+                    source: "AISettingsView"
+                )
+                _ = try await PrivateAIIntegrationService.prepareModel(model) { progress in
+                    await MainActor.run {
+                        guard self.privateAISelectedModelID == model.id else { return }
+                        self.privateAILoadState = .downloading(
+                            modelID: model.id,
+                            progress: progress.fractionCompleted
+                        )
+                    }
                 }
+                guard self.privateAISelectedModelID == model.id else { return }
+                self.privateAILoadState = .loading(modelID: model.id)
+                let start = ContinuousClock.now
+                let verified = await self.viewModel.verifyPrivateAIProvider(model: model)
+                let latencyMilliseconds = Self.elapsedMilliseconds(since: start)
+                guard self.privateAISelectedModelID == model.id else { return }
+                if verified {
+                    self.privateAILoadState = .loaded(modelID: model.id, latencyMilliseconds: latencyMilliseconds)
+                } else {
+                    let message = self.viewModel.connectionErrorMessage.isEmpty
+                        ? "Model downloaded, but verification failed."
+                        : self.viewModel.connectionErrorMessage
+                    self.privateAILoadState = .failed(modelID: model.id, message: message)
+                }
+            } catch {
+                guard self.privateAISelectedModelID == model.id else { return }
+                self.privateAILoadState = .failed(
+                    modelID: model.id,
+                    message: Self.errorMessage(for: error)
+                )
             }
+            self.viewModel.refreshProviderItems()
         }
     }
 
-    private func sendFluid1Interest(email: String) async -> Bool {
-        guard let url = URL(string: "https://altic.dev/api/fluid/fluid-model-interest") else {
-            DebugLogger.shared.error("Invalid Fluid-1 interest API URL", source: "AISettingsView")
-            return false
+    private func verifyPrivateAIConnection(_ model: PrivateAIRegisteredModel) {
+        self.privateAILoadState = .loading(modelID: model.id)
+        Task { @MainActor in
+            let start = ContinuousClock.now
+            let verified = await self.viewModel.verifyPrivateAIProvider(model: model)
+            let latencyMilliseconds = Self.elapsedMilliseconds(since: start)
+            guard self.privateAISelectedModelID == model.id else { return }
+            if verified {
+                self.privateAILoadState = .loaded(modelID: model.id, latencyMilliseconds: latencyMilliseconds)
+            } else {
+                let message = self.viewModel.connectionErrorMessage.isEmpty
+                    ? "Model verification failed."
+                    : self.viewModel.connectionErrorMessage
+                self.privateAILoadState = .failed(modelID: model.id, message: message)
+            }
+            self.viewModel.refreshProviderItems()
+        }
+    }
+
+    private var selectedPrivateAIModel: PrivateAIRegisteredModel {
+        PrivateAIModelRegistry.model(id: self.privateAISelectedModelID) ?? PrivateAIModelRegistry.defaultModel
+    }
+
+    private func privateAIModelStatus(
+        for model: PrivateAIRegisteredModel
+    ) -> PrivateAIProviderModelStatus {
+        if self.privateAILoadState.isDownloading(model.id) {
+            let progress = self.privateAILoadState.downloadProgress(for: model.id)
+            return PrivateAIProviderModelStatus(
+                title: "Downloading model",
+                detail: "Downloading \(model.displayName)\(Self.downloadProgressSuffix(progress)). This can take a few minutes on first setup.",
+                icon: "arrow.down.circle.fill",
+                detailIcon: "arrow.down.circle.fill",
+                color: self.theme.palette.accent
+            )
         }
 
-        let payload: [String: Any] = [
-            "emailId": email,
-            "modelName": "Fluid-1",
-        ]
+        if self.privateAILoadState.isLoading(model.id) {
+            return PrivateAIProviderModelStatus(
+                title: "Loading model",
+                detail: "\(model.displayName) is warming into memory.",
+                icon: "arrow.triangle.2.circlepath",
+                detailIcon: "memorychip",
+                color: self.theme.palette.accent
+            )
+        }
 
-        guard JSONSerialization.isValidJSONObject(payload) else { return false }
+        if self.privateAILoadState.isLoaded(model.id) {
+            let latency = self.privateAILoadState.latencyMilliseconds(for: model.id)
+            return PrivateAIProviderModelStatus(
+                title: "Model loaded",
+                detail: "\(model.displayName) loaded\(Self.loadDurationText(latency)) and will stay warm until unloaded or switched.",
+                icon: "memorychip.fill",
+                detailIcon: "checkmark.shield.fill",
+                color: Color.fluidGreen
+            )
+        }
 
+        if let message = self.privateAILoadState.failureMessage(for: model.id) {
+            return PrivateAIProviderModelStatus(
+                title: "Load failed",
+                detail: message,
+                icon: "exclamationmark.triangle.fill",
+                detailIcon: "info.circle",
+                color: .red
+            )
+        }
+
+        if PrivateAIIntegrationService.isModelInstalled(model) {
+            return PrivateAIProviderModelStatus(
+                title: "Local model ready",
+                detail: "\(model.displayName) is installed. Load it to keep it warm in memory.",
+                icon: "checkmark.circle.fill",
+                detailIcon: "checkmark.shield.fill",
+                color: Color.fluidGreen
+            )
+        }
+
+        if PrivateAIIntegrationService.isLocalRuntimeConfigured {
+            return PrivateAIProviderModelStatus(
+                title: "Local override ready",
+                detail: "A local GGUF override is configured for this developer build.",
+                icon: "checkmark.circle.fill",
+                detailIcon: "checkmark.shield.fill",
+                color: Color.fluidGreen
+            )
+        }
+
+        if model.canDownload {
+            return PrivateAIProviderModelStatus(
+                title: "Download available",
+                detail: "\(model.displayName) can be downloaded and verified locally.",
+                icon: "arrow.down.circle.fill",
+                detailIcon: "arrow.down.circle",
+                color: self.theme.palette.accent
+            )
+        }
+
+        return PrivateAIProviderModelStatus(
+            title: "Model not installed",
+            detail: "Waiting for the Hugging Face URL/checksum to be locked in the registry.",
+            icon: "externaldrive.badge.questionmark",
+            detailIcon: "info.circle",
+            color: .orange
+        )
+    }
+
+    private func revealPrivateAIModelFolder() {
+        let directoryURL = PrivateAIIntegrationService.modelDirectoryURL
         do {
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
-
-            let (_, response) = try await URLSession.shared.data(for: request)
-            if let httpResponse = response as? HTTPURLResponse {
-                let success = (200...299).contains(httpResponse.statusCode)
-                if success {
-                    DebugLogger.shared.info("Fluid-1 interest submitted", source: "AISettingsView")
-                } else {
-                    DebugLogger.shared.error(
-                        "Fluid-1 interest submission failed with status: \(httpResponse.statusCode)",
-                        source: "AISettingsView"
-                    )
-                }
-                return success
-            }
-            return false
+            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            NSWorkspace.shared.open(directoryURL)
         } catch {
             DebugLogger.shared.error(
-                "Network error submitting Fluid-1 interest: \(error.localizedDescription)",
+                "Failed to open Private AI Provider models folder: \(error.localizedDescription)",
                 source: "AISettingsView"
             )
-            return false
         }
     }
 
-    private func isValidEmail(_ email: String) -> Bool {
-        let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.contains("@") else { return false }
-        let parts = trimmed.split(separator: "@", omittingEmptySubsequences: false)
-        guard parts.count == 2 else { return false }
+    func refreshPrivateAILoadState() {
+        Task { @MainActor in
+            guard let loaded = await PrivateAIIntegrationService.shared.loadedModelState(),
+                  loaded.state == .ready
+            else {
+                self.privateAILoadState = .idle
+                return
+            }
 
-        let local = String(parts[0])
-        let domain = String(parts[1])
-        guard !local.isEmpty, !domain.isEmpty else { return false }
-        guard !local.hasPrefix("."), !local.hasSuffix(".") else { return false }
-        guard !domain.hasPrefix("."), !domain.hasSuffix(".") else { return false }
-        guard !local.contains(".."), !domain.contains("..") else { return false }
+            self.privateAILoadState = .loaded(modelID: loaded.modelID, latencyMilliseconds: nil)
+        }
+    }
 
-        let domainParts = domain.split(separator: ".", omittingEmptySubsequences: false)
-        guard domainParts.count >= 2 else { return false }
-        guard domainParts.allSatisfy({ !$0.isEmpty }) else { return false }
-        guard let tld = domainParts.last, tld.count >= 2 else { return false }
+    private func loadPrivateAIModel(_ model: PrivateAIRegisteredModel) {
+        guard PrivateAIIntegrationService.isModelInstalled(model) else {
+            self.privateAILoadState = .failed(modelID: model.id, message: "Model file is not installed.")
+            return
+        }
 
-        return true
+        self.privateAILoadState = .loading(modelID: model.id)
+        Task { @MainActor in
+            do {
+                let start = ContinuousClock.now
+                let status = try await PrivateAIIntegrationService.shared.loadModel(model)
+                let latencyMilliseconds = Self.elapsedMilliseconds(since: start)
+                guard self.privateAISelectedModelID == model.id else { return }
+                switch status.state {
+                case .ready:
+                    self.privateAILoadState = .loaded(modelID: model.id, latencyMilliseconds: latencyMilliseconds)
+                default:
+                    self.privateAILoadState = .failed(
+                        modelID: model.id,
+                        message: status.message ?? "Model did not report ready."
+                    )
+                }
+            } catch {
+                guard self.privateAISelectedModelID == model.id else { return }
+                self.privateAILoadState = .failed(
+                    modelID: model.id,
+                    message: Self.errorMessage(for: error)
+                )
+            }
+            self.viewModel.refreshProviderItems()
+        }
+    }
+
+    private func unloadPrivateAIModel() {
+        self.privateAILoadState = .idle
+        Task { @MainActor in
+            await PrivateAIIntegrationService.shared.unloadCachedRuntime(reason: "user")
+            self.viewModel.refreshProviderItems()
+        }
+    }
+
+    private static func errorMessage(for error: Error) -> String {
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription
+        {
+            return description
+        }
+        return String(describing: error)
+    }
+
+    private static func downloadProgressSuffix(_ progress: Double?) -> String {
+        guard let progress else { return "" }
+        return " \(Int(progress * 100))%"
+    }
+
+    private static func downloadButtonText(progress: Double?) -> String {
+        guard let progress else { return "Downloading..." }
+        return "Downloading \(Int(progress * 100))%"
+    }
+
+    private static func elapsedMilliseconds(since start: ContinuousClock.Instant) -> Int {
+        let elapsed = start.duration(to: ContinuousClock.now)
+        return Int(elapsed.components.seconds * 1000) + Int(elapsed.components.attoseconds / 1_000_000_000_000_000)
+    }
+
+    private static func loadDurationText(_ milliseconds: Int?) -> String {
+        guard let milliseconds else { return "" }
+        if milliseconds >= 1000 {
+            let seconds = Double(milliseconds) / 1000
+            return String(format: " in %.1fs", seconds)
+        }
+        return " in \(milliseconds)ms"
+    }
+
+    private func persistPrivateAIModelSelection(_ value: String) {
+        let model = PrivateAIModelRegistry.model(id: value) ?? PrivateAIModelRegistry.defaultModel
+        let providerKey = self.viewModel.providerKey(for: PrivateAIProviderFeature.shared.providerID)
+        let models = PrivateAIModelRegistry.modelIDs()
+
+        self.privateAISelectedModelID = model.id
+        UserDefaults.standard.set(model.id, forKey: PrivateAIIntegrationService.selectedModelDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: PrivateAIIntegrationService.localModelPathDefaultsKey)
+
+        self.viewModel.availableModelsByProvider[providerKey] = models
+        self.viewModel.selectedModelByProvider[providerKey] = model.id
+        self.viewModel.settings.availableModelsByProvider = self.viewModel.availableModelsByProvider
+        self.viewModel.settings.selectedModelByProvider = self.viewModel.selectedModelByProvider
+
+        if self.viewModel.selectedProviderID == PrivateAIProviderFeature.shared.providerID {
+            self.viewModel.availableModels = models
+            self.viewModel.selectedModel = model.id
+        }
+        self.viewModel.resetVerification(for: PrivateAIProviderFeature.shared.providerID)
+        self.viewModel.refreshProviderItems()
+        if PrivateAIIntegrationService.isModelInstalled(model) {
+            self.loadPrivateAIModel(model)
+        } else {
+            self.privateAILoadState = .idle
+        }
     }
 
     private func providerDetailsSection(for item: ProviderItem) -> AnyView {
@@ -1076,6 +1399,16 @@ extension AIEnhancementSettingsView {
         let providerKey = self.viewModel.providerKey(for: item.id)
         let models = self.viewModel.availableModelsByProvider[providerKey] ?? []
         let isSelected = item.id == self.viewModel.selectedProviderID
+        let isPrivateAIProvider = item.id == PrivateAIProviderFeature.shared.providerID
+        let fluidModel = self.selectedPrivateAIModel
+        let fluidStatus = self.privateAIModelStatus(for: fluidModel)
+        let isFluidInstalled = PrivateAIIntegrationService.isModelInstalled(fluidModel)
+        let isFluidDownloading = self.privateAILoadState.isDownloading(fluidModel.id)
+        let isFluidLoading = self.privateAILoadState.isLoading(fluidModel.id)
+        let isFluidLoaded = self.privateAILoadState.isLoaded(fluidModel.id)
+        let hasFluidLoadFailure = self.privateAILoadState.failureMessage(for: fluidModel.id) != nil
+        let isFluidTesting = self.viewModel.isTestingConnection && self.viewModel.selectedProviderID == PrivateAIProviderFeature.shared.providerID
+        let isFluidBusy = isFluidDownloading || isFluidLoading || isFluidTesting
         let isRefreshing = self.viewModel.isFetchingModels && self.viewModel.selectedProviderID == item.id
         let baseURL = self.providerBaseURL(for: item).trimmingCharacters(in: .whitespacesAndNewlines)
         let isLocal = self.viewModel.isLocalEndpoint(baseURL)
@@ -1113,35 +1446,104 @@ extension AIEnhancementSettingsView {
                 Spacer()
 
                 SearchableModelPicker(
-                    models: models,
-                    selectedModel: self.modelBinding(for: item.id),
+                    models: isPrivateAIProvider ? PrivateAIModelRegistry.modelIDs() : models,
+                    selectedModel: isPrivateAIProvider ? self.privateAIModelBinding : self.modelBinding(for: item.id),
                     onRefresh: {
-                        self.activateProvider(item.id)
-                        await self.viewModel.fetchModelsForCurrentProvider()
+                        if isPrivateAIProvider {
+                            await MainActor.run {
+                                self.refreshPrivateAIProviderModels()
+                            }
+                        } else {
+                            self.activateProvider(item.id)
+                            await self.viewModel.fetchModelsForCurrentProvider()
+                        }
                     },
                     isRefreshing: isRefreshing,
-                    refreshEnabled: canFetchModels,
-                    selectionEnabled: hasModels,
+                    refreshEnabled: isPrivateAIProvider ? true : canFetchModels,
+                    selectionEnabled: isPrivateAIProvider ? !isFluidBusy : hasModels,
                     controlWidth: 180,
                     controlHeight: 28
                 )
 
-                self.reasoningButton(for: item.id)
-
-                Button("Edit") {
-                    self.activateProvider(item.id)
-                    if isEditing {
-                        self.viewModel.clearEditProviderDraft()
-                        self.viewModel.setEditingAPIKey(false, for: item.id)
-                    } else {
-                        self.viewModel.startEditingProvider()
-                        self.viewModel.setEditingAPIKey(true, for: item.id)
+                if isPrivateAIProvider {
+                    Button(action: { self.loadPrivateAIModel(fluidModel) }) {
+                        if isFluidLoading {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .fixedSize()
+                        } else {
+                            Image(systemName: "memorychip")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
                     }
+                    .buttonStyle(CompactButtonStyle(foreground: isFluidLoaded ? Color.fluidGreen : nil))
+                    .frame(width: 28, height: 28)
+                    .disabled(!isFluidInstalled || isFluidBusy)
+                    .help("Load selected model")
+
+                    Button(action: { self.unloadPrivateAIModel() }) {
+                        Image(systemName: "eject")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .buttonStyle(CompactButtonStyle())
+                    .frame(width: 28, height: 28)
+                    .disabled(isFluidBusy || !isFluidLoaded)
+                    .help("Unload selected model")
+
+                    Button(action: { self.revealPrivateAIModelFolder() }) {
+                        Image(systemName: "folder")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .buttonStyle(CompactButtonStyle())
+                    .frame(width: 28, height: 28)
+                    .help("Open models folder")
+
+                    if !isFluidInstalled {
+                        Button(action: { self.downloadPrivateAIModel(fluidModel) }) {
+                            if isFluidDownloading {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                    .fixedSize()
+                            } else {
+                                Image(systemName: "arrow.down.circle")
+                                    .font(.system(size: 12, weight: .semibold))
+                            }
+                        }
+                        .buttonStyle(CompactButtonStyle())
+                        .frame(width: 28, height: 28)
+                        .disabled(!fluidModel.canDownload || isFluidBusy)
+                        .help(fluidModel.canDownload ? "Download and verify selected model" : "Download URL is not configured yet")
+                    }
+                } else {
+                    self.reasoningButton(for: item.id)
+
+                    Button("Edit") {
+                        self.activateProvider(item.id)
+                        if isEditing {
+                            self.viewModel.clearEditProviderDraft()
+                            self.viewModel.setEditingAPIKey(false, for: item.id)
+                        } else {
+                            self.viewModel.startEditingProvider()
+                            self.viewModel.setEditingAPIKey(true, for: item.id)
+                        }
+                    }
+                    .buttonStyle(CompactButtonStyle())
                 }
-                .buttonStyle(CompactButtonStyle())
             }
 
-            if isEditing {
+            if isPrivateAIProvider, isFluidDownloading || isFluidLoading || isFluidLoaded || hasFluidLoadFailure || !isFluidInstalled {
+                HStack(spacing: 6) {
+                    Image(systemName: fluidStatus.detailIcon)
+                        .font(.caption)
+                    Text(fluidStatus.detail)
+                        .font(.caption)
+                        .lineLimit(2)
+                }
+                .foregroundStyle(fluidStatus.color)
+                .padding(.top, 8)
+            }
+
+            if !isPrivateAIProvider, isEditing {
                 Divider()
                     .background(self.theme.palette.separator.opacity(0.5))
                     .padding(.vertical, 10)
@@ -1149,7 +1551,10 @@ extension AIEnhancementSettingsView {
                 self.editProviderSection
             }
 
-            if self.viewModel.showingReasoningConfig && self.viewModel.selectedProviderID == item.id {
+            if !isPrivateAIProvider,
+               self.viewModel.showingReasoningConfig,
+               self.viewModel.selectedProviderID == item.id
+            {
                 Divider()
                     .background(self.theme.palette.separator.opacity(0.5))
                     .padding(.vertical, 10)
@@ -1220,7 +1625,7 @@ extension AIEnhancementSettingsView {
         let id = item.id.lowercased()
         let name = item.name.lowercased()
 
-        if id.contains("fluid-1") || name.contains("fluid") {
+        if id.contains(PrivateAIProviderFeature.shared.providerID) || name.contains("fluid") {
             return Color(red: 0.1, green: 0.1, blue: 0.12) // Dark/black
         }
         if id.contains("anthropic") || name.contains("anthropic") {
@@ -1267,7 +1672,7 @@ extension AIEnhancementSettingsView {
         let id = item.id.lowercased()
         let name = item.name.lowercased()
 
-        if id.contains("fluid-1") || name.contains("fluid") {
+        if id.contains(PrivateAIProviderFeature.shared.providerID) || name.contains("fluid") {
             return "Provider_Fluid1"
         }
         if id.contains("openai") || name.contains("openai") {

--- a/Sources/Fluid/UI/AISettingsView+AdvancedSettings.swift
+++ b/Sources/Fluid/UI/AISettingsView+AdvancedSettings.swift
@@ -62,7 +62,8 @@ extension AIEnhancementSettingsView {
         onManage: (() -> Void)? = nil,
         onResetDefault: (() -> Void)? = nil,
         canResetDefault: Bool = false,
-        onDelete: (() -> Void)? = nil
+        onDelete: (() -> Void)? = nil,
+        isEnabled: Bool = true
     ) -> some View {
         let tone = self.modeAccentColor(mode)
         let selectedStrokeOpacity: Double = mode.normalized == .dictate ? 0.52 : 0.38
@@ -72,7 +73,10 @@ extension AIEnhancementSettingsView {
                 .fill(isHovering ? tone.opacity(0.5) : .clear)
                 .frame(width: 3, height: 34)
 
-            Button(action: onUse) {
+            Button(action: {
+                guard isEnabled else { return }
+                onUse()
+            }) {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Text(title)
@@ -101,6 +105,7 @@ extension AIEnhancementSettingsView {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .disabled(!isEnabled)
 
             Spacer(minLength: 8)
 
@@ -136,10 +141,12 @@ extension AIEnhancementSettingsView {
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(self.theme.palette.secondaryText)
+                    .disabled(!isEnabled)
                 }
             }
         }
         .padding(12)
+        .opacity(isEnabled ? 1 : 0.48)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(self.theme.palette.cardBackground.opacity(0.64))
@@ -182,7 +189,17 @@ extension AIEnhancementSettingsView {
     }
 
     private var promptProcessingControl: some View {
+        let isPrivateAILocked = self.viewModel.isPrivateAIModelSelected()
         let isOff = self.viewModel.isPrimaryDictationPromptSelectionOff()
+        let helpText: String = {
+            if isOff {
+                return "Off: dictation types the raw transcript. Prompts and app overrides are paused."
+            }
+            if isPrivateAILocked {
+                return "On: \(PrivateAIProviderFeature.displayName) uses the \(PrivateAIProviderFeature.displayName) prompt."
+            }
+            return "On: dictation follows the selected prompt scope."
+        }()
 
         return HStack(alignment: .center, spacing: 7) {
             Text("AI Enhancement")
@@ -192,7 +209,7 @@ extension AIEnhancementSettingsView {
 
             self.cleanupSegmentedControl(isOff: isOff, mode: .dictate)
         }
-        .help(isOff ? "Off: dictation types the raw transcript. Prompts and app overrides are paused." : "On: dictation follows the selected prompt scope.")
+        .help(helpText)
     }
 
     private var promptModeTabSelector: some View {
@@ -257,7 +274,8 @@ extension AIEnhancementSettingsView {
         let customProfiles = self.viewModel.dictationPromptProfiles
             .filter { $0.mode.normalized == mode }
         let tone = self.modeAccentColor(mode)
-        let isSelectedAppsOnly = self.viewModel.promptRoutingScope(for: mode) == .selectedAppsOnly
+        let isPrivateAILocked = mode.normalized == .dictate && self.viewModel.isPrivateAIModelSelected()
+        let isSelectedAppsOnly = !isPrivateAILocked && self.viewModel.promptRoutingScope(for: mode) == .selectedAppsOnly
         let isPromptRoutingPaused = mode.normalized == .dictate && self.viewModel.isPrimaryDictationPromptSelectionOff()
 
         VStack(alignment: .leading, spacing: 8) {
@@ -295,15 +313,32 @@ extension AIEnhancementSettingsView {
                         subtitle: self.viewModel.promptPreview(self.viewModel.defaultPromptBodyPreview(for: mode)),
                         mode: mode,
                         isSelected: mode.normalized == .dictate
-                            ? (!self.viewModel.isPrimaryDictationPromptSelectionOff() && self.viewModel.selectedPromptID(for: mode) == nil)
+                            ? (!isPrivateAILocked && !self.viewModel.isPrimaryDictationPromptSelectionOff() && self.viewModel.selectedPromptID(for: mode) == nil)
                             : self.viewModel.selectedPromptID(for: mode) == nil,
                         onUse: {
                             self.viewModel.setSelectedPromptID(nil, for: mode)
                         },
                         onManage: { self.viewModel.openDefaultPromptViewer(for: mode) },
                         onResetDefault: { self.viewModel.resetDefaultPromptOverride(for: mode) },
-                        canResetDefault: self.viewModel.hasDefaultPromptOverride(for: mode)
+                        canResetDefault: self.viewModel.hasDefaultPromptOverride(for: mode),
+                        isEnabled: !isPrivateAILocked
                     )
+
+                    if mode.normalized == .dictate && PrivateFeatures.privateAIProvider {
+                        self.promptProfileCard(
+                            cardKey: "\(mode.normalized.rawValue)-\(PrivateAIProviderFeature.shared.providerID)",
+                            title: PrivateAIProviderFeature.displayName,
+                            subtitle: isPrivateAILocked
+                                ? "Uses the \(PrivateAIProviderFeature.displayName) prompt."
+                                : "Select \(PrivateAIProviderFeature.displayName) to enable.",
+                            mode: mode,
+                            isSelected: self.viewModel.isPrivateAIPromptSelected(),
+                            onUse: {
+                                self.viewModel.selectPrivateAIPromptIfAvailable()
+                            },
+                            isEnabled: isPrivateAILocked
+                        )
+                    }
 
                     if customProfiles.isEmpty {
                         Text("No custom \(self.friendlyModeName(mode).lowercased()) prompts yet.")
@@ -319,17 +354,25 @@ extension AIEnhancementSettingsView {
                                     ? "Empty prompt (uses Default)"
                                     : self.viewModel.promptPreview(SettingsStore.stripBasePrompt(for: profile.mode, from: profile.prompt)),
                                 mode: profile.mode,
-                                isSelected: self.viewModel.selectedPromptID(for: profile.mode) == profile.id,
+                                isSelected: !isPrivateAILocked && self.viewModel.selectedPromptID(for: profile.mode) == profile.id,
                                 onUse: {
                                     self.viewModel.setSelectedPromptID(profile.id, for: profile.mode)
                                 },
                                 onManage: { self.viewModel.openEditor(for: profile) },
-                                onDelete: { self.viewModel.requestDeletePrompt(profile) }
+                                onDelete: { self.viewModel.requestDeletePrompt(profile) },
+                                isEnabled: !isPrivateAILocked
                             )
                         }
                     }
 
-                    self.appPromptBindingsSection(mode: mode)
+                    self.appPromptBindingsSection(mode: mode, isEnabled: !isPrivateAILocked)
+                }
+
+                if isPrivateAILocked {
+                    Text("\(PrivateAIProviderFeature.displayName) selected. Only the \(PrivateAIProviderFeature.displayName) prompt is available when AI Enhancement is On.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
                 }
             }
             .opacity(isPromptRoutingPaused ? 0.34 : 1)
@@ -379,7 +422,13 @@ extension AIEnhancementSettingsView {
                     key: "on",
                     isSelected: !isOff,
                     tone: tone,
-                    action: { self.viewModel.setSelectedPromptID(nil, for: mode) }
+                    action: {
+                        if mode.normalized == .dictate, self.viewModel.isPrivateAIModelSelected() {
+                            self.viewModel.selectPrivateAIPromptIfAvailable()
+                        } else {
+                            self.viewModel.setSelectedPromptID(nil, for: mode)
+                        }
+                    }
                 )
             }
             .font(.system(size: 12, weight: .semibold))
@@ -404,21 +453,25 @@ extension AIEnhancementSettingsView {
         let isHovering = self.hoveredCleanupControlKey == key
         let cornerRadius: CGFloat = 9
 
-        return Button(title, action: action)
-            .buttonStyle(.plain)
-            .padding(.horizontal, 12)
-            .frame(height: 26)
-            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .fluidControlSurface(
-                isSelected: isSelected,
-                isHovered: isHovering,
-                tone: tone,
-                cornerRadius: cornerRadius
-            )
-            .foregroundStyle(isSelected ? tone : (isHovering ? self.theme.palette.primaryText : self.theme.palette.secondaryText))
-            .onHover { hovering in
-                self.hoveredCleanupControlKey = hovering ? key : nil
-            }
+        return Button {
+            action()
+        } label: {
+            Text(title)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 12)
+        .frame(height: 26)
+        .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .fluidControlSurface(
+            isSelected: isSelected,
+            isHovered: isHovering,
+            tone: tone,
+            cornerRadius: cornerRadius
+        )
+        .foregroundStyle(isSelected ? tone : (isHovering ? self.theme.palette.primaryText : self.theme.palette.secondaryText))
+        .onHover { hovering in
+            self.hoveredCleanupControlKey = hovering ? key : nil
+        }
     }
 
     private func promptRoutingScopeRow(mode: SettingsStore.PromptMode) -> some View {
@@ -470,13 +523,16 @@ extension AIEnhancementSettingsView {
         mode: SettingsStore.PromptMode
     ) -> some View {
         let selectedScope = self.viewModel.promptRoutingScope(for: mode)
-        let isSelected = selectedScope == scope
         let key = "\(mode.normalized.rawValue)-\(scope.rawValue)"
-        let isHovering = self.hoveredPromptScopeKey == key
+        let isPrivateAILocked = mode.normalized == .dictate && self.viewModel.isPrivateAIModelSelected()
+        let isSelected = isPrivateAILocked ? scope == .allApps : selectedScope == scope
+        let isEnabled = !isPrivateAILocked
+        let isHovering = isEnabled && self.hoveredPromptScopeKey == key
         let tone = self.modeAccentColor(mode)
         let cornerRadius: CGFloat = 9
 
         return Button {
+            guard isEnabled else { return }
             self.viewModel.setPromptRoutingScope(scope, for: mode)
         } label: {
             Text(title)
@@ -492,8 +548,10 @@ extension AIEnhancementSettingsView {
                 )
         }
         .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.48)
         .onHover { hovering in
-            self.hoveredPromptScopeKey = hovering ? key : nil
+            self.hoveredPromptScopeKey = hovering && isEnabled ? key : nil
         }
     }
 
@@ -604,7 +662,7 @@ extension AIEnhancementSettingsView {
     }
 
     @ViewBuilder
-    private func appPromptBindingsSection(mode: SettingsStore.PromptMode, isEmphasized: Bool = false) -> some View {
+    private func appPromptBindingsSection(mode: SettingsStore.PromptMode, isEmphasized: Bool = false, isEnabled: Bool = true) -> some View {
         let bindings = self.viewModel.appBindings(for: mode)
         let appTargets = self.viewModel.appBindingTargets(for: mode)
         let modeProfiles = self.viewModel.dictationPromptProfiles
@@ -641,6 +699,8 @@ extension AIEnhancementSettingsView {
                 }
                 .buttonStyle(CompactButtonStyle(isReady: true))
                 .frame(minHeight: 26)
+                .disabled(!isEnabled)
+                .opacity(isEnabled ? 1 : 0.48)
 
                 Spacer(minLength: 8)
             }
@@ -660,7 +720,8 @@ extension AIEnhancementSettingsView {
                     self.appPromptBindingRow(
                         binding: binding,
                         mode: mode,
-                        modeProfiles: modeProfiles
+                        modeProfiles: modeProfiles,
+                        isEnabled: isEnabled
                     )
                 }
             }
@@ -672,7 +733,8 @@ extension AIEnhancementSettingsView {
     private func appPromptBindingRow(
         binding: SettingsStore.AppPromptBinding,
         mode: SettingsStore.PromptMode,
-        modeProfiles: [SettingsStore.DictationPromptProfile]
+        modeProfiles: [SettingsStore.DictationPromptProfile],
+        isEnabled: Bool = true
     ) -> some View {
         HStack(spacing: 10) {
             self.appIconView(bundleID: binding.appBundleID)
@@ -729,8 +791,10 @@ extension AIEnhancementSettingsView {
             }
             .menuStyle(.borderlessButton)
             .fixedSize(horizontal: true, vertical: false)
+            .disabled(!isEnabled)
 
             Button {
+                guard isEnabled else { return }
                 self.viewModel.removeAppPromptBinding(binding)
             } label: {
                 Image(systemName: "trash")
@@ -738,8 +802,10 @@ extension AIEnhancementSettingsView {
                     .foregroundStyle(.red.opacity(0.9))
             }
             .buttonStyle(.plain)
+            .disabled(!isEnabled)
             .help("Remove app-specific override")
         }
+        .opacity(isEnabled ? 1 : 0.48)
         .padding(8)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)

--- a/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
+++ b/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
@@ -275,88 +275,6 @@ extension VoiceEngineSettingsView {
                 .animation(.spring(response: 0.5, dampingFraction: 0.7), value: model.id)
             }
 
-            if model == .cohereTranscribeSixBit {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(alignment: .center, spacing: 10) {
-                        Image(systemName: "globe")
-                            .font(.caption)
-                            .foregroundStyle(self.theme.palette.accent)
-
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text("Select Language Manually")
-                                .font(.caption)
-                                .fontWeight(.semibold)
-                            Text("Choose the language token injected into Cohere's transcription prompt.")
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(2)
-                        }
-
-                        Spacer(minLength: 8)
-
-                        Picker("Cohere Language", selection: Binding(
-                            get: { self.settings.selectedCohereLanguage },
-                            set: { newValue in
-                                guard newValue != self.settings.selectedCohereLanguage else { return }
-                                self.settings.selectedCohereLanguage = newValue
-                            }
-                        )) {
-                            ForEach(SettingsStore.CohereLanguage.allCases) { language in
-                                Text(language.displayName).tag(language)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .labelsHidden()
-                        .disabled(self.viewModel.asr.isRunning)
-                    }
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(self.theme.palette.accent.opacity(0.08))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(self.theme.palette.accent.opacity(0.20), lineWidth: 1)
-                        )
-                )
-            }
-
-            if model == .nemotronOffline || model == .nemotronStreaming || model == .nemotronStreaming320 {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(alignment: .center, spacing: 10) {
-                        Image(systemName: "globe")
-                            .font(.caption)
-                            .foregroundStyle(self.theme.palette.accent)
-
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text("Select Language")
-                                .font(.caption)
-                                .fontWeight(.semibold)
-                            Text("Choose Auto mode or select a manual language from the list.")
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(2)
-                        }
-
-                        Spacer(minLength: 8)
-
-                        self.nemotronLanguagePickerButton
-                            .disabled(self.viewModel.asr.isRunning)
-                    }
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(self.theme.palette.accent.opacity(0.08))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(self.theme.palette.accent.opacity(0.20), lineWidth: 1)
-                        )
-                )
-            }
-
             if supportsCustomWords {
                 HStack(alignment: .center, spacing: 10) {
                     Image(systemName: "checkmark.seal.fill")
@@ -498,6 +416,9 @@ extension VoiceEngineSettingsView {
                 HStack(spacing: 8) {
                     if isConfiguredActive {
                         let isLoading = (self.viewModel.asr.isLoadingModel || self.viewModel.asr.isDownloadingModel) && !self.viewModel.asr.isAsrReady
+                        self.speechModelLanguagePicker(for: model)
+                            .disabled(self.viewModel.asr.isRunning)
+
                         Text(isLoading ? "Loading…" : "Active")
                             .font(.caption2)
                             .fontWeight(.semibold)
@@ -604,6 +525,57 @@ extension VoiceEngineSettingsView {
         .allowsHitTesting(!self.viewModel.asr.isRunning)
     }
 
+    @ViewBuilder
+    private func speechModelLanguagePicker(for model: SettingsStore.SpeechModel) -> some View {
+        if model == .cohereTranscribeSixBit {
+            Menu {
+                ForEach(SettingsStore.CohereLanguage.allCases) { language in
+                    Button {
+                        guard language != self.settings.selectedCohereLanguage else { return }
+                        self.settings.selectedCohereLanguage = language
+                    } label: {
+                        HStack {
+                            Text(language.displayName)
+                            if language == self.settings.selectedCohereLanguage {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                self.languageChipLabel(self.settings.selectedCohereLanguage.displayName)
+            }
+            .buttonStyle(.plain)
+        } else if model == .nemotronOffline || model == .nemotronStreaming || model == .nemotronStreaming320 {
+            self.nemotronLanguagePickerButton
+        }
+    }
+
+    private func languageChipLabel(_ title: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: "globe")
+                .font(.caption2)
+                .foregroundStyle(self.theme.palette.accent)
+            Text(title)
+                .lineLimit(1)
+                .fontWeight(.semibold)
+            Image(systemName: "chevron.down")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+        }
+        .font(.caption2)
+        .frame(minHeight: 24)
+        .padding(.horizontal, 9)
+        .background(
+            Capsule()
+                .fill(self.theme.palette.accent.opacity(0.10))
+                .overlay(
+                    Capsule()
+                        .stroke(self.theme.palette.accent.opacity(0.28), lineWidth: 1)
+                )
+        )
+    }
+
     private func speechModelSubtitle(for model: SettingsStore.SpeechModel) -> String {
         switch model {
         case .nemotronStreaming, .nemotronStreaming320:
@@ -617,24 +589,7 @@ extension VoiceEngineSettingsView {
         Button {
             self.isShowingNemotronLanguagePicker.toggle()
         } label: {
-            HStack(spacing: 8) {
-                Text(self.settings.selectedNemotronLanguage.displayName)
-                    .lineLimit(1)
-                Image(systemName: "chevron.down")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
-            .font(.caption)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(self.theme.palette.cardBackground.opacity(0.9))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(self.theme.palette.cardBorder.opacity(0.6), lineWidth: 1)
-                    )
-            )
+            self.languageChipLabel(self.settings.selectedNemotronLanguage.compactDisplayName)
         }
         .buttonStyle(.plain)
         .popover(isPresented: self.$isShowingNemotronLanguagePicker, arrowEdge: .bottom) {

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -61,6 +61,8 @@ struct SettingsView: View {
     @State private var showAreYouSureToStopAnalytics: Bool = false
     @State private var rollbackVersion: String = ""
     @State private var isRollingBack: Bool = false
+    @State private var audioHistoryBudgetText: String = Self.audioBudgetText(for: SettingsStore.shared.audioHistoryBudgetGB)
+    @State private var audioHistoryUsageBytes: Int64 = DictationAudioHistoryStore.shared.audioUsageBytes()
 
     let hotkeyManager: GlobalHotkeyManager?
     let menuBarManager: MenuBarManager
@@ -137,6 +139,8 @@ struct SettingsView: View {
                     return "__OFF__"
                 case .default:
                     return "__DEFAULT__"
+                case .privateAI:
+                    return PrivateAIProviderPromptFormat.promptSelectionID
                 case let .profile(id):
                     return id
                 }
@@ -146,8 +150,13 @@ struct SettingsView: View {
                 case "__OFF__":
                     self.settings.setDictationPromptSelection(.off, for: slot)
                 case "__DEFAULT__":
+                    guard !PrivateAIProviderPromptFormat.isAvailable(settings: self.settings) else { return }
                     self.settings.setDictationPromptSelection(.default, for: slot)
+                case PrivateAIProviderPromptFormat.promptSelectionID:
+                    guard PrivateAIProviderPromptFormat.isAvailable(settings: self.settings) else { return }
+                    self.settings.setDictationPromptSelection(.privateAI, for: slot)
                 default:
+                    guard !PrivateAIProviderPromptFormat.isAvailable(settings: self.settings) else { return }
                     self.settings.setDictationPromptSelection(.profile(newValue), for: slot)
                 }
             }
@@ -157,6 +166,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func dictationPromptPicker(for slot: SettingsStore.DictationShortcutSlot) -> some View {
         let profiles = self.settings.promptProfiles(for: .dictate)
+        let privateAILocked = PrivateAIProviderPromptFormat.isAvailable(settings: self.settings)
         HStack {
             Text("AI Prompt")
                 .font(.subheadline)
@@ -165,9 +175,16 @@ struct SettingsView: View {
             Spacer()
             Picker("", selection: self.dictationPromptSelectionBinding(for: slot)) {
                 Text("Off").tag("__OFF__")
-                Text("Default").tag("__DEFAULT__")
+                Text("Default").tag("__DEFAULT__").disabled(privateAILocked)
+                if PrivateFeatures.privateAIProvider {
+                    Text(PrivateAIProviderFeature.displayName)
+                        .tag(PrivateAIProviderPromptFormat.promptSelectionID)
+                        .disabled(!privateAILocked)
+                }
                 ForEach(profiles) { profile in
-                    Text(profile.name.isEmpty ? "Untitled" : profile.name).tag(profile.id)
+                    Text(profile.name.isEmpty ? "Untitled" : profile.name)
+                        .tag(profile.id)
+                        .disabled(privateAILocked)
                 }
             }
             .frame(width: 190)
@@ -815,10 +832,36 @@ struct SettingsView: View {
                                         description: "Save transcriptions for stats tracking. Disable for privacy.",
                                         isOn: Binding(
                                             get: { SettingsStore.shared.saveTranscriptionHistory },
-                                            set: { SettingsStore.shared.saveTranscriptionHistory = $0 }
+                                            set: {
+                                                SettingsStore.shared.saveTranscriptionHistory = $0
+                                                self.refreshAudioHistoryUsage()
+                                            }
                                         )
                                     )
                                     Divider().opacity(0.2)
+
+                                    self.optionToggleRow(
+                                        title: "Save Audio With History",
+                                        description: "Store actual microphone audio locally with dictation history. Disabled by default.",
+                                        isOn: Binding(
+                                            get: { SettingsStore.shared.saveAudioWithTranscriptionHistory },
+                                            set: {
+                                                SettingsStore.shared.saveAudioWithTranscriptionHistory = $0
+                                                self.refreshAudioHistoryUsage()
+                                            }
+                                        )
+                                    )
+                                    .disabled(!SettingsStore.shared.saveTranscriptionHistory)
+
+                                    if SettingsStore.shared.saveTranscriptionHistory,
+                                       SettingsStore.shared.saveAudioWithTranscriptionHistory
+                                    {
+                                        self.audioHistoryControls()
+                                            .padding(.top, 2)
+                                        Divider().opacity(0.2)
+                                    } else {
+                                        Divider().opacity(0.2)
+                                    }
 
                                     self.optionToggleRow(
                                         title: "Notify AI Enhancement Failures",
@@ -1497,6 +1540,7 @@ struct SettingsView: View {
                 self.cachedDefaultOutputName = AudioDevice.getDefaultOutputDevice()?.name ?? ""
                 self.refreshRollbackState()
                 self.settings.refreshLaunchAtStartupStatus(clearError: true, logMismatch: false)
+                self.refreshAudioHistoryUsage()
             }
         }
         .onChange(of: self.visualizerNoiseThreshold) { _, newValue in
@@ -1588,6 +1632,85 @@ struct SettingsView: View {
         self.shareAnonymousAnalytics = SettingsStore.shared.shareAnonymousAnalytics
         self.pendingAnalyticsValue = nil
         self.showAreYouSureToStopAnalytics = false
+        self.refreshAudioHistoryUsage()
+    }
+
+    private func refreshAudioHistoryUsage() {
+        self.audioHistoryUsageBytes = DictationAudioHistoryStore.shared.audioUsageBytes()
+        self.audioHistoryBudgetText = Self.audioBudgetText(for: SettingsStore.shared.audioHistoryBudgetGB)
+    }
+
+    private func applyAudioHistoryBudget() {
+        let normalized = self.audioHistoryBudgetText
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: ",", with: ".")
+        guard let value = Double(normalized), value > 0 else {
+            self.presentErrorAlert(title: "Invalid Budget", message: "Enter a positive number of GB.")
+            self.refreshAudioHistoryUsage()
+            return
+        }
+
+        let newBudget = max(0.1, value)
+        let newBudgetBytes = DictationAudioHistoryStore.bytes(forGigabytes: newBudget)
+        if self.audioHistoryUsageBytes > newBudgetBytes {
+            let confirm = NSAlert()
+            confirm.messageText = "Prune saved audio?"
+            confirm.informativeText = """
+            This budget is below current audio usage. FluidVoice will delete the oldest saved audio first and keep transcript history.
+            """
+            confirm.alertStyle = .warning
+            confirm.addButton(withTitle: "Apply and Prune")
+            confirm.addButton(withTitle: "Cancel")
+            guard confirm.runModal() == .alertFirstButtonReturn else {
+                self.refreshAudioHistoryUsage()
+                return
+            }
+        }
+
+        SettingsStore.shared.audioHistoryBudgetGB = newBudget
+        let pruned = TranscriptionHistoryStore.shared.pruneAudioToBudget()
+        self.refreshAudioHistoryUsage()
+        if pruned > 0 {
+            self.presentInfoAlert(title: "Audio Pruned", message: "Deleted oldest saved audio from \(pruned) history entries.")
+        }
+    }
+
+    private func deleteSavedAudio() {
+        let confirm = NSAlert()
+        confirm.messageText = "Delete saved audio?"
+        confirm.informativeText = "This removes saved dictation audio only. Transcript history stays intact."
+        confirm.alertStyle = .warning
+        confirm.addButton(withTitle: "Delete Audio")
+        confirm.addButton(withTitle: "Cancel")
+        guard confirm.runModal() == .alertFirstButtonReturn else { return }
+
+        let removed = TranscriptionHistoryStore.shared.deleteAllSavedAudio()
+        self.refreshAudioHistoryUsage()
+        self.presentInfoAlert(title: "Audio Deleted", message: "Removed audio from \(removed) history entries.")
+    }
+
+    private func exportAudioZip() {
+        do {
+            guard TranscriptionHistoryStore.shared.entries.contains(where: {
+                DictationAudioHistoryStore.shared.audioFileExists(for: $0)
+            }) else {
+                throw DictationAudioHistoryError.noAudioEntries
+            }
+
+            let panel = NSSavePanel()
+            panel.canCreateDirectories = true
+            panel.allowedContentTypes = [.zip]
+            panel.nameFieldStringValue = DictationAudioHistoryStore.shared.suggestedAudioExportFilename()
+
+            guard panel.runModal() == .OK, let url = panel.url else { return }
+            try DictationAudioHistoryStore.shared.exportAudioArchive(
+                entries: TranscriptionHistoryStore.shared.entries,
+                to: url
+            )
+            self.presentInfoAlert(title: "Audio Export Saved", message: "Saved your dictation audio export to:\n\(url.path)")
+        } catch {
+            self.presentErrorAlert(title: "Audio Export Failed", message: error.localizedDescription)
+        }
     }
 
     private func presentInfoAlert(title: String, message: String) {
@@ -1738,6 +1861,86 @@ struct SettingsView: View {
                 .controlSize(.regular)
             }
         }
+    }
+
+    private func audioHistoryControls() -> some View {
+        VStack(spacing: 12) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Audio Storage")
+                        .font(.body)
+                    Text("Audio history: \(DictationAudioHistoryStore.formattedGigabytes(self.audioHistoryUsageBytes)) / \(Self.audioBudgetText(for: SettingsStore.shared.audioHistoryBudgetGB)) GB Budget")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ProgressView(value: self.audioHistoryUsageFraction())
+                        .progressViewStyle(.linear)
+                        .frame(maxWidth: 220)
+                }
+
+                Spacer(minLength: 16)
+
+                HStack(spacing: 8) {
+                    Text("Budget")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    TextField("4", text: self.$audioHistoryBudgetText)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 58)
+
+                    Text("GB")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Button("Apply") {
+                        self.applyAudioHistoryBudget()
+                    }
+                    .controlSize(.small)
+                }
+            }
+
+            Divider().opacity(0.2)
+
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Export Audio")
+                        .font(.body)
+                    Text("ZIP with manifest.jsonl and WAV audio.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 16)
+
+                Button {
+                    self.exportAudioZip()
+                } label: {
+                    Label("Export ZIP", systemImage: "square.and.arrow.up")
+                }
+                .controlSize(.small)
+
+                Button(role: .destructive) {
+                    self.deleteSavedAudio()
+                } label: {
+                    Label("Delete Audio", systemImage: "trash")
+                }
+                .controlSize(.small)
+                .disabled(self.audioHistoryUsageBytes <= 0)
+            }
+        }
+    }
+
+    private static func audioBudgetText(for value: Double) -> String {
+        value.truncatingRemainder(dividingBy: 1) == 0
+            ? String(format: "%.0f", value)
+            : String(format: "%.1f", value)
+    }
+
+    private func audioHistoryUsageFraction() -> Double {
+        let budget = SettingsStore.shared.audioHistoryBudgetBytes
+        guard budget > 0 else { return 0 }
+        return min(1, Double(self.audioHistoryUsageBytes) / Double(budget))
     }
 
     private func optionToggleRow(

--- a/Sources/Fluid/UI/TranscriptionHistoryView.swift
+++ b/Sources/Fluid/UI/TranscriptionHistoryView.swift
@@ -1,4 +1,6 @@
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct TranscriptionHistoryView: View {
     @ObservedObject private var historyStore = TranscriptionHistoryStore.shared
@@ -6,6 +8,8 @@ struct TranscriptionHistoryView: View {
 
     @State private var searchQuery: String = ""
     @State private var showClearConfirmation: Bool = false
+    @State private var showFeedbackPlaceholder: Bool = false
+    @State private var selectedFeedbackEntry: TranscriptionHistoryEntry?
     @State private var selectedEntryID: UUID?
 
     private var filteredEntries: [TranscriptionHistoryEntry] {
@@ -67,6 +71,18 @@ struct TranscriptionHistoryView: View {
             }
         } message: {
             Text("This will permanently delete all \(self.historyStore.entries.count) transcription entries. This action cannot be undone.")
+        }
+        .alert("Feedback placeholder", isPresented: self.$showFeedbackPlaceholder) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Nothing was sent. This is reserved for opt-in bad result reporting with review and redaction before upload.")
+        }
+        .sheet(item: self.$selectedFeedbackEntry) { entry in
+            TranscriptionFeedbackPlaceholderSheet(entry: entry) {
+                self.selectedFeedbackEntry = nil
+                self.showFeedbackPlaceholder = true
+            }
+            .environment(\.theme, self.theme)
         }
     }
 
@@ -143,6 +159,13 @@ struct TranscriptionHistoryView: View {
                             )
                     }
 
+                    if self.hasAudio(entry) {
+                        Image(systemName: "waveform")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(isSelected ? .white.opacity(0.8) : self.theme.palette.accent)
+                            .help("Saved local dictation audio")
+                    }
+
                     if entry.aiProcessingError != nil {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 10, weight: .bold))
@@ -193,6 +216,30 @@ struct TranscriptionHistoryView: View {
                 } label: {
                     Label("Copy Both", systemImage: "doc.on.doc")
                 }
+            }
+
+            if self.hasAudio(entry) {
+                Divider()
+
+                Button {
+                    self.exportPair(entry)
+                } label: {
+                    Label("Export Pair...", systemImage: "square.and.arrow.up")
+                }
+
+                Button {
+                    self.revealAudio(entry)
+                } label: {
+                    Label("Reveal Audio", systemImage: "waveform")
+                }
+            }
+
+            Divider()
+
+            Button {
+                self.openFeedbackPlaceholder(for: entry)
+            } label: {
+                Label("Report Bad Result...", systemImage: "hand.thumbsup.slash")
             }
 
             Divider()
@@ -293,6 +340,36 @@ struct TranscriptionHistoryView: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+
+                        if self.hasAudio(entry) {
+                            Button {
+                                self.exportPair(entry)
+                            } label: {
+                                Label("Export Pair", systemImage: "square.and.arrow.up")
+                                    .font(.system(size: 12, weight: .medium))
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+
+                            Button {
+                                self.revealAudio(entry)
+                            } label: {
+                                Label("Audio", systemImage: "waveform")
+                                    .font(.system(size: 12, weight: .medium))
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+
+                        Button {
+                            self.openFeedbackPlaceholder(for: entry)
+                        } label: {
+                            Label("Report", systemImage: "hand.thumbsup.slash")
+                                .font(.system(size: 12, weight: .medium))
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .help("Placeholder only. Nothing is sent.")
 
                         if entry.wasAIProcessed {
                             Button {
@@ -452,6 +529,7 @@ struct TranscriptionHistoryView: View {
                 self.metadataItem(icon: "macwindow", label: "Window", value: entry.windowTitle.isEmpty ? "Unknown" : entry.windowTitle)
                 self.metadataItem(icon: "character.cursor.ibeam", label: "Characters", value: "\(entry.characterCount)")
                 self.metadataItem(icon: "sparkles", label: "AI Processed", value: entry.wasAIProcessed ? "Yes" : "No")
+                self.metadataItem(icon: "waveform", label: "Audio", value: self.audioMetadataText(for: entry))
             }
         }
     }
@@ -486,8 +564,52 @@ struct TranscriptionHistoryView: View {
         NSPasteboard.general.setString(text, forType: .string)
     }
 
+    private func openFeedbackPlaceholder(for entry: TranscriptionHistoryEntry) {
+        self.selectedFeedbackEntry = entry
+    }
+
     private func combinedText(for entry: TranscriptionHistoryEntry) -> String {
         "\(entry.rawText)\n\n\(entry.processedText)"
+    }
+
+    private func hasAudio(_ entry: TranscriptionHistoryEntry) -> Bool {
+        DictationAudioHistoryStore.shared.audioFileExists(for: entry)
+    }
+
+    private func audioMetadataText(for entry: TranscriptionHistoryEntry) -> String {
+        guard let audio = entry.audio, self.hasAudio(entry) else { return "No" }
+        let seconds = Double(audio.durationMilliseconds) / 1000.0
+        let size = ByteCountFormatter.string(fromByteCount: Int64(audio.byteCount), countStyle: .file)
+        return "\(String(format: "%.1f", seconds))s, \(size)"
+    }
+
+    private func revealAudio(_ entry: TranscriptionHistoryEntry) {
+        guard let url = DictationAudioHistoryStore.shared.audioFileURL(for: entry),
+              FileManager.default.fileExists(atPath: url.path)
+        else {
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    private func exportPair(_ entry: TranscriptionHistoryEntry) {
+        do {
+            guard self.hasAudio(entry) else { throw DictationAudioHistoryError.audioMissing }
+            let panel = NSSavePanel()
+            panel.canCreateDirectories = true
+            panel.allowedContentTypes = [.zip]
+            panel.nameFieldStringValue = DictationAudioHistoryStore.shared.suggestedPairExportFilename(for: entry)
+
+            guard panel.runModal() == .OK, let url = panel.url else { return }
+            try DictationAudioHistoryStore.shared.exportPair(entry: entry, to: url)
+        } catch {
+            let alert = NSAlert()
+            alert.messageText = "Pair Export Failed"
+            alert.informativeText = error.localizedDescription
+            alert.alertStyle = .critical
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        }
     }
 
     // MARK: - No Selection View
@@ -504,6 +626,82 @@ struct TranscriptionHistoryView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(self.theme.palette.contentBackground)
+    }
+}
+
+private struct TranscriptionFeedbackPlaceholderSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.theme) private var theme
+
+    @State private var inputText: String
+    @State private var outputText: String
+    @State private var comment: String
+
+    let onSend: () -> Void
+
+    init(entry: TranscriptionHistoryEntry, onSend: @escaping () -> Void) {
+        _inputText = State(initialValue: entry.rawText)
+        _outputText = State(initialValue: entry.processedText)
+        _comment = State(initialValue: "")
+        self.onSend = onSend
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Report bad result")
+                    .font(.system(size: 18, weight: .semibold))
+                Text("Review or edit what would be sent. Nothing is uploaded yet.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            self.feedbackField(title: "Input", text: self.$inputText, height: 88)
+            self.feedbackField(title: "Output", text: self.$outputText, height: 88)
+            self.feedbackField(title: "Comment optional", text: self.$comment, height: 72)
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    self.dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Send") {
+                    self.onSend()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(self.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    && self.outputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 520)
+        .background(self.theme.palette.contentBackground)
+    }
+
+    private func feedbackField(title: String, text: Binding<String>, height: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+
+            TextEditor(text: text)
+                .font(.system(size: 13))
+                .scrollContentBackground(.hidden)
+                .padding(8)
+                .frame(height: height)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(self.theme.palette.cardBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(self.theme.palette.cardBorder.opacity(0.55), lineWidth: 1)
+                        )
+                )
+        }
     }
 }
 

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -1650,6 +1650,7 @@ struct OnboardingFlowView: View {
         Task { @MainActor in
             if self.asr.isRunning {
                 let transcribed = await self.asr.stop()
+                _ = self.asr.consumeLastCompletedAudioSnapshot()
                 self.asr.finalText = ASRService.applyGAAVFormatting(transcribed)
                 if !self.asr.finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     self.markPlaygroundValidated()

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -1284,6 +1284,10 @@ private struct BottomOverlayPromptMenuView: View {
     let onDismissRequested: () -> Void
     @State private var hoveredRowID: String?
 
+    private var privateAILocked: Bool {
+        self.promptMode.normalized == .dictate && PrivateAIProviderPromptFormat.isAvailable(settings: self.settings)
+    }
+
     private func rowBackground(isSelected: Bool, rowID: String) -> some View {
         let isHovered = self.hoveredRowID == rowID
         let fillColor: Color
@@ -1346,10 +1350,11 @@ private struct BottomOverlayPromptMenuView: View {
     @ViewBuilder
     private func defaultRow(selectedID: String?) -> some View {
         let activeSlot = self.contentState.activeDictationShortcutSlot ?? .primary
-        let isSelected = self.promptMode.normalized == .dictate
+        let isSelected = !self.privateAILocked && (self.promptMode.normalized == .dictate
             ? (self.settings.dictationPromptSelection(for: activeSlot) == .default)
-            : (selectedID == nil)
+            : (selectedID == nil))
         Button(action: {
+            guard !self.privateAILocked else { return }
             if self.promptMode.normalized == .dictate {
                 self.contentState.onDictationPromptSelectionRequested?(.default)
             } else {
@@ -1371,18 +1376,53 @@ private struct BottomOverlayPromptMenuView: View {
             .background(self.rowBackground(isSelected: isSelected, rowID: "default"))
         }
         .buttonStyle(.plain)
+        .disabled(self.privateAILocked)
+        .opacity(self.privateAILocked ? 0.45 : 1)
         .onHover { hovering in
-            self.hoveredRowID = hovering ? "default" : nil
+            self.hoveredRowID = hovering && !self.privateAILocked ? "default" : nil
+        }
+    }
+
+    @ViewBuilder
+    private func privateAIRow() -> some View {
+        let activeSlot = self.contentState.activeDictationShortcutSlot ?? .primary
+        let isAvailable = PrivateAIProviderPromptFormat.isAvailable(settings: self.settings)
+        let isSelected = self.settings.dictationPromptSelection(for: activeSlot) == .privateAI
+        Button(action: {
+            guard isAvailable else { return }
+            self.contentState.onDictationPromptSelectionRequested?(.privateAI)
+            self.restoreTypingTargetApp()
+            self.onDismissRequested()
+        }) {
+            HStack {
+                Text(PrivateAIProviderFeature.displayName)
+                Spacer()
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(self.rowBackground(isSelected: isSelected, rowID: PrivateAIProviderFeature.shared.providerID))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isAvailable)
+        .opacity(isAvailable ? 1 : 0.45)
+        .help(isAvailable ? "Use \(PrivateAIProviderFeature.displayName)" : "Select \(PrivateAIProviderFeature.displayName) to enable this prompt")
+        .onHover { hovering in
+            self.hoveredRowID = hovering && isAvailable ? PrivateAIProviderFeature.shared.providerID : nil
         }
     }
 
     @ViewBuilder
     private func profileRow(_ profile: SettingsStore.DictationPromptProfile, selectedID: String?) -> some View {
         let activeSlot = self.contentState.activeDictationShortcutSlot ?? .primary
-        let isSelected = self.promptMode.normalized == .dictate
+        let isSelected = !self.privateAILocked && (self.promptMode.normalized == .dictate
             ? (self.settings.dictationPromptSelection(for: activeSlot) == .profile(profile.id))
-            : (selectedID == profile.id)
+            : (selectedID == profile.id))
         Button(action: {
+            guard !self.privateAILocked else { return }
             if self.promptMode.normalized == .dictate {
                 self.contentState.onDictationPromptSelectionRequested?(.profile(profile.id))
             } else {
@@ -1404,8 +1444,10 @@ private struct BottomOverlayPromptMenuView: View {
             .background(self.rowBackground(isSelected: isSelected, rowID: profile.id))
         }
         .buttonStyle(.plain)
+        .disabled(self.privateAILocked)
+        .opacity(self.privateAILocked ? 0.45 : 1)
         .onHover { hovering in
-            self.hoveredRowID = hovering ? profile.id : nil
+            self.hoveredRowID = hovering && !self.privateAILocked ? profile.id : nil
         }
     }
 
@@ -1421,9 +1463,15 @@ private struct BottomOverlayPromptMenuView: View {
                     .padding(.vertical, 4)
             }
 
-            self.defaultRow(selectedID: selectedID)
+            if !self.privateAILocked {
+                self.defaultRow(selectedID: selectedID)
+            }
 
-            if !profiles.isEmpty {
+            if self.promptMode.normalized == .dictate && PrivateFeatures.privateAIProvider {
+                self.privateAIRow()
+            }
+
+            if !self.privateAILocked && !profiles.isEmpty {
                 Divider()
                     .padding(.vertical, 4)
 
@@ -2072,12 +2120,17 @@ struct BottomOverlayView: View {
         self.shouldReservePreviewArea && self.contentState.isProcessing && self.processingStatusVisible
     }
 
+    private var shouldShowAIProcessingFailure: Bool {
+        self.shouldReservePreviewArea && self.contentState.isAIProcessingFailureVisible && !self.contentState.isProcessing
+    }
+
     private var shouldSuppressPreviewDuringRelease: Bool {
         self.contentState.isBottomOverlayReleaseTransitioning || self.contentState.isBottomOverlayDismissing
     }
 
     private func previewResizeBucket(for previewText: String) -> Int {
         guard self.shouldReservePreviewArea else { return 0 }
+        if self.shouldShowAIProcessingFailure { return 1 }
         let trimmed = previewText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return self.shouldShowProcessingStatus ? 1 : 0 }
 
@@ -2475,6 +2528,44 @@ struct BottomOverlayView: View {
         .help("Open Preferences")
     }
 
+    private func failureIconButton(systemName: String, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: max(self.layout.transFontSize - 1, 10), weight: .semibold))
+                .foregroundStyle(.white.opacity(0.86))
+                .frame(width: 20, height: 20)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(0.12))
+                )
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private var aiProcessingFailureView: some View {
+        HStack(spacing: 8) {
+            Text("AI Enhancement failed")
+                .font(.system(size: self.layout.transFontSize, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer(minLength: 4)
+
+            self.failureIconButton(systemName: "arrow.clockwise", help: "Try again") {
+                self.contentState.clearAIProcessingFailure()
+                self.contentState.onReprocessLastRequested?()
+            }
+
+            self.failureIconButton(systemName: "xmark", help: "Dismiss") {
+                self.contentState.clearAIProcessingFailure()
+                NotchOverlayManager.shared.hide()
+            }
+        }
+        .frame(maxWidth: self.previewMaxWidth, alignment: .leading)
+    }
+
     var body: some View {
         VStack(spacing: max(4, self.layout.vPadding / 2)) {
             if self.layout.showsTopControls {
@@ -2498,6 +2589,8 @@ struct BottomOverlayView: View {
                         Group {
                             if self.shouldSuppressPreviewDuringRelease {
                                 Color.clear
+                            } else if self.shouldShowAIProcessingFailure {
+                                self.aiProcessingFailureView
                             } else if self.shouldShowProcessingStatus {
                                 // Temporarily hidden; the waveform sweep carries processing state.
                                 // ShimmerText(
@@ -2554,6 +2647,8 @@ struct BottomOverlayView: View {
                         Group {
                             if self.shouldSuppressPreviewDuringRelease {
                                 Color.clear
+                            } else if self.shouldShowAIProcessingFailure {
+                                self.aiProcessingFailureView
                             } else if self.hasTranscription && !self.contentState.isProcessing {
                                 let previewText = self.transcriptionPreviewText
                                 if !previewText.isEmpty {
@@ -2748,6 +2843,10 @@ struct BottomOverlayView: View {
             if !self.layout.usesFixedCanvas {
                 self.refreshDynamicPreviewSizeIfNeeded(for: self.currentPreviewSizingText)
             }
+        }
+        .onChange(of: self.contentState.isAIProcessingFailureVisible) { _, _ in
+            guard !self.layout.usesFixedCanvas else { return }
+            self.refreshDynamicPreviewSizeIfNeeded(for: self.currentPreviewSizingText)
         }
         .onChange(of: self.processingStatusVisible) { _, _ in
             guard !self.layout.usesFixedCanvas else { return }

--- a/Sources/Fluid/Views/CommandModeView.swift
+++ b/Sources/Fluid/Views/CommandModeView.swift
@@ -583,6 +583,7 @@ struct CommandModeView: View {
         if self.asr.isRunning {
             Task {
                 let command = await self.asr.stop().trimmingCharacters(in: .whitespacesAndNewlines)
+                _ = self.asr.consumeLastCompletedAudioSnapshot()
                 guard !command.isEmpty else { return }
                 await MainActor.run {
                     self.inputText = command

--- a/Sources/Fluid/Views/NotchContentViews.swift
+++ b/Sources/Fluid/Views/NotchContentViews.swift
@@ -22,6 +22,7 @@ class NotchContentState: ObservableObject {
     @Published var mode: OverlayMode = .dictation
     @Published var promptPickerMode: SettingsStore.PromptMode = .dictate
     @Published var isProcessing: Bool = false // AI processing state
+    @Published var isAIProcessingFailureVisible: Bool = false
     @Published var activeDictationShortcutSlot: SettingsStore.DictationShortcutSlot? = nil
     @Published var promptModeOverrideProfileName: String? = nil // Name shown in overlay when prompt mode hotkey is active
     @Published var promptModeOverrideProfileID: String? = nil // ID of the active override profile (for checkmark in menu)
@@ -89,7 +90,18 @@ class NotchContentState: ObservableObject {
 
     /// Set AI processing state
     func setProcessing(_ processing: Bool) {
+        if processing {
+            self.clearAIProcessingFailure()
+        }
         self.isProcessing = processing
+    }
+
+    func showAIProcessingFailure() {
+        self.isAIProcessingFailureVisible = true
+    }
+
+    func clearAIProcessingFailure() {
+        self.isAIProcessingFailureVisible = false
     }
 
     /// Update transcription and recompute cached lines
@@ -635,9 +647,13 @@ struct NotchExpandedView: View {
         _ title: String,
         rowID: String,
         isSelected: Bool,
+        isEnabled: Bool = true,
         action: @escaping () -> Void
     ) -> some View {
-        Button(action: action) {
+        Button(action: {
+            guard isEnabled else { return }
+            action()
+        }) {
             Text(title)
                 .font(.system(size: 9, weight: isSelected ? .semibold : .medium))
                 .foregroundStyle(.white.opacity(isSelected ? 0.96 : 0.84))
@@ -649,14 +665,17 @@ struct NotchExpandedView: View {
                 .background(self.promptMenuRowBackground(isSelected: isSelected, rowID: rowID))
         }
         .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.45)
         .onHover { hovering in
-            self.hoveredPromptMenuRowID = hovering ? rowID : nil
+            self.hoveredPromptMenuRowID = hovering && isEnabled ? rowID : nil
         }
     }
 
     private func promptMenuContent() -> some View {
         let promptMode = self.activePromptMode ?? .dictate
         let activeDictationSlot = self.activeDictationShortcutSlot
+        let privateAILocked = promptMode.normalized == .dictate && PrivateAIProviderPromptFormat.isAvailable(settings: self.settings)
         return VStack(alignment: .leading, spacing: 2) {
             Text("AI Prompt")
                 .font(.system(size: 8, weight: .semibold))
@@ -675,7 +694,8 @@ struct NotchExpandedView: View {
                         self.promptMenuRow(
                             "Off",
                             rowID: "off",
-                            isSelected: self.settings.dictationPromptSelection(for: activeDictationSlot) == .off
+                            isSelected: self.settings.dictationPromptSelection(for: activeDictationSlot) == .off,
+                            isEnabled: true
                         ) {
                             self.contentState.onDictationPromptSelectionRequested?(.off)
                             self.restoreRecordingTargetFocus()
@@ -683,17 +703,33 @@ struct NotchExpandedView: View {
                         }
                     }
 
-                    self.promptMenuRow("Default", rowID: "default", isSelected: defaultSelected) {
-                        if promptMode.normalized == .dictate {
-                            self.contentState.onDictationPromptSelectionRequested?(.default)
-                        } else {
-                            self.settings.setSelectedPromptID(nil, for: promptMode)
+                    if !privateAILocked {
+                        self.promptMenuRow("Default", rowID: "default", isSelected: defaultSelected) {
+                            if promptMode.normalized == .dictate {
+                                self.contentState.onDictationPromptSelectionRequested?(.default)
+                            } else {
+                                self.settings.setSelectedPromptID(nil, for: promptMode)
+                            }
+                            self.restoreRecordingTargetFocus()
+                            self.dismissPromptHoverMenu()
                         }
-                        self.restoreRecordingTargetFocus()
-                        self.dismissPromptHoverMenu()
                     }
 
-                    let profiles = self.settings.promptProfiles(for: promptMode)
+                    if promptMode.normalized == .dictate && PrivateFeatures.privateAIProvider {
+                        let privateAIAvailable = PrivateAIProviderPromptFormat.isAvailable(settings: self.settings)
+                        self.promptMenuRow(
+                            PrivateAIProviderFeature.displayName,
+                            rowID: PrivateAIProviderFeature.shared.providerID,
+                            isSelected: self.settings.dictationPromptSelection(for: activeDictationSlot) == .privateAI,
+                            isEnabled: privateAIAvailable
+                        ) {
+                            self.contentState.onDictationPromptSelectionRequested?(.privateAI)
+                            self.restoreRecordingTargetFocus()
+                            self.dismissPromptHoverMenu()
+                        }
+                    }
+
+                    let profiles = privateAILocked ? [] : self.settings.promptProfiles(for: promptMode)
                     if !profiles.isEmpty {
                         ForEach(profiles) { profile in
                             let isSelected = promptMode.normalized == .dictate
@@ -859,7 +895,42 @@ struct NotchExpandedView: View {
 
             self.promptHoverMenuRow
 
-            if self.presentationPolicy.showsStreamingPreview && self.hasTranscription && !self.contentState.isProcessing {
+            if self.contentState.isAIProcessingFailureVisible && !self.contentState.isProcessing {
+                HStack(spacing: 6) {
+                    Text("AI Enhancement failed")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.82))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    Spacer(minLength: 2)
+
+                    Button {
+                        self.contentState.clearAIProcessingFailure()
+                        self.contentState.onReprocessLastRequested?()
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 9, weight: .bold))
+                            .frame(width: 16, height: 16)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Try again")
+
+                    Button {
+                        self.contentState.clearAIProcessingFailure()
+                        NotchOverlayManager.shared.hide()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 9, weight: .bold))
+                            .frame(width: 16, height: 16)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Dismiss")
+                }
+                .foregroundStyle(.white.opacity(0.9))
+                .frame(width: self.previewMaxWidth, alignment: .leading)
+                .transition(.opacity.combined(with: .scale(scale: 0.95)))
+            } else if self.presentationPolicy.showsStreamingPreview && self.hasTranscription && !self.contentState.isProcessing {
                 let previewText = self.visiblePreviewText
                 if !previewText.isEmpty {
                     ScrollViewReader { proxy in

--- a/Sources/Fluid/Views/RewriteModeView.swift
+++ b/Sources/Fluid/Views/RewriteModeView.swift
@@ -261,7 +261,10 @@ struct RewriteModeView: View {
 
     private func toggleRecording() {
         if self.asr.isRunning {
-            Task { await self.asr.stop() }
+            Task {
+                _ = await self.asr.stop()
+                _ = self.asr.consumeLastCompletedAudioSnapshot()
+            }
         } else {
             Task { await self.asr.start() }
         }

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -11,12 +11,17 @@ final class DictationE2ETests: XCTestCase {
     private let appPromptBindingsKey = "AppPromptBindings"
     private let selectedDictationPromptIDKey = "SelectedDictationPromptID"
     private let selectedEditPromptIDKey = "SelectedEditPromptID"
+    private let dictationPromptOffKey = "DictationPromptOff"
     private let defaultDictationPromptOverrideKey = "DefaultDictationPromptOverride"
     private let defaultEditPromptOverrideKey = "DefaultEditPromptOverride"
     private let savedProvidersKey = "SavedProviders"
     private let selectedProviderIDKey = "SelectedProviderID"
     private let availableModelsByProviderKey = "AvailableModelsByProvider"
     private let selectedModelByProviderKey = "SelectedModelByProvider"
+    private var privateAISelectedModelIDKey: String { PrivateAIProviderFeature.shared.selectedModelDefaultsKey }
+    private var privateAILocalModelPathKey: String { PrivateAIProviderFeature.shared.localModelPathDefaultsKey }
+    private var privateAIPrefixKVCacheEnabledKey: String { PrivateAIProviderFeature.shared.prefixCacheDefaultsKey }
+    private let verifiedProviderFingerprintsKey = "VerifiedProviderFingerprints"
 
     func testTranscriptionStartSound_noneOptionHasNoFile() {
         XCTAssertEqual(SettingsStore.TranscriptionStartSound.none.displayName, "None")
@@ -182,6 +187,40 @@ final class DictationE2ETests: XCTestCase {
         }
     }
 
+    func testLegacyBlockedPromptPlaceholderIsRemoved() {
+        self.withPromptSettingsRestored {
+            let settings = SettingsStore.shared
+
+            let blocked = SettingsStore.DictationPromptProfile(
+                name: "Blocked",
+                prompt: "Blocked prompt",
+                mode: .dictate
+            )
+            let real = SettingsStore.DictationPromptProfile(
+                name: "Keep Me",
+                prompt: "Real user prompt",
+                mode: .dictate
+            )
+
+            settings.dictationPromptProfiles = [blocked, real]
+            settings.selectedDictationPromptID = blocked.id
+            settings.appPromptBindings = [
+                SettingsStore.AppPromptBinding(
+                    mode: .dictate,
+                    appBundleID: "com.apple.notes",
+                    appName: "Notes",
+                    promptID: blocked.id
+                ),
+            ]
+
+            settings.reconcilePromptStateAfterProfileChanges()
+
+            XCTAssertEqual(settings.dictationPromptProfiles.map(\.id), [real.id])
+            XCTAssertNil(settings.selectedDictationPromptID)
+            XCTAssertEqual(settings.appPromptBindings.first?.promptID, nil)
+        }
+    }
+
     func testCustomProviderSettingsRoundTripThroughSettingsStore() {
         self.withProviderSettingsRestored {
             let settings = SettingsStore.shared
@@ -202,6 +241,156 @@ final class DictationE2ETests: XCTestCase {
             XCTAssertEqual(settings.savedProviders, [provider])
             XCTAssertEqual(settings.availableModelsByProvider[providerKey], provider.models)
             XCTAssertEqual(settings.selectedModelByProvider[providerKey], provider.models[0])
+        }
+    }
+
+    func testUnavailableSelectedProviderFallsBackToOpenAI() {
+        self.withProviderSettingsRestored {
+            let settings = SettingsStore.shared
+
+            settings.savedProviders = []
+            settings.selectedProviderID = "removed-provider"
+
+            XCTAssertEqual(settings.selectedProviderID, "openai")
+        }
+    }
+
+    func testPrivateAIProviderDictationPromptSelection_allowsOffAndRestoresNonFluidPrompt() {
+        self.withPromptAndProviderSettingsRestored {
+            let settings = SettingsStore.shared
+            let custom = SettingsStore.DictationPromptProfile(
+                name: "Custom Dictate",
+                prompt: "Use the custom prompt",
+                mode: .dictate
+            )
+            settings.dictationPromptProfiles = [custom]
+            settings.selectedModelByProvider = [
+                "openai": "gpt-4.1",
+                PrivateAIProviderFeature.shared.providerID: PrivateAIProviderFeature.shared.providerID,
+            ]
+            settings.selectedProviderID = "openai"
+            settings.setDictationPromptSelection(.profile(custom.id))
+
+            XCTAssertEqual(settings.dictationPromptSelection(for: .primary), .profile(custom.id))
+
+            settings.selectedProviderID = PrivateAIProviderFeature.shared.providerID
+            if PrivateFeatures.privateAIProvider {
+                XCTAssertEqual(settings.dictationPromptSelection(for: .primary), .privateAI)
+            } else {
+                XCTAssertEqual(settings.dictationPromptSelection(for: .primary), .profile(custom.id))
+            }
+
+            settings.setDictationPromptSelection(.off)
+            XCTAssertEqual(settings.dictationPromptSelection(for: .primary), .off)
+
+            settings.selectedProviderID = "openai"
+            XCTAssertEqual(settings.dictationPromptSelection(for: .primary), .off)
+
+            settings.setDictationPromptSelection(.profile(custom.id))
+            XCTAssertEqual(settings.dictationPromptSelection(for: .primary), .profile(custom.id))
+        }
+    }
+
+    func testPrivateAIProviderDictationPromptSelection_usesOnlyFluidPromptOrOffWhileSelected() {
+        self.withPromptAndProviderSettingsRestored {
+            let settings = SettingsStore.shared
+            let custom = SettingsStore.DictationPromptProfile(
+                name: "Custom Dictate",
+                prompt: "Use the custom prompt",
+                mode: .dictate
+            )
+            settings.dictationPromptProfiles = [custom]
+            settings.selectedModelByProvider = [
+                "openai": "gpt-4.1",
+                PrivateAIProviderFeature.shared.providerID: PrivateAIProviderFeature.shared.providerID,
+            ]
+
+            settings.selectedProviderID = PrivateAIProviderFeature.shared.providerID
+            settings.setDictationPromptSelection(.default)
+            XCTAssertEqual(
+                settings.dictationPromptSelection(for: .primary),
+                PrivateFeatures.privateAIProvider ? .privateAI : .default
+            )
+
+            settings.setDictationPromptSelection(.profile(custom.id))
+            XCTAssertEqual(
+                settings.dictationPromptSelection(for: .primary),
+                PrivateFeatures.privateAIProvider ? .privateAI : .profile(custom.id)
+            )
+
+            settings.setDictationPromptSelection(.off)
+            XCTAssertEqual(settings.dictationPromptSelection(for: .primary), .off)
+            XCTAssertEqual(settings.dictationPromptDisplayName(for: .primary, appBundleID: nil), "Off")
+
+            settings.selectedProviderID = "openai"
+            settings.setDictationPromptSelection(.profile(custom.id))
+            XCTAssertEqual(settings.dictationPromptSelection(for: .primary), .profile(custom.id))
+        }
+    }
+
+    func testPrivateAIProviderPrefixKVCache_defaultsOnAndPersistsToggle() {
+        self.withRestoredDefaults(keys: [self.privateAIPrefixKVCacheEnabledKey]) {
+            let settings = SettingsStore.shared
+
+            XCTAssertTrue(settings.privateAIPrefixKVCacheEnabled)
+
+            settings.privateAIPrefixKVCacheEnabled = false
+            XCTAssertFalse(settings.privateAIPrefixKVCacheEnabled)
+
+            settings.privateAIPrefixKVCacheEnabled = true
+            XCTAssertTrue(settings.privateAIPrefixKVCacheEnabled)
+        }
+    }
+
+    func testPrivateAIProviderLocalRuntimeOnlyHandlesPrivateModels() {
+        self.withRestoredDefaults(keys: [self.privateAILocalModelPathKey]) {
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("FluidVoice-PrivateAI-\(UUID().uuidString).gguf")
+            XCTAssertTrue(FileManager.default.createFile(atPath: tempURL.path, contents: Data(), attributes: nil))
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+
+            UserDefaults.standard.set(tempURL.path, forKey: self.privateAILocalModelPathKey)
+
+            XCTAssertEqual(
+                PrivateAIIntegrationService.isLocalRuntimeConfigured,
+                PrivateFeatures.privateAIProvider
+            )
+            XCTAssertFalse(PrivateAIIntegrationService.shouldHandleDictation(model: "gpt-4.1"))
+            XCTAssertEqual(
+                PrivateAIIntegrationService.shouldHandleDictation(model: PrivateAIProviderFeature.shared.providerID),
+                PrivateFeatures.privateAIProvider
+            )
+        }
+    }
+
+    func testPrivateAIProviderLocalRuntimeDoesNotConfigureNonFluidProvider() {
+        self.withRestoredDefaults(
+            keys: [
+                self.privateAILocalModelPathKey,
+                self.selectedProviderIDKey,
+                self.selectedModelByProviderKey,
+                self.verifiedProviderFingerprintsKey,
+                self.selectedDictationPromptIDKey,
+                self.dictationPromptOffKey,
+            ]
+        ) {
+            let settings = SettingsStore.shared
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("FluidVoice-PrivateAI-\(UUID().uuidString).gguf")
+            XCTAssertTrue(FileManager.default.createFile(atPath: tempURL.path, contents: Data(), attributes: nil))
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+
+            UserDefaults.standard.set(tempURL.path, forKey: self.privateAILocalModelPathKey)
+            settings.selectedProviderID = "openai"
+            settings.selectedModelByProvider = ["openai": "gpt-4.1"]
+            settings.verifiedProviderFingerprints = [:]
+            settings.setDictationPromptSelection(.default)
+
+            XCTAssertEqual(
+                PrivateAIIntegrationService.isLocalRuntimeConfigured,
+                PrivateFeatures.privateAIProvider
+            )
+            XCTAssertFalse(DictationAIPostProcessingGate.isConfigured(for: .primary, appBundleID: nil))
         }
     }
 
@@ -314,6 +503,7 @@ final class DictationE2ETests: XCTestCase {
                 self.appPromptBindingsKey,
                 self.selectedDictationPromptIDKey,
                 self.selectedEditPromptIDKey,
+                self.dictationPromptOffKey,
                 self.defaultDictationPromptOverrideKey,
                 self.defaultEditPromptOverrideKey,
             ],
@@ -328,6 +518,26 @@ final class DictationE2ETests: XCTestCase {
                 self.selectedProviderIDKey,
                 self.availableModelsByProviderKey,
                 self.selectedModelByProviderKey,
+            ],
+            run: run
+        )
+    }
+
+    private func withPromptAndProviderSettingsRestored(run: () -> Void) {
+        self.withRestoredDefaults(
+            keys: [
+                self.dictationPromptProfilesKey,
+                self.appPromptBindingsKey,
+                self.selectedDictationPromptIDKey,
+                self.selectedEditPromptIDKey,
+                self.dictationPromptOffKey,
+                self.defaultDictationPromptOverrideKey,
+                self.defaultEditPromptOverrideKey,
+                self.savedProvidersKey,
+                self.selectedProviderIDKey,
+                self.availableModelsByProviderKey,
+                self.selectedModelByProviderKey,
+                self.privateAISelectedModelIDKey,
             ],
             run: run
         )


### PR DESCRIPTION
## Description
Prepares the app for the 1.6.0 provider and dictation update. Adds guarded private-provider plumbing, improves AI prompt routing, adds model load/download controls, expands dictation/audio history support, and tightens ASR finalization behavior.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update

## Related Issues
- N/A

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `sh build_incremental.sh`

## Notes
- N/A

## Screenshots / Video
N/A
