### PR TITLE
[codex] Prefer built-in mic with Bluetooth output

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -343,6 +343,9 @@ struct ContentView: View {
             .onChange(of: self.audioObserver.changeTick) { _, _ in
                 // Hardware change detected → refresh device lists
                 self.refreshDevices()
+                if let builtInInput = AudioDevice.applyBuiltInInputForBluetoothOutputIfNeeded(source: "ContentView") {
+                    self.selectedInputUID = builtInInput.uid
+                }
 
                 // Only sync UI with system defaults when sync is enabled
                 // When sync is disabled, keep the user's preferred device selection
@@ -576,6 +579,10 @@ struct ContentView: View {
                self.inputDevices.contains(where: { $0.uid == systemInputUID })
             {
                 self.selectedInputUID = systemInputUID
+            }
+
+            if let builtInInput = AudioDevice.applyBuiltInInputForBluetoothOutputIfNeeded(source: "ContentView") {
+                self.selectedInputUID = builtInInput.uid
             }
 
             if let prefOut = SettingsStore.shared.preferredOutputDeviceUID,
@@ -4072,7 +4079,9 @@ private extension ContentView {
         self.isRewriteModeShortcutEnabled = SettingsStore.shared.rewriteModeShortcutEnabled
         self.playgroundUsed = SettingsStore.shared.playgroundUsed
         self.visualizerNoiseThreshold = SettingsStore.shared.visualizerNoiseThreshold
-        self.selectedInputUID = AudioDevice.getDefaultInputDevice()?.uid ?? ""
+        self.selectedInputUID = AudioDevice.applyBuiltInInputForBluetoothOutputIfNeeded(source: "ContentView")?.uid
+            ?? AudioDevice.getDefaultInputDevice()?.uid
+            ?? ""
         self.selectedOutputUID = SettingsStore.shared.preferredOutputDeviceUID ?? ""
         self.enableDebugLogs = SettingsStore.shared.enableDebugLogs
         self.hotkeyMode = SettingsStore.shared.hotkeyMode

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -56,6 +56,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let textInsertionMode: SettingsStore.TextInsertionMode
     let preferredInputDeviceUID: String?
     let preferredOutputDeviceUID: String?
+    let preferBuiltInMicrophoneForBluetoothOutput: Bool?
     let visualizerNoiseThreshold: Double
     let overlayPosition: SettingsStore.OverlayPosition
     let overlayBottomOffset: Double

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1601,6 +1601,16 @@ final class SettingsStore: ObservableObject {
         set { self.defaults.set(newValue, forKey: Keys.preferredOutputDeviceUID) }
     }
 
+    var preferBuiltInMicrophoneForBluetoothOutput: Bool {
+        get {
+            self.defaults.object(forKey: Keys.preferBuiltInMicrophoneForBluetoothOutput) as? Bool ?? false
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.preferBuiltInMicrophoneForBluetoothOutput)
+        }
+    }
+
     /// When enabled, changing audio devices in FluidVoice will also update macOS system audio settings.
     /// ALWAYS TRUE: Independent mode removed due to CoreAudio aggregate device limitations (OSStatus -10851)
     var syncAudioDevicesWithSystem: Bool {
@@ -2741,6 +2751,7 @@ final class SettingsStore: ObservableObject {
             textInsertionMode: self.textInsertionMode,
             preferredInputDeviceUID: self.preferredInputDeviceUID,
             preferredOutputDeviceUID: self.preferredOutputDeviceUID,
+            preferBuiltInMicrophoneForBluetoothOutput: self.preferBuiltInMicrophoneForBluetoothOutput,
             visualizerNoiseThreshold: self.visualizerNoiseThreshold,
             overlayPosition: self.overlayPosition,
             overlayBottomOffset: self.overlayBottomOffset,
@@ -2831,6 +2842,9 @@ final class SettingsStore: ObservableObject {
         self.textInsertionMode = payload.textInsertionMode
         self.preferredInputDeviceUID = payload.preferredInputDeviceUID
         self.preferredOutputDeviceUID = payload.preferredOutputDeviceUID
+        if let preferBuiltInMicrophoneForBluetoothOutput = payload.preferBuiltInMicrophoneForBluetoothOutput {
+            self.preferBuiltInMicrophoneForBluetoothOutput = preferBuiltInMicrophoneForBluetoothOutput
+        }
         self.visualizerNoiseThreshold = payload.visualizerNoiseThreshold
         self.overlayPosition = payload.overlayPosition
         self.overlayBottomOffset = payload.overlayBottomOffset
@@ -4276,6 +4290,7 @@ private extension SettingsStore {
         static let primaryDictationShortcutsKey = "PrimaryDictationShortcuts"
         static let preferredInputDeviceUID = "PreferredInputDeviceUID"
         static let preferredOutputDeviceUID = "PreferredOutputDeviceUID"
+        static let preferBuiltInMicrophoneForBluetoothOutput = "PreferBuiltInMicrophoneForBluetoothOutput"
         static let syncAudioDevicesWithSystem = "SyncAudioDevicesWithSystem"
         static let visualizerNoiseThreshold = "VisualizerNoiseThreshold"
         static let launchAtStartup = "LaunchAtStartup"

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -824,6 +824,8 @@ final class ASRService: ObservableObject {
         defer { self.isStarting = false }
 
         do {
+            AudioDevice.applyBuiltInInputForBluetoothOutputIfNeeded(source: "ASRService")
+
             DebugLogger.shared.debug("⚙️ Calling configureSession()...", source: "ASRService")
             try self.configureSession()
             DebugLogger.shared.debug("✅ configureSession() completed", source: "ASRService")
@@ -2086,34 +2088,51 @@ final class ASRService: ObservableObject {
                        currentDevice.uid != preferredUID,
                        currentDevice.uid == systemDefault?.uid
                     {
-                        DebugLogger.shared.info(
-                            "🔌 Preferred device '\(preferredDevice.name)' reconnected. Auto-switching...",
-                            source: "ASRService"
-                        )
-
-                        if self.isRunning {
+                        if SettingsStore.shared.preferBuiltInMicrophoneForBluetoothOutput,
+                           preferredDevice.isBluetoothAudioDevice
+                        {
                             DebugLogger.shared.info(
-                                "Recording in progress - deferring preferred device switch until audio route recovery",
+                                "Preferred Bluetooth input '\(preferredDevice.name)' reconnected. Keeping built-in microphone preference active.",
                                 source: "ASRService"
                             )
-                            self.scheduleAudioRouteRecovery(reason: "preferred input reconnected")
+                            _ = AudioDevice.applyBuiltInInputForBluetoothOutputIfNeeded(source: "ASRService")
                         } else {
-                            DebugLogger.shared.info("Not recording - updating binding for next session", source: "ASRService")
-                            _ = self.setEngineInputDevice(
-                                deviceID: preferredDevice.id,
-                                deviceUID: preferredDevice.uid,
-                                deviceName: preferredDevice.name
+                            DebugLogger.shared.info(
+                                "🔌 Preferred device '\(preferredDevice.name)' reconnected. Auto-switching...",
+                                source: "ASRService"
                             )
+
+                            if self.isRunning {
+                                DebugLogger.shared.info(
+                                    "Recording in progress - deferring preferred device switch until audio route recovery",
+                                    source: "ASRService"
+                                )
+                                self.scheduleAudioRouteRecovery(reason: "preferred input reconnected")
+                            } else {
+                                DebugLogger.shared.info("Not recording - updating binding for next session", source: "ASRService")
+                                _ = self.setEngineInputDevice(
+                                    deviceID: preferredDevice.id,
+                                    deviceUID: preferredDevice.uid,
+                                    deviceName: preferredDevice.name
+                                )
+                            }
                         }
                     }
                 }
 
                 // Check for newly connected Bluetooth devices (auto-switch)
                 for device in currentDevices {
-                    if device.name.localizedCaseInsensitiveContains("airpods") ||
-                        device.name.localizedCaseInsensitiveContains("bluetooth")
-                    {
+                    if device.isBluetoothAudioDevice {
                         if !cachedUIDs.contains(device.uid) {
+                            if SettingsStore.shared.preferBuiltInMicrophoneForBluetoothOutput {
+                                DebugLogger.shared.info(
+                                    "🎧 New Bluetooth input detected: '\(device.name)'. Keeping built-in microphone preference active.",
+                                    source: "ASRService"
+                                )
+                                _ = AudioDevice.applyBuiltInInputForBluetoothOutputIfNeeded(source: "ASRService")
+                                continue
+                            }
+
                             DebugLogger.shared.info(
                                 "🎧 New Bluetooth device detected: '\(device.name)'. Auto-switching...",
                                 source: "ASRService"

--- a/Sources/Fluid/Services/AudioDeviceService.swift
+++ b/Sources/Fluid/Services/AudioDeviceService.swift
@@ -18,6 +18,28 @@ enum AudioDevice {
         let name: String
         let hasInput: Bool
         let hasOutput: Bool
+        let transportType: UInt32?
+
+        var isBluetoothAudioDevice: Bool {
+            if self.transportType == kAudioDeviceTransportTypeBluetooth ||
+                self.transportType == kAudioDeviceTransportTypeBluetoothLE
+            {
+                return true
+            }
+
+            let searchableText = "\(self.name) \(self.uid)".lowercased()
+            return searchableText.contains("airpods") ||
+                searchableText.contains("bluetooth")
+        }
+
+        var isBuiltInMicrophone: Bool {
+            let searchableText = "\(self.name) \(self.uid)".lowercased()
+            return self.hasInput &&
+                searchableText.contains("microphone") &&
+                (searchableText.contains("built") ||
+                    searchableText.contains("macbook") ||
+                    self.uid == "BuiltInMicrophoneDevice")
+        }
     }
 
     static func listAllDevices() -> [Device] {
@@ -64,10 +86,60 @@ enum AudioDevice {
             let uid = self.getStringProperty(devId, selector: kAudioDevicePropertyDeviceUID, scope: kAudioObjectPropertyScopeGlobal) ?? ""
             let hasIn = self.hasChannels(devId, scope: kAudioObjectPropertyScopeInput)
             let hasOut = self.hasChannels(devId, scope: kAudioObjectPropertyScopeOutput)
-            devices.append(Device(id: devId, uid: uid, name: name, hasInput: hasIn, hasOutput: hasOut))
+            let transportType = self.getUInt32Property(
+                devId,
+                selector: kAudioDevicePropertyTransportType,
+                scope: kAudioObjectPropertyScopeGlobal
+            )
+            devices.append(Device(id: devId, uid: uid, name: name, hasInput: hasIn, hasOutput: hasOut, transportType: transportType))
         }
 
         return devices.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    static func builtInInputForBluetoothOutput(
+        currentInput: Device?,
+        output: Device?,
+        inputDevices: [Device]
+    ) -> Device? {
+        guard output?.isBluetoothAudioDevice == true else { return nil }
+        guard currentInput == nil || currentInput?.isBluetoothAudioDevice == true else { return nil }
+        return inputDevices.first { $0.isBuiltInMicrophone }
+    }
+
+    @discardableResult
+    static func applyBuiltInInputForBluetoothOutputIfNeeded(source: String) -> Device? {
+        guard SettingsStore.shared.preferBuiltInMicrophoneForBluetoothOutput else { return nil }
+
+        let inputDevices = self.listInputDevices()
+        let currentInput = self.getDefaultInputDevice()
+        let currentOutput = self.getDefaultOutputDevice()
+
+        guard let builtInInput = self.builtInInputForBluetoothOutput(
+            currentInput: currentInput,
+            output: currentOutput,
+            inputDevices: inputDevices
+        ) else {
+            return nil
+        }
+
+        SettingsStore.shared.preferredInputDeviceUID = builtInInput.uid
+
+        guard currentInput?.uid != builtInInput.uid else { return builtInInput }
+
+        if self.setDefaultInputDevice(uid: builtInInput.uid) {
+            DebugLogger.shared.info(
+                "Using built-in microphone '\(builtInInput.name)' while Bluetooth output is active",
+                source: source
+            )
+            return builtInInput
+        }
+
+        DebugLogger.shared.warning(
+            "Failed to switch input to built-in microphone '\(builtInInput.name)' while Bluetooth output is active",
+            source: source
+        )
+        return nil
     }
 
     static func listInputDevices() -> [Device] {
@@ -171,6 +243,24 @@ enum AudioDevice {
         let status = AudioObjectGetPropertyData(devId, &address, 0, nil, &dataSize, &value)
         guard status == noErr else { return nil }
         return value?.takeRetainedValue() as String?
+    }
+
+    private static func getUInt32Property(
+        _ devId: AudioObjectID,
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope
+    ) -> UInt32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var value: UInt32 = 0
+        var dataSize = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(devId, &address, 0, nil, &dataSize, &value)
+        guard status == noErr else { return nil }
+        return value
     }
 
     private static func hasChannels(_ devId: AudioObjectID, scope: AudioObjectPropertyScope) -> Bool {

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -577,6 +577,7 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
 
         if SettingsStore.shared.syncAudioDevicesWithSystem {
             _ = AudioDevice.setDefaultInputDevice(uid: uid)
+            _ = AudioDevice.applyBuiltInInputForBluetoothOutputIfNeeded(source: "MenuBarManager")
         }
 
         self.refreshMicrophoneMenu()

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -1042,6 +1042,20 @@ struct SettingsView: View {
                         .padding(.vertical, 4)
 
                         VStack(alignment: .leading, spacing: 12) {
+                            self.settingsToggleRow(
+                                title: "Prefer Built-in Mic with Bluetooth Output",
+                                description: "Use the Mac microphone instead of a Bluetooth headset mic while Bluetooth headphones are the output device.",
+                                isOn: Binding(
+                                    get: { self.settings.preferBuiltInMicrophoneForBluetoothOutput },
+                                    set: { newValue in
+                                        self.settings.preferBuiltInMicrophoneForBluetoothOutput = newValue
+                                        if newValue {
+                                            self.applyBuiltInInputPreferenceForBluetoothOutput()
+                                        }
+                                    }
+                                )
+                            )
+
                             HStack {
                                 Text("Input Device")
                                     .font(self.theme.typography.bodyStrong)
@@ -1077,6 +1091,7 @@ struct SettingsView: View {
                                     // Only change system default if sync is enabled
                                     if SettingsStore.shared.syncAudioDevicesWithSystem {
                                         _ = AudioDevice.setDefaultInputDevice(uid: newUID)
+                                        self.applyBuiltInInputPreferenceForBluetoothOutput()
                                     }
                                 }
                                 // Sync selection when devices load or change
@@ -1097,6 +1112,7 @@ struct SettingsView: View {
                                             }
                                         }
                                     }
+                                    self.applyBuiltInInputPreferenceForBluetoothOutput()
                                 }
                             }
 
@@ -1135,6 +1151,7 @@ struct SettingsView: View {
                                     // Only change system default if sync is enabled
                                     if SettingsStore.shared.syncAudioDevicesWithSystem {
                                         _ = AudioDevice.setDefaultOutputDevice(uid: newUID)
+                                        self.applyBuiltInInputPreferenceForBluetoothOutput()
                                     }
                                 }
                                 // Sync selection when devices load or change
@@ -1158,6 +1175,7 @@ struct SettingsView: View {
                                             }
                                         }
                                     }
+                                    self.applyBuiltInInputPreferenceForBluetoothOutput()
                                 }
                             }
 
@@ -1583,6 +1601,7 @@ struct SettingsView: View {
                 // This avoids the CoreAudio/SwiftUI AttributeGraph race condition that causes EXC_BAD_ACCESS.
                 self.cachedDefaultInputName = AudioDevice.getDefaultInputDevice()?.name ?? ""
                 self.cachedDefaultOutputName = AudioDevice.getDefaultOutputDevice()?.name ?? ""
+                self.applyBuiltInInputPreferenceForBluetoothOutput()
                 self.refreshRollbackState()
                 self.settings.refreshLaunchAtStartupStatus(clearError: true, logMismatch: false)
                 self.refreshAudioHistoryUsage()
@@ -1831,6 +1850,12 @@ struct SettingsView: View {
         SettingsStore.shared.shareAnonymousAnalytics = enabled
         AnalyticsService.shared.setEnabled(enabled)
         AnalyticsService.shared.capture(.analyticsConsentChanged, properties: ["enabled": enabled])
+    }
+
+    private func applyBuiltInInputPreferenceForBluetoothOutput() {
+        guard let inputDevice = AudioDevice.applyBuiltInInputForBluetoothOutputIfNeeded(source: "SettingsView") else { return }
+        self.selectedInputUID = inputDevice.uid
+        self.cachedDefaultInputName = inputDevice.name
     }
 
     // MARK: - Helper Views

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -1,4 +1,5 @@
 @testable import FluidVoice_Debug
+import CoreAudio
 import Foundation
 import XCTest
 
@@ -22,6 +23,7 @@ final class DictationE2ETests: XCTestCase {
     private let commandModeLinkedToGlobalKey = "CommandModeLinkedToGlobal"
     private let commandModeSelectedProviderIDKey = "CommandModeSelectedProviderID"
     private let commandModeSelectedModelKey = "CommandModeSelectedModel"
+    private let preferBuiltInMicrophoneForBluetoothOutputKey = "PreferBuiltInMicrophoneForBluetoothOutput"
     private var privateAISelectedModelIDKey: String {
         PrivateAIProviderFeature.shared.selectedModelDefaultsKey
     }
@@ -67,6 +69,89 @@ final class DictationE2ETests: XCTestCase {
             XCTAssertNil(defaults.object(forKey: self.enableTranscriptionSoundsKey))
             XCTAssertEqual(defaults.string(forKey: self.transcriptionStartSoundKey), SettingsStore.TranscriptionStartSound.fluidSfx2.rawValue)
         }
+    }
+
+    func testPreferBuiltInMicrophoneForBluetoothOutput_defaultsOffAndPersistsToggle() {
+        self.withRestoredDefaults(keys: [self.preferBuiltInMicrophoneForBluetoothOutputKey]) {
+            let settings = SettingsStore.shared
+            UserDefaults.standard.removeObject(forKey: self.preferBuiltInMicrophoneForBluetoothOutputKey)
+
+            XCTAssertFalse(settings.preferBuiltInMicrophoneForBluetoothOutput)
+
+            settings.preferBuiltInMicrophoneForBluetoothOutput = true
+            XCTAssertTrue(settings.preferBuiltInMicrophoneForBluetoothOutput)
+
+            settings.preferBuiltInMicrophoneForBluetoothOutput = false
+            XCTAssertFalse(settings.preferBuiltInMicrophoneForBluetoothOutput)
+        }
+    }
+
+    func testBuiltInMicrophonePreferenceReplacesBluetoothInputWhenBluetoothOutputActive() {
+        let airPodsInput = self.audioDevice(
+            id: 1,
+            uid: "airpods-input",
+            name: "Noah AirPods Pro",
+            hasInput: true,
+            hasOutput: false,
+            transportType: kAudioDeviceTransportTypeBluetooth
+        )
+        let airPodsOutput = self.audioDevice(
+            id: 2,
+            uid: "airpods-output",
+            name: "Noah AirPods Pro",
+            hasInput: false,
+            hasOutput: true,
+            transportType: kAudioDeviceTransportTypeBluetooth
+        )
+        let builtInMic = self.audioDevice(
+            id: 3,
+            uid: "BuiltInMicrophoneDevice",
+            name: "MacBook Pro Microphone",
+            hasInput: true,
+            hasOutput: false
+        )
+
+        XCTAssertEqual(
+            AudioDevice.builtInInputForBluetoothOutput(
+                currentInput: airPodsInput,
+                output: airPodsOutput,
+                inputDevices: [airPodsInput, builtInMic]
+            )?.uid,
+            builtInMic.uid
+        )
+    }
+
+    func testBuiltInMicrophonePreferenceKeepsExternalInputWhenBluetoothOutputActive() {
+        let usbMic = self.audioDevice(
+            id: 1,
+            uid: "usb-mic",
+            name: "Shure MV7",
+            hasInput: true,
+            hasOutput: false
+        )
+        let airPodsOutput = self.audioDevice(
+            id: 2,
+            uid: "airpods-output",
+            name: "Noah AirPods Pro",
+            hasInput: false,
+            hasOutput: true,
+            transportType: kAudioDeviceTransportTypeBluetooth
+        )
+        let builtInMic = self.audioDevice(
+            id: 3,
+            uid: "BuiltInMicrophoneDevice",
+            name: "MacBook Pro Microphone",
+            hasInput: true,
+            hasOutput: false
+        )
+
+        XCTAssertNil(
+            AudioDevice.builtInInputForBluetoothOutput(
+                currentInput: usbMic,
+                output: airPodsOutput,
+                inputDevices: [usbMic, builtInMic]
+            )
+        )
     }
 
     func testDictionaryTransferDocument_encodesSimpleUserFormat() throws {
@@ -1004,6 +1089,24 @@ final class DictationE2ETests: XCTestCase {
         }
 
         run()
+    }
+
+    private func audioDevice(
+        id: AudioObjectID,
+        uid: String,
+        name: String,
+        hasInput: Bool,
+        hasOutput: Bool,
+        transportType: UInt32? = nil
+    ) -> AudioDevice.Device {
+        AudioDevice.Device(
+            id: id,
+            uid: uid,
+            name: name,
+            hasInput: hasInput,
+            hasOutput: hasOutput,
+            transportType: transportType
+        )
     }
 
     private func withPromptSettingsRestored(run: () -> Void) {


### PR DESCRIPTION
## Summary
- add an optional setting to prefer the Mac built-in microphone while Bluetooth headphones are the active output
- switch away from Bluetooth headset input only when the current input is Bluetooth, so USB/external microphones are preserved
- apply the preference during startup, device refresh, settings/menu changes, recording start, and Bluetooth reconnect handling

## Why
When AirPods are both output and input, starting dictation can force macOS onto the Bluetooth headset microphone route and briefly interrupt media playback. This keeps AirPods as output while avoiding the Bluetooth microphone path.

Closes #136.
Related: #317.

## Behavior
- New setting: Prefer Built-in Mic with Bluetooth Output
- Default: off
- If Bluetooth output is active and the current input is Bluetooth, FluidVoice switches system input to the built-in Mac microphone when available
- If the current input is a non-Bluetooth external mic, FluidVoice leaves it alone

## Validation
- xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination "platform=macOS,arch=arm64" -only-testing:FluidDictationIntegrationTests/DictationE2ETests/testPreferBuiltInMicrophoneForBluetoothOutput_defaultsOffAndPersistsToggle -only-testing:FluidDictationIntegrationTests/DictationE2ETests/testBuiltInMicrophonePreferenceReplacesBluetoothInputWhenBluetoothOutputActive -only-testing:FluidDictationIntegrationTests/DictationE2ETests/testBuiltInMicrophonePreferenceKeepsExternalInputWhenBluetoothOutputActive -skipPackagePluginValidation -skipMacroValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
- xcodebuild build -project Fluid.xcodeproj -scheme Fluid -configuration Release -destination "platform=macOS,arch=arm64" -derivedDataPath build/DerivedData -skipPackagePluginValidation -skipMacroValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
- Local custom app installed and launched from /Applications with the setting enabled; system route confirmed as MacBook Pro Microphone input + AirPods output
