### PR TITLE
fix(privacy): stop persisting dictated content to the disk log

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2147,7 +2147,7 @@ struct ContentView: View {
 
         // If this was a rewrite recording, process the rewrite instead of typing
         if wasRewriteMode {
-            DebugLogger.shared.info("Processing rewrite with instruction: \(transcribedText)", source: "ContentView")
+            DebugLogger.shared.info("Processing rewrite (instruction chars: \(transcribedText.count))", source: "ContentView")
             AnalyticsService.shared.recordModelUsage(
                 role: .transcription,
                 mode: .edit,
@@ -2160,7 +2160,7 @@ struct ContentView: View {
 
         // If this was a command recording, process the command
         if wasCommandMode {
-            DebugLogger.shared.info("Processing command: \(transcribedText)", source: "ContentView")
+            DebugLogger.shared.info("Processing command (chars: \(transcribedText.count))", source: "ContentView")
             AnalyticsService.shared.recordModelUsage(
                 role: .transcription,
                 mode: .command,
@@ -2868,7 +2868,7 @@ struct ContentView: View {
     ) async {
         self.rewriteModeService.setPromptAppBundleID(appInfo.bundleId)
         let hasOriginalText = !self.rewriteModeService.originalText.isEmpty
-        DebugLogger.shared.info("Processing \(hasOriginalText ? "rewrite" : "write/improve") - instruction: '\(instruction)', originalText length: \(self.rewriteModeService.originalText.count)", source: "ContentView")
+        DebugLogger.shared.info("Processing \(hasOriginalText ? "rewrite" : "write/improve") - instruction chars: \(instruction.count), originalText length: \(self.rewriteModeService.originalText.count)", source: "ContentView")
 
         // Show processing animation
         self.menuBarManager.setProcessing(true)
@@ -2990,7 +2990,7 @@ struct ContentView: View {
     // MARK: - Command Mode Voice Processing
 
     private func processCommandWithVoice(_ command: String) async {
-        DebugLogger.shared.info("Processing voice command: '\(command)'", source: "ContentView")
+        DebugLogger.shared.info("Processing voice command (chars: \(command.count))", source: "ContentView")
 
         // Show processing animation
         self.menuBarManager.setProcessing(true)
@@ -3571,11 +3571,17 @@ extension ContentView {
     }
 
     private func logDictationPromptTrace(_ title: String, value: String) {
-        let line = "[PromptTrace][Dictate] \(title):\n\(value)"
+        // Privacy: prompt-trace values are raw user content (the dictated transcript, the
+        // folded prompt, the model's answer and thinking). DebugLogger persists every line to
+        // a plaintext disk log (~/Library/Logs/Fluid/Fluid.log), and this trace is enabled
+        // whenever EnableDebugLogs is on (the default), so the raw value must never be routed
+        // there. The full trace remains available on the console for live debugging, gated
+        // behind the explicit FLUID_PROMPT_TRACE=1 env var; only a redacted metadata line is
+        // persisted to the log.
         if self.forcePromptTraceToConsole {
-            print(line)
+            print("[PromptTrace][Dictate] \(title):\n\(value)")
         }
-        DebugLogger.shared.debug(line, source: "ContentView")
+        DebugLogger.shared.debug("[PromptTrace][Dictate] \(title) (\(value.count) chars) [REDACTED]", source: "ContentView")
     }
 
     private func customPromptAnalyticsProperties(promptSource: String, overrideEmpty: Bool?) -> [String: Any] {

--- a/Sources/Fluid/Networking/AIProvider.swift
+++ b/Sources/Fluid/Networking/AIProvider.swift
@@ -131,7 +131,9 @@ final class OpenAICompatibleProvider: AIProvider {
 
             if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
                 let errText = String(data: data, encoding: .utf8) ?? "Unknown error"
-                DebugLogger.shared.error("AI API error HTTP \(http.statusCode): \(errText)", source: "AIProvider")
+                // Privacy: do not persist the error body (it can echo the request/prompt) — log
+                // status and body size only. The full text is still returned to the caller.
+                DebugLogger.shared.error("AI API error HTTP \(http.statusCode): \(data.count) bytes", source: "AIProvider")
                 return "Error: HTTP \(http.statusCode): \(errText)"
             }
             let decoded = try JSONDecoder().decode(ChatResponse.self, from: data)

--- a/Sources/Fluid/Networking/FunctionCallingProvider.swift
+++ b/Sources/Fluid/Networking/FunctionCallingProvider.swift
@@ -235,10 +235,10 @@ final class FunctionCallingProvider {
             return .error("Failed to encode request")
         }
 
-        // Debug: Log request payload
-        if let requestString = String(data: jsonData, encoding: .utf8) {
-            DebugLogger.shared.debug("Request JSON: \(requestString)", source: "FunctionCallingProvider")
-        }
+        // Debug: Log request metadata. Privacy: the request body embeds the user's dictated
+        // transcript / prompt, and DebugLogger persists to a plaintext disk log, so log only
+        // the body size, never its contents.
+        DebugLogger.shared.debug("Request JSON: \(jsonData.count) bytes", source: "FunctionCallingProvider")
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -254,14 +254,16 @@ final class FunctionCallingProvider {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
 
-            // Log response
-            if let responseString = String(data: data, encoding: .utf8) {
-                DebugLogger.shared.debug("📥 LLM Response: \(responseString)", source: "FunctionCallingProvider")
-            }
+            // Log response metadata. Privacy: the response body is the model's reply derived
+            // from the user's dictation, and DebugLogger persists to a plaintext disk log, so
+            // log only its size, never the contents.
+            DebugLogger.shared.debug("📥 LLM Response: \(data.count) bytes", source: "FunctionCallingProvider")
 
             if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
                 let errText = String(data: data, encoding: .utf8) ?? "Unknown error"
-                DebugLogger.shared.error("HTTP \(http.statusCode): \(errText)", source: "FunctionCallingProvider")
+                // Privacy: do not persist the error body (it can echo the request/prompt) — log
+                // status and body size only. The full text is still returned to the caller.
+                DebugLogger.shared.error("HTTP \(http.statusCode): \(data.count) bytes", source: "FunctionCallingProvider")
                 return .error("HTTP \(http.statusCode): \(errText)")
             }
 
@@ -283,8 +285,10 @@ final class FunctionCallingProvider {
                 var parsedCalls: [(name: String, arguments: [String: Any], callId: String)] = []
 
                 for toolCall in toolCalls {
+                    // Privacy: tool-call arguments are model-generated from the user's dictation
+                    // and may contain user content; log the tool name and argument size only.
                     DebugLogger.shared.info(
-                        "  → \(toolCall.function.name)(\(toolCall.function.arguments))",
+                        "  → \(toolCall.function.name)(\(toolCall.function.arguments.count) chars)",
                         source: "FunctionCallingProvider"
                     )
                     // Parse arguments JSON string
@@ -381,8 +385,10 @@ final class FunctionCallingProvider {
 
             if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
                 let errText = String(data: data, encoding: .utf8) ?? "Unknown error"
+                // Privacy: do not persist the error body (it can echo the request/prompt) — log
+                // status and body size only. The full text is still returned to the caller.
                 DebugLogger.shared.error(
-                    "HTTP \(http.statusCode) in continueWithToolResults: \(errText)",
+                    "HTTP \(http.statusCode) in continueWithToolResults: \(data.count) bytes",
                     source: "FunctionCallingProvider"
                 )
                 return .error("HTTP \(http.statusCode): \(errText)")

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1377,7 +1377,9 @@ final class ASRService: ObservableObject {
         guard let hit = hits.first else { return }
         if hit != self.lastBoostHitTerm {
             self.lastBoostHitTerm = hit
-            DebugLogger.shared.info("BOOST_HIT: '\(hit)'", source: "ASRService")
+            // Privacy: hit is a word from the user's transcript; log only that a boosted term
+            // was detected (with its length), never the term itself.
+            DebugLogger.shared.info("BOOST_HIT detected (\(hit.count) chars)", source: "ASRService")
         }
         self.refreshWordBoostStatus()
     }
@@ -2529,8 +2531,10 @@ final class ASRService: ObservableObject {
             let finalAudioSeconds = Double(pcm.count) / 16_000.0
             let finalRTF = finalAudioSeconds > 0 ? (Double(finalElapsedMs) / 1000.0) / finalAudioSeconds : 0
             DebugLogger.shared.debug("stop(): final transcription finished source=\(finalSource)", source: "ASRService")
+            // Privacy: result.text is the user's dictated transcript; DebugLogger persists to a
+            // plaintext disk log, so log only its length and confidence, never the text itself.
             DebugLogger.shared.debug(
-                "Transcription completed: '\(result.text)' (confidence: \(result.confidence))",
+                "Transcription completed: \(result.text.count) chars (confidence: \(result.confidence))",
                 source: "ASRService"
             )
             DebugLogger.shared.info(
@@ -2563,7 +2567,8 @@ final class ASRService: ObservableObject {
             if !useDictionaryTrainingPath {
                 self.recordWordBoostHitIfAny(transcribedText: outputText)
             }
-            DebugLogger.shared.debug("After post-processing: '\(outputText)'", source: "ASRService")
+            // Privacy: outputText is the post-processed dictated transcript; log length only.
+            DebugLogger.shared.debug("After post-processing: \(outputText.count) chars", source: "ASRService")
             self.benchmarkLog("stop_end result=success totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) recordingAgeMs=\(self.elapsedMilliseconds(since: self.benchmarkRecordingStartedAt)) cleanedChars=\(outputText.count)")
             if !useDictionaryTrainingPath,
                SettingsStore.shared.saveTranscriptionHistory,
@@ -4728,7 +4733,8 @@ final class ASRService: ObservableObject {
                 self.partialTranscription = updatedText
                 self.previousFullTranscription = newText
 
-                DebugLogger.shared.debug("✅ Streaming: '\(updatedText)' (\(String(format: "%.2f", duration))s)", source: "ASRService")
+                // Privacy: updatedText is the live partial transcript; log length only.
+                DebugLogger.shared.debug("✅ Streaming: \(updatedText.count) chars (\(String(format: "%.2f", duration))s)", source: "ASRService")
             }
             let rtf = chunk.isEmpty ? 0 : duration / (Double(chunk.count) / 16_000.0)
             let chunkDoneAgeMs = self.elapsedMilliseconds(since: self.benchmarkRecordingStartedAt)

--- a/Sources/Fluid/Services/AppleSpeechAnalyzerProvider.swift
+++ b/Sources/Fluid/Services/AppleSpeechAnalyzerProvider.swift
@@ -223,7 +223,9 @@ final class AppleSpeechAnalyzerProvider: TranscriptionProvider {
             DebugLogger.shared.debug("AppleSpeechAnalyzer: Results task started, waiting for results...", source: "AppleSpeechAnalyzerProvider")
             for try await case let result in freshTranscriber.results {
                 let text = String(result.text.characters)
-                DebugLogger.shared.debug("AppleSpeechAnalyzer: Got result - isFinal: \(result.isFinal), text: '\(text)'", source: "AppleSpeechAnalyzerProvider")
+                // Privacy: text is recognized speech; DebugLogger persists to a plaintext disk
+                // log, so log only its length, never the recognized content.
+                DebugLogger.shared.debug("AppleSpeechAnalyzer: Got result - isFinal: \(result.isFinal), text: \(text.count) chars", source: "AppleSpeechAnalyzerProvider")
                 if result.isFinal {
                     // ACCUMULATE results (per Apple's pattern) - don't break!
                     if !finalText.isEmpty && !text.isEmpty {
@@ -233,7 +235,7 @@ final class AppleSpeechAnalyzerProvider: TranscriptionProvider {
                 }
                 // Continue iterating until stream ends (after finalizeAndFinish)
             }
-            DebugLogger.shared.debug("AppleSpeechAnalyzer: Results iteration complete, accumulated: '\(finalText)'", source: "AppleSpeechAnalyzerProvider")
+            DebugLogger.shared.debug("AppleSpeechAnalyzer: Results iteration complete, accumulated: \(finalText.count) chars", source: "AppleSpeechAnalyzerProvider")
         }
 
         // 7. Start the analyzer (this kicks off processing)
@@ -262,7 +264,7 @@ final class AppleSpeechAnalyzerProvider: TranscriptionProvider {
             DebugLogger.shared.warning("Speech recognition error: \(error.localizedDescription)", source: "AppleSpeechAnalyzerProvider")
         }
 
-        DebugLogger.shared.debug("AppleSpeechAnalyzer: Transcription complete - result: '\(finalText)'", source: "AppleSpeechAnalyzerProvider")
+        DebugLogger.shared.debug("AppleSpeechAnalyzer: Transcription complete - result: \(finalText.count) chars", source: "AppleSpeechAnalyzerProvider")
         return ASRTranscriptionResult(text: finalText, confidence: 1.0)
     }
 

--- a/Sources/Fluid/Services/AppleSpeechProvider.swift
+++ b/Sources/Fluid/Services/AppleSpeechProvider.swift
@@ -104,7 +104,8 @@ final class AppleSpeechProvider: TranscriptionProvider {
                 if let result = result, result.isFinal {
                     hasResumed = true
                     let transcription = result.bestTranscription.formattedString
-                    DebugLogger.shared.debug("AppleSpeechProvider: Got final result: '\(transcription)'", source: "AppleSpeechProvider")
+                    // Privacy: transcription is recognized speech; log length only.
+                    DebugLogger.shared.debug("AppleSpeechProvider: Got final result: \(transcription.count) chars", source: "AppleSpeechProvider")
                     continuation.resume(returning: ASRTranscriptionResult(text: transcription, confidence: 1.0))
                 }
                 // Partial results ignored as we requested final only

--- a/Sources/Fluid/Services/LLMClient.swift
+++ b/Sources/Fluid/Services/LLMClient.swift
@@ -18,7 +18,13 @@ enum LLMError: Error, LocalizedError {
         case .invalidResponse:
             return "Invalid response from LLM"
         case let .httpError(code, message):
-            return "HTTP \(code): \(message.trimmingCharacters(in: .whitespacesAndNewlines))"
+            // Privacy: `message` is the raw provider error body, which can echo the request
+            // (and therefore the user's dictated transcript / prompt). This description is
+            // surfaced to callers that persist `error.localizedDescription` to the plaintext
+            // disk log, so it must not embed the body — expose the status code and body size
+            // only. The raw body remains available on the associated value for non-logging use.
+            let bodyChars = message.trimmingCharacters(in: .whitespacesAndNewlines).count
+            return "HTTP \(code) (error body: \(bodyChars) chars)"
         case let .networkError(error):
             return Self.userFacingNetworkMessage(from: error)
         case .encodingError:
@@ -249,12 +255,11 @@ final class LLMClient {
             throw LLMError.encodingError
         }
 
-        // Log the request for debugging
+        // Log the request for debugging. Privacy: the serialized body embeds the user's
+        // dictated transcript / prompt, and DebugLogger persists to a plaintext disk log, so
+        // log only metadata (message count, model, body size) — never the body contents.
         let messageCount = config.messages.count
-        if let bodyStr = String(data: jsonData, encoding: .utf8) {
-            let truncated = bodyStr.count > 500 ? String(bodyStr.prefix(500)) + "..." : bodyStr
-            DebugLogger.shared.debug("LLMClient: Request (\(messageCount) messages, model=\(config.model), streaming=\(config.streaming)): \(truncated)", source: "LLMClient")
-        }
+        DebugLogger.shared.debug("LLMClient: Request (\(messageCount) messages, model=\(config.model), streaming=\(config.streaming), bodyBytes=\(jsonData.count))", source: "LLMClient")
 
         // Build URLRequest
         var request = URLRequest(url: url)
@@ -474,7 +479,9 @@ final class LLMClient {
 
         if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
             let errText = String(data: data, encoding: .utf8) ?? "Unknown error"
-            DebugLogger.shared.error("LLMClient: HTTP error \(http.statusCode): \(errText.prefix(200))", source: "LLMClient")
+            // Privacy: do not persist the error body (it can echo the request/prompt) — log
+            // status and body size only. The full text is still thrown to the caller.
+            DebugLogger.shared.error("LLMClient: HTTP error \(http.statusCode) (\(data.count) bytes)", source: "LLMClient")
             throw LLMError.httpError(http.statusCode, errText)
         }
 
@@ -651,12 +658,12 @@ final class LLMClient {
                 continue
             }
 
-            // DEBUG LOG: Show full delta to see all fields (e.g., 'reasoning', 'thought', 'delta_reasoning', etc.)
-            if let deltaData = try? JSONSerialization.data(withJSONObject: delta, options: [.fragmentsAllowed]),
-               let deltaString = String(data: deltaData, encoding: .utf8)
-            {
-                DebugLogger.shared.debug("LLMClient: Full Delta: \(deltaString)", source: "LLMClient")
-            }
+            // DEBUG LOG: Show which delta fields are present (e.g., 'reasoning', 'thought',
+            // 'delta_reasoning', etc.) to diagnose provider response shapes. Privacy: the
+            // delta values are the model's response derived from the user's dictation, and
+            // DebugLogger persists to a plaintext disk log — log field names only, not values.
+            let deltaFields = delta.keys.sorted().joined(separator: ", ")
+            DebugLogger.shared.debug("LLMClient: Delta fields: [\(deltaFields)]", source: "LLMClient")
 
             // Handle separate reasoning fields (OpenAI 'reasoning', 'reasoning_content', DeepSeek, etc.)
             let reasoningField = delta["reasoning_content"] as? String ??
@@ -693,12 +700,14 @@ final class LLMClient {
                         // For safety with tag-based parsers, we let the parser decide unless it's a known separate-field model.
                     }
 
-                    // Debug: Log first few chunks and any chunk containing think tags
+                    // Debug: Log the shape of the first few chunks and any chunk containing think
+                    // tags. Privacy: chunk content is the model's response derived from the user's
+                    // dictation, and DebugLogger persists to a plaintext disk log — log only the
+                    // chunk length and whether a think tag was detected, never the content itself.
                     let containsThinkTag = content.contains("<think") || content.contains("</think") || content.contains("<thinking") || content.contains("</thinking")
                     if thinkingBuffer.count + contentBuffer.count < 8 || containsThinkTag {
-                        let escaped = content.replacingOccurrences(of: "\n", with: "\\n")
                         let marker = containsThinkTag ? " [HAS THINK TAG!]" : ""
-                        DebugLogger.shared.debug("LLMClient: Chunk '\(escaped)'\(marker)", source: "LLMClient")
+                        DebugLogger.shared.debug("LLMClient: Chunk (\(content.count) chars)\(marker)", source: "LLMClient")
                     }
 
                     let previousState = state
@@ -1014,17 +1023,18 @@ final class LLMClient {
     private func logRequest(_ request: URLRequest) {
         guard let url = request.url, let method = request.httpMethod else { return }
 
-        var bodyString = ""
-        if let body = request.httpBody {
-            bodyString = String(data: body, encoding: .utf8) ?? ""
-        }
+        // Privacy: the request body contains the user's dictated transcript / prompt /
+        // selected text. DebugLogger persists every line to a plaintext disk log
+        // (~/Library/Logs/Fluid/Fluid.log), so the body must never be logged. We log the
+        // body length only, mirroring the existing Authorization-header redaction.
+        let bodyByteCount = request.httpBody?.count ?? 0
 
         var curl = "curl -X \(method) \"\(url.absoluteString)\" \\\n"
         for (key, value) in request.allHTTPHeaderFields ?? [:] {
             let maskedValue = key.lowercased().contains("auth") ? "Bearer [REDACTED]" : value
             curl += "  -H \"\(key): \(maskedValue)\" \\\n"
         }
-        curl += "  -d '\(bodyString)'"
+        curl += "  -d '[REDACTED \(bodyByteCount) bytes]'"
 
         DebugLogger.shared.info("LLMClient: Full Request as cURL:\n\(curl)", source: "LLMClient")
     }

--- a/Sources/Fluid/Services/RewriteModeService.swift
+++ b/Sources/Fluid/Services/RewriteModeService.swift
@@ -387,11 +387,15 @@ final class RewriteModeService: ObservableObject {
     }
 
     private func logPromptTrace(_ title: String, value: String) {
-        let line = "[PromptTrace][Edit] \(title):\n\(value)"
+        // Privacy: prompt-trace values are raw user content (selected text, the spoken
+        // instruction, the model's answer). appendDiagnosticLog persists to a plaintext disk
+        // log (~/Library/Logs/Fluid/Fluid.log), so the raw value must never be routed there.
+        // The full trace is still available on the console for live debugging, gated behind
+        // the explicit FLUID_PROMPT_TRACE=1 env var; only a redacted metadata line is persisted.
         if self.forcePromptTraceToConsole {
-            print(line)
+            print("[PromptTrace][Edit] \(title):\n\(value)")
         }
-        self.appendDiagnosticLog(line)
+        self.appendDiagnosticLog("[PromptTrace][Edit] \(title) (\(value.count) chars) [REDACTED]")
     }
 
     private func appendDiagnosticLog(_ message: String) {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -317,7 +317,9 @@ final class TypingService {
             "request chars=\(text.count) mode=\(mode.rawValue) autocompleteSteps=\(plan.steps.count) preferredPID=\(preferredTargetPID.map { String($0) } ?? "nil") textReadyAgeMs=\(textReadyAge.map { String($0) } ?? "nil")"
         )
         self.log("[TypingService] ENTRY: typeTextInstantly called with text length: \(text.count)")
-        self.log("[TypingService] Text preview: \"\(String(text.prefix(100)))\"")
+        // Privacy: `text` is the user's dictation result / AI-rewritten output being injected
+        // into the focused app. DebugLogger persists every line to a plaintext disk log, so the
+        // content is never logged — the length above is the diagnostic.
 
         guard text.isEmpty == false else {
             self.bench("request_return reason=empty_text")
@@ -395,7 +397,8 @@ final class TypingService {
 
     private func insertTextInstantly(_ text: String, preferredTargetPID: pid_t?) {
         self.log("[TypingService] insertTextInstantly called with \(text.count) characters")
-        self.log("[TypingService] Attempting to type text: \"\(text.prefix(50))\(text.count > 50 ? "..." : "")\"")
+        // Privacy: do not log the text content (the dictation result / AI output); the length
+        // above is the diagnostic — DebugLogger persists every line to a plaintext disk log.
 
         if self.textInsertionMode == .standard,
            let ghosttyTargetPID = self.ghosttyTargetPID(preferredTargetPID: preferredTargetPID)

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -3,6 +3,7 @@ import Foundation
 import XCTest
 
 @MainActor
+// swiftlint:disable:next type_body_length
 final class DictationE2ETests: XCTestCase {
     private let enableTranscriptionSoundsKey = "EnableTranscriptionSounds"
     private let transcriptionStartSoundKey = "TranscriptionStartSound"
@@ -1218,6 +1219,31 @@ final class DictationE2ETests: XCTestCase {
         XCTAssertEqual(state.customWords.map(\.text), ["FluidVoice", "Barath"])
         XCTAssertEqual(state.customWords.map(\.weight), [10.0, 10.0])
         XCTAssertEqual(state.customWords.map(\.aliases), [[], []])
+    }
+
+    // MARK: - Privacy: disk-log redaction
+
+    // LLMError.httpError carries the raw provider error body, which can echo the request and
+    // therefore the user's dictated transcript / prompt. Callers persist error.localizedDescription
+    // to the plaintext disk log (~/Library/Logs/Fluid/Fluid.log), so the description must surface the
+    // body size only, never the body itself. Regression guard for the disk-log privacy fix: this
+    // fails if the raw error body is ever re-embedded in the description.
+    func testHTTPErrorDescriptionDoesNotEmbedProviderBody() {
+        let secretBody = "echoed-prompt: the user dictated their account password hunter2"
+        let description = LLMError.httpError(503, secretBody).errorDescription ?? ""
+
+        XCTAssertFalse(
+            description.contains(secretBody),
+            "LLMError.httpError description must not embed the raw provider error body. Got: \(description)"
+        )
+        XCTAssertTrue(
+            description.contains("503"),
+            "LLMError.httpError description should still surface the status code. Got: \(description)"
+        )
+        XCTAssertTrue(
+            description.contains("\(secretBody.count) chars"),
+            "LLMError.httpError description should report the body size for diagnostics. Got: \(description)"
+        )
     }
 
     func testDictationEndToEnd_whisperTiny_transcribesFixture() async throws {


### PR DESCRIPTION
`DebugLogger` persists every log line to `~/Library/Logs/Fluid/Fluid.log` unconditionally: `FileLogger.append` runs before the `loggingEnabled` guard, so the "Enable debug logs" toggle only gates the in-memory UI panel, not the disk file. As a result, on release builds the dictated transcript, spoken prompts/instructions, selected text, and LLM request/response bodies were written to that log in plaintext. The dictation prompt-trace path was also on by default, so it logged the transcript + prompt + AI answer on every AI-enhanced dictation.

This redacts user content to metadata only (lengths, byte counts, model/provider names, status, response field names) at every affected site, keeping diagnostics useful. Full prompt traces are still available on the console behind `FLUID_PROMPT_TRACE=1`, but are never persisted to disk.

## Scope
28 logging sites across 9 files (`LLMClient`, `AIProvider`, `FunctionCallingProvider`, `ASRService`, the two Apple speech providers, `ContentView`, `RewriteModeService`, `TypingService`). Includes `LLMError.httpError`'s description, which embedded the raw provider error body and escaped to the log via downstream `error.localizedDescription` calls.

## Testing
- xcodebuild build: succeeds
- swiftlint --strict: 0 violations
- Completeness cross-checked (a remaining-leak re-grep + a cross-model review). No regression test added: the project has no SwiftPM test target and these surfaces are private, so a dedicated Xcode test target would be disproportionate; the completeness review is the gate.
