### PR TITLE
fix(settings): preserve provider API keys until Keychain write succeeds

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7C5AF14C2F15041600DE21B0 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7C9A71022F58B00000FB7CAF /* TranscribeCpp in Frameworks */ = {isa = PBXBuildFile; productRef = 7C9A71012F58B00000FB7CAF /* TranscribeCpp */; };
 		7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */; };
+		7C91B0032F42AA0100C0DEF0 /* ProviderAPIKeyMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0042F42AA0100C0DEF0 /* ProviderAPIKeyMigrationTests.swift */; };
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
 		CD1C7A0000000000000000B2 /* CustomDictionaryManualEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
@@ -70,6 +71,7 @@
 		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
 		7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidDictationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
+		7C91B0042F42AA0100C0DEF0 /* ProviderAPIKeyMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderAPIKeyMigrationTests.swift; sourceTree = "<group>"; };
 		CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDictionaryManualEntryTests.swift; sourceTree = "<group>"; };
 		7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingServiceTransientPasteboardTests.swift; sourceTree = "<group>"; };
 		803000000000000000000001 /* MediaPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackServiceTests.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */,
 				7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */,
 				803000000000000000000001 /* MediaPlaybackServiceTests.swift */,
+				7C91B0042F42AA0100C0DEF0 /* ProviderAPIKeyMigrationTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
 			sourceTree = "<group>";
@@ -324,6 +327,7 @@
 				DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */,
 				7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */,
 				803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */,
+				7C91B0032F42AA0100C0DEF0 /* ProviderAPIKeyMigrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Fluid/Persistence/KeychainService.swift
+++ b/Sources/Fluid/Persistence/KeychainService.swift
@@ -20,7 +20,15 @@ enum KeychainServiceError: Error, LocalizedError {
 
 /// Lightweight helper for storing provider API keys in the system Keychain.
 /// Keys are stored as generic passwords scoped to the FluidVoice service.
-final class KeychainService {
+protocol ProviderKeychain {
+    func storeKey(_ key: String, for providerID: String) throws
+    func fetchAllKeys() throws -> [String: String]
+    func storeAllKeys(_ values: [String: String]) throws
+    func legacyProviderEntries() throws -> [String: String]
+    func removeLegacyEntries(providerIDs: [String]) throws
+}
+
+final class KeychainService: ProviderKeychain {
     static let shared = KeychainService()
 
     private let service = "com.fluidvoice.provider-api-keys"
@@ -168,7 +176,6 @@ final class KeychainService {
 
         switch status {
         case errSecSuccess:
-            try self.removeLegacyEntries()
             return
         case errSecDuplicateItem:
             let updateAttributes: [String: Any] = [
@@ -181,7 +188,6 @@ final class KeychainService {
             guard updateStatus == errSecSuccess else {
                 throw KeychainServiceError.unhandled(updateStatus)
             }
-            try self.removeLegacyEntries()
         default:
             throw KeychainServiceError.unhandled(status)
         }

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -25,14 +25,20 @@ final class SettingsStore: ObservableObject {
     static let privateAIDictationRoundTripTokenCost = 2.75
     static let privateAIBackendPreferenceDefaultsKey = "FluidIntelligenceBackendPreference"
     private static let forcedOnboardingResetIntroducedAt = Date(timeIntervalSince1970: 1_782_091_732)
-    private let defaults = UserDefaults.standard
-    private let keychain = KeychainService.shared
+    private let defaults: UserDefaults
+    private var keychain: ProviderKeychain
     private(set) var launchAtStartupEnabled = false
     private(set) var launchAtStartupErrorMessage: String?
     private(set) var launchAtStartupStatusMessage =
         "FluidVoice reflects the actual macOS login item state. Unsigned or development builds may fail to enable this."
 
-    private init() {
+    private init(
+        defaults: UserDefaults = .standard,
+        keychain: ProviderKeychain = KeychainService.shared
+    ) {
+        self.defaults = defaults
+        self.keychain = keychain
+
         self.migrateTranscriptionStartSoundIfNeeded()
         self.ensureDebugLoggingDefaults()
         self.migrateProviderAPIKeysIfNeeded()
@@ -1491,7 +1497,34 @@ final class SettingsStore: ObservableObject {
     func saveProviderAPIKeys(_ values: [String: String]) throws -> [String: String] {
         let trimmed = self.sanitizeAPIKeys(values)
         try self.keychain.storeAllKeys(trimmed)
+        self.purgeRemovedProvidersFromLegacySources(keeping: trimmed)
         return try self.keychain.fetchAllKeys()
+    }
+
+    /// While migration is incomplete, legacy plaintext defaults and per-provider Keychain
+    /// entries still exist. A provider removed from the consolidated store must also leave
+    /// those sources, or a later migration pass would resurrect the deleted key.
+    private func purgeRemovedProvidersFromLegacySources(keeping stored: [String: String]) {
+        guard self.defaults.bool(forKey: Keys.providerAPIKeyMigrationCompleted) == false else { return }
+
+        var legacyDefaults = (self.defaults.dictionary(forKey: Keys.providerAPIKeys) as? [String: String]) ?? [:]
+        let legacyKeychainIDs = (try? self.keychain.legacyProviderEntries().keys).map(Array.init) ?? []
+        let removed = Set(legacyDefaults.keys).union(legacyKeychainIDs).filter { stored[$0] == nil }
+        guard removed.isEmpty == false else { return }
+
+        let removedFromDefaults = removed.filter { legacyDefaults[$0] != nil }
+        if removedFromDefaults.isEmpty == false {
+            for providerID in removedFromDefaults {
+                legacyDefaults.removeValue(forKey: providerID)
+            }
+            if legacyDefaults.isEmpty {
+                self.defaults.removeObject(forKey: Keys.providerAPIKeys)
+            } else {
+                self.defaults.set(legacyDefaults, forKey: Keys.providerAPIKeys)
+            }
+        }
+
+        try? self.keychain.removeLegacyEntries(providerIDs: Array(removed))
     }
 
     /// Securely retrieve API key for a provider, handling custom prefix logic
@@ -3450,31 +3483,63 @@ final class SettingsStore: ObservableObject {
     private func migrateProviderAPIKeysIfNeeded() {
         self.defaults.removeObject(forKey: Keys.providerAPIKeyIdentifiers)
 
-        var merged = (try? self.keychain.fetchAllKeys()) ?? [:]
-        var didMutate = false
-
-        if let legacyDefaults = defaults.dictionary(forKey: Keys.providerAPIKeys) as? [String: String],
-           legacyDefaults.isEmpty == false
-        {
-            merged.merge(self.sanitizeAPIKeys(legacyDefaults)) { _, new in new }
-            didMutate = true
-        }
-        self.defaults.removeObject(forKey: Keys.providerAPIKeys)
-
-        if let legacyKeychain = try? keychain.legacyProviderEntries(),
-           legacyKeychain.isEmpty == false
-        {
-            merged.merge(self.sanitizeAPIKeys(legacyKeychain)) { _, new in new }
-            didMutate = true
-            try? self.keychain.removeLegacyEntries(providerIDs: Array(legacyKeychain.keys))
-        }
-
-        if didMutate {
+        if self.defaults.bool(forKey: Keys.providerAPIKeyMigrationCompleted) {
+            self.defaults.removeObject(forKey: Keys.providerAPIKeys)
             do {
-                _ = try self.saveProviderAPIKeys(merged)
+                let legacyKeychain = try self.keychain.legacyProviderEntries()
+                if legacyKeychain.isEmpty == false {
+                    try? self.keychain.removeLegacyEntries(providerIDs: Array(legacyKeychain.keys))
+                }
             } catch {
                 self.logProviderAPIKeyPersistenceFailure(error)
             }
+            return
+        }
+
+        let legacyKeychain: [String: String]
+        let didReadLegacyKeychain: Bool
+        do {
+            legacyKeychain = try self.keychain.legacyProviderEntries()
+            didReadLegacyKeychain = true
+        } catch {
+            self.logProviderAPIKeyPersistenceFailure(error)
+            legacyKeychain = [:]
+            didReadLegacyKeychain = false
+        }
+
+        var merged = (try? self.keychain.fetchAllKeys()) ?? [:]
+        let legacyDefaults = (self.defaults.dictionary(forKey: Keys.providerAPIKeys) as? [String: String]) ?? [:]
+        let sanitizedLegacyDefaults = self.sanitizeAPIKeys(legacyDefaults)
+        let hasLegacySources = legacyDefaults.isEmpty == false || legacyKeychain.isEmpty == false
+
+        if legacyKeychain.isEmpty == false {
+            for (provider, key) in self.sanitizeAPIKeys(legacyKeychain) {
+                guard merged[provider] == nil || merged[provider] == sanitizedLegacyDefaults[provider] else {
+                    continue
+                }
+                merged[provider] = key
+            }
+        }
+
+        if legacyDefaults.isEmpty == false {
+            merged.merge(sanitizedLegacyDefaults) { current, _ in current }
+        }
+
+        guard hasLegacySources else { return }
+
+        do {
+            _ = try self.saveProviderAPIKeys(merged)
+        } catch {
+            self.logProviderAPIKeyPersistenceFailure(error)
+            return
+        }
+
+        guard didReadLegacyKeychain else { return }
+
+        self.defaults.set(true, forKey: Keys.providerAPIKeyMigrationCompleted)
+        self.defaults.removeObject(forKey: Keys.providerAPIKeys)
+        if legacyKeychain.isEmpty == false {
+            try? self.keychain.removeLegacyEntries(providerIDs: Array(legacyKeychain.keys))
         }
     }
 
@@ -3730,6 +3795,13 @@ final class SettingsStore: ObservableObject {
             do {
                 try self.keychain.storeKey(trimmed, for: keyID)
                 didModify = true
+                decoded[index] = SavedProvider(
+                    id: provider.id,
+                    name: provider.name,
+                    baseURL: provider.baseURL,
+                    apiKey: "",
+                    models: provider.models
+                )
             } catch {
                 DebugLogger.shared
                     .error(
@@ -3737,14 +3809,6 @@ final class SettingsStore: ObservableObject {
                         source: "SettingsStore"
                     )
             }
-
-            decoded[index] = SavedProvider(
-                id: provider.id,
-                name: provider.name,
-                baseURL: provider.baseURL,
-                apiKey: "",
-                models: provider.models
-            )
         }
 
         if didModify,
@@ -5210,6 +5274,27 @@ final class SettingsStore: ObservableObject {
     }
 }
 
+#if DEBUG
+extension SettingsStore {
+    static func makeForTesting(defaults: UserDefaults, keychain: ProviderKeychain) -> SettingsStore {
+        SettingsStore(defaults: defaults, keychain: keychain)
+    }
+
+    func replaceKeychainForTesting(_ keychain: ProviderKeychain) {
+        self.keychain = keychain
+    }
+
+    func migrateProviderAPIKeysForTesting() {
+        self.migrateProviderAPIKeysIfNeeded()
+    }
+
+    func scrubSavedProviderAPIKeysForTesting() {
+        self.scrubSavedProviderAPIKeys()
+    }
+
+}
+#endif
+
 // swiftlint:enable type_body_length
 
 private extension SettingsStore {
@@ -5233,6 +5318,7 @@ private extension SettingsStore {
         static let privateAIContextDefaultMigratedTo4K = "PrivateAIProviderContextDefaultMigratedTo4K"
         static let providerAPIKeys = "ProviderAPIKeys"
         static let providerAPIKeyIdentifiers = "ProviderAPIKeyIdentifiers"
+        static let providerAPIKeyMigrationCompleted = "ProviderAPIKeyMigrationCompleted"
         static let savedProviders = "SavedProviders"
         static let verifiedProviderFingerprints = "VerifiedProviderFingerprints"
         static let shareAnonymousAnalytics = "ShareAnonymousAnalytics"

--- a/Tests/FluidDictationIntegrationTests/ProviderAPIKeyMigrationTests.swift
+++ b/Tests/FluidDictationIntegrationTests/ProviderAPIKeyMigrationTests.swift
@@ -1,0 +1,381 @@
+@testable import FluidVoice_Debug
+import Foundation
+import XCTest
+
+@MainActor
+final class ProviderAPIKeyMigrationTests: XCTestCase {
+    private let savedProvidersKey = "SavedProviders"
+    private let providerAPIKeysKey = "ProviderAPIKeys"
+    private let providerAPIKeyMigrationCompletedKey = "ProviderAPIKeyMigrationCompleted"
+    private static var retainedStores: [SettingsStore] = []
+
+    func testScrubPreservesAPIKeyWhenKeychainStoreFailsForThatProvider() throws {
+        try self.withIsolatedProviderState { store, defaults in
+            let keychain = MockProviderKeychain()
+            store.replaceKeychainForTesting(keychain)
+            keychain.failingProviderIDs = ["custom:failing-provider"]
+
+            let succeeding = SettingsStore.SavedProvider(
+                id: "custom:ok-provider",
+                name: "OK Provider",
+                baseURL: "https://ok.example",
+                apiKey: "sk-ok",
+                models: []
+            )
+            let failing = SettingsStore.SavedProvider(
+                id: "custom:failing-provider",
+                name: "Failing Provider",
+                baseURL: "https://fail.example",
+                apiKey: "sk-keep-me",
+                models: []
+            )
+            defaults.set(try JSONEncoder().encode([succeeding, failing]), forKey: self.savedProvidersKey)
+
+            store.scrubSavedProviderAPIKeysForTesting()
+
+            let data = try XCTUnwrap(defaults.data(forKey: self.savedProvidersKey))
+            let result = try JSONDecoder().decode([SettingsStore.SavedProvider].self, from: data)
+            let failingResult = try XCTUnwrap(result.first { $0.id == "custom:failing-provider" })
+            let okResult = try XCTUnwrap(result.first { $0.id == "custom:ok-provider" })
+
+            XCTAssertEqual(failingResult.apiKey, "sk-keep-me")
+            XCTAssertEqual(okResult.apiKey, "")
+            XCTAssertEqual(keychain.consolidatedKeys["custom:ok-provider"], "sk-ok")
+        }
+    }
+
+    func testMigrateKeepsLegacySourcesWhenConsolidatedSaveFails() throws {
+        try self.withIsolatedProviderState { store, defaults in
+            let keychain = MockProviderKeychain()
+            store.replaceKeychainForTesting(keychain)
+            keychain.legacyEntries = ["anthropic": "legacy-keychain-secret"]
+            keychain.shouldThrowOnWrite = true
+            defaults.set(["openai": "legacy-defaults-secret"], forKey: self.providerAPIKeysKey)
+
+            store.migrateProviderAPIKeysForTesting()
+
+            let legacyDefaults = try XCTUnwrap(defaults.dictionary(forKey: self.providerAPIKeysKey) as? [String: String])
+            XCTAssertEqual(legacyDefaults["openai"], "legacy-defaults-secret")
+            XCTAssertEqual(keychain.legacyEntries["anthropic"], "legacy-keychain-secret")
+            XCTAssertFalse(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+            XCTAssertTrue(keychain.removedLegacyProviderIDs.isEmpty)
+        }
+    }
+
+    func testMigratePersistsDefaultsWhenLegacyKeychainReadFails() throws {
+        try self.withIsolatedProviderState { store, defaults in
+            let keychain = MockProviderKeychain()
+            store.replaceKeychainForTesting(keychain)
+            keychain.shouldThrowOnLegacyRead = true
+            defaults.set(["openai": "legacy-defaults-secret"], forKey: self.providerAPIKeysKey)
+
+            store.migrateProviderAPIKeysForTesting()
+
+            let legacyDefaults = try XCTUnwrap(defaults.dictionary(forKey: self.providerAPIKeysKey) as? [String: String])
+            XCTAssertEqual(keychain.consolidatedKeys["openai"], "legacy-defaults-secret")
+            XCTAssertEqual(legacyDefaults["openai"], "legacy-defaults-secret")
+            XCTAssertFalse(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+            XCTAssertTrue(keychain.removedLegacyProviderIDs.isEmpty)
+        }
+    }
+
+    func testMigrateRecoveredLegacyKeychainOverridesFallbackDefaultsEcho() throws {
+        try self.withIsolatedProviderState { store, defaults in
+            let keychain = MockProviderKeychain()
+            store.replaceKeychainForTesting(keychain)
+            keychain.shouldThrowOnLegacyRead = true
+            defaults.set(["anthropic": "stale-key"], forKey: self.providerAPIKeysKey)
+
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertEqual(keychain.consolidatedKeys["anthropic"], "stale-key")
+            XCTAssertFalse(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+
+            keychain.shouldThrowOnLegacyRead = false
+            keychain.legacyEntries = ["anthropic": "fresh-key"]
+
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertEqual(keychain.consolidatedKeys["anthropic"], "fresh-key")
+            XCTAssertNil(defaults.dictionary(forKey: self.providerAPIKeysKey))
+            XCTAssertTrue(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+            XCTAssertNil(keychain.legacyEntries["anthropic"])
+            XCTAssertEqual(keychain.removedLegacyProviderIDs, [["anthropic"]])
+        }
+    }
+
+    func testClearingKeyDuringFallbackWindowDoesNotResurrectItAfterRecovery() throws {
+        try self.withIsolatedProviderState { store, defaults in
+            let keychain = MockProviderKeychain()
+            store.replaceKeychainForTesting(keychain)
+            keychain.shouldThrowOnLegacyRead = true
+            keychain.legacyEntries = ["anthropic": "stale-key"]
+            defaults.set(["anthropic": "stale-key"], forKey: self.providerAPIKeysKey)
+
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertEqual(keychain.consolidatedKeys["anthropic"], "stale-key")
+            XCTAssertFalse(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+
+            keychain.shouldThrowOnLegacyRead = false
+            _ = try store.saveProviderAPIKeys([:])
+
+            XCTAssertNil(defaults.dictionary(forKey: self.providerAPIKeysKey))
+            XCTAssertNil(keychain.legacyEntries["anthropic"])
+            XCTAssertNil(keychain.consolidatedKeys["anthropic"])
+
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertNil(keychain.consolidatedKeys["anthropic"])
+            XCTAssertNil(defaults.dictionary(forKey: self.providerAPIKeysKey))
+        }
+    }
+
+    func testMigrateMarksCompleteAndRemovesDefaultsWhenLegacyCleanupFailsAfterSave() throws {
+        try self.withIsolatedProviderState { store, defaults in
+            let keychain = MockProviderKeychain()
+            store.replaceKeychainForTesting(keychain)
+            keychain.legacyEntries = ["anthropic": "legacy-keychain-secret"]
+            keychain.shouldThrowOnLegacyRemoval = true
+            defaults.set(["openai": "legacy-defaults-secret"], forKey: self.providerAPIKeysKey)
+
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertNil(defaults.dictionary(forKey: self.providerAPIKeysKey))
+            XCTAssertEqual(keychain.consolidatedKeys["openai"], "legacy-defaults-secret")
+            XCTAssertEqual(keychain.consolidatedKeys["anthropic"], "legacy-keychain-secret")
+            XCTAssertTrue(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+            XCTAssertEqual(keychain.legacyEntries["anthropic"], "legacy-keychain-secret")
+            XCTAssertEqual(keychain.removedLegacyProviderIDs, [["anthropic"]])
+        }
+    }
+
+    func testMigrateDoesNotLetStaleLegacyKeychainOverrideConsolidatedKey() throws {
+        let keychain = MockProviderKeychain(
+            consolidatedKeys: ["anthropic": "rotated-consolidated-secret"],
+            legacyEntries: ["anthropic": "stale-legacy-secret"]
+        )
+        try self.withIsolatedProviderState { store, defaults in
+            store.replaceKeychainForTesting(keychain)
+            keychain.shouldThrowOnLegacyRemoval = true
+
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertEqual(keychain.consolidatedKeys["anthropic"], "rotated-consolidated-secret")
+            XCTAssertEqual(keychain.legacyEntries["anthropic"], "stale-legacy-secret")
+            XCTAssertTrue(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+            XCTAssertEqual(keychain.removedLegacyProviderIDs, [["anthropic"]])
+        }
+    }
+
+    func testMigratePrefersLegacyKeychainOverDefaultsWhenConsolidatedKeyIsMissing() throws {
+        try self.withIsolatedProviderState { store, defaults in
+            let keychain = MockProviderKeychain(legacyEntries: ["anthropic": "legacy-keychain-secret"])
+            store.replaceKeychainForTesting(keychain)
+            defaults.set(["anthropic": "stale-defaults-secret"], forKey: self.providerAPIKeysKey)
+
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertEqual(keychain.consolidatedKeys["anthropic"], "legacy-keychain-secret")
+            XCTAssertNil(defaults.dictionary(forKey: self.providerAPIKeysKey))
+            XCTAssertTrue(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+            XCTAssertNil(keychain.legacyEntries["anthropic"])
+            XCTAssertEqual(keychain.removedLegacyProviderIDs, [["anthropic"]])
+        }
+    }
+
+    func testCompletedMigrationDoesNotResurrectDeletedKeyFromStaleLegacyKeychain() throws {
+        let keychain = MockProviderKeychain(
+            consolidatedKeys: ["anthropic": "legacy-keychain-secret"],
+            legacyEntries: ["anthropic": "legacy-keychain-secret"]
+        )
+        try self.withIsolatedProviderState { store, defaults in
+            store.replaceKeychainForTesting(keychain)
+            keychain.shouldThrowOnLegacyRemoval = true
+
+            store.migrateProviderAPIKeysForTesting()
+            XCTAssertTrue(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+
+            keychain.consolidatedKeys.removeValue(forKey: "anthropic")
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertNil(keychain.consolidatedKeys["anthropic"])
+            XCTAssertEqual(keychain.legacyEntries["anthropic"], "legacy-keychain-secret")
+            XCTAssertEqual(keychain.removedLegacyProviderIDs, [["anthropic"], ["anthropic"]])
+        }
+    }
+
+    func testCompletedMigrationRemovesLegacyDefaultsWhenLegacyKeychainReadFails() throws {
+        try self.withIsolatedProviderState { store, defaults in
+            let keychain = MockProviderKeychain()
+            store.replaceKeychainForTesting(keychain)
+            keychain.shouldThrowOnLegacyRead = true
+            defaults.set(true, forKey: self.providerAPIKeyMigrationCompletedKey)
+            defaults.set(["openai": "legacy-defaults-secret"], forKey: self.providerAPIKeysKey)
+
+            store.migrateProviderAPIKeysForTesting()
+
+            XCTAssertNil(defaults.dictionary(forKey: self.providerAPIKeysKey))
+            XCTAssertTrue(defaults.bool(forKey: self.providerAPIKeyMigrationCompletedKey))
+            XCTAssertTrue(keychain.consolidatedKeys.isEmpty)
+        }
+    }
+
+    private func withIsolatedProviderState(
+        _ body: (SettingsStore, UserDefaults) throws -> Void
+    ) throws {
+        let defaults = InMemoryUserDefaults()
+
+        let store = SettingsStore.makeForTesting(defaults: defaults, keychain: MockProviderKeychain())
+        Self.retainedStores.append(store)
+        try body(store, defaults)
+    }
+}
+
+// swiftlint:disable discouraged_optional_collection
+private final class InMemoryUserDefaults: UserDefaults {
+    private var storage: [String: Any] = [:]
+
+    override func object(forKey defaultName: String) -> Any? {
+        self.storage[defaultName]
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        self.storage[defaultName] = value
+    }
+
+    override func set(_ value: Int, forKey defaultName: String) {
+        self.storage[defaultName] = value
+    }
+
+    override func set(_ value: Float, forKey defaultName: String) {
+        self.storage[defaultName] = value
+    }
+
+    override func set(_ value: Double, forKey defaultName: String) {
+        self.storage[defaultName] = value
+    }
+
+    override func set(_ value: Bool, forKey defaultName: String) {
+        self.storage[defaultName] = value
+    }
+
+    override func set(_ url: URL?, forKey defaultName: String) {
+        self.storage[defaultName] = url
+    }
+
+    override func removeObject(forKey defaultName: String) {
+        self.storage.removeValue(forKey: defaultName)
+    }
+
+    override func string(forKey defaultName: String) -> String? {
+        self.storage[defaultName] as? String
+    }
+
+    override func array(forKey defaultName: String) -> [Any]? {
+        self.storage[defaultName] as? [Any]
+    }
+
+    override func dictionary(forKey defaultName: String) -> [String: Any]? {
+        if let dictionary = self.storage[defaultName] as? [String: Any] {
+            return dictionary
+        }
+        if let dictionary = self.storage[defaultName] as? [String: String] {
+            return dictionary.mapValues { $0 as Any }
+        }
+        return nil
+    }
+
+    override func data(forKey defaultName: String) -> Data? {
+        self.storage[defaultName] as? Data
+    }
+
+    override func stringArray(forKey defaultName: String) -> [String]? {
+        self.storage[defaultName] as? [String]
+    }
+
+    override func integer(forKey defaultName: String) -> Int {
+        self.storage[defaultName] as? Int ?? 0
+    }
+
+    override func float(forKey defaultName: String) -> Float {
+        self.storage[defaultName] as? Float ?? 0
+    }
+
+    override func double(forKey defaultName: String) -> Double {
+        self.storage[defaultName] as? Double ?? 0
+    }
+
+    override func bool(forKey defaultName: String) -> Bool {
+        self.storage[defaultName] as? Bool ?? false
+    }
+
+    override func url(forKey defaultName: String) -> URL? {
+        self.storage[defaultName] as? URL
+    }
+
+    override func dictionaryRepresentation() -> [String: Any] {
+        self.storage
+    }
+
+    override func synchronize() -> Bool {
+        true
+    }
+}
+// swiftlint:enable discouraged_optional_collection
+
+private final class MockProviderKeychain: ProviderKeychain {
+    enum Failure: Error {
+        case readLegacy
+        case removeLegacy
+        case write
+    }
+
+    var consolidatedKeys: [String: String]
+    var legacyEntries: [String: String]
+    var failingProviderIDs: Set<String> = []
+    var shouldThrowOnWrite = false
+    var shouldThrowOnLegacyRead = false
+    var shouldThrowOnLegacyRemoval = false
+    private(set) var removedLegacyProviderIDs: [[String]] = []
+
+    init(consolidatedKeys: [String: String] = [:], legacyEntries: [String: String] = [:]) {
+        self.consolidatedKeys = consolidatedKeys
+        self.legacyEntries = legacyEntries
+    }
+
+    func storeKey(_ key: String, for providerID: String) throws {
+        if self.shouldThrowOnWrite || self.failingProviderIDs.contains(providerID) {
+            throw Failure.write
+        }
+        self.consolidatedKeys[providerID] = key
+    }
+
+    func storeAllKeys(_ values: [String: String]) throws {
+        if self.shouldThrowOnWrite {
+            throw Failure.write
+        }
+        self.consolidatedKeys = values
+    }
+
+    func fetchAllKeys() throws -> [String: String] {
+        self.consolidatedKeys
+    }
+
+    func legacyProviderEntries() throws -> [String: String] {
+        if self.shouldThrowOnLegacyRead {
+            throw Failure.readLegacy
+        }
+        return self.legacyEntries
+    }
+
+    func removeLegacyEntries(providerIDs: [String]) throws {
+        self.removedLegacyProviderIDs.append(providerIDs)
+        if self.shouldThrowOnLegacyRemoval {
+            throw Failure.removeLegacy
+        }
+        for providerID in providerIDs {
+            self.legacyEntries.removeValue(forKey: providerID)
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixes provider API-key persistence so failed Keychain writes do not erase the last saved copy of a key.

The migration path now keeps legacy defaults and legacy Keychain entries until the consolidated Keychain save succeeds, marks migration complete only after that save, and keeps consolidated keys ahead of stale legacy values on retry. The saved-provider scrub path now blanks plaintext API keys only after `storeKey` succeeds. A small `ProviderKeychain` protocol makes the behavior testable without the real Keychain.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Chore
- [ ] Documentation update

## Related Issue or Discussion
Updates this PR: #433. No separate issue was filed.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 15.7.7
- [x] Ran linter locally: SwiftLint on touched Swift files
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: targeted `ProviderAPIKeyMigrationTests` passed, 10 tests, 0 failures
- [x] `git diff --check`
- [x] Confirmed no `ProviderAPIKeyMigrationTests.*.plist` files remained
- [x] Confirmed `SelectedSpeechModel` stayed/restored to `parakeet-tdt-v2`
- [x] Full integration suite passed, 83 tests, 0 failures after the migration precedence fix.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Hosted-test defaults contamination is a separate follow-up and is not fixed by this PR.

