### PR TITLE
fix: honor hide-from-dock when launching at login without window (#396)

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -141,8 +141,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             == OSType(keyAELaunchedAsLogInItem)
     }
 
-    private func openMainWindowOnLaunch() {
+    /// Apply the user's dock-visibility preference ("Hide from dock", issue #162).
+    /// Re-applied after operations that can reset the process activation policy - notably the
+    /// LaunchServices reopen below, which restores the bundle default (.regular) even when the
+    /// app is reopened without activation, so hide-from-dock is honored on login launches (#396).
+    private func applyDockVisibilityPolicy() {
         NSApp.setActivationPolicy(SettingsStore.shared.showInDock ? .regular : .accessory)
+    }
+
+    private func openMainWindowOnLaunch() {
+        self.applyDockVisibilityPolicy()
 
         // Users can opt out of showing the window for login-item launches (#369).
         // The window must still be CREATED either way - ContentView's appearance
@@ -215,9 +223,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
 
         DebugLogger.shared.info("Requesting LaunchServices reopen to create SwiftUI main window", source: "AppDelegate")
-        NSWorkspace.shared.openApplication(at: Bundle.main.bundleURL, configuration: configuration) { _, error in
+        NSWorkspace.shared.openApplication(at: Bundle.main.bundleURL, configuration: configuration) { [weak self] _, error in
             if let error {
                 DebugLogger.shared.error("LaunchServices reopen failed: \(error.localizedDescription)", source: "AppDelegate")
+            }
+            // The reopen restores the app's bundle default activation policy (.regular), which
+            // would surface the Dock icon even when the user enabled "Hide from dock". Re-apply
+            // the configured policy so login launches honor the setting (#396). The completion
+            // runs off the main thread, so hop back before touching NSApp.
+            DispatchQueue.main.async {
+                self?.applyDockVisibilityPolicy()
             }
         }
     }


### PR DESCRIPTION
Fixes #396.

Edge case in the login-launch feature from #379. With "Launch at startup" on, "Show window when launched at login" off, and "Hide from dock" on, 1.6.0 launches silently at login but the Dock icon still shows even though hide-from-dock is enabled. The window is correctly hidden, so the lone Dock icon is the only visible symptom.

## Root cause

On login launches the SwiftUI main window often is not ready during the early reveal retries in openMainWindowOnLaunch, so it falls back to a LaunchServices reopen (NSWorkspace.openApplication) to create it. Because the app bundle ships LSUIElement=false, that reopen restores the bundle default activation policy (.regular) even when reopened with activates=false. Hide-from-dock is applied at runtime via setActivationPolicy(.accessory), and nothing re-applies it after the reopen, so the Dock icon comes back.

I confirmed the reopen behavior with a small standalone AppKit probe: an LSUIElement=false bundle set .accessory, reopened itself with activates=false, and came back as .regular. Re-asserting .accessory in the reopen completion put it back and it stuck. Ordering the window front (orderFrontRegardless) and NSApp.activate on their own did not change the policy.

## Fix

Re-apply the configured activation policy (showInDock ? .regular : .accessory) in the reopen completion handler so the setting is honored on login launches. The completion runs off the main thread, so the policy update hops back to main before touching NSApp. The existing policy call is factored into a small applyDockVisibilityPolicy() helper and reused. This also covers login + show-window, which can hit the same reopen fallback.

## Testing

- swiftlint --strict --config .swiftlint.yml: 0 violations
- xcodebuild build -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64': BUILD SUCCEEDED

I could not reproduce a real login-item launch end to end since it only happens at actual login. On-device check: set launch-at-startup on, show-at-login off, hide-from-dock on, reboot, log in, confirm no Dock icon. The FLUID_SIMULATE_LOGIN_LAUNCH=1 hook from #379 exercises the same branch.

No regression test: the failure lives in LaunchServices reopen plus process-activation glue with no clean unit-testable seam in the current test target. A showInDock to policy mapping test would only assert a one-line ternary that was never the broken part, so it would not catch this.
