### PR TITLE
feat: Continuous Dictation Mode — chain transcriptions with smart caps

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -112,7 +112,7 @@ enum ShortcutRecordingTarget: Hashable {
 
 // NOTE: Streaming and AI response parsing is now handled by LLMClient
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 struct ContentView: View {
     private enum ActiveRecordingMode: String {
         case none
@@ -178,6 +178,7 @@ struct ContentView: View {
     @State private var previousSidebarItem: SidebarItem? = nil // Track previous for mode transitions
     @State private var playgroundUsed: Bool = SettingsStore.shared.playgroundUsed
     @State private var recordingAppInfo: (name: String, bundleId: String, windowTitle: String)? = nil
+    @State private var recordingPrecedingText: String = ""
 
     // Command Mode State
     // @State private var showCommandMode: Bool = false
@@ -1442,6 +1443,18 @@ struct ContentView: View {
             "Captured recording app context: app=\(info.name), bundleId=\(info.bundleId), title=\(info.windowTitle)",
             source: "ContentView"
         )
+
+        // Capture text before the caret for Continuous Dictation Mode smart caps.
+        // Only read the field when the feature is enabled (low-resource: one AX round-trip).
+        if SettingsStore.shared.continuousDictationModeEnabled {
+            self.recordingPrecedingText = TypingService.textBeforeCursorInFocusedField()
+            DebugLogger.shared.debug(
+                "Captured preceding text for continuous dictation (chars=\(self.recordingPrecedingText.count))",
+                source: "ContentView"
+            )
+        } else {
+            self.recordingPrecedingText = ""
+        }
     }
 
     private func resolveTypingTargetPID() -> (pid: pid_t?, shouldRestoreOriginalFocus: Bool) {
@@ -2062,6 +2075,10 @@ struct ContentView: View {
         // Apply GAAV formatting as the FINAL step (after AI post-processing)
         // This ensures the user's preference for no capitalization/period is respected
         finalText = ASRService.applyGAAVFormatting(finalText)
+        // Apply Continuous Dictation Mode after GAAV so smart caps use the field
+        // context captured at recording start, and the trailing space enables chaining.
+        finalText = ASRService.applyContinuousDictationFormatting(finalText, precedingText: self.recordingPrecedingText)
+        self.recordingPrecedingText = ""
         self.asr.finalText = finalText
         if route == .onboardingSandbox,
            self.isOnboardingVoicePlaygroundStepActive,
@@ -2353,7 +2370,11 @@ struct ContentView: View {
             self.cancelPrewarmDictationIfNeeded()
         }
 
-        let finalText = ASRService.applyGAAVFormatting(text)
+        let gaavText = ASRService.applyGAAVFormatting(text)
+        let precedingText = SettingsStore.shared.continuousDictationModeEnabled
+            ? TypingService.textBeforeCursorInFocusedField()
+            : ""
+        let finalText = ASRService.applyContinuousDictationFormatting(gaavText, precedingText: precedingText)
         let appInfo = self.getCurrentAppInfo()
 
         if saveToHistory, SettingsStore.shared.saveTranscriptionHistory {
@@ -2431,6 +2452,8 @@ struct ContentView: View {
         self.menuBarManager.setProcessing(false)
 
         finalText = ASRService.applyGAAVFormatting(finalText)
+        finalText = ASRService.applyContinuousDictationFormatting(finalText, precedingText: self.recordingPrecedingText)
+        self.recordingPrecedingText = ""
 
         if SettingsStore.shared.saveTranscriptionHistory {
             TranscriptionHistoryStore.shared.addEntry(

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -885,6 +885,7 @@ struct ContentView: View {
     private func shortcutConflictMessage(for shortcut: HotkeyShortcut, target: ShortcutRecordingTarget) -> String? {
         let configuredShortcuts: [(ShortcutRecordingTarget, HotkeyShortcut)] = [
             (.primaryDictation, self.hotkeyShortcut),
+            (.secondaryDictation, self.promptModeHotkeyShortcut),
             (.command, self.commandModeHotkeyShortcut),
             (.edit, self.rewriteModeHotkeyShortcut),
             (.cancel, self.cancelRecordingHotkeyShortcut),

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -894,6 +894,9 @@ struct ContentView: View {
             if configuredShortcut == shortcut {
                 return "Duplicate with \(otherTarget.title)"
             }
+            if shortcut.conflictsWith(configuredShortcut) {
+                return "Overlaps \(otherTarget.title) — use a different modifier key"
+            }
         }
 
         let targetPromptKey = target.promptConfigurationKey
@@ -905,6 +908,9 @@ struct ContentView: View {
             }
             if assignment.shortcut == shortcut {
                 return "Duplicate with Prompt Shortcut"
+            }
+            if shortcut.conflictsWith(assignment.shortcut) {
+                return "Overlaps Prompt Shortcut — use a different modifier key"
             }
         }
 

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2457,7 +2457,10 @@ struct ContentView: View {
         self.menuBarManager.setProcessing(false)
 
         finalText = ASRService.applyGAAVFormatting(finalText)
-        finalText = ASRService.applyContinuousDictationFormatting(finalText, precedingText: self.recordingPrecedingText)
+        let precedingText = SettingsStore.shared.needsDictationFormattingContext
+            ? TypingService.textBeforeCursorInFocusedField()
+            : ""
+        finalText = ASRService.applyContinuousDictationFormatting(finalText, precedingText: precedingText)
         self.recordingPrecedingText = ""
 
         if SettingsStore.shared.saveTranscriptionHistory {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2135,6 +2135,7 @@ struct ContentView: View {
                 processedText: finalText,
                 appName: appInfo.name,
                 windowTitle: appInfo.windowTitle,
+                wasAIProcessed: postProcessingModel != nil && aiFallbackReason == nil,
                 processingModel: postProcessingModel,
                 aiProcessingError: aiFallbackReason
             )
@@ -2388,7 +2389,8 @@ struct ContentView: View {
                 rawText: text,
                 processedText: finalText,
                 appName: appInfo.name,
-                windowTitle: appInfo.windowTitle
+                windowTitle: appInfo.windowTitle,
+                wasAIProcessed: false
             )
         }
 
@@ -2470,6 +2472,7 @@ struct ContentView: View {
                 processedText: finalText,
                 appName: appInfo.name,
                 windowTitle: appInfo.windowTitle,
+                wasAIProcessed: postProcessingModel != nil && aiFallbackReason == nil,
                 processingModel: postProcessingModel,
                 aiProcessingError: aiFallbackReason
             )

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1444,9 +1444,8 @@ struct ContentView: View {
             source: "ContentView"
         )
 
-        // Capture text before the caret for Continuous Dictation Mode smart caps.
-        // Only read the field when the feature is enabled (low-resource: one AX round-trip).
-        if SettingsStore.shared.continuousDictationModeEnabled {
+        // Capture text before the caret only when formatting needs focused-field context.
+        if SettingsStore.shared.needsDictationFormattingContext {
             self.recordingPrecedingText = TypingService.textBeforeCursorInFocusedField()
             DebugLogger.shared.debug(
                 "Captured preceding text for continuous dictation (chars=\(self.recordingPrecedingText.count))",
@@ -2371,7 +2370,7 @@ struct ContentView: View {
         }
 
         let gaavText = ASRService.applyGAAVFormatting(text)
-        let precedingText = SettingsStore.shared.continuousDictationModeEnabled
+        let precedingText = SettingsStore.shared.needsDictationFormattingContext
             ? TypingService.textBeforeCursorInFocusedField()
             : ""
         let finalText = ASRService.applyContinuousDictationFormatting(gaavText, precedingText: precedingText)

--- a/Sources/Fluid/Models/HotkeyShortcut.swift
+++ b/Sources/Fluid/Models/HotkeyShortcut.swift
@@ -191,6 +191,20 @@ extension HotkeyShortcut {
         Self.modifierFlag(forKeyCode: self.keyCode)
     }
 
+    /// True when two modifier-only shortcuts would overlap — either identical
+    /// or one is a subset of the other's modifiers (e.g. ⌥ vs ⌥+⇧). Prevents
+    /// the shared `modifierOnlyKeyDown` release race in GlobalHotkeyManager.
+    func conflictsWith(_ other: HotkeyShortcut) -> Bool {
+        guard self.isModifierOnlyShortcut, other.isModifierOnlyShortcut else { return false }
+
+        let lhs = Set(self.normalizedModifierKeyCodes)
+        let rhs = Set(other.normalizedModifierKeyCodes)
+
+        guard !lhs.isEmpty, !rhs.isEmpty else { return false }
+
+        return lhs.isSubset(of: rhs) || rhs.isSubset(of: lhs)
+    }
+
     var isModifierOnlyShortcut: Bool {
         self.modifierTriggerFlag != nil
     }

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -67,6 +67,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let fillerWords: [String]
     let removeFillerWordsEnabled: Bool
     let gaavModeEnabled: Bool
+    let continuousDictationModeEnabled: Bool
     let pauseMediaDuringTranscription: Bool
     let vocabularyBoostingEnabled: Bool
     let customDictionaryEntries: [SettingsStore.CustomDictionaryEntry]

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -67,7 +67,11 @@ struct SettingsBackupPayload: Codable, Equatable {
     let fillerWords: [String]
     let removeFillerWordsEnabled: Bool
     let gaavModeEnabled: Bool
-    let continuousDictationModeEnabled: Bool
+    let gaavLowercaseFirstLetterEnabled: Bool?
+    let gaavRemoveTrailingPeriodEnabled: Bool?
+    let continuousDictationModeEnabled: Bool?
+    let continuousDictationSpacingEnabled: Bool?
+    let contextAwareCapitalizationEnabled: Bool?
     let pauseMediaDuringTranscription: Bool
     let vocabularyBoostingEnabled: Bool
     let customDictionaryEntries: [SettingsStore.CustomDictionaryEntry]

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2688,6 +2688,7 @@ final class SettingsStore: ObservableObject {
             fillerWords: self.fillerWords,
             removeFillerWordsEnabled: self.removeFillerWordsEnabled,
             gaavModeEnabled: self.gaavModeEnabled,
+            continuousDictationModeEnabled: self.continuousDictationModeEnabled,
             pauseMediaDuringTranscription: self.pauseMediaDuringTranscription,
             vocabularyBoostingEnabled: self.vocabularyBoostingEnabled,
             customDictionaryEntries: self.customDictionaryEntries,
@@ -2779,6 +2780,7 @@ final class SettingsStore: ObservableObject {
         self.fillerWords = payload.fillerWords
         self.removeFillerWordsEnabled = payload.removeFillerWordsEnabled
         self.gaavModeEnabled = payload.gaavModeEnabled
+        self.continuousDictationModeEnabled = payload.continuousDictationModeEnabled
         self.pauseMediaDuringTranscription = payload.pauseMediaDuringTranscription
         self.vocabularyBoostingEnabled = payload.vocabularyBoostingEnabled
         self.customDictionaryEntries = payload.customDictionaryEntries
@@ -3369,6 +3371,20 @@ final class SettingsStore: ObservableObject {
         set {
             objectWillChange.send()
             self.defaults.set(newValue, forKey: Keys.gaavModeEnabled)
+        }
+    }
+
+    // MARK: - Continuous Dictation Mode
+
+    /// Continuous Dictation Mode: Appends a trailing space to transcriptions and adjusts
+    /// capitalization based on the text already in the focused field, so multiple dictation
+    /// segments chain naturally without manual spacebar presses.
+    /// Implements the chaining behavior requested in GitHub issue #390.
+    var continuousDictationModeEnabled: Bool {
+        get { self.defaults.object(forKey: Keys.continuousDictationModeEnabled) as? Bool ?? false }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.continuousDictationModeEnabled)
         }
     }
 
@@ -4203,6 +4219,9 @@ private extension SettingsStore {
 
         /// GAAV Mode (removes capitalization and trailing punctuation)
         static let gaavModeEnabled = "GAAVModeEnabled"
+
+        /// Continuous Dictation Mode (append trailing space + smart caps for chaining)
+        static let continuousDictationModeEnabled = "ContinuousDictationModeEnabled"
 
         // Custom Dictionary
         static let customDictionaryEntries = "CustomDictionaryEntries"

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2688,7 +2688,11 @@ final class SettingsStore: ObservableObject {
             fillerWords: self.fillerWords,
             removeFillerWordsEnabled: self.removeFillerWordsEnabled,
             gaavModeEnabled: self.gaavModeEnabled,
+            gaavLowercaseFirstLetterEnabled: self.gaavLowercaseFirstLetterEnabled,
+            gaavRemoveTrailingPeriodEnabled: self.gaavRemoveTrailingPeriodEnabled,
             continuousDictationModeEnabled: self.continuousDictationModeEnabled,
+            continuousDictationSpacingEnabled: self.continuousDictationSpacingEnabled,
+            contextAwareCapitalizationEnabled: self.contextAwareCapitalizationEnabled,
             pauseMediaDuringTranscription: self.pauseMediaDuringTranscription,
             vocabularyBoostingEnabled: self.vocabularyBoostingEnabled,
             customDictionaryEntries: self.customDictionaryEntries,
@@ -2780,7 +2784,21 @@ final class SettingsStore: ObservableObject {
         self.fillerWords = payload.fillerWords
         self.removeFillerWordsEnabled = payload.removeFillerWordsEnabled
         self.gaavModeEnabled = payload.gaavModeEnabled
-        self.continuousDictationModeEnabled = payload.continuousDictationModeEnabled
+        if let gaavLowercaseFirstLetterEnabled = payload.gaavLowercaseFirstLetterEnabled {
+            self.gaavLowercaseFirstLetterEnabled = gaavLowercaseFirstLetterEnabled
+        }
+        if let gaavRemoveTrailingPeriodEnabled = payload.gaavRemoveTrailingPeriodEnabled {
+            self.gaavRemoveTrailingPeriodEnabled = gaavRemoveTrailingPeriodEnabled
+        }
+        if let continuousDictationModeEnabled = payload.continuousDictationModeEnabled {
+            self.continuousDictationModeEnabled = continuousDictationModeEnabled
+        }
+        if let continuousDictationSpacingEnabled = payload.continuousDictationSpacingEnabled {
+            self.continuousDictationSpacingEnabled = continuousDictationSpacingEnabled
+        }
+        if let contextAwareCapitalizationEnabled = payload.contextAwareCapitalizationEnabled {
+            self.contextAwareCapitalizationEnabled = contextAwareCapitalizationEnabled
+        }
         self.pauseMediaDuringTranscription = payload.pauseMediaDuringTranscription
         self.vocabularyBoostingEnabled = payload.vocabularyBoostingEnabled
         self.customDictionaryEntries = payload.customDictionaryEntries
@@ -3363,9 +3381,7 @@ final class SettingsStore: ObservableObject {
 
     // MARK: - GAAV Mode
 
-    /// GAAV Mode: Removes first letter capitalization and trailing period from transcriptions.
-    /// Useful for search queries, form fields, or casual text input where sentence formatting is unwanted.
-    /// Feature requested by maxgaav – thank you for the suggestion!
+    /// Legacy combined GAAV setting. New behavior uses the split formatting toggles below.
     var gaavModeEnabled: Bool {
         get { self.defaults.object(forKey: Keys.gaavModeEnabled) as? Bool ?? false }
         set {
@@ -3374,18 +3390,59 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    var gaavLowercaseFirstLetterEnabled: Bool {
+        get {
+            self.defaults.object(forKey: Keys.gaavLowercaseFirstLetterEnabled) as? Bool ?? self.gaavModeEnabled
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.gaavLowercaseFirstLetterEnabled)
+        }
+    }
+
+    var gaavRemoveTrailingPeriodEnabled: Bool {
+        get {
+            self.defaults.object(forKey: Keys.gaavRemoveTrailingPeriodEnabled) as? Bool ?? self.gaavModeEnabled
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.gaavRemoveTrailingPeriodEnabled)
+        }
+    }
+
     // MARK: - Continuous Dictation Mode
 
-    /// Continuous Dictation Mode: Appends a trailing space to transcriptions and adjusts
-    /// capitalization based on the text already in the focused field, so multiple dictation
-    /// segments chain naturally without manual spacebar presses.
-    /// Implements the chaining behavior requested in GitHub issue #390.
+    /// Legacy combined continuous-dictation setting. New behavior uses the split toggles below.
     var continuousDictationModeEnabled: Bool {
         get { self.defaults.object(forKey: Keys.continuousDictationModeEnabled) as? Bool ?? false }
         set {
             objectWillChange.send()
             self.defaults.set(newValue, forKey: Keys.continuousDictationModeEnabled)
         }
+    }
+
+    var continuousDictationSpacingEnabled: Bool {
+        get {
+            self.defaults.object(forKey: Keys.continuousDictationSpacingEnabled) as? Bool ?? self.continuousDictationModeEnabled
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.continuousDictationSpacingEnabled)
+        }
+    }
+
+    var contextAwareCapitalizationEnabled: Bool {
+        get {
+            self.defaults.object(forKey: Keys.contextAwareCapitalizationEnabled) as? Bool ?? self.continuousDictationModeEnabled
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.contextAwareCapitalizationEnabled)
+        }
+    }
+
+    var needsDictationFormattingContext: Bool {
+        self.continuousDictationSpacingEnabled || self.contextAwareCapitalizationEnabled
     }
 
     // MARK: - Media Playback Control
@@ -4219,9 +4276,13 @@ private extension SettingsStore {
 
         /// GAAV Mode (removes capitalization and trailing punctuation)
         static let gaavModeEnabled = "GAAVModeEnabled"
+        static let gaavLowercaseFirstLetterEnabled = "GAAVLowercaseFirstLetterEnabled"
+        static let gaavRemoveTrailingPeriodEnabled = "GAAVRemoveTrailingPeriodEnabled"
 
         /// Continuous Dictation Mode (append trailing space + smart caps for chaining)
         static let continuousDictationModeEnabled = "ContinuousDictationModeEnabled"
+        static let continuousDictationSpacingEnabled = "ContinuousDictationSpacingEnabled"
+        static let contextAwareCapitalizationEnabled = "ContextAwareCapitalizationEnabled"
 
         // Custom Dictionary
         static let customDictionaryEntries = "CustomDictionaryEntries"

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2783,22 +2783,14 @@ final class SettingsStore: ObservableObject {
         self.weekendsDontBreakStreak = payload.weekendsDontBreakStreak
         self.fillerWords = payload.fillerWords
         self.removeFillerWordsEnabled = payload.removeFillerWordsEnabled
-        self.gaavModeEnabled = payload.gaavModeEnabled
-        if let gaavLowercaseFirstLetterEnabled = payload.gaavLowercaseFirstLetterEnabled {
-            self.gaavLowercaseFirstLetterEnabled = gaavLowercaseFirstLetterEnabled
-        }
-        if let gaavRemoveTrailingPeriodEnabled = payload.gaavRemoveTrailingPeriodEnabled {
-            self.gaavRemoveTrailingPeriodEnabled = gaavRemoveTrailingPeriodEnabled
-        }
-        if let continuousDictationModeEnabled = payload.continuousDictationModeEnabled {
-            self.continuousDictationModeEnabled = continuousDictationModeEnabled
-        }
-        if let continuousDictationSpacingEnabled = payload.continuousDictationSpacingEnabled {
-            self.continuousDictationSpacingEnabled = continuousDictationSpacingEnabled
-        }
-        if let contextAwareCapitalizationEnabled = payload.contextAwareCapitalizationEnabled {
-            self.contextAwareCapitalizationEnabled = contextAwareCapitalizationEnabled
-        }
+        let restoredGaavModeEnabled = payload.gaavModeEnabled
+        let restoredContinuousDictationModeEnabled = payload.continuousDictationModeEnabled ?? false
+        self.gaavModeEnabled = restoredGaavModeEnabled
+        self.gaavLowercaseFirstLetterEnabled = payload.gaavLowercaseFirstLetterEnabled ?? restoredGaavModeEnabled
+        self.gaavRemoveTrailingPeriodEnabled = payload.gaavRemoveTrailingPeriodEnabled ?? restoredGaavModeEnabled
+        self.continuousDictationModeEnabled = restoredContinuousDictationModeEnabled
+        self.continuousDictationSpacingEnabled = payload.continuousDictationSpacingEnabled ?? restoredContinuousDictationModeEnabled
+        self.contextAwareCapitalizationEnabled = payload.contextAwareCapitalizationEnabled ?? restoredContinuousDictationModeEnabled
         self.pauseMediaDuringTranscription = payload.pauseMediaDuringTranscription
         self.vocabularyBoostingEnabled = payload.vocabularyBoostingEnabled
         self.customDictionaryEntries = payload.customDictionaryEntries

--- a/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
+++ b/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
@@ -33,6 +33,7 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         processedText: String,
         appName: String,
         windowTitle: String,
+        wasAIProcessed: Bool,
         processingModel: String? = nil,
         aiProcessingError: String? = nil,
         audio: DictationAudioMetadata? = nil
@@ -44,7 +45,7 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         self.appName = appName
         self.windowTitle = windowTitle
         self.characterCount = processedText.count
-        self.wasAIProcessed = rawText != processedText
+        self.wasAIProcessed = wasAIProcessed
         self.processingModel = processingModel
         self.aiProcessingError = aiProcessingError
         self.audio = audio
@@ -176,6 +177,7 @@ final class TranscriptionHistoryStore: ObservableObject {
         processedText: String,
         appName: String,
         windowTitle: String,
+        wasAIProcessed: Bool? = nil,
         processingModel: String? = nil,
         aiProcessingError: String? = nil,
         audio: DictationAudioMetadata? = nil
@@ -190,6 +192,7 @@ final class TranscriptionHistoryStore: ObservableObject {
             processedText: processedText,
             appName: appName,
             windowTitle: windowTitle,
+            wasAIProcessed: wasAIProcessed ?? (processingModel != nil && aiProcessingError == nil),
             processingModel: processingModel,
             aiProcessingError: aiProcessingError,
             audio: audio

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -2923,6 +2923,47 @@ final class ASRService: ObservableObject {
 
         return result
     }
+
+    // MARK: - Continuous Dictation Mode Formatting
+
+    /// Applies Continuous Dictation Mode formatting so transcribed segments chain naturally.
+    /// - Appends a trailing space so the next dictation continues without a manual spacebar press.
+    /// - Adjusts capitalization based on the text already in the field: if the preceding text
+    ///   (after trimming trailing whitespace) ends with sentence-ending punctuation (.!?), the
+    ///   first character is capitalized; otherwise it is lowercased so segments flow inline.
+    ///   An empty field is treated as a sentence start (capitalized).
+    /// Only applied when `continuousDictationModeEnabled` is on.
+    ///
+    /// Implements the chaining behavior requested in GitHub issue #390.
+    static func applyContinuousDictationFormatting(_ text: String, precedingText: String) -> String {
+        guard SettingsStore.shared.continuousDictationModeEnabled else { return text }
+        guard !text.isEmpty else { return text }
+
+        var result = text
+
+        let precedingTrimmed = precedingText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if precedingTrimmed.isEmpty {
+            // Empty field = sentence start: capitalize first alphabetic character.
+            if let first = result.first, first.isLetter, first.isLowercase {
+                result = first.uppercased() + result.dropFirst()
+            }
+        } else if let lastChar = precedingTrimmed.last, lastChar.isLetter || lastChar.isNumber {
+            // Last char before cursor is alphanumeric (no terminal punctuation): lowercase the
+            // first character so this segment flows inline with the existing text.
+            if let first = result.first, first.isUppercase {
+                result = first.lowercased() + result.dropFirst()
+            }
+        }
+        // If preceding text ends with .!? (or any other punctuation), leave the model's
+        // capitalization as-is (sentence start).
+
+        // Append a trailing space so the next dictation chains without a manual spacebar press.
+        if !result.hasSuffix(" ") {
+            result += " "
+        }
+
+        return result
+    }
 }
 
 // swiftlint:enable type_body_length

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -2936,8 +2936,9 @@ final class ASRService: ObservableObject {
         var result = text
 
         if smartCapsEnabled {
-            let precedingTrimmed = precedingText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if precedingTrimmed.isEmpty || precedingTrimmed.last?.isSentenceEndingPunctuation == true {
+            let precedingTrimmed = precedingText.trimmingCharacters(in: .whitespaces)
+            let boundaryCharacter = self.lastCapitalizationBoundaryCharacter(in: precedingTrimmed)
+            if boundaryCharacter == nil || boundaryCharacter?.isSentenceEndingPunctuation == true {
                 result = self.replacingFirstLetter(in: result, transform: { $0.uppercased() })
             } else {
                 result = self.replacingFirstLetter(in: result, transform: { $0.lowercased() })
@@ -2960,6 +2961,19 @@ final class ASRService: ObservableObject {
         return result
     }
 
+    private static func lastCapitalizationBoundaryCharacter(in text: String) -> Character? {
+        for character in text.reversed() {
+            if character.isNewline {
+                return nil
+            }
+            if character.isHorizontalWhitespace || character.isClosingPunctuationWrapper {
+                continue
+            }
+            return character
+        }
+        return nil
+    }
+
     private static func replacingFirstLetter(in text: String, transform: (Character) -> String) -> String {
         guard let index = text.firstIndex(where: { $0.isLetter }) else { return text }
         let nextIndex = text.index(after: index)
@@ -2970,6 +2984,19 @@ final class ASRService: ObservableObject {
 private extension Character {
     var isSentenceEndingPunctuation: Bool {
         self == "." || self == "!" || self == "?"
+    }
+
+    var isHorizontalWhitespace: Bool {
+        self.unicodeScalars.allSatisfy { CharacterSet.whitespaces.contains($0) }
+    }
+
+    var isClosingPunctuationWrapper: Bool {
+        switch self {
+        case "\"", "'", "”", "’", "»", "›", ")", "]", "}", "」", "』":
+            return true
+        default:
+            return false
+        }
     }
 }
 

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -2906,18 +2906,15 @@ final class ASRService: ObservableObject {
     ///
     /// Feature requested by maxgaav – thank you for the suggestion!
     static func applyGAAVFormatting(_ text: String) -> String {
-        guard SettingsStore.shared.gaavModeEnabled else { return text }
         guard !text.isEmpty else { return text }
 
         var result = text
 
-        // Remove trailing period (if present)
-        if result.hasSuffix(".") {
+        if SettingsStore.shared.gaavRemoveTrailingPeriodEnabled, result.hasSuffix(".") {
             result.removeLast()
         }
 
-        // Lowercase the first character (if it's uppercase)
-        if let first = result.first, first.isUppercase {
+        if SettingsStore.shared.gaavLowercaseFirstLetterEnabled, let first = result.first, first.isUppercase {
             result = first.lowercased() + result.dropFirst()
         }
 
@@ -2926,43 +2923,38 @@ final class ASRService: ObservableObject {
 
     // MARK: - Continuous Dictation Mode Formatting
 
-    /// Applies Continuous Dictation Mode formatting so transcribed segments chain naturally.
-    /// - Appends a trailing space so the next dictation continues without a manual spacebar press.
-    /// - Adjusts capitalization based on the text already in the field: if the preceding text
-    ///   (after trimming trailing whitespace) ends with sentence-ending punctuation (.!?), the
-    ///   first character is capitalized; otherwise it is lowercased so segments flow inline.
-    ///   An empty field is treated as a sentence start (capitalized).
-    /// Only applied when `continuousDictationModeEnabled` is on.
+    /// Applies split continuous-dictation formatting so transcribed segments chain naturally.
+    /// Spacing and context-aware capitalization are independently controlled.
     ///
     /// Implements the chaining behavior requested in GitHub issue #390.
     static func applyContinuousDictationFormatting(_ text: String, precedingText: String) -> String {
-        guard SettingsStore.shared.continuousDictationModeEnabled else { return text }
         guard !text.isEmpty else { return text }
+        let spacingEnabled = SettingsStore.shared.continuousDictationSpacingEnabled
+        let smartCapsEnabled = SettingsStore.shared.contextAwareCapitalizationEnabled
+        guard spacingEnabled || smartCapsEnabled else { return text }
 
         var result = text
 
-        let precedingTrimmed = precedingText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if precedingTrimmed.isEmpty {
-            result = self.replacingFirstLetter(in: result, transform: { $0.uppercased() })
-        } else if let lastChar = precedingTrimmed.last, lastChar.isLetter || lastChar.isNumber {
-            // Last char before cursor is alphanumeric (no terminal punctuation): lowercase the
-            // first character so this segment flows inline with the existing text.
-            result = self.replacingFirstLetter(in: result, transform: { $0.lowercased() })
-        }
-        // If preceding text ends with .!? (or any other punctuation), leave the model's
-        // capitalization as-is (sentence start).
-
-        // Add a separator when continuing after existing inline text, then leave a trailing
-        // space so the next dictation can chain without a manual spacebar press.
-        if let lastPreceding = precedingText.last,
-           !lastPreceding.isWhitespace,
-           result.first?.isWhitespace != true
-        {
-            result = " " + result
+        if smartCapsEnabled {
+            let precedingTrimmed = precedingText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if precedingTrimmed.isEmpty || precedingTrimmed.last?.isSentenceEndingPunctuation == true {
+                result = self.replacingFirstLetter(in: result, transform: { $0.uppercased() })
+            } else {
+                result = self.replacingFirstLetter(in: result, transform: { $0.lowercased() })
+            }
         }
 
-        if result.last?.isWhitespace != true {
-            result += " "
+        if spacingEnabled {
+            if let lastPreceding = precedingText.last,
+               !lastPreceding.isWhitespace,
+               result.first?.isWhitespace != true
+            {
+                result = " " + result
+            }
+
+            if result.last?.isWhitespace != true {
+                result += " "
+            }
         }
 
         return result
@@ -2972,6 +2964,12 @@ final class ASRService: ObservableObject {
         guard let index = text.firstIndex(where: { $0.isLetter }) else { return text }
         let nextIndex = text.index(after: index)
         return String(text[..<index]) + transform(text[index]) + String(text[nextIndex...])
+    }
+}
+
+private extension Character {
+    var isSentenceEndingPunctuation: Bool {
+        self == "." || self == "!" || self == "?"
     }
 }
 

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -2943,26 +2943,35 @@ final class ASRService: ObservableObject {
 
         let precedingTrimmed = precedingText.trimmingCharacters(in: .whitespacesAndNewlines)
         if precedingTrimmed.isEmpty {
-            // Empty field = sentence start: capitalize first alphabetic character.
-            if let first = result.first, first.isLetter, first.isLowercase {
-                result = first.uppercased() + result.dropFirst()
-            }
+            result = self.replacingFirstLetter(in: result, transform: { $0.uppercased() })
         } else if let lastChar = precedingTrimmed.last, lastChar.isLetter || lastChar.isNumber {
             // Last char before cursor is alphanumeric (no terminal punctuation): lowercase the
             // first character so this segment flows inline with the existing text.
-            if let first = result.first, first.isUppercase {
-                result = first.lowercased() + result.dropFirst()
-            }
+            result = self.replacingFirstLetter(in: result, transform: { $0.lowercased() })
         }
         // If preceding text ends with .!? (or any other punctuation), leave the model's
         // capitalization as-is (sentence start).
 
-        // Append a trailing space so the next dictation chains without a manual spacebar press.
-        if !result.hasSuffix(" ") {
+        // Add a separator when continuing after existing inline text, then leave a trailing
+        // space so the next dictation can chain without a manual spacebar press.
+        if let lastPreceding = precedingText.last,
+           !lastPreceding.isWhitespace,
+           result.first?.isWhitespace != true
+        {
+            result = " " + result
+        }
+
+        if result.last?.isWhitespace != true {
             result += " "
         }
 
         return result
+    }
+
+    private static func replacingFirstLetter(in text: String, transform: (Character) -> String) -> String {
+        guard let index = text.firstIndex(where: { $0.isLetter }) else { return text }
+        let nextIndex = text.index(after: index)
+        return String(text[..<index]) + transform(text[index]) + String(text[nextIndex...])
     }
 }
 

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -169,6 +169,47 @@ final class TypingService {
         return pid
     }
 
+    /// Best-effort: returns the text immediately before the caret in the currently focused
+    /// text field. Used by Continuous Dictation Mode to decide capitalization when chaining
+    /// transcribed segments. Returns "" when the focused field/context is unavailable.
+    /// Low-resource: single AX round-trip with a range fallback; no polling, no timers.
+    static func textBeforeCursorInFocusedField() -> String {
+        guard AXIsProcessTrusted() else { return "" }
+
+        let systemWideElement = AXUIElementCreateSystemWide()
+        var focusedElementRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            systemWideElement,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedElementRef
+        )
+        guard result == .success, let focusedElementRef else { return "" }
+        guard CFGetTypeID(focusedElementRef) == AXUIElementGetTypeID() else { return "" }
+        let element = unsafeBitCast(focusedElementRef, to: AXUIElement.self)
+
+        var rangeRef: CFTypeRef?
+        let rangeResult = AXUIElementCopyAttributeValue(
+            element,
+            kAXSelectedTextRangeAttribute as CFString,
+            &rangeRef
+        )
+        guard rangeResult == .success, let rangeRef else { return "" }
+        guard CFGetTypeID(rangeRef) == AXValueGetTypeID() else { return "" }
+
+        var range = CFRange()
+        guard AXValueGetValue(unsafeBitCast(rangeRef, to: AXValue.self), .cfRange, &range) else { return "" }
+        guard range.location != kCFNotFound, range.location >= 0 else { return "" }
+
+        var valueRef: CFTypeRef?
+        let valueResult = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
+        guard valueResult == .success, let fullText = valueRef as? String else { return "" }
+
+        let nsText = fullText as NSString
+        let location = min(range.location, nsText.length)
+        guard location > 0 else { return "" }
+        return nsText.substring(with: NSRange(location: 0, length: location))
+    }
+
     @discardableResult
     static func restoreCapturedFocus(in pid: pid_t) -> Bool {
         guard AXIsProcessTrusted() else { return false }

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -172,42 +172,8 @@ final class TypingService {
     /// Best-effort: returns the text immediately before the caret in the currently focused
     /// text field. Used by Continuous Dictation Mode to decide capitalization when chaining
     /// transcribed segments. Returns "" when the focused field/context is unavailable.
-    /// Low-resource: single AX round-trip with a range fallback; no polling, no timers.
     static func textBeforeCursorInFocusedField() -> String {
-        guard AXIsProcessTrusted() else { return "" }
-
-        let systemWideElement = AXUIElementCreateSystemWide()
-        var focusedElementRef: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(
-            systemWideElement,
-            kAXFocusedUIElementAttribute as CFString,
-            &focusedElementRef
-        )
-        guard result == .success, let focusedElementRef else { return "" }
-        guard CFGetTypeID(focusedElementRef) == AXUIElementGetTypeID() else { return "" }
-        let element = unsafeBitCast(focusedElementRef, to: AXUIElement.self)
-
-        var rangeRef: CFTypeRef?
-        let rangeResult = AXUIElementCopyAttributeValue(
-            element,
-            kAXSelectedTextRangeAttribute as CFString,
-            &rangeRef
-        )
-        guard rangeResult == .success, let rangeRef else { return "" }
-        guard CFGetTypeID(rangeRef) == AXValueGetTypeID() else { return "" }
-
-        var range = CFRange()
-        guard AXValueGetValue(unsafeBitCast(rangeRef, to: AXValue.self), .cfRange, &range) else { return "" }
-        guard range.location != kCFNotFound, range.location >= 0 else { return "" }
-
-        var valueRef: CFTypeRef?
-        let valueResult = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
-        guard valueResult == .success, let fullText = valueRef as? String else { return "" }
-
-        let nsText = fullText as NSString
-        let location = min(range.location, nsText.length)
-        guard location > 0 else { return "" }
-        return nsText.substring(with: NSRange(location: 0, length: location))
+        TypingService().captureTextBeforeCursorInFocusedField()
     }
 
     @discardableResult
@@ -1030,6 +996,32 @@ final class TypingService {
             appScriptValue: appScriptSnapshot?.value,
             appScriptSelectedRange: appScriptSnapshot?.selectedRange
         )
+    }
+
+    private func captureTextBeforeCursorInFocusedField() -> String {
+        guard let snapshot = self.captureFocusedTextSnapshot() else { return "" }
+
+        let scriptRange = snapshot.appScriptSelectedRange ?? snapshot.selectedRange
+        if let scriptValue = snapshot.appScriptValue,
+           let scriptRange
+        {
+            return Self.prefix(in: scriptValue, before: scriptRange.location)
+        }
+
+        if let value = snapshot.value,
+           let selectedRange = snapshot.selectedRange
+        {
+            return Self.prefix(in: value, before: selectedRange.location)
+        }
+
+        return ""
+    }
+
+    private static func prefix(in text: String, before location: Int) -> String {
+        let nsText = text as NSString
+        let safeLocation = max(0, min(location, nsText.length))
+        guard safeLocation > 0 else { return "" }
+        return nsText.substring(with: NSRange(location: 0, length: safeLocation))
     }
 
     private struct AppScriptTextSnapshot {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -1001,9 +1001,8 @@ final class TypingService {
     private func captureTextBeforeCursorInFocusedField() -> String {
         guard let snapshot = self.captureFocusedTextSnapshot() else { return "" }
 
-        let scriptRange = snapshot.appScriptSelectedRange ?? snapshot.selectedRange
         if let scriptValue = snapshot.appScriptValue,
-           let scriptRange
+           let scriptRange = snapshot.appScriptSelectedRange
         {
             return Self.prefix(in: scriptValue, before: scriptRange.location)
         }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -878,6 +878,17 @@ struct SettingsView: View {
                                     Divider().opacity(0.2)
 
                                     self.optionToggleRow(
+                                        title: "Continuous Dictation Mode",
+                                        description: "Append a trailing space and adjust capitalization so consecutive dictations chain naturally. "
+                                            + "Smart caps: if the text in the field ends with a period, the next segment starts capitalized; otherwise it flows inline.",
+                                        isOn: Binding(
+                                            get: { SettingsStore.shared.continuousDictationModeEnabled },
+                                            set: { SettingsStore.shared.continuousDictationModeEnabled = $0 }
+                                        )
+                                    )
+                                    Divider().opacity(0.2)
+
+                                    self.optionToggleRow(
                                         title: "Pause Media During Transcription",
                                         description: "Automatically pause currently playing audio/video when transcription starts. Resumes only if FluidVoice paused it.",
                                         isOn: Binding(

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -868,22 +868,41 @@ struct SettingsView: View {
                                     Divider().opacity(0.2)
 
                                     self.optionToggleRow(
-                                        title: "GAAV Mode",
-                                        description: "Remove first letter capitalization and trailing period. Useful for search queries, form fields, or casual text.\nFeature requested by MaxGaav.",
+                                        title: "Lowercase First Letter",
+                                        description: "Start each transcription with a lowercase letter. Useful for search queries, form fields, or casual text.",
                                         isOn: Binding(
-                                            get: { SettingsStore.shared.gaavModeEnabled },
-                                            set: { SettingsStore.shared.gaavModeEnabled = $0 }
+                                            get: { SettingsStore.shared.gaavLowercaseFirstLetterEnabled },
+                                            set: { SettingsStore.shared.gaavLowercaseFirstLetterEnabled = $0 }
                                         )
                                     )
                                     Divider().opacity(0.2)
 
                                     self.optionToggleRow(
-                                        title: "Continuous Dictation Mode",
-                                        description: "Append a trailing space and adjust capitalization so consecutive dictations chain naturally. "
-                                            + "Smart caps: if the text in the field ends with a period, the next segment starts capitalized; otherwise it flows inline.",
+                                        title: "Remove Trailing Period",
+                                        description: "Drop a final period from transcriptions. Feature requested by MaxGaav.",
                                         isOn: Binding(
-                                            get: { SettingsStore.shared.continuousDictationModeEnabled },
-                                            set: { SettingsStore.shared.continuousDictationModeEnabled = $0 }
+                                            get: { SettingsStore.shared.gaavRemoveTrailingPeriodEnabled },
+                                            set: { SettingsStore.shared.gaavRemoveTrailingPeriodEnabled = $0 }
+                                        )
+                                    )
+                                    Divider().opacity(0.2)
+
+                                    self.optionToggleRow(
+                                        title: "Space Between Dictations",
+                                        description: "Add spacing so consecutive dictations chain without manually pressing the spacebar.",
+                                        isOn: Binding(
+                                            get: { SettingsStore.shared.continuousDictationSpacingEnabled },
+                                            set: { SettingsStore.shared.continuousDictationSpacingEnabled = $0 }
+                                        )
+                                    )
+                                    Divider().opacity(0.2)
+
+                                    self.optionToggleRow(
+                                        title: "Smart Capitalization",
+                                        description: "Use text before the cursor to decide whether the next dictation should start capitalized or lowercase.",
+                                        isOn: Binding(
+                                            get: { SettingsStore.shared.contextAwareCapitalizationEnabled },
+                                            set: { SettingsStore.shared.contextAwareCapitalizationEnabled = $0 }
                                         )
                                     )
                                     Divider().opacity(0.2)


### PR DESCRIPTION
## What

Adds a **Continuous Dictation Mode** toggle that appends a trailing space to transcribed text and adjusts capitalization based on the text already in the focused field, so consecutive dictations chain naturally without manual spacebar presses.

Closes #390

## How it works

- **Trailing space**: appended so the next dictation continues inline without a manual spacebar press.
- **Smart caps** based on the text before the caret (read via Accessibility at recording start):
  - Empty field → capitalize first letter (sentence start)
  - Field ends with alphanumeric (no terminal punctuation) → lowercase first letter (inline flow)
  - Field ends with `.!?` or other punctuation → keep model capitalization (sentence start)

## Implementation

Mirrors the existing **GAAV Mode** pattern for consistency:

| Layer | Change |
|-------|--------|
| `TypingService` | New `textBeforeCursorInFocusedField()` — single AX round-trip to read text before caret |
| `ASRService` | New `applyContinuousDictationFormatting(_:precedingText:)` — formatter |
| `SettingsStore` | New `continuousDictationModeEnabled` property + `Keys` entry |
| `BackupService` | Added to `SettingsBackupPayload` + get/set for backup/restore |
| `SettingsView` | Toggle row in the same section as GAAV Mode |
| `ContentView` | Capture preceding text at recording start; apply at 3 dictation output sites (finalize, history re-output, reprocess) |

Applied **after** GAAV formatting at the final output stage so both modes compose correctly.

## Low-resource design

- AX field read is a single round-trip, only when the feature is enabled
- No polling, no timers, no background work
- Preceding text captured once at recording start and cleared after use

## Verification

- `swiftformat` + `swiftlint --strict` — 0 violations
- `sh build_with_FI_incremental.sh` — **BUILD SUCCEEDED**, app installed and launched
- Ready for manual QA: toggle on, dictate a segment, dictate again — should chain with a space and correct caps

## Release notes

Updated local `RELEASE_NOTES_1.6.0.md` (gitignored).