### PR TITLE
feat(menu-bar): add copy last transcript action

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2444,18 +2444,8 @@ struct ContentView: View {
     }
 
     private func copyLastDictationFromHistory() {
-        guard let last = TranscriptionHistoryStore.shared.entries.first else {
-            DebugLogger.shared.info("Actions: Copy requested but history is empty", source: "ContentView")
-            return
-        }
-
-        // Fallback to raw text when no processed text is available
-        // (for example older entries or edge cases with AI enhancement off).
-        let processed = last.processedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let raw = last.rawText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let text = processed.isEmpty ? raw : processed
-        guard !text.isEmpty else {
-            DebugLogger.shared.info("Actions: Copy skipped because latest history text is empty", source: "ContentView")
+        guard let text = TranscriptionHistoryStore.shared.latestClipboardText else {
+            DebugLogger.shared.info("Actions: Copy requested but no transcription is available", source: "ContentView")
             return
         }
 

--- a/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
+++ b/Sources/Fluid/Persistence/TranscriptionHistoryStore.swift
@@ -106,6 +106,13 @@ struct TranscriptionHistoryEntry: Codable, Identifiable, Equatable {
         return text
     }
 
+    var clipboardText: String? {
+        let processed = self.processedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let raw = self.rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = processed.isEmpty ? raw : processed
+        return text.isEmpty ? nil : text
+    }
+
     /// Relative time string for display
     var relativeTimeString: String {
         let formatter = RelativeDateTimeFormatter()
@@ -167,6 +174,10 @@ final class TranscriptionHistoryStore: ObservableObject {
     var selectedEntry: TranscriptionHistoryEntry? {
         guard let id = selectedEntryID else { return nil }
         return self.entries.first(where: { $0.id == id })
+    }
+
+    var latestClipboardText: String? {
+        self.entries.first?.clipboardText
     }
 
     /// Add a new transcription entry

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -304,6 +304,7 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
 
         // Track processing state to prevent hide during AI refinement
         self.isProcessingActive = processing
+        self.updateMenuItemsText()
 
         if processing {
             self.pendingProcessingShowOperation?.cancel()
@@ -390,6 +391,7 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
 
         // Create menu
         self.menu = NSMenu()
+        self.menu?.autoenablesItems = false
         self.menu?.delegate = self
         statusItem.menu = self.menu
 
@@ -585,7 +587,9 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
     }
 
     @objc private func copyLastTranscript(_ sender: Any?) {
-        guard let text = TranscriptionHistoryStore.shared.latestClipboardText else {
+        guard self.canCopyLastTranscript,
+              let text = TranscriptionHistoryStore.shared.latestClipboardText
+        else {
             DebugLogger.shared.info("Menu action: Copy last transcript requested but history is empty", source: "MenuBarManager")
             return
         }

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -17,6 +17,7 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
 
     // Cached menu items to avoid rebuilding entire menu
     private var statusMenuItem: NSMenuItem?
+    private var copyLastTranscriptMenuItem: NSMenuItem?
     private var rollbackMenuItem: NSMenuItem?
     private var microphoneMenuItem: NSMenuItem?
     private var microphoneSubmenu: NSMenu?
@@ -417,6 +418,15 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
             menu.addItem(statusItem)
         }
 
+        let copyLastTranscriptItem = NSMenuItem(
+            title: "Copy Last Transcript",
+            action: #selector(copyLastTranscript(_:)),
+            keyEquivalent: ""
+        )
+        copyLastTranscriptItem.target = self
+        menu.addItem(copyLastTranscriptItem)
+        self.copyLastTranscriptMenuItem = copyLastTranscriptItem
+
         menu.addItem(.separator())
 
         // Open Main Window
@@ -497,6 +507,7 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
         let hotkeyInfo = hotkeyDisplay.isEmpty ? "" : " (\(hotkeyDisplay))"
         let statusTitle = self.isRecording ? "Recording...\(hotkeyInfo)" : "Ready to Record\(hotkeyInfo)"
         self.statusMenuItem?.title = statusTitle
+        self.copyLastTranscriptMenuItem?.isEnabled = self.canCopyLastTranscript
         self.microphoneMenuItem?.isEnabled = true
 
         // Update rollback availability text
@@ -567,6 +578,20 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
 
     private func currentPreferredInputUID(defaultInputUID: String?) -> String? {
         return defaultInputUID
+    }
+
+    private var canCopyLastTranscript: Bool {
+        !self.isProcessingActive && TranscriptionHistoryStore.shared.latestClipboardText != nil
+    }
+
+    @objc private func copyLastTranscript(_ sender: Any?) {
+        guard let text = TranscriptionHistoryStore.shared.latestClipboardText else {
+            DebugLogger.shared.info("Menu action: Copy last transcript requested but history is empty", source: "MenuBarManager")
+            return
+        }
+
+        _ = ClipboardService.copyToClipboard(text)
+        DebugLogger.shared.info("Menu action: Copied latest transcription to clipboard", source: "MenuBarManager")
     }
 
     @objc private func selectMicrophone(_ sender: NSMenuItem) {

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -1533,10 +1533,7 @@ private struct BottomOverlayActionsMenuView: View {
 
     private var canCopyLast: Bool {
         guard !self.contentState.isProcessing else { return false }
-        guard let latest = self.latestEntry else { return false }
-        let processed = latest.processedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let raw = latest.rawText.trimmingCharacters(in: .whitespacesAndNewlines)
-        return !(processed.isEmpty && raw.isEmpty)
+        return self.latestEntry?.clipboardText != nil
     }
 
     private var canUndoLastAI: Bool {

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -36,6 +36,42 @@ final class DictationE2ETests: XCTestCase {
 
     private let verifiedProviderFingerprintsKey = "VerifiedProviderFingerprints"
 
+    func testTranscriptionHistoryEntryClipboardTextPrefersProcessedText() {
+        let entry = TranscriptionHistoryEntry(
+            rawText: " raw transcript ",
+            processedText: " processed transcript ",
+            appName: "Notes",
+            windowTitle: "Draft",
+            wasAIProcessed: true
+        )
+
+        XCTAssertEqual(entry.clipboardText, "processed transcript")
+    }
+
+    func testTranscriptionHistoryEntryClipboardTextFallsBackToRawText() {
+        let entry = TranscriptionHistoryEntry(
+            rawText: " raw transcript ",
+            processedText: "   ",
+            appName: "Notes",
+            windowTitle: "Draft",
+            wasAIProcessed: false
+        )
+
+        XCTAssertEqual(entry.clipboardText, "raw transcript")
+    }
+
+    func testTranscriptionHistoryEntryClipboardTextSkipsEmptyText() {
+        let entry = TranscriptionHistoryEntry(
+            rawText: "   ",
+            processedText: "   ",
+            appName: "Notes",
+            windowTitle: "Draft",
+            wasAIProcessed: false
+        )
+
+        XCTAssertNil(entry.clipboardText)
+    }
+
     func testTranscriptionStartSound_noneOptionHasNoFile() {
         XCTAssertEqual(SettingsStore.TranscriptionStartSound.none.displayName, "None")
         XCTAssertNil(SettingsStore.TranscriptionStartSound.none.startSoundFileName)


### PR DESCRIPTION
## Summary

Adds a `Copy Last Transcript` item directly under the menu bar status row (`Ready to Record...`) so users can copy the most recent saved dictation without opening the main window or overlay actions menu.

## What changed

- Adds the menu item to `MenuBarManager` immediately below the status item.
- Reuses the existing transcription history and clipboard service.
- Centralizes the latest-copy text selection so both the overlay action and menu bar action prefer processed text, then fall back to raw text.
- Adds focused tests for the clipboard text selection behavior.

## Validation

- `git diff --check`
- `plutil -lint Fluid.xcodeproj/project.pbxproj Info.plist Fluid.entitlements`
- `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' -only-testing:FluidDictationIntegrationTests/DictationE2ETests/testTranscriptionHistoryEntryClipboardTextPrefersProcessedText -only-testing:FluidDictationIntegrationTests/DictationE2ETests/testTranscriptionHistoryEntryClipboardTextFallsBackToRawText -only-testing:FluidDictationIntegrationTests/DictationE2ETests/testTranscriptionHistoryEntryClipboardTextSkipsEmptyText CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project Fluid.xcodeproj -scheme Fluid -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`