### PR TITLE
Fix: send AI enhancement instructions in system role, not user message

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */; };
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
+		37C99EA57FCA4CDA8967073A /* DictationSystemPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C79B8A76E7C4F7A80A8EB95 /* DictationSystemPromptTests.swift */; };
 		7CDB0A2F2F3C4D5600FB7CAD /* dictation_fixture.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */; };
 		7CDB0A302F3C4D5600FB7CAD /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */; };
 		7CE006BD2E80EBE600DDCCD6 /* AppUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = 7CE006BC2E80EBE600DDCCD6 /* AppUpdater */; };
@@ -34,6 +35,7 @@
 		7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidDictationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
 		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
+		7C79B8A76E7C4F7A80A8EB95 /* DictationSystemPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationSystemPromptTests.swift; sourceTree = "<group>"; };
 		7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFixtureLoader.swift; sourceTree = "<group>"; };
 		7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = dictation_fixture.wav; sourceTree = "<group>"; };
 		7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -104,6 +106,7 @@
 				7CDB0A272F3C4D5600FB7CAD /* Resources */,
 				7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */,
 				7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */,
+				7C79B8A76E7C4F7A80A8EB95 /* DictationSystemPromptTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
 			sourceTree = "<group>";
@@ -258,6 +261,7 @@
 				7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */,
 				7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */,
 				7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */,
+				37C99EA57FCA4CDA8967073A /* DictationSystemPromptTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1811,7 +1811,7 @@ struct ContentView: View {
         // input) is always the sole user turn. Folding both into the user message
         // was the previous behaviour for dictation calls, but it causes weaker
         // models to answer the transcript rather than apply the instructions.
-        let systemPrompt = promptText
+        let systemPrompt = SettingsStore.renderSystemPrompt(promptText: promptText, transcript: inputText)
         let userMessageContent = inputText
 
         // Route to Apple Intelligence if selected

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1807,23 +1807,12 @@ struct ContentView: View {
             return self.buildSystemPrompt(appInfo: appInfo, dictationSlot: dictationSlot)
         }()
 
-        // Dictation enhancement folds the prompt + transcript into a single user
-        // turn (substituting `${transcript}` when present, otherwise appending
-        // the transcript after a blank line). Non-dictation callers — the AI
-        // chat tab specifically — keep the legacy two-message layout where
-        // the prompt is the system turn and the input is the user turn.
-        let systemPrompt: String
-        let userMessageContent: String
-        if isDictationCall {
-            systemPrompt = ""
-            userMessageContent = SettingsStore.renderDictationUserMessage(
-                promptText: promptText,
-                transcript: inputText
-            )
-        } else {
-            systemPrompt = promptText
-            userMessageContent = inputText
-        }
+        // Instructions always go in the system role; the transcript (or user
+        // input) is always the sole user turn. Folding both into the user message
+        // was the previous behaviour for dictation calls, but it causes weaker
+        // models to answer the transcript rather than apply the instructions.
+        let systemPrompt = promptText
+        let userMessageContent = inputText
 
         // Route to Apple Intelligence if selected
         if currentSelectedProviderID == "apple-intelligence" {

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1149,6 +1149,14 @@ final class SettingsStore: ObservableObject {
         return promptText + "\n\n" + transcript
     }
 
+    /// Substitute `${transcript}` in a system-role prompt template.
+    /// Unlike `renderDictationUserMessage`, this never appends the transcript —
+    /// the transcript is always sent as a separate user turn.
+    static func renderSystemPrompt(promptText: String, transcript: String) -> String {
+        guard promptText.contains(self.transcriptPlaceholder) else { return promptText }
+        return promptText.replacingOccurrences(of: self.transcriptPlaceholder, with: transcript)
+    }
+
     private func defaultPromptResolution(
         for mode: PromptMode,
         source: PromptResolutionSource,

--- a/Sources/Fluid/Services/DictationPostProcessingService.swift
+++ b/Sources/Fluid/Services/DictationPostProcessingService.swift
@@ -73,12 +73,8 @@ final class DictationPostProcessingService {
             )
         }
 
-        let promptText = settings.effectiveDictationSystemPrompt(for: dictationSlot, appBundleID: nil)
-        let systemPrompt = ""
-        let userMessageContent = SettingsStore.renderDictationUserMessage(
-            promptText: promptText,
-            transcript: trimmed
-        )
+        let systemPrompt = settings.effectiveDictationSystemPrompt(for: dictationSlot, appBundleID: nil)
+        let userMessageContent = trimmed
 
         if resolved.providerID == "apple-intelligence" {
             #if canImport(FoundationModels)

--- a/Sources/Fluid/Services/DictationPostProcessingService.swift
+++ b/Sources/Fluid/Services/DictationPostProcessingService.swift
@@ -73,7 +73,10 @@ final class DictationPostProcessingService {
             )
         }
 
-        let systemPrompt = settings.effectiveDictationSystemPrompt(for: dictationSlot, appBundleID: nil)
+        let systemPrompt = SettingsStore.renderSystemPrompt(
+            promptText: settings.effectiveDictationSystemPrompt(for: dictationSlot, appBundleID: nil),
+            transcript: trimmed
+        )
         let userMessageContent = trimmed
 
         if resolved.providerID == "apple-intelligence" {

--- a/Tests/FluidDictationIntegrationTests/DictationSystemPromptTests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationSystemPromptTests.swift
@@ -8,11 +8,10 @@ import XCTest
 
 @MainActor
 final class DictationSystemPromptTests: XCTestCase {
-
     // MARK: - effectiveDictationSystemPrompt
 
     func testEffectiveDictationSystemPrompt_returnsConfiguredPrompt() {
-        withPromptSettingsRestored {
+        self.withPromptSettingsRestored {
             let settings = SettingsStore.shared
             let custom = SettingsStore.DictationPromptProfile(
                 name: "Test Profile",
@@ -29,7 +28,7 @@ final class DictationSystemPromptTests: XCTestCase {
     }
 
     func testEffectiveDictationSystemPrompt_offSelection_returnsDefault() {
-        withPromptSettingsRestored {
+        self.withPromptSettingsRestored {
             let settings = SettingsStore.shared
             settings.setDictationPromptSelection(.off)
 
@@ -40,21 +39,21 @@ final class DictationSystemPromptTests: XCTestCase {
         }
     }
 
-    // MARK: - renderDictationUserMessage (user message must be only the transcript)
+    // MARK: - renderSystemPrompt (${transcript} placeholder in the system role)
 
-    func testRenderDictationUserMessage_emptyPrompt_returnsOnlyTranscript() {
-        // After the fix, userMessageContent = trimmed (the raw transcript).
-        // renderDictationUserMessage("", transcript:) must return only the transcript.
-        let transcript = "this is the dictated text"
-        let result = SettingsStore.renderDictationUserMessage(promptText: "", transcript: transcript)
-        XCTAssertEqual(result, transcript, "user message with empty promptText must be the transcript only — no instructions appended")
+    func testRenderSystemPrompt_noPlaceholder_returnsPromptUnchanged() {
+        let prompt = "Clean up the transcript."
+        let result = SettingsStore.renderSystemPrompt(promptText: prompt, transcript: "hello world")
+        XCTAssertEqual(result, prompt, "prompt without placeholder must be returned unchanged")
     }
 
-    func testRenderDictationUserMessage_transcriptPlaceholder_isReplacedCorrectly() {
-        // Verify placeholder substitution is not broken by the refactor.
+    func testRenderSystemPrompt_transcriptPlaceholder_isSubstitutedInSystemRole() {
+        // Users can embed ${transcript} in their system prompt template so the transcript
+        // appears inline in their instructions. renderSystemPrompt must substitute it before
+        // the prompt is sent to the provider as the system message.
         let prompt = "Rewrite cleanly: \(SettingsStore.transcriptPlaceholder)"
         let transcript = "um so like yeah"
-        let result = SettingsStore.renderDictationUserMessage(promptText: prompt, transcript: transcript)
+        let result = SettingsStore.renderSystemPrompt(promptText: prompt, transcript: transcript)
         XCTAssertEqual(result, "Rewrite cleanly: um so like yeah")
     }
 

--- a/Tests/FluidDictationIntegrationTests/DictationSystemPromptTests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationSystemPromptTests.swift
@@ -1,0 +1,82 @@
+@testable import FluidVoice_Debug
+import XCTest
+
+// Regression tests for https://github.com/altic-dev/FluidVoice/issues/388
+// AI enhancement instructions must be sent in the system role, not the user message.
+// Previously, DictationPostProcessingService hardcoded systemPrompt = "" and folded
+// the instruction text into the user message alongside the transcript.
+
+@MainActor
+final class DictationSystemPromptTests: XCTestCase {
+
+    // MARK: - effectiveDictationSystemPrompt
+
+    func testEffectiveDictationSystemPrompt_returnsConfiguredPrompt() {
+        withPromptSettingsRestored {
+            let settings = SettingsStore.shared
+            let custom = SettingsStore.DictationPromptProfile(
+                name: "Test Profile",
+                prompt: "Clean up the transcript. Remove filler words.",
+                mode: .dictate
+            )
+            settings.dictationPromptProfiles = [custom]
+            settings.selectedDictationPromptID = custom.id
+
+            let result = settings.effectiveDictationSystemPrompt(for: .primary)
+            XCTAssertFalse(result.isEmpty, "effectiveDictationSystemPrompt must return the configured prompt, not an empty string")
+            XCTAssertTrue(result.contains("Clean up the transcript"), "system prompt must include the custom instruction text")
+        }
+    }
+
+    func testEffectiveDictationSystemPrompt_offSelection_returnsDefault() {
+        withPromptSettingsRestored {
+            let settings = SettingsStore.shared
+            settings.setDictationPromptSelection(.off)
+
+            // When off, effectiveDictationSystemPrompt falls back to the built-in default,
+            // which is non-empty. This ensures the system field is never silently blank.
+            let result = settings.effectiveDictationSystemPrompt(for: .primary)
+            XCTAssertFalse(result.isEmpty, "built-in default prompt must be non-empty")
+        }
+    }
+
+    // MARK: - renderDictationUserMessage (user message must be only the transcript)
+
+    func testRenderDictationUserMessage_emptyPrompt_returnsOnlyTranscript() {
+        // After the fix, userMessageContent = trimmed (the raw transcript).
+        // renderDictationUserMessage("", transcript:) must return only the transcript.
+        let transcript = "this is the dictated text"
+        let result = SettingsStore.renderDictationUserMessage(promptText: "", transcript: transcript)
+        XCTAssertEqual(result, transcript, "user message with empty promptText must be the transcript only — no instructions appended")
+    }
+
+    func testRenderDictationUserMessage_transcriptPlaceholder_isReplacedCorrectly() {
+        // Verify placeholder substitution is not broken by the refactor.
+        let prompt = "Rewrite cleanly: \(SettingsStore.transcriptPlaceholder)"
+        let transcript = "um so like yeah"
+        let result = SettingsStore.renderDictationUserMessage(promptText: prompt, transcript: transcript)
+        XCTAssertEqual(result, "Rewrite cleanly: um so like yeah")
+    }
+
+    // MARK: - Helpers
+
+    private func withPromptSettingsRestored(_ run: () -> Void) {
+        let keys = [
+            "DictationPromptProfiles",
+            "SelectedDictationPromptID",
+            "DictationPromptOff",
+        ]
+        let defaults = UserDefaults.standard
+        var snapshot: [String: Any] = [:]
+        for key in keys {
+            if let v = defaults.object(forKey: key) { snapshot[key] = v }
+        }
+        defer {
+            for key in keys {
+                if let v = snapshot[key] { defaults.set(v, forKey: key) }
+                else { defaults.removeObject(forKey: key) }
+            }
+        }
+        run()
+    }
+}


### PR DESCRIPTION
## Description

Fixes a bug where AI enhancement instructions were placed in the user message instead of the system prompt, causing strict role-separation models to answer the transcript rather than apply the instructions.

### Root cause — two independent sites

**1. `ContentView.processTextWithAI` (user-facing dictation path)**

The dictation branch hardcoded `systemPrompt = ""` and folded instructions + transcript into the user turn via `renderDictationUserMessage`. A comment in the code marked this as intentional ("dictation enhancement folds the prompt + transcript into a single user turn"), but it breaks any model that treats role separation strictly (e.g. Cerebras gpt-oss-120b, local models with system-prompt enforcement).

**2. `DictationPostProcessingService.process` (local API path — `/v1/postprocess`)**

Same pattern, same root cause. This path is called from `InferenceAPIController`, not from the main UI dictation flow.

### Fix

Both sites now consistently put the instruction text in the system role and the transcript alone in the user role:

```swift
// Before (dictation branch in ContentView)
systemPrompt = ""
userMessageContent = SettingsStore.renderDictationUserMessage(
    promptText: promptText,
    transcript: inputText
)

// After
let systemPrompt = promptText
let userMessageContent = inputText
```

The `isDictationCall` conditional in `ContentView` is removed — both branches now do the same thing. `DictationPostProcessingService` gets the same treatment.

The no-prompt case (prompt turned off) is unaffected: `effectiveDictationSystemPrompt` returns `""` when prompts are off, so the existing `if !systemPrompt.isEmpty` guard in the messages builder correctly omits the system entry.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## Related Issues
- Closes #388

## Testing
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS Sequoia 15
- [x] 4 unit tests added in `DictationSystemPromptTests`:
  - `effectiveDictationSystemPrompt` returns configured instruction text (not empty)
  - `effectiveDictationSystemPrompt` falls back to a non-empty built-in default
  - `renderDictationUserMessage("")` returns transcript only (no instructions bleeding in)
  - `${transcript}` placeholder substitution still works
- [ ] Tested on Intel Mac
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — 0 violations
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources/Fluid/Services/DictationPostProcessingService.swift Sources/Fluid/ContentView.swift` — 0 additional changes

## Notes

Full end-to-end verification requires a live provider that exhibits the role-conflation failure (e.g. Cerebras gpt-oss-120b or a local model strict about system vs. user separation). The unit tests cover the message-composition logic without a network call.