### PR TITLE
fix(localapi): reject over-limit inline audio instead of silently truncating

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7C5AF14C2F15041600DE21B0 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7C9A71022F58B00000FB7CAF /* TranscribeCpp in Frameworks */ = {isa = PBXBuildFile; productRef = 7C9A71012F58B00000FB7CAF /* TranscribeCpp */; };
 		7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */; };
+		7CFA1D0A2F500000C0DEF001 /* LocalAPIAudioDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0A2F500000C0DEF002 /* LocalAPIAudioDecoderTests.swift */; };
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
 		CD1C7A0000000000000000B2 /* CustomDictionaryManualEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7CFA1D0A2F500000C0DEF002 /* LocalAPIAudioDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAPIAudioDecoderTests.swift; sourceTree = "<group>"; };
 		343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMClientRequestBodyTests.swift; sourceTree = "<group>"; };
 		980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSupportTests.swift; sourceTree = "<group>"; };
 		A11A00000000000000000001 /* AnalyticsDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsDatabaseTests.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */,
 				7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */,
 				803000000000000000000001 /* MediaPlaybackServiceTests.swift */,
+				7CFA1D0A2F500000C0DEF002 /* LocalAPIAudioDecoderTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
 			sourceTree = "<group>";
@@ -324,6 +327,7 @@
 				DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */,
 				7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */,
 				803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */,
+				7CFA1D0A2F500000C0DEF001 /* LocalAPIAudioDecoderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIAudioDecoder.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIAudioDecoder.swift
@@ -9,7 +9,10 @@ enum LocalAPIAudioDecoder {
         let file = try AVAudioFile(forReading: fileURL)
         let sourceFormat = file.processingFormat
         let maxFrames = AVAudioFramePosition(sourceFormat.sampleRate * self.maxDurationSeconds)
-        let framesToRead = min(file.length, maxFrames)
+        guard file.length <= maxFrames else {
+            throw self.durationLimitExceededError()
+        }
+        let framesToRead = file.length
         guard framesToRead > 0 else { return [] }
 
         guard let sourceBuffer = AVAudioPCMBuffer(
@@ -47,13 +50,17 @@ enum LocalAPIAudioDecoder {
 
         let maxFrames = AVAudioFramePosition(sourceFormat.sampleRate * self.maxDurationSeconds)
         guard file.length <= maxFrames else {
-            throw NSError(
-                domain: "LocalAPIAudioDecoder",
-                code: -5,
-                userInfo: [NSLocalizedDescriptionKey: "Audio file exceeds the \(Int(self.maxDurationSeconds)) second API limit."]
-            )
+            throw self.durationLimitExceededError()
         }
 
         return Int((Double(file.length) * self.sampleRate / sourceFormat.sampleRate).rounded())
+    }
+
+    private static func durationLimitExceededError() -> NSError {
+        NSError(
+            domain: "LocalAPIAudioDecoder",
+            code: -5,
+            userInfo: [NSLocalizedDescriptionKey: "Audio file exceeds the \(Int(self.maxDurationSeconds)) second API limit."]
+        )
     }
 }

--- a/Tests/FluidDictationIntegrationTests/LocalAPIAudioDecoderTests.swift
+++ b/Tests/FluidDictationIntegrationTests/LocalAPIAudioDecoderTests.swift
@@ -1,0 +1,105 @@
+import AVFoundation
+@testable import FluidVoice_Debug
+import Foundation
+import XCTest
+
+final class LocalAPIAudioDecoderTests: XCTestCase {
+    // The LocalAPI enforces a 300-second limit on transcription audio.
+    private let overLimitSeconds: Double = 305
+    private let underLimitSeconds: Double = 1
+    private let fixtureSampleRate: Double = 8_000
+
+    func testInlineAudioOverLimitThrowsInsteadOfTruncating() throws {
+        let data = try Self.makeSilentWavData(durationSeconds: self.overLimitSeconds, sampleRate: self.fixtureSampleRate)
+
+        XCTAssertThrowsError(
+            try LocalAPIAudioDecoder.samples(fromAudioData: data, suggestedExtension: "wav"),
+            "Inline audio over the 300s limit must throw instead of silently truncating."
+        ) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, "LocalAPIAudioDecoder")
+            XCTAssertEqual(nsError.code, -5)
+        }
+    }
+
+    func testInlineAudioUnderLimitDecodesNormally() throws {
+        let data = try Self.makeSilentWavData(durationSeconds: self.underLimitSeconds, sampleRate: self.fixtureSampleRate)
+
+        let samples = try LocalAPIAudioDecoder.samples(fromAudioData: data, suggestedExtension: "wav")
+
+        // Source is 1s of mono audio resampled to 16 kHz, so expect roughly 16k samples.
+        XCTAssertGreaterThan(samples.count, 8_000, "Under-limit inline audio should decode to samples.")
+        XCTAssertLessThan(samples.count, 24_000, "Decoded sample count should stay near the 16 kHz expectation.")
+    }
+
+    func testFilePathDecodeRejectsOverLimitAudio() throws {
+        let url = try Self.makeSilentWavFile(durationSeconds: self.overLimitSeconds, sampleRate: self.fixtureSampleRate)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try LocalAPIAudioDecoder.samples(from: url)) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, "LocalAPIAudioDecoder")
+            XCTAssertEqual(nsError.code, -5)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func makeSilentWavData(durationSeconds: Double, sampleRate: Double) throws -> Data {
+        let url = try makeSilentWavFile(durationSeconds: durationSeconds, sampleRate: sampleRate)
+        defer { try? FileManager.default.removeItem(at: url) }
+        return try Data(contentsOf: url)
+    }
+
+    private static func makeSilentWavFile(durationSeconds: Double, sampleRate: Double) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fluidvoice-decoder-test-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+        try writeSilentWav(to: url, durationSeconds: durationSeconds, sampleRate: sampleRate)
+        return url
+    }
+
+    private static func writeSilentWav(to url: URL, durationSeconds: Double, sampleRate: Double) throws {
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: sampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false
+        ]
+        // AVAudioFile flushes and closes the file when this local reference deallocates
+        // at the end of this function, so callers can safely read the bytes afterwards.
+        let file = try AVAudioFile(forWriting: url, settings: settings)
+
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw NSError(
+                domain: "LocalAPIAudioDecoderTests",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Unable to create writer audio format."]
+            )
+        }
+
+        let totalFrames = AVAudioFrameCount((sampleRate * durationSeconds).rounded())
+        let chunkSize: AVAudioFrameCount = 16_000
+        var remaining = totalFrames
+        while remaining > 0 {
+            let thisChunk = min(chunkSize, remaining)
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: thisChunk) else {
+                throw NSError(
+                    domain: "LocalAPIAudioDecoderTests",
+                    code: -2,
+                    userInfo: [NSLocalizedDescriptionKey: "Unable to allocate writer buffer."]
+                )
+            }
+            buffer.frameLength = thisChunk
+            try file.write(from: buffer)
+            remaining -= thisChunk
+        }
+    }
+}


### PR DESCRIPTION
## Description
LocalAPI has a 300-second audio limit, but inline audio decoded through `LocalAPIAudioDecoder.samples(fromAudioData:suggestedExtension:)` could be silently truncated to the first 300 seconds because the shared decoder capped `framesToRead` with `min(file.length, maxFrames)`.

This changes the shared decode path to reject over-limit audio with the same `LocalAPIAudioDecoder` duration-limit error instead of truncating. Under-limit inline audio still decodes normally.

The PR also centralizes the duration-limit error in `durationLimitExceededError()`, so file-path and inline/body uploads return the same error domain, code, and message.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📝 Documentation update

## Related Issue or Discussion
Tracking discussion: #429.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 15.7.7
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources Tests/FluidDictationIntegrationTests/LocalAPIAudioDecoderTests.swift`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `xcodebuild build-for-testing -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Added `LocalAPIAudioDecoderTests` coverage:
- `testInlineAudioOverLimitThrowsInsteadOfTruncating`
- `testInlineAudioUnderLimitDecodesNormally`
- `testFilePathDecodeRejectsOverLimitAudio`

The tests build synthetic silent WAV fixtures/data, so they do not require downloading or running a speech model.

## Notes
This is API behavior only. It does not change UI, settings, onboarding, overlay, menu bar, or visual behavior.

Full hosted test execution was not run locally because the installed FluidVoice app was open; the hosted test runner can hang in that state. `build-for-testing` compiled the app and test target, and CI should run the full hosted suite after the branch update.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.
