### PR TITLE
Add adjustable tail recording to capture the last word

### DIFF
--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -81,6 +81,8 @@ struct SettingsBackupPayload: Codable, Equatable {
     let visualizerNoiseThreshold: Double
     let overlayPosition: SettingsStore.OverlayPosition
     let overlayBottomOffset: Double
+    // Optional so backups written before this field existed still decode.
+    let recordingTailDuration: Double?
     let overlaySize: SettingsStore.OverlaySize
     let transcriptionPreviewCharLimit: Int
     let userTypingWPM: Int

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2160,6 +2160,21 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Extra seconds to keep recording after the user presses stop, so the tail of their
+    /// last word isn't clipped. Default 0.2; range 0–0.4s. Read by ASRService at stop time.
+    var recordingTailDuration: Double {
+        get {
+            // 0 is a valid value here (disables the tail), so don't treat a stored 0 as "unset".
+            guard self.defaults.object(forKey: Keys.recordingTailDuration) != nil else { return 0.2 }
+            return self.defaults.double(forKey: Keys.recordingTailDuration)
+        }
+        set {
+            objectWillChange.send()
+            let clamped = max(min(newValue, 0.4), 0.0)
+            self.defaults.set(clamped, forKey: Keys.recordingTailDuration)
+        }
+    }
+
     /// The size of the recording overlay (default: medium)
     var overlaySize: OverlaySize {
         get {
@@ -3292,6 +3307,7 @@ final class SettingsStore: ObservableObject {
             visualizerNoiseThreshold: self.visualizerNoiseThreshold,
             overlayPosition: self.overlayPosition,
             overlayBottomOffset: self.overlayBottomOffset,
+            recordingTailDuration: self.recordingTailDuration,
             overlaySize: self.overlaySize,
             transcriptionPreviewCharLimit: self.transcriptionPreviewCharLimit,
             userTypingWPM: self.userTypingWPM,
@@ -3445,6 +3461,9 @@ final class SettingsStore: ObservableObject {
         self.visualizerNoiseThreshold = payload.visualizerNoiseThreshold
         self.overlayPosition = payload.overlayPosition
         self.overlayBottomOffset = payload.overlayBottomOffset
+        if let recordingTailDuration = payload.recordingTailDuration {
+            self.recordingTailDuration = recordingTailDuration
+        }
         self.overlaySize = payload.overlaySize
         self.transcriptionPreviewCharLimit = payload.transcriptionPreviewCharLimit
         self.userTypingWPM = payload.userTypingWPM
@@ -5452,6 +5471,7 @@ private extension SettingsStore {
         static let overlayPosition = "OverlayPosition"
         static let notchPresentationMode = "NotchPresentationMode"
         static let overlayBottomOffset = "OverlayBottomOffset"
+        static let recordingTailDuration = "RecordingTailDuration"
         static let overlayBottomOffsetMigratedTo50 = "OverlayBottomOffsetMigratedTo50"
         static let overlaySize = "OverlaySize"
         static let transcriptionPreviewCharLimit = "TranscriptionPreviewCharLimit"

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -202,6 +202,7 @@ final class ASRService: ObservableObject {
     private(set) var dictionaryTrainingAudioGeneration = 0
 
     @Published private(set) var isStarting: Bool = false // Guard against re-entrant start() calls
+    private var isStopping: Bool = false // Guard against re-entrant stop() during the tail-capture grace window
     private var audioCaptureStartWaiters: [CheckedContinuation<Void, Never>] = []
     var isRunningOrStarting: Bool {
         self.isRunning || self.isStarting
@@ -1127,6 +1128,13 @@ final class ASRService: ObservableObject {
     private let audioEngineStandbyNanoseconds: UInt64 = 8_000_000_000
     private var isEngineTapInstalled = false
     private var isRecoveringAudioRoute = false
+    /// Extra time the mic tap stays live after the user triggers stop, so the tail
+    /// of their final word isn't clipped by input-pipeline latency. User-configurable
+    /// via Settings -> "Extra recording after stop" (seconds); 0 disables.
+    private var stopTailCaptureGraceNanoseconds: UInt64 {
+        let seconds = max(0, SettingsStore.shared.recordingTailDuration)
+        return UInt64(seconds * 1_000_000_000)
+    }
 
     /// Tracks whether we paused system media for this recording session.
     /// Used to resume playback only if we were the ones who paused it.
@@ -2337,11 +2345,20 @@ final class ASRService: ObservableObject {
         if self.isStarting, self.isRunning == false {
             await self.cancelPendingAudioCaptureStart(reason: "recording_stop")
         }
+        // Re-entrancy guard: a second stop() can arrive while the first is parked in the
+        // tail-capture grace sleep below. Bail before touching any shared state, so we never
+        // tear down a session the in-flight stop() already owns. Checked ahead of the isRunning
+        // guard for that reason - it must not clear isDictionaryTrainingCaptureActive.
+        guard !self.isStopping else {
+            DebugLogger.shared.warning("⚠️ STOP() - already stopping, returning empty string", source: "ASRService")
+            return ""
+        }
         guard self.isRunning else {
             self.isDictionaryTrainingCaptureActive = false
             DebugLogger.shared.warning("⚠️ STOP() - not running, returning empty string", source: "ASRService")
             return ""
         }
+        self.isStopping = true
         let useDictionaryTrainingPath = forDictionaryTraining || self.isDictionaryTrainingCaptureActive
         defer {
             self.applyPendingParakeetVocabularyReloadIfNeeded()
@@ -2356,6 +2373,25 @@ final class ASRService: ObservableObject {
 
         DebugLogger.shared.debug("📍 Preparing final transcription", source: "ASRService")
 
+        // Tail-capture grace: keep the mic live for a short window after the stop trigger so
+        // the tail of the user's final word isn't clipped by input-pipeline latency.
+        // Order matters: this sleep must happen BEFORE markRecordingEnd() below, which freezes
+        // the acquisition boundary. Sleeping first pushes that boundary later, so the extra
+        // audio is inside the session instead of being trimmed off it.
+        let tailGraceNanoseconds = self.stopTailCaptureGraceNanoseconds
+        if tailGraceNanoseconds > 0 {
+            DebugLogger.shared.debug("⏳ Tail-capture grace: keeping mic live for \(tailGraceNanoseconds / 1_000_000)ms...", source: "ASRService")
+            try? await Task.sleep(nanoseconds: tailGraceNanoseconds)
+        }
+
+        // A cancel (stopWithoutTranscription) can run during the grace sleep above and tear the
+        // session down (isRunning -> false). If so, bail without transcribing so the canceled
+        // dictation isn't inserted - the cancel path already owns the teardown and buffer clear.
+        guard self.isRunning else {
+            self.isStopping = false
+            return ""
+        }
+
         // Freeze an exact acquisition boundary before stopping hardware. The
         // direct IOProc is synchronously drained and the pipeline trims the
         // final hardware packet to this host time, preserving the last phoneme
@@ -2365,6 +2401,9 @@ final class ASRService: ObservableObject {
         // Set isRunning to false before teardown so in-flight ASR chunks stop safely.
         DebugLogger.shared.debug("🚫 Setting isRunning = false...", source: "ASRService")
         self.isRunning = false
+        // Release the stop guard as soon as the session isn't "running": holding it across the
+        // slow final transcription would block stopping a recording started during finalization.
+        self.isStopping = false
         DebugLogger.shared.debug("✅ isRunning disabled", source: "ASRService")
 
         // Stop monitoring device to prevent callbacks after stop

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -836,6 +836,32 @@ struct SettingsView: View {
                                     }
                                     Divider().opacity(0.2)
 
+                                    HStack(alignment: .center) {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text("Extra recording after stop")
+                                                .font(self.theme.typography.bodyStrong)
+                                                .foregroundStyle(self.settingsTitleText)
+                                            Text("Keeps recording briefly after you press stop so your last word isn't cut off.")
+                                                .font(self.theme.typography.bodySmall)
+                                                .foregroundStyle(self.settingsSecondaryText)
+                                        }
+
+                                        Spacer()
+
+                                        HStack(spacing: 6) {
+                                            Slider(value: self.$settings.recordingTailDuration, in: 0...0.4, step: 0.05)
+                                                .frame(width: 110)
+                                                .controlSize(.small)
+
+                                            Text(String(format: "%.2f s", self.settings.recordingTailDuration))
+                                                .font(.caption.monospaced())
+                                                .foregroundStyle(self.settingsSecondaryText)
+                                                .frame(width: 54, alignment: .trailing)
+                                        }
+                                        .frame(width: 170, alignment: .trailing)
+                                    }
+                                    Divider().opacity(0.2)
+
                                     self.optionToggleRow(
                                         title: "Copy to Clipboard",
                                         description: "Automatically copy transcribed text to clipboard as a backup.",


### PR DESCRIPTION
## Description
Dictation was clipping the last word. When you trigger stop, the final ~50–130 ms of audio is still in CoreAudio's input pipeline (and people tend to release the key a hair early), but capture freezes immediately — so the tail of the last word is lost.

This keeps the mic tap live for a short, **configurable** grace period after the stop trigger, so the trailing audio lands in the buffer before the engine tears down. The duration is exposed as a slider in Settings.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issues
- N/A

## What changed
- **`ASRService.stop()`** now `await`s a short grace period *before* `audioCapturePipeline.setRecordingEnabled(false)`, so the tap keeps appending the trailing audio. The exact cessation point (the tap's `guard enabled` check) is why the delay has to go before that line — anything after it is already discarded.
- Guarded by a new **`isStopping`** flag to close the re-entrancy window the delay opens: while `stop()` is sleeping, `isRunning` is still `true`, so the un-guarded playground/Welcome stop path could otherwise slip in a second `stop()`.
- New persisted setting **`SettingsStore.recordingTailDuration`** (seconds, default **0.2**, clamped 0–0.4). Read live at stop time, so a change applies on the very next dictation. `0` disables the tail entirely (the getter uses a `nil`-check so `0` persists instead of snapping back to the default).
- Slider added under **Settings → Global Hotkey → Options → "Extra recording after stop"**, mirroring the existing "Bottom Offset" slider pattern.
- Wired through settings **backup/restore** as an optional field, so older backups still decode.
- The **Cancel** path (`stopWithoutTranscription()`) is intentionally left undelayed.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`

Built Release (arm64) successfully, signed, installed, and launched on Apple Silicon / macOS 26. End-to-end dictation tail behavior (and dragging the slider) should be confirmed manually, since it needs live mic input.

## Notes
- **Latency tradeoff:** stop→text grows by the configured tail (default 0.2 s). Reasonable for catching the last word; the user can tune it down to 0 or up to 0.4 s.
- **Parakeet fast-preview interaction:** the extra tail audio more often trips the `tail_has_audio` guard, so finalize runs a full transcription instead of reusing the streaming preview — slightly slower finalize on that path, but that's exactly what recovers the last word.
- **No overlay flicker:** the overlay already flips to "Transcribing" before `stop()` is called, and `isProcessingActive` keeps it visible while `isRunning` flips a beat later.

## Screenshots / Video
The new control lives in **Settings → Global Hotkey card → Options**, directly under "Activation Mode" — label "Extra recording after stop", a 0.00–0.40 s slider showing the live value. _Screenshot to be added._
