### PR TITLE
Fix dictation prompt role separation

### DIFF
--- a/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fluid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -83,6 +83,15 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -116,6 +125,42 @@
       "state" : {
         "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
         "version" : "2.3.5"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
+      }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+        "version" : "1.6.3"
       }
     },
     {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1845,15 +1845,17 @@ struct ContentView: View {
             return self.buildSystemPrompt(appInfo: appInfo, dictationSlot: dictationSlot)
         }()
 
-        // Dictation enhancement folds the prompt + transcript into a single user
-        // turn (substituting `${transcript}` when present, otherwise appending
-        // the transcript after a blank line). Non-dictation callers — the AI
-        // chat tab specifically — keep the legacy two-message layout where
-        // the prompt is the system turn and the input is the user turn.
+        // Dictation enhancement normally sends prompt instructions as the
+        // system turn and only the tagged transcript as the user turn. Explicit
+        // `${transcript}` templates keep their legacy single user-message shape.
+        // Non-dictation callers — the AI chat tab specifically — keep the
+        // legacy two-message layout where the prompt is the system turn and
+        // the input is the user turn.
         let systemPrompt: String
         let userMessageContent: String
         if isDictationCall {
-            systemPrompt = ""
+            let usesTranscriptTemplate = promptText.contains(SettingsStore.transcriptPlaceholder)
+            systemPrompt = usesTranscriptTemplate ? "" : promptText
             userMessageContent = SettingsStore.renderDictationUserMessage(
                 promptText: promptText,
                 transcript: inputText
@@ -1931,10 +1933,10 @@ struct ContentView: View {
             )
         }
 
-        // Build messages array. For dictation enhancement the whole prompt +
-        // transcript is folded into a single user message, so we omit the
-        // (empty) system role. Non-dictation callers keep the legacy
-        // system + user shape.
+        // Build messages array. Dictation enhancement uses system + user by
+        // default, but explicit `${transcript}` templates omit the system role
+        // because the full template is already the user message. Non-dictation
+        // callers keep the legacy system + user shape.
         var messages: [[String: Any]] = []
         if !systemPrompt.isEmpty {
             messages.append(["role": "system", "content": systemPrompt])

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1230,18 +1230,16 @@ final class SettingsStore: ObservableObject {
     /// when composing the user message for a dictation enhancement call.
     static let transcriptPlaceholder = "${transcript}"
 
-    /// Compose the user-turn string for a dictation enhancement call by folding
-    /// the transcript into the prompt template. If the template contains the
-    /// `${transcript}` placeholder, the placeholder is replaced; otherwise
-    /// the transcript is appended after a blank line, matching the pre-PR
-    /// behaviour of sending the transcript as a separate user message.
+    /// Compose the user-turn string for a dictation enhancement call.
+    /// If the prompt explicitly contains the `${transcript}` placeholder, keep
+    /// honoring that full user-message template. Otherwise the prompt belongs
+    /// in the system turn, and the user turn contains only tagged transcript
+    /// content.
     static func renderDictationUserMessage(promptText: String, transcript: String) -> String {
         if promptText.contains(self.transcriptPlaceholder) {
             return promptText.replacingOccurrences(of: self.transcriptPlaceholder, with: transcript)
         }
-        let trimmedPrompt = promptText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedPrompt.isEmpty { return transcript }
-        return promptText + "\n\n" + transcript
+        return "<transcript>\n\(transcript)\n</transcript>"
     }
 
     private func defaultPromptResolution(

--- a/Sources/Fluid/Services/DictationPostProcessingService.swift
+++ b/Sources/Fluid/Services/DictationPostProcessingService.swift
@@ -199,7 +199,8 @@ final class DictationPostProcessingService {
         }
 
         let promptText = settings.effectiveDictationSystemPrompt(for: dictationSlot, appBundleID: nil)
-        let systemPrompt = ""
+        let usesTranscriptTemplate = promptText.contains(SettingsStore.transcriptPlaceholder)
+        let systemPrompt = usesTranscriptTemplate ? "" : promptText
         let userMessageContent = SettingsStore.renderDictationUserMessage(
             promptText: promptText,
             transcript: trimmed

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -1465,6 +1465,16 @@ final class DictationE2ETests: XCTestCase {
         }
     }
 
+    func testDictationUserMessageWrapsTranscriptWithoutPromptInstructions() {
+        let userMessage = SettingsStore.renderDictationUserMessage(
+            promptText: "Clean up this transcript and output only the edited text.",
+            transcript: "hello fluid voice"
+        )
+
+        XCTAssertEqual(userMessage, "<transcript>\nhello fluid voice\n</transcript>")
+        XCTAssertFalse(userMessage.contains("Clean up this transcript"))
+    }
+
     func testCustomProviderSettingsRoundTripThroughSettingsStore() {
         self.withProviderSettingsRestored {
             let settings = SettingsStore.shared


### PR DESCRIPTION
## Description
Fixes dictation post-processing prompt composition so cleanup instructions are sent as the system message and the transcript is sent separately as tagged user content. Legacy custom prompts that still use `${transcript}` continue to render with replacement behavior.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Related Issues
- Closes #388

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.2
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Built locally: `sh build_incremental.sh`

Additional validation run locally:
- [x] `xcodebuild clean build -project Fluid.xcodeproj -scheme Fluid -destination platform=macOS,arch=arm64 -derivedDataPath /private/tmp/FluidVoiceDerivedData CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -quiet`
- [x] `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination platform=macOS,arch=arm64 -derivedDataPath /private/tmp/FluidVoiceDerivedData CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -quiet`
- [x] `git diff --check`

## Notes
- The SwiftPM lockfile updates `modelcontextprotocol/swift-sdk` to 0.12.1 because the previously pinned 0.10.2 fails to compile under Xcode 26.5 / Swift 6 strict-concurrency checking.
- `sh build_incremental.sh` currently fails in this checkout because it references `build_dev.sh`, which is not present in the repository. Direct `xcodebuild` build and test commands passed instead.
- Full `swiftformat --config .swiftformat Sources` was not committed because it rewrites broad pre-existing formatting drift outside this focused bugfix.

## Screenshots / Video 
N/A - no UI changes.