### PR TITLE
fix: surface Apple speech models in onboarding (#354)

### DIFF
--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -1044,7 +1044,12 @@ struct OnboardingFlowView: View {
                                 .foregroundStyle(self.theme.palette.primaryText)
 
                             VStack(spacing: 8) {
-                                ForEach(Array(self.onboardingAlternativeModels.prefix(3))) { model in
+                                // Cap of 5 fits the longest alternatives list any branch
+                                // produces (Intel + macOS 26: Apple Speech, Apple Speech
+                                // Analyzer, Whisper Tiny/Small/Medium), so adding the Apple
+                                // offline models never evicts a previously reachable Whisper
+                                // option.
+                                ForEach(Array(self.onboardingAlternativeModels.prefix(5))) { model in
                                     self.onboardingModelOptionRow(for: model)
                                 }
                             }

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -594,7 +594,7 @@ struct OnboardingFlowView: View {
             case .multipleLanguages:
                 return "Uses Parakeet TDT v3 or Cohere"
             case .other:
-                return "Whisper and manual choices"
+                return "Whisper, Apple Speech (no download), and manual choices"
             }
         }
     }
@@ -693,8 +693,8 @@ struct OnboardingFlowView: View {
 
     private var onboardingModelOptions: [SettingsStore.SpeechModel] {
         let candidates: [SettingsStore.SpeechModel] = CPUArchitecture.isAppleSilicon
-            ? [.parakeetTDT, .cohereTranscribeSixBit, .parakeetRealtime, .parakeetTDTv2, .whisperBase, .whisperSmall]
-            : [.whisperBase, .whisperTiny, .whisperSmall, .whisperMedium]
+            ? [.parakeetTDT, .cohereTranscribeSixBit, .parakeetRealtime, .parakeetTDTv2, .appleSpeech, .appleSpeechAnalyzer, .whisperBase, .whisperSmall]
+            : [.appleSpeech, .appleSpeechAnalyzer, .whisperBase, .whisperTiny, .whisperSmall, .whisperMedium]
 
         var seenModelIDs = Set<String>()
         return candidates.filter { model in


### PR DESCRIPTION
## What
Adds the built-in Apple speech models (Apple ASR Legacy, Apple Speech for macOS 26+) to the onboarding voice-model picker. Previously onboarding only offered download-required models (Parakeet/Cohere/Whisper), so a user on a restricted network where the HuggingFace download is blocked could not complete setup.

## Why
The two Apple models were absent from the hardcoded onboarding candidate list even though `SpeechModel.availableModels` already admits them. `apple-speech` runs fully on-device with no download — the true offline fallback. `apple-speech-analyzer` is an on-device OS API (macOS 26+) but may fetch locale speech assets on first use, so it is not guaranteed zero-download; both are valid options, gated by OS/arch.

## How
- Add `.appleSpeech` + `.appleSpeechAnalyzer` (before the Whisper entries) to both candidate branches; the existing `availableModels` filter gates them by OS/arch (analyzer excluded < macOS 26).
- Built-ins show a no-download "Use" button and selection proceeds with no network.
- Update the "Other" language subtitle to name the no-download Apple Speech option.

## Notes
On Apple Silicon the Apple models surface under "More options" (via the "Other" language path). Surfacing them in the default flow / prominently on a download failure is a possible follow-up.

## Verification
`swiftlint --strict` clean; `xcodebuild build` succeeds.

Closes #354
