### PR TITLE
Fix model setup cancellation and support link

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -179,7 +179,7 @@ struct ContentView: View {
     @State private var accessibilityEnabled = false
     @State private var primaryDictationShortcuts: [HotkeyShortcut] = SettingsStore.shared.primaryDictationShortcuts
     @State private var promptModeHotkeyShortcut: HotkeyShortcut = SettingsStore.shared.promptModeHotkeyShortcut
-    @State private var commandModeHotkeyShortcut: HotkeyShortcut = SettingsStore.shared.commandModeHotkeyShortcut
+    @State private var commandModeHotkeyShortcut: HotkeyShortcut? = SettingsStore.shared.commandModeHotkeyShortcut
     @State private var rewriteModeHotkeyShortcut: HotkeyShortcut = SettingsStore.shared.rewriteModeHotkeyShortcut
     @State private var cancelRecordingHotkeyShortcut: HotkeyShortcut = SettingsStore.shared.cancelRecordingHotkeyShortcut
     @State private var isPromptModeShortcutEnabled: Bool = SettingsStore.shared.promptModeShortcutEnabled
@@ -442,6 +442,10 @@ struct ContentView: View {
             }
             .onChange(of: self.activeShortcutRecordingTarget) { _, _ in
                 self.hotkeyManager?.resetModifierOnlyShortcutTracking()
+            }
+            .onChange(of: self.commandModeHotkeyShortcut) { _, newValue in
+                SettingsStore.shared.commandModeHotkeyShortcut = newValue
+                self.hotkeyManager?.updateCommandModeShortcut(newValue)
             }
             .onChange(of: self.isPromptModeShortcutEnabled) { newValue in
                 self.handlePromptShortcutEnabledChange(newValue)
@@ -990,12 +994,23 @@ struct ContentView: View {
 
         let configuredShortcuts: [(ShortcutRecordingTarget, HotkeyShortcut)] = [
             (.secondaryDictation, self.promptModeHotkeyShortcut),
-            (.command, self.commandModeHotkeyShortcut),
             (.edit, self.rewriteModeHotkeyShortcut),
             (.cancel, self.cancelRecordingHotkeyShortcut),
         ]
+        let optionalConfiguredShortcuts: [(ShortcutRecordingTarget, HotkeyShortcut?)] = [
+            (.command, self.commandModeHotkeyShortcut),
+        ]
 
         for (otherTarget, configuredShortcut) in configuredShortcuts where otherTarget != target {
+            if configuredShortcut == shortcut {
+                return "Duplicate with \(otherTarget.title)"
+            }
+            if shortcut.conflictsWith(configuredShortcut) {
+                return "Overlaps \(otherTarget.title) — use a different modifier key"
+            }
+        }
+        for (otherTarget, configuredShortcut) in optionalConfiguredShortcuts where otherTarget != target {
+            guard let configuredShortcut else { continue }
             if configuredShortcut == shortcut {
                 return "Duplicate with \(otherTarget.title)"
             }

--- a/Sources/Fluid/Networking/ModelDownloader.swift
+++ b/Sources/Fluid/Networking/ModelDownloader.swift
@@ -11,6 +11,7 @@ final class HuggingFaceModelDownloader {
     struct HFEntry: Decodable {
         let type: String
         let path: String
+        let size: Int64?
     }
 
     struct ModelItem {
@@ -95,22 +96,38 @@ final class HuggingFaceModelDownloader {
     }
 
     func ensureModelsPresent(at targetRoot: URL, onProgress: ((Double, String) -> Void)? = nil) async throws {
+        try Task.checkCancellation()
         try FileManager.default.createDirectory(at: targetRoot, withIntermediateDirectories: true)
+        onProgress?(0.0, "")
 
         // Build list of files to download (flatten directories via HF API tree)
         var pendingFiles: [String] = []
+        var listedSizeByPath: [String: Int64] = [:]
         for item in self.requiredItems() {
+            try Task.checkCancellation()
             if item.isDirectory {
                 let files = try await listFilesRecursively(relativePath: item.path)
-                for rel in files {
+                for entry in files {
+                    let rel = entry.path
+                    if let size = entry.size, size >= 0 {
+                        listedSizeByPath[rel] = size
+                    }
                     let dest = targetRoot.appendingPathComponent(rel)
-                    if self.needsDownload(relativePath: rel, at: dest) {
+                    if self.needsDownload(relativePath: rel, at: dest, expectedBytes: entry.size) {
                         pendingFiles.append(rel)
                     }
                 }
             } else {
                 let dest = targetRoot.appendingPathComponent(item.path)
-                if self.needsDownload(relativePath: item.path, at: dest) {
+                let expectedBytes = try await self.headExpectedLength(relativePath: item.path)
+                if expectedBytes > 0 {
+                    listedSizeByPath[item.path] = expectedBytes
+                }
+                if self.needsDownload(
+                    relativePath: item.path,
+                    at: dest,
+                    expectedBytes: expectedBytes > 0 ? expectedBytes : nil
+                ) {
                     pendingFiles.append(item.path)
                 }
             }
@@ -118,7 +135,15 @@ final class HuggingFaceModelDownloader {
 
         // If nothing to download, say so clearly
         if pendingFiles.isEmpty {
+            guard Self.artifactsAreComplete(root: targetRoot, items: self.requiredItems()) else {
+                throw NSError(
+                    domain: "HF",
+                    code: -4,
+                    userInfo: [NSLocalizedDescriptionKey: "Cached model artifacts are incomplete. Please try again."]
+                )
+            }
             DebugLogger.shared.info("[ModelDL] All required model files are already present. Nothing to download.", source: "ModelDownloader")
+            try Task.checkCancellation()
             onProgress?(1.0, "")
             return
         }
@@ -127,7 +152,13 @@ final class HuggingFaceModelDownloader {
         var sizeByPath: [String: Int64] = [:]
         var totalBytes: Int64 = 0
         for rel in pendingFiles {
-            let expected = try await headExpectedLength(relativePath: rel)
+            try Task.checkCancellation()
+            let expected: Int64
+            if let listedSize = listedSizeByPath[rel] {
+                expected = listedSize
+            } else {
+                expected = try await self.headExpectedLength(relativePath: rel)
+            }
             sizeByPath[rel] = expected
             if expected > 0 { totalBytes += expected }
         }
@@ -136,34 +167,60 @@ final class HuggingFaceModelDownloader {
         DebugLogger.shared.info("[ModelDL] Files to download: \(pendingFiles.count), total size: \(totalHuman)", source: "ModelDownloader")
 
         var downloadedBytes: Int64 = 0
-        let fallbackTotal = pendingFiles.count
-        var fallbackCompleted = 0
+        // Never synthesize progress from file count: model artifacts vary from bytes to
+        // gigabytes. Report byte progress for known-size files and hold steady for unknown-size
+        // files until the validated bundle can truthfully report completion.
+        let maximumIncompleteProgress = 0.999
 
         for (idx, rel) in pendingFiles.enumerated() {
+            try Task.checkCancellation()
             DebugLogger.shared.info("[ModelDL] (\(idx + 1)/\(pendingFiles.count)) Downloading: \(rel)", source: "ModelDownloader")
+            let completedBytesBeforeFile = downloadedBytes
             try await self.downloadFile(relativePath: rel, to: targetRoot.appendingPathComponent(rel)) { perFilePct in
-                if totalBytes > 0 {
-                    let expected = sizeByPath[rel] ?? 0
-                    if expected > 0 {
-                        let overallBase = Double(downloadedBytes) / Double(totalBytes)
-                        let combined = min(1.0, overallBase + (perFilePct * Double(expected)) / Double(totalBytes))
-                        onProgress?(combined, rel)
-                        DebugLogger.shared.debug(String(format: "[ModelDL] File progress: %.1f%% (%@)", perFilePct * 100.0, rel), source: "ModelDownloader")
-                        DebugLogger.shared.debug(String(format: "[ModelDL] Overall progress (est.): %.1f%%", combined * 100.0), source: "ModelDownloader")
-                    }
+                let expected = sizeByPath[rel] ?? 0
+                if expected > 0, totalBytes > 0 {
+                    let overallBase = Double(completedBytesBeforeFile) / Double(totalBytes)
+                    let combined = min(
+                        maximumIncompleteProgress,
+                        overallBase + (perFilePct * Double(expected)) / Double(totalBytes)
+                    )
+                    onProgress?(combined, rel)
+                    DebugLogger.shared.debug(String(format: "[ModelDL] File progress: %.1f%% (%@)", perFilePct * 100.0, rel), source: "ModelDownloader")
+                    DebugLogger.shared.debug(String(format: "[ModelDL] Overall progress: %.1f%%", combined * 100.0), source: "ModelDownloader")
                 }
             }
-            if totalBytes > 0 {
-                downloadedBytes += (sizeByPath[rel] ?? 0)
-                let pct = min(1.0, Double(downloadedBytes) / Double(totalBytes))
+            try Task.checkCancellation()
+            let expectedFileBytes = sizeByPath[rel] ?? 0
+            if expectedFileBytes > 0 {
+                let destination = targetRoot.appendingPathComponent(rel)
+                let attributes = try? FileManager.default.attributesOfItem(atPath: destination.path)
+                let actualBytes = (attributes?[.size] as? NSNumber)?.int64Value
+                guard actualBytes == expectedFileBytes else {
+                    try? FileManager.default.removeItem(at: destination)
+                    throw NSError(
+                        domain: "HF",
+                        code: -5,
+                        userInfo: [NSLocalizedDescriptionKey: "Downloaded file size mismatch for \(rel). Please try again."]
+                    )
+                }
+            }
+            if expectedFileBytes > 0, totalBytes > 0 {
+                downloadedBytes += expectedFileBytes
+                let pct = min(maximumIncompleteProgress, Double(downloadedBytes) / Double(totalBytes))
                 onProgress?(pct, rel)
                 DebugLogger.shared.info(String(format: "[ModelDL] Overall progress: %.1f%% (\(Self.formatBytes(downloadedBytes))/\(Self.formatBytes(totalBytes)))", pct * 100.0), source: "ModelDownloader")
-            } else if fallbackTotal > 0 {
-                fallbackCompleted += 1
-                onProgress?(Double(fallbackCompleted) / Double(fallbackTotal), rel)
-                DebugLogger.shared.info("[ModelDL] Overall progress: \(fallbackCompleted)/\(fallbackTotal)", source: "ModelDownloader")
             }
         }
+
+        guard Self.artifactsAreComplete(root: targetRoot, items: self.requiredItems()) else {
+            throw NSError(
+                domain: "HF",
+                code: -4,
+                userInfo: [NSLocalizedDescriptionKey: "Downloaded model artifacts are incomplete. Please try again."]
+            )
+        }
+        try Task.checkCancellation()
+        onProgress?(1.0, "")
     }
 
     private func requiredItems() -> [ModelItem] {
@@ -178,15 +235,24 @@ final class HuggingFaceModelDownloader {
     /// stuck forever, because `downloadFile` (and its validator) only runs for pending files.
     /// A present markup file is deleted here so a clean copy is fetched; on a read error the
     /// file is left in place and treated as valid, so we never delete on uncertainty.
-    private func needsDownload(relativePath: String, at destination: URL) -> Bool {
+    private func needsDownload(relativePath: String, at destination: URL, expectedBytes: Int64? = nil) -> Bool {
         guard FileManager.default.fileExists(atPath: destination.path) else {
             return true
         }
-        guard Self.cachedFileIsMarkup(at: destination) else {
-            return false
+        if let expectedBytes, expectedBytes >= 0,
+           let attributes = try? FileManager.default.attributesOfItem(atPath: destination.path),
+           let localSize = attributes[.size] as? NSNumber,
+           localSize.int64Value != expectedBytes
+        {
+            try? FileManager.default.removeItem(at: destination)
+            return true
         }
+        guard !Self.artifactIsComplete(at: destination, isDirectory: false) else { return false }
+        let reason = Self.cachedFileIsMarkup(at: destination)
+            ? "an HTML/markup page, not model data"
+            : "empty or not a regular file"
         DebugLogger.shared.warning(
-            "[ModelDL] Cached file is an HTML/markup page, not model data; deleting to re-download: \(relativePath)",
+            "[ModelDL] Cached file is \(reason); deleting to re-download: \(relativePath)",
             source: "ModelDownloader"
         )
         do {
@@ -205,7 +271,8 @@ final class HuggingFaceModelDownloader {
 
         // Download entire directory by enumerating all files
         let files = try await listFilesRecursively(relativePath: relativePath)
-        for rel in files {
+        for entry in files {
+            let rel = entry.path
             let dest = destination.deletingLastPathComponent().appendingPathComponent(rel)
             try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
             try await self.downloadFile(relativePath: rel, to: dest)
@@ -215,38 +282,129 @@ final class HuggingFaceModelDownloader {
     private func downloadFile(relativePath: String, to destination: URL, perFileProgress: ((Double) -> Void)? = nil) async throws {
         let fileURL = self.baseResolveURL.appendingPathComponent(relativePath)
 
-        let delegate = DownloadProgressDelegate(onProgress: perFileProgress)
-        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        let task = session.downloadTask(with: fileURL)
-
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            delegate.onFinish = { tempUrl, response in
-                do {
-                    if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
-                        continuation.resume(throwing: NSError(domain: "HF", code: http.statusCode))
-                        return
-                    }
-                    // Reject HTML error/block pages (e.g. a corporate proxy returning its
-                    // notification page with HTTP 200) before persisting them as a model
-                    // file, otherwise a corrupt payload is cached permanently. See #353.
-                    try Self.validateDownloadedFile(at: tempUrl, response: response, relativePath: relativePath)
-                    try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-                    if FileManager.default.fileExists(atPath: destination.path) {
-                        try FileManager.default.removeItem(at: destination)
-                    }
-                    try FileManager.default.moveItem(at: tempUrl, to: destination)
-                    continuation.resume()
-                } catch {
-                    // Never leave a rejected/partial payload behind.
-                    try? FileManager.default.removeItem(at: tempUrl)
-                    continuation.resume(throwing: error)
-                }
-            }
-            delegate.onError = { error in
-                continuation.resume(throwing: error)
-            }
-            task.resume()
+        let delegate = DownloadProgressDelegate { totalBytesWritten, totalBytesExpected in
+            guard totalBytesExpected > 0 else { return }
+            perFileProgress?(min(1.0, Double(totalBytesWritten) / Double(totalBytesExpected)))
         }
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+
+        var temporaryURL: URL?
+        do {
+            let result = try await withTaskCancellationHandler {
+                try await session.download(from: fileURL)
+            } onCancel: {
+                session.invalidateAndCancel()
+            }
+            temporaryURL = result.0
+            let response = result.1
+
+            try Task.checkCancellation()
+            if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+                throw NSError(domain: "HF", code: http.statusCode)
+            }
+
+            // Reject HTML error/block pages (e.g. a corporate proxy returning its
+            // notification page with HTTP 200) before persisting them as a model
+            // file, otherwise a corrupt payload is cached permanently. See #353.
+            try Self.validateDownloadedFile(at: result.0, response: response, relativePath: relativePath)
+            try Task.checkCancellation()
+            try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: result.0, to: destination)
+            temporaryURL = nil
+        } catch {
+            if let temporaryURL {
+                try? FileManager.default.removeItem(at: temporaryURL)
+            }
+            session.invalidateAndCancel()
+            if Task.isCancelled || Self.isCancellationError(error) {
+                throw CancellationError()
+            }
+            throw error
+        }
+    }
+
+    static func artifactsAreComplete(root: URL, items: [ModelItem]) -> Bool {
+        items.allSatisfy { item in
+            Self.artifactIsComplete(
+                at: root.appendingPathComponent(item.path, isDirectory: item.isDirectory),
+                isDirectory: item.isDirectory
+            )
+        }
+    }
+
+    static func artifactIsComplete(at url: URL, isDirectory: Bool) -> Bool {
+        guard isDirectory else { return self.fileHasContents(at: url) }
+
+        if url.pathExtension == "mlpackage" {
+            let manifestURL = url.appendingPathComponent("Manifest.json")
+            guard
+                Self.fileHasContents(at: manifestURL),
+                let data = try? Data(contentsOf: manifestURL),
+                let manifestObject = try? JSONSerialization.jsonObject(with: data),
+                let manifest = manifestObject as? [String: Any],
+                let entries = manifest["itemInfoEntries"] as? [String: [String: Any]],
+                !entries.isEmpty
+            else {
+                return false
+            }
+
+            return entries.values.allSatisfy { entry in
+                guard let relativePath = entry["path"] as? String else { return false }
+                let artifact = url
+                    .appendingPathComponent("Data", isDirectory: true)
+                    .appendingPathComponent(relativePath)
+                var isDirectory: ObjCBool = false
+                guard FileManager.default.fileExists(atPath: artifact.path, isDirectory: &isDirectory) else {
+                    return false
+                }
+                return Self.artifactIsComplete(at: artifact, isDirectory: isDirectory.boolValue)
+            }
+        }
+        if url.pathExtension == "mlmodelc" {
+            // `model.mil` is optional in valid compiled bundles (the Flash preprocessor ships
+            // without it), so installation truth comes from compiled metadata plus weights.
+            return self.fileHasContents(at: url.appendingPathComponent("coremldata.bin"))
+                && self.fileHasContents(at: url.appendingPathComponent("metadata.json"))
+                && self.fileHasContents(
+                    at: url
+                        .appendingPathComponent("weights", isDirectory: true)
+                        .appendingPathComponent("weight.bin")
+                )
+        }
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+        for case let fileURL as URL in enumerator where Self.fileHasContents(at: fileURL) {
+            return true
+        }
+        return false
+    }
+
+    private static func fileHasContents(at url: URL) -> Bool {
+        guard
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let type = attributes[.type] as? FileAttributeType,
+            type == .typeRegular,
+            let size = attributes[.size] as? NSNumber
+        else {
+            return false
+        }
+        return size.int64Value > 0 && !Self.cachedFileIsMarkup(at: url)
+    }
+
+    private static func isCancellationError(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
 
     // MARK: - Content Validation
@@ -259,8 +417,26 @@ final class HuggingFaceModelDownloader {
     /// markup — by its `Content-Type` or by its leading bytes — since no model artifact
     /// (CoreML binary, JSON vocab, `.mil`) is a markup document. See issue #353.
     static func validateDownloadedFile(at fileURL: URL, response: URLResponse?, relativePath: String) throws {
+        if let expectedBytes = response?.expectedContentLength, expectedBytes > 0 {
+            let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+            guard
+                let actualBytes = attributes[.size] as? NSNumber,
+                actualBytes.int64Value == expectedBytes
+            else {
+                throw NSError(
+                    domain: "HF",
+                    code: -5,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Could not download \(relativePath): the received file size did not match the server response.",
+                    ]
+                )
+            }
+        }
+
         if let http = response as? HTTPURLResponse,
-           let contentType = http.value(forHTTPHeaderField: "Content-Type") {
+           let contentType = http.value(forHTTPHeaderField: "Content-Type")
+        {
             let lowered = contentType.lowercased()
             if lowered.contains("text/html") || lowered.contains("text/xml") || lowered.contains("application/xml") {
                 throw Self.invalidContentError(
@@ -360,15 +536,16 @@ final class HuggingFaceModelDownloader {
     /// match. See issue #353.
     static func looksLikeHTML(_ data: Data) -> Bool {
         var bytes = [UInt8](data.prefix(512))
-        if bytes.starts(with: [0xEF, 0xBB, 0xBF]) {
+        if bytes.starts(with: [0xef, 0xbb, 0xbf]) {
             bytes.removeFirst(3)
         }
         while let first = bytes.first,
-              first == 0x20 || first == 0x09 || first == 0x0A || first == 0x0D {
+              first == 0x20 || first == 0x09 || first == 0x0a || first == 0x0d
+        {
             bytes.removeFirst()
         }
         // Must begin with `<` (0x3C)…
-        guard bytes.first == 0x3C, bytes.count >= 2 else {
+        guard bytes.first == 0x3c, bytes.count >= 2 else {
             return false
         }
         // …immediately followed by a markup-ish byte: an ASCII letter (a tag such as
@@ -376,8 +553,8 @@ final class HuggingFaceModelDownloader {
         // a stray closing tag). Requiring this second byte avoids over-rejecting a
         // hypothetical text artifact that merely contains a stray `<` not followed by markup.
         let second = bytes[1]
-        let isAsciiLetter = (second >= 0x41 && second <= 0x5A) || (second >= 0x61 && second <= 0x7A)
-        return isAsciiLetter || second == 0x21 || second == 0x3F || second == 0x2F
+        let isAsciiLetter = (second >= 0x41 && second <= 0x5a) || (second >= 0x61 && second <= 0x7a)
+        return isAsciiLetter || second == 0x21 || second == 0x3f || second == 0x2f
     }
 
     private static func invalidContentError(relativePath: String, detail: String) -> NSError {
@@ -387,43 +564,45 @@ final class HuggingFaceModelDownloader {
         ])
     }
 
-    private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate {
-        private let onProgress: ((Double) -> Void)?
-        var onFinish: ((URL, URLResponse) -> Void)?
-        var onError: ((Error) -> Void)?
+    private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+        private let onProgress: (Int64, Int64) -> Void
 
-        init(onProgress: ((Double) -> Void)?) {
+        init(onProgress: @escaping (Int64, Int64) -> Void) {
             self.onProgress = onProgress
         }
 
         func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-            guard let response = downloadTask.response else { return }
-            self.onFinish?(location, response)
-        }
-
-        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-            if let error = error { self.onError?(error) }
+            // The async URLSession API owns completion; this delegate only reports bytes.
         }
 
         func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
             guard totalBytesExpectedToWrite > 0 else { return }
-            let pct = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
-            self.onProgress?(pct)
+            self.onProgress(totalBytesWritten, totalBytesExpectedToWrite)
         }
     }
 
     private func headExpectedLength(relativePath: String) async throws -> Int64 {
+        try Task.checkCancellation()
         let fileURL = self.baseResolveURL.appendingPathComponent(relativePath)
         var req = URLRequest(url: fileURL)
         req.httpMethod = "HEAD"
-        let (_, resp) = try await URLSession.shared.data(for: req)
-        guard let http = resp as? HTTPURLResponse, http.statusCode < 400 else {
+        do {
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            try Task.checkCancellation()
+            guard let http = resp as? HTTPURLResponse, http.statusCode < 400 else {
+                return 0
+            }
+            return http.expectedContentLength
+        } catch {
+            if Task.isCancelled || Self.isCancellationError(error) {
+                throw CancellationError()
+            }
             return 0
         }
-        return http.expectedContentLength
     }
 
-    private func listFilesRecursively(relativePath: String) async throws -> [String] {
+    private func listFilesRecursively(relativePath: String) async throws -> [HFEntry] {
+        try Task.checkCancellation()
         let listingURL = self.baseApiURL
             .appendingPathComponent(relativePath)
         guard var comps = URLComponents(url: listingURL, resolvingAgainstBaseURL: false) else {
@@ -435,6 +614,7 @@ final class HuggingFaceModelDownloader {
             throw NSError(domain: "HF", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid listing URL"])
         }
         let (data, resp) = try await URLSession.shared.data(from: url)
+        try Task.checkCancellation()
         if let http = resp as? HTTPURLResponse, http.statusCode >= 400 {
             throw NSError(domain: "HF", code: http.statusCode)
         }
@@ -444,7 +624,6 @@ final class HuggingFaceModelDownloader {
 
         return entries
             .filter { $0.type == "file" }
-            .map { $0.path }
     }
 
     private static func formatBytes(_ bytes: Int64) -> String {

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -25,7 +25,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let promptModeShortcutEnabled: Bool
     let promptModeSelectedPromptID: String?
     let secondaryDictationPromptOff: Bool?
-    let commandModeHotkeyShortcut: HotkeyShortcut
+    let commandModeHotkeyShortcut: HotkeyShortcut?
     let commandModeShortcutEnabled: Bool
     let commandModeSelectedModel: String?
     let commandModeSelectedProviderID: String

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2353,7 +2353,7 @@ final class SettingsStore: ObservableObject {
     var commandModeShortcutEnabled: Bool {
         get {
             let value = self.defaults.object(forKey: Keys.commandModeShortcutEnabled)
-            return value as? Bool ?? true
+            return value as? Bool ?? false
         }
         set {
             objectWillChange.send()
@@ -2361,18 +2361,21 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    var commandModeHotkeyShortcut: HotkeyShortcut {
+    var commandModeHotkeyShortcut: HotkeyShortcut? {
         get {
             if let data = defaults.data(forKey: Keys.commandModeHotkeyShortcut),
                let shortcut = try? JSONDecoder().decode(HotkeyShortcut.self, from: data)
             {
                 return shortcut
             }
-            // Default to Right Command key (keyCode: 54, no modifiers for the key itself)
-            return HotkeyShortcut(keyCode: 54, modifierFlags: [])
+            return nil
         }
         set {
             objectWillChange.send()
+            guard let newValue else {
+                self.defaults.removeObject(forKey: Keys.commandModeHotkeyShortcut)
+                return
+            }
             if let data = try? JSONEncoder().encode(newValue) {
                 self.defaults.set(data, forKey: Keys.commandModeHotkeyShortcut)
             }
@@ -3661,22 +3664,41 @@ final class SettingsStore: ObservableObject {
 
         var downloadSize: String {
             switch self {
-            case .parakeetTDT: return "~500 MB"
-            case .parakeetTDTv2: return "~500 MB"
-            case .parakeetRealtime: return "~250 MB"
-            case .qwen3Asr: return "~2.0 GB"
-            case .cohereTranscribeSixBit: return "~1.4 GB"
-            case .nemotronOffline: return "~530 MB"
-            case .nemotronStreaming: return "~670 MB"
-            case .nemotronStreaming320: return "~670 MB"
+            case .parakeetTDT: return "~460.9 MiB"
+            case .parakeetTDTv2: return "~442.9 MiB"
+            case .parakeetRealtime: return "~428.4 MiB"
+            case .qwen3Asr: return "~2.0 GiB"
+            case .cohereTranscribeSixBit: return "~1.54 GiB"
+            case .nemotronOffline: return "~530.8 MiB"
+            case .nemotronStreaming: return "~668.2 MiB"
+            case .nemotronStreaming320: return "~668.2 MiB"
             case .appleSpeech: return "Built-in"
             case .appleSpeechAnalyzer: return "Built-in"
-            case .whisperTiny: return "~75 MB"
-            case .whisperBase: return "~142 MB"
-            case .whisperSmall: return "~466 MB"
-            case .whisperMedium: return "~1.5 GB"
-            case .whisperLargeTurbo: return "~1.6 GB"
-            case .whisperLarge: return "~2.9 GB"
+            case .whisperTiny: return "~74.1 MiB"
+            case .whisperBase: return "~141.1 MiB"
+            case .whisperSmall: return "~465.0 MiB"
+            case .whisperMedium: return "~1.43 GiB"
+            case .whisperLargeTurbo: return "~1.51 GiB"
+            case .whisperLarge: return "~2.88 GiB"
+            }
+        }
+
+        var expectedDownloadBytes: Int64 {
+            switch self {
+            case .parakeetTDT: return 483_288_717
+            case .parakeetTDTv2: return 464_421_712
+            case .parakeetRealtime: return 449_190_189
+            case .qwen3Asr: return 2000 * 1024 * 1024
+            case .cohereTranscribeSixBit: return 1_650_748_785
+            case .nemotronOffline: return 556_552_620
+            case .nemotronStreaming, .nemotronStreaming320: return 700_685_415
+            case .whisperTiny: return 77_691_713
+            case .whisperBase: return 147_951_465
+            case .whisperSmall: return 487_601_967
+            case .whisperMedium: return 1_533_763_059
+            case .whisperLargeTurbo: return 1_624_555_275
+            case .whisperLarge: return 3_095_033_483
+            case .appleSpeech, .appleSpeechAnalyzer: return 0
             }
         }
 
@@ -4078,13 +4100,23 @@ final class SettingsStore: ObservableObject {
             case .appleSpeech, .appleSpeechAnalyzer:
                 return true
             case .parakeetTDT:
-                // Hardcoded path check for NVIDIA v3
-                return Self.parakeetCacheDirectory(version: "parakeet-tdt-0.6b-v3-coreml")
+                #if canImport(FluidAudio)
+                return Self.parakeetModelsExist(version: .v3)
+                #else
+                return false
+                #endif
             case .parakeetTDTv2:
-                // Hardcoded path check for NVIDIA v2
-                return Self.parakeetCacheDirectory(version: "parakeet-tdt-0.6b-v2-coreml")
+                #if canImport(FluidAudio)
+                return Self.parakeetModelsExist(version: .v2)
+                #else
+                return false
+                #endif
             case .parakeetRealtime:
-                return Self.parakeetCacheDirectory(version: "parakeet-eou-streaming/parakeet-eou-streaming/160ms")
+                #if canImport(FluidAudio)
+                return Self.parakeetRealtimeModelsExist()
+                #else
+                return false
+                #endif
             case .qwen3Asr:
                 #if canImport(FluidAudio) && ENABLE_QWEN
                 if #available(macOS 15.0, *) {
@@ -4101,7 +4133,7 @@ final class SettingsStore: ObservableObject {
                 else {
                     return false
                 }
-                return spec.validateArtifacts(at: directory)
+                return spec.validatesInstalledArtifacts(at: directory)
             case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
                 let hint: String
                 switch self {
@@ -4112,41 +4144,63 @@ final class SettingsStore: ObservableObject {
                 }
                 let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
                     .appendingPathComponent(hint, isDirectory: true)
-                let requiredEntries = [
-                    "metadata.json",
-                    "preprocessor.mlpackage",
-                    "encoder.mlpackage",
-                    "decoder.mlpackage",
-                    "joint.mlpackage",
-                    "joint_decision.mlpackage",
-                    "tokenizer.model",
-                ]
-                return directory.map { url in
-                    requiredEntries.allSatisfy {
-                        FileManager.default.fileExists(atPath: url.appendingPathComponent($0).path)
-                    }
-                } ?? false
+                #if arch(arm64)
+                return directory.map { NemotronProvider.artifactsAreComplete(at: $0) } ?? false
+                #else
+                return false
+                #endif
             default:
                 // Whisper models
                 guard let whisperFile = self.whisperModelFile else { return false }
                 let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
                     .appendingPathComponent("WhisperModels")
                 let modelURL = directory?.appendingPathComponent(whisperFile)
-                return modelURL.map { FileManager.default.fileExists(atPath: $0.path) } ?? false
+                guard
+                    let modelURL,
+                    let attributes = try? FileManager.default.attributesOfItem(atPath: modelURL.path),
+                    let size = attributes[.size] as? NSNumber,
+                    size.int64Value > 0
+                else {
+                    return false
+                }
+                return size.int64Value == self.expectedDownloadBytes
             }
         }
 
-        private static func parakeetCacheDirectory(version: String) -> Bool {
-            #if canImport(FluidAudio)
-            let baseCacheDir = AsrModels.defaultCacheDirectory().deletingLastPathComponent()
-            let modelDir = baseCacheDir.appendingPathComponent(version)
-            return FileManager.default.fileExists(atPath: modelDir.path)
-            #else
-            let baseCacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
-                .appendingPathComponent(version)
-            return baseCacheDir.map { FileManager.default.fileExists(atPath: $0.path) } ?? false
-            #endif
+        #if canImport(FluidAudio)
+        private static func parakeetModelsExist(version: AsrModelVersion) -> Bool {
+            let directory = AsrModels.defaultCacheDirectory(for: version)
+            let vocabulary = directory.appendingPathComponent(ModelNames.ASR.vocabularyFile)
+            guard
+                AsrModels.modelsExist(at: directory, version: version),
+                HuggingFaceModelDownloader.artifactIsComplete(at: vocabulary, isDirectory: false)
+            else {
+                return false
+            }
+
+            return AsrModels.requiredModelNames.allSatisfy { modelName in
+                HuggingFaceModelDownloader.artifactIsComplete(
+                    at: directory.appendingPathComponent(modelName, isDirectory: true),
+                    isDirectory: true
+                )
+            }
         }
+
+        private static func parakeetRealtimeModelsExist() -> Bool {
+            let modelsDirectory = AsrModels.defaultCacheDirectory().deletingLastPathComponent()
+            let modelDirectory = modelsDirectory
+                .appendingPathComponent("parakeet-eou-streaming", isDirectory: true)
+                .appendingPathComponent(Repo.parakeetEou160.folderName, isDirectory: true)
+
+            return ModelNames.ParakeetEOU.requiredModels.allSatisfy { modelName in
+                let artifact = modelDirectory.appendingPathComponent(modelName)
+                return HuggingFaceModelDownloader.artifactIsComplete(
+                    at: artifact,
+                    isDirectory: modelName.hasSuffix(".mlmodelc")
+                )
+            }
+        }
+        #endif
 
         /// Brand/provider name for the model (NVIDIA, Apple, OpenAI)
         var brandName: String {

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -40,24 +40,6 @@ private actor TranscriptionExecutor {
     }
 }
 
-private actor ModelDownloadRegistry {
-    private var tasks: [String: Task<Void, Error>] = [:]
-
-    func run(for key: String, operation: @escaping () async throws -> Void) async throws {
-        if let existing = tasks[key] {
-            return try await existing.value
-        }
-
-        let task = Task {
-            try await operation()
-        }
-        self.tasks[key] = task
-        defer { tasks[key] = nil }
-
-        try await task.value
-    }
-}
-
 // swiftlint:disable type_body_length
 /// A comprehensive speech recognition service that handles real-time audio transcription.
 ///
@@ -107,16 +89,16 @@ final class ASRService: ObservableObject {
     @Published var isAsrReady: Bool = false
     @Published var isDownloadingModel: Bool = false
     @Published var isLoadingModel: Bool = false // True when loading cached model into memory (not downloading)
+    @Published private(set) var isCancellingModelPreparation: Bool = false
     @Published var modelsExistOnDisk: Bool = false
     @Published var downloadProgress: Double? = nil
     @Published var downloadingModelId: String? = nil // Tracks which model is currently being downloaded
+    @Published private(set) var isCancellingModelDownload: Bool = false
 
     private var isStarting: Bool = false // Guard against re-entrant start() calls
-    private var downloadProgressTask: Task<Void, Never>?
     private var hasCompletedFirstTranscription: Bool = false // Track if model has warmed up with first transcription
     private var lastBoostHitTerm: String?
     private var hasPendingParakeetVocabularyReload: Bool = false
-    private let downloadRegistry = ModelDownloadRegistry()
     private var vocabularyChangeObserver: NSObjectProtocol?
 
     // MARK: - Error Handling
@@ -128,6 +110,9 @@ final class ASRService: ObservableObject {
     /// Returns a user-friendly status message for model loading state
     var modelStatusMessage: String {
         if self.isAsrReady { return "Model ready" }
+        if self.isCancellingModelPreparation { return "Cancelling model preparation..." }
+        if self.isCancellingModelDownload { return "Cancelling model download..." }
+        if self.downloadingModelId != nil { return "Downloading model..." }
         if self.isDownloadingModel { return "Downloading model..." }
         if self.isLoadingModel { return "Loading model into memory..." }
         if self.modelsExistOnDisk { return "Model cached, needs loading" }
@@ -149,7 +134,34 @@ final class ASRService: ObservableObject {
     /// Prevent concurrent provider.prepare() calls (download/load) from overlapping.
     /// Subsequent callers await the in-flight task.
     private var ensureReadyTask: Task<Void, Error>?
+    private var ensureReadyTaskID: UUID?
     private var ensureReadyProviderKey: String?
+    private var ensureReadyOperationID: UUID?
+    private var modelDownloadTask: Task<Void, Error>?
+    private var modelDownloadOperationID: UUID?
+    private var modelExistenceCheckID: UUID?
+
+    var hasActiveModelPreparation: Bool {
+        self.ensureReadyTask != nil
+    }
+
+    var hasActiveModelDownload: Bool {
+        self.modelDownloadTask != nil
+    }
+
+    func cancelModelPreparation() {
+        guard let task = self.ensureReadyTask else { return }
+
+        DebugLogger.shared.info("Cancelling ASR model preparation", source: "ASRService")
+        self.isCancellingModelPreparation = true
+        task.cancel()
+    }
+
+    func cancelModelDownload() {
+        guard let task = self.modelDownloadTask else { return }
+        self.isCancellingModelDownload = true
+        task.cancel()
+    }
 
     /// The transcription provider, selected based on the unified SpeechModel setting.
     /// Uses the new SettingsStore.selectedSpeechModel instead of old TranscriptionProviderOption.
@@ -389,43 +401,72 @@ final class ASRService: ObservableObject {
     ///   - model: The model to download
     ///   - progressHandler: Optional callback for download progress (0.0 to 1.0)
     func downloadModel(_ model: SettingsStore.SpeechModel, progressHandler: ((Double) -> Void)?) async throws {
-        try await self.downloadRegistry.run(for: model.id) { [weak self] in
+        guard self.modelDownloadTask == nil, self.ensureReadyTask == nil else {
+            throw NSError(
+                domain: "ASRService",
+                code: -2001,
+                userInfo: [NSLocalizedDescriptionKey: "Another model operation is already in progress."]
+            )
+        }
+
+        let operationID = UUID()
+        let provider = self.getProvider(for: model)
+        let progressRelay = ModelPreparationProgressRelay(progressHandler)
+        self.modelDownloadOperationID = operationID
+        self.downloadingModelId = model.id
+        self.downloadProgress = 0.0
+        self.isCancellingModelDownload = false
+
+        let task = Task { @MainActor [weak self] in
             guard let self else { return }
-
-            await MainActor.run {
-                self.downloadingModelId = model.id
-            }
-
-            // Use do-catch to ensure cleanup happens regardless of success/failure
             do {
                 DebugLogger.shared.info("Downloading model: \(model.displayName) (without changing active selection)", source: "ASRService")
-
-                // Get a fresh provider for this specific model (uses modelOverride for Whisper)
-                let provider = await MainActor.run { self.getProvider(for: model) }
-
-                // Prepare (download) the model
                 try await provider.prepare(progressHandler: { progress in
                     let clamped = max(0.0, min(1.0, progress))
-                    progressHandler?(clamped)
+                    Task { @MainActor in
+                        guard
+                            self.modelDownloadOperationID == operationID,
+                            !self.isCancellingModelDownload
+                        else {
+                            return
+                        }
+                        let monotonic = max(self.downloadProgress ?? 0.0, clamped)
+                        self.downloadProgress = monotonic
+                        progressRelay.report(monotonic)
+                    }
                 })
-
+                try Task.checkCancellation()
                 DebugLogger.shared.info("Model download completed: \(model.displayName)", source: "ASRService")
-
-                // Synchronously clear downloadingModelId on success
-                await MainActor.run {
-                    if self.downloadingModelId == model.id {
-                        self.downloadingModelId = nil
-                    }
-                }
             } catch {
-                // Synchronously clear downloadingModelId on failure
-                await MainActor.run {
-                    if self.downloadingModelId == model.id {
-                        self.downloadingModelId = nil
-                    }
+                let wasCancelled = Task.isCancelled || Self.isModelPreparationCancellation(error)
+                if wasCancelled,
+                   provider.shouldClearCacheAfterCancellation,
+                   provider.modelsExistOnDisk() == false
+                {
+                    try? await provider.clearCache()
+                }
+                if wasCancelled {
+                    throw CancellationError()
                 }
                 throw error
             }
+        }
+        self.modelDownloadTask = task
+
+        defer {
+            if self.modelDownloadOperationID == operationID {
+                self.modelDownloadTask = nil
+                self.modelDownloadOperationID = nil
+                self.downloadingModelId = nil
+                self.downloadProgress = nil
+                self.isCancellingModelDownload = false
+            }
+        }
+
+        try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
         }
     }
 
@@ -438,12 +479,19 @@ final class ASRService: ObservableObject {
         self.modelsExistOnDisk = false
         self.isLoadingModel = false
         self.isDownloadingModel = false
-        self.downloadProgress = nil
+        if !self.hasActiveModelDownload {
+            self.downloadProgress = nil
+        }
         self.hasCompletedFirstTranscription = false // Reset warm-up state when switching models
-        self.stopDownloadProgressMonitor()
-        self.ensureReadyTask?.cancel()
-        self.ensureReadyTask = nil
+        let retiringTask = self.ensureReadyTask
+        if let task = retiringTask {
+            self.isCancellingModelPreparation = true
+            task.cancel()
+        }
+        // Keep the task handle until its provider has stopped and cancellation cleanup has
+        // completed. The next ensureAsrReady call waits for it before touching the same cache.
         self.ensureReadyProviderKey = nil
+        self.ensureReadyOperationID = nil
         self.lastBoostHitTerm = nil
         self.wordBoostStatusText = "Word boost: off"
 
@@ -460,6 +508,8 @@ final class ASRService: ObservableObject {
         // Use Task for async check to support providers like AppleSpeechAnalyzerProvider
         Task { [weak self] in
             guard let self = self else { return }
+            _ = await retiringTask?.result
+            guard SettingsStore.shared.selectedSpeechModel == newModel else { return }
             await self.checkIfModelsExistAsync()
             await MainActor.run {
                 self.refreshWordBoostStatus()
@@ -716,6 +766,7 @@ final class ASRService: ObservableObject {
     /// **Note**: For `AppleSpeechAnalyzerProvider`, this returns a cached value that may be stale.
     /// Use `checkIfModelsExistAsync()` for an up-to-date result.
     func checkIfModelsExist() {
+        self.modelExistenceCheckID = UUID()
         self.modelsExistOnDisk = self.transcriptionProvider.modelsExistOnDisk()
         DebugLogger.shared.debug("Models exist on disk: \(self.modelsExistOnDisk)", source: "ASRService")
     }
@@ -726,20 +777,29 @@ final class ASRService: ObservableObject {
     /// (e.g., `AppleSpeechAnalyzerProvider` uses `SpeechTranscriber.installedLocales`).
     func checkIfModelsExistAsync() async {
         let model = SettingsStore.shared.selectedSpeechModel
+        let checkID = UUID()
+        self.modelExistenceCheckID = checkID
+        let exists: Bool
 
         // For Apple Speech Analyzer, use the async refresh method
         if model == .appleSpeechAnalyzer {
             if #available(macOS 26.0, *) {
                 let provider = self.getAppleSpeechAnalyzerProvider()
-                let isInstalled = await provider.refreshModelsExistOnDiskAsync()
-                self.modelsExistOnDisk = isInstalled
-                DebugLogger.shared.debug("Models exist on disk (async): \(self.modelsExistOnDisk)", source: "ASRService")
-                return
+                exists = await provider.refreshModelsExistOnDiskAsync()
+            } else {
+                exists = self.getAppleSpeechProvider().modelsExistOnDisk()
             }
+        } else {
+            exists = model.isInstalled
         }
 
-        // For other providers, use the synchronous method
-        self.modelsExistOnDisk = self.transcriptionProvider.modelsExistOnDisk()
+        guard
+            self.modelExistenceCheckID == checkID,
+            SettingsStore.shared.selectedSpeechModel == model
+        else {
+            return
+        }
+        self.modelsExistOnDisk = exists
         DebugLogger.shared.debug("Models exist on disk: \(self.modelsExistOnDisk)", source: "ASRService")
     }
 
@@ -2232,37 +2292,88 @@ final class ASRService: ObservableObject {
     /// Ensures ASR models are ready, with an optional external progress handler.
     /// - Parameter progressHandler: Optional callback for download progress (0.0 to 1.0)
     func ensureAsrReady(progressHandler: ((Double) -> Void)?) async throws {
+        guard self.modelDownloadTask == nil else {
+            throw NSError(
+                domain: "ASRService",
+                code: -2001,
+                userInfo: [NSLocalizedDescriptionKey: "Another model download is already in progress."]
+            )
+        }
         let provider = self.transcriptionProvider
-        let providerKey = "\(type(of: provider)):\(provider.name)"
         let model = SettingsStore.shared.selectedSpeechModel
+        let providerKey = "\(model.id):\(type(of: provider)):\(provider.name)"
         DebugLogger.shared.info(
             "ensureAsrReady() requested for model=\(model.id) [supportsStreaming=\(model.supportsStreaming)] provider=\(providerKey)",
             source: "ASRService"
         )
 
-        // Single-flight: if a prepare is already running for this provider, await it.
-        if let task = ensureReadyTask, ensureReadyProviderKey == providerKey {
-            try await task.value
-            return
-        }
+        // Single-flight for the same model. A reset invalidates the provider key but retains
+        // the retiring task so replacements can wait for cache cleanup before starting.
+        while let existingTask = self.ensureReadyTask {
+            let existingTaskID = self.ensureReadyTaskID
+            if self.ensureReadyProviderKey == providerKey,
+               self.ensureReadyOperationID == existingTaskID,
+               !self.isCancellingModelPreparation
+            {
+                try await existingTask.value
+                return
+            }
 
-        let task = Task { @MainActor in
-            try await self.performEnsureAsrReady(provider: provider, externalProgressHandler: progressHandler)
-        }
-        self.ensureReadyTask = task
-        self.ensureReadyProviderKey = providerKey
-
-        defer {
-            if ensureReadyProviderKey == providerKey {
-                ensureReadyTask = nil
-                ensureReadyProviderKey = nil
+            self.isCancellingModelPreparation = true
+            existingTask.cancel()
+            _ = await existingTask.result
+            if self.ensureReadyTaskID == existingTaskID {
+                self.ensureReadyTask = nil
+                self.ensureReadyTaskID = nil
+                self.ensureReadyProviderKey = nil
+                self.isCancellingModelPreparation = false
             }
         }
 
-        try await task.value
+        guard SettingsStore.shared.selectedSpeechModel == model else {
+            throw CancellationError()
+        }
+
+        let operationID = UUID()
+        let task = Task { @MainActor in
+            try await self.performEnsureAsrReady(
+                provider: provider,
+                operationID: operationID,
+                externalProgressHandler: progressHandler
+            )
+        }
+        self.ensureReadyTask = task
+        self.ensureReadyTaskID = operationID
+        self.ensureReadyProviderKey = providerKey
+        self.ensureReadyOperationID = operationID
+        self.isCancellingModelPreparation = false
+
+        defer {
+            if ensureReadyTaskID == operationID {
+                ensureReadyTask = nil
+                ensureReadyTaskID = nil
+                ensureReadyProviderKey = nil
+                if ensureReadyOperationID == operationID {
+                    ensureReadyOperationID = nil
+                }
+                isCancellingModelPreparation = false
+            }
+        }
+
+        try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 
-    private func performEnsureAsrReady(provider: TranscriptionProvider, externalProgressHandler: ((Double) -> Void)? = nil) async throws {
+    private func performEnsureAsrReady(
+        provider: TranscriptionProvider,
+        operationID: UUID,
+        externalProgressHandler: ((Double) -> Void)? = nil
+    ) async throws {
+        guard self.ensureReadyOperationID == operationID else { throw CancellationError() }
+        self.isCancellingModelPreparation = false
         DebugLogger.shared.debug(
             "ensureAsrReady(begin): provider=\(provider.name), providerReady=\(provider.isReady), isAsrReady=\(self.isAsrReady), isRunning=\(self.isRunning)",
             source: "ASRService"
@@ -2281,6 +2392,7 @@ final class ASRService: ObservableObject {
         }
 
         self.isAsrReady = false
+        let modelsAlreadyCached = provider.modelsExistOnDisk()
 
         let totalStartTime = Date()
         do {
@@ -2288,7 +2400,6 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.info("=== ASR INITIALIZATION START ===", source: "ASRService")
             DebugLogger.shared.info("Using provider: \(provider.name) [providerReady=\(provider.isReady)]", source: "ASRService")
 
-            let modelsAlreadyCached = provider.modelsExistOnDisk()
             DebugLogger.shared.info("Models already cached on disk: \(modelsAlreadyCached)", source: "ASRService")
             DebugLogger.shared.debug("Model cache lookup complete in \(String(format: "%.3f", Date().timeIntervalSince(totalStartTime)))s", source: "ASRService")
 
@@ -2314,21 +2425,19 @@ final class ASRService: ObservableObject {
                 }
             }
 
-            // Set correct loading state based on whether models are cached
-            DispatchQueue.main.async {
-                if modelsAlreadyCached {
-                    self.isLoadingModel = true
-                    self.isDownloadingModel = false
-                    self.downloadProgress = nil
-                    self.stopDownloadProgressMonitor()
-                    DebugLogger.shared.info("📦 LOADING cached model into memory...", source: "ASRService")
-                } else {
-                    self.isDownloadingModel = true
-                    self.isLoadingModel = false
-                    self.downloadProgress = nil
-                    self.startParakeetDownloadProgressMonitor()
-                    DebugLogger.shared.info("⬇️ DOWNLOADING model...", source: "ASRService")
-                }
+            // Set correct loading state based on whether models are cached.
+            try Task.checkCancellation()
+            guard self.ensureReadyOperationID == operationID else { throw CancellationError() }
+            if modelsAlreadyCached {
+                self.isLoadingModel = true
+                self.isDownloadingModel = false
+                self.downloadProgress = nil
+                DebugLogger.shared.info("📦 LOADING cached model into memory...", source: "ASRService")
+            } else {
+                self.isDownloadingModel = true
+                self.isLoadingModel = false
+                self.downloadProgress = 0.0
+                DebugLogger.shared.info("⬇️ DOWNLOADING model...", source: "ASRService")
             }
 
             // Use the transcription provider to prepare models
@@ -2339,44 +2448,93 @@ final class ASRService: ObservableObject {
                 modelsAlreadyCached: modelsAlreadyCached,
                 progressHandler: { [weak self] progress in
                     DispatchQueue.main.async {
+                        guard
+                            let self,
+                            self.ensureReadyOperationID == operationID,
+                            self.isDownloadingModel,
+                            !self.isCancellingModelPreparation
+                        else {
+                            return
+                        }
                         let clamped = max(0.0, min(1.0, progress))
-                        let monotonic = max(self?.downloadProgress ?? 0.0, clamped)
-                        self?.downloadProgress = monotonic
+                        let monotonic = max(self.downloadProgress ?? 0.0, clamped)
+                        self.downloadProgress = monotonic
                         externalProgressHandler?(monotonic)
+                        if clamped >= 1.0 {
+                            self.isDownloadingModel = false
+                            self.isLoadingModel = true
+                            self.downloadProgress = nil
+                        }
                     }
                 }
             )
+            try Task.checkCancellation()
+            guard self.ensureReadyOperationID == operationID else { throw CancellationError() }
             let downloadDuration = Date().timeIntervalSince(downloadStartTime)
             DebugLogger.shared.info("✓ Provider preparation completed in \(String(format: "%.1f", downloadDuration)) seconds", source: "ASRService")
 
-            DispatchQueue.main.async {
-                self.isDownloadingModel = false
-                // Keep isLoadingModel true until first transcription completes (for large models that need warm-up)
-                if !self.hasCompletedFirstTranscription {
-                    self.isLoadingModel = true
-                    DebugLogger.shared.info("⏳ Model loaded, waiting for first transcription to complete...", source: "ASRService")
-                } else {
-                    self.isLoadingModel = false
-                }
-                self.downloadProgress = nil
-                self.stopDownloadProgressMonitor()
-                self.modelsExistOnDisk = true
+            self.isDownloadingModel = false
+            // Keep isLoadingModel true until first transcription completes (for large models that need warm-up)
+            if !self.hasCompletedFirstTranscription {
+                self.isLoadingModel = true
+                DebugLogger.shared.info("⏳ Model loaded, waiting for first transcription to complete...", source: "ASRService")
+            } else {
+                self.isLoadingModel = false
             }
+            self.downloadProgress = nil
+            self.modelsExistOnDisk = true
 
             let totalDuration = Date().timeIntervalSince(initializationStart)
             DebugLogger.shared.info("=== ASR INITIALIZATION COMPLETE ===", source: "ASRService")
             DebugLogger.shared.info("Total initialization time: \(String(format: "%.1f", totalDuration)) seconds", source: "ASRService")
 
             self.isAsrReady = true
+            self.isCancellingModelPreparation = false
             self.refreshWordBoostStatus()
-        } catch {
-            DebugLogger.shared.error("ASR initialization failed with error: \(error)", source: "ASRService")
-            DebugLogger.shared.error("Error details: \(error.localizedDescription)", source: "ASRService")
-            DispatchQueue.main.async {
+        } catch is CancellationError {
+            DebugLogger.shared.info("ASR initialization cancelled", source: "ASRService")
+            if provider.shouldClearCacheAfterCancellation,
+               provider.modelsExistOnDisk() == false
+            {
+                do {
+                    try await provider.clearCache()
+                } catch {
+                    DebugLogger.shared.warning(
+                        "Failed to clear incomplete model cache after cancellation: \(error)",
+                        source: "ASRService"
+                    )
+                }
+            }
+            if self.ensureReadyOperationID == operationID {
                 self.isDownloadingModel = false
                 self.isLoadingModel = false
                 self.downloadProgress = nil
-                self.stopDownloadProgressMonitor()
+                self.modelsExistOnDisk = provider.modelsExistOnDisk()
+                self.isCancellingModelPreparation = false
+            }
+            throw CancellationError()
+        } catch {
+            if Task.isCancelled || Self.isModelPreparationCancellation(error) {
+                if provider.shouldClearCacheAfterCancellation,
+                   provider.modelsExistOnDisk() == false
+                {
+                    try? await provider.clearCache()
+                }
+                if self.ensureReadyOperationID == operationID {
+                    self.isDownloadingModel = false
+                    self.isLoadingModel = false
+                    self.downloadProgress = nil
+                    self.modelsExistOnDisk = provider.modelsExistOnDisk()
+                    self.isCancellingModelPreparation = false
+                }
+                throw CancellationError()
+            }
+            DebugLogger.shared.error("ASR initialization failed with error: \(error)", source: "ASRService")
+            DebugLogger.shared.error("Error details: \(error.localizedDescription)", source: "ASRService")
+            if self.ensureReadyOperationID == operationID {
+                self.isDownloadingModel = false
+                self.isLoadingModel = false
+                self.downloadProgress = nil
             }
             throw error
         }
@@ -2397,6 +2555,9 @@ final class ASRService: ObservableObject {
             )
             return
         } catch {
+            if Task.isCancelled || Self.isModelPreparationCancellation(error) {
+                throw CancellationError()
+            }
             firstError = error
             DebugLogger.shared.error("ASRService: First prepare attempt for \(provider.name) failed after \(String(format: "%.2f", Date().timeIntervalSince(start)))s", source: "ASRService")
             DebugLogger.shared.warning(
@@ -2418,6 +2579,7 @@ final class ASRService: ObservableObject {
             )
         }
 
+        try Task.checkCancellation()
         do {
             DebugLogger.shared.info("ASRService: Clearing provider cache before retry for \(provider.name)", source: "ASRService")
             try await provider.clearCache()
@@ -2429,7 +2591,15 @@ final class ASRService: ObservableObject {
         }
 
         // One strict retry. If this fails, we let the caller handle the error.
-        try await provider.prepare(progressHandler: progressHandler)
+        try Task.checkCancellation()
+        do {
+            try await provider.prepare(progressHandler: progressHandler)
+        } catch {
+            if Task.isCancelled || Self.isModelPreparationCancellation(error) {
+                throw CancellationError()
+            }
+            throw error
+        }
         DebugLogger.shared.info(
             "ASRService: Provider '\(provider.name)' prepared successfully after cache-clear retry",
             source: "ASRService"
@@ -2441,85 +2611,10 @@ final class ASRService: ObservableObject {
         return "Unknown error"
     }
 
-    private func startParakeetDownloadProgressMonitor() {
-        let model = SettingsStore.shared.selectedSpeechModel
-        guard model == .parakeetTDT || model == .parakeetTDTv2 || model == .parakeetRealtime else { return }
-        guard let modelDir = self.parakeetCacheDirectory(for: model) else { return }
-
-        self.stopDownloadProgressMonitor()
-        self.downloadProgress = 0.0
-
-        let estimatedBytes = self.estimatedParakeetSizeBytes(for: model)
-        self.downloadProgressTask = Task(priority: .background) { [weak self] in
-            guard let self = self else { return }
-            while !Task.isCancelled {
-                let isDownloading = await MainActor.run { self.isDownloadingModel }
-                if !isDownloading { break }
-                let size = self.directorySize(at: modelDir)
-                let pct = estimatedBytes > 0 ? min(0.99, Double(size) / Double(estimatedBytes)) : 0.0
-                await MainActor.run {
-                    self.downloadProgress = max(self.downloadProgress ?? 0.0, pct)
-                }
-                try? await Task.sleep(nanoseconds: 700_000_000)
-            }
-        }
-    }
-
-    private func stopDownloadProgressMonitor() {
-        self.downloadProgressTask?.cancel()
-        self.downloadProgressTask = nil
-    }
-
-    private func parakeetCacheDirectory(for model: SettingsStore.SpeechModel) -> URL? {
-        #if arch(arm64)
-        let baseCacheDir = AsrModels.defaultCacheDirectory().deletingLastPathComponent()
-        let folder: String
-        switch model {
-        case .parakeetTDTv2:
-            folder = "parakeet-tdt-0.6b-v2-coreml"
-        case .parakeetRealtime:
-            folder = "parakeet-eou-streaming"
-        default:
-            folder = "parakeet-tdt-0.6b-v3-coreml"
-        }
-        return baseCacheDir.appendingPathComponent(folder)
-        #else
-        return nil
-        #endif
-    }
-
-    private func estimatedParakeetSizeBytes(for model: SettingsStore.SpeechModel) -> Int64 {
-        // Approximate size for progress display only.
-        switch model {
-        case .parakeetTDT, .parakeetTDTv2:
-            return 520 * 1024 * 1024
-        case .parakeetRealtime:
-            return 250 * 1024 * 1024
-        default:
-            return 0
-        }
-    }
-
-    private func directorySize(at url: URL) -> Int64 {
-        let fm = FileManager.default
-        guard let enumerator = fm.enumerator(
-            at: url,
-            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return 0
-        }
-
-        var total: Int64 = 0
-        for case let fileURL as URL in enumerator {
-            if let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
-               values.isRegularFile == true,
-               let size = values.fileSize
-            {
-                total += Int64(size)
-            }
-        }
-        return total
+    private nonisolated static func isModelPreparationCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
 
     // MARK: - Model lifecycle helpers (parity with original API)
@@ -2532,6 +2627,8 @@ final class ASRService: ObservableObject {
             do {
                 try await self.ensureAsrReady()
                 DebugLogger.shared.info("Model predownload completed successfully", source: "ASRService")
+            } catch is CancellationError {
+                DebugLogger.shared.info("Model predownload cancelled", source: "ASRService")
             } catch {
                 DebugLogger.shared.error("Model predownload failed: \(error)", source: "ASRService")
                 self.errorTitle = "Download Failed"

--- a/Sources/Fluid/Services/AppleSpeechAnalyzerProvider.swift
+++ b/Sources/Fluid/Services/AppleSpeechAnalyzerProvider.swift
@@ -20,6 +20,7 @@ final class AppleSpeechAnalyzerProvider: TranscriptionProvider {
     }
 
     private(set) var isReady: Bool = false
+    var shouldClearCacheAfterCancellation: Bool { false }
 
     /// Buffer converter for audio format conversion
     private var converter: BufferConverter?
@@ -38,6 +39,7 @@ final class AppleSpeechAnalyzerProvider: TranscriptionProvider {
     // MARK: - Lifecycle
 
     func prepare(progressHandler: ((Double) -> Void)?) async throws {
+        try Task.checkCancellation()
         let locale = self.selectedSpeechLocale()
         let localeID = self.normalizedIdentifier(for: locale)
 
@@ -51,6 +53,7 @@ final class AppleSpeechAnalyzerProvider: TranscriptionProvider {
 
         // 2. Check if locale is supported
         let supportedLocales = await SpeechTranscriber.supportedLocales
+        try Task.checkCancellation()
         let isSupported = supportedLocales.map { self.normalizedIdentifier(for: $0) }.contains(localeID)
 
         guard isSupported else {
@@ -63,6 +66,7 @@ final class AppleSpeechAnalyzerProvider: TranscriptionProvider {
 
         // 3. Check if model is installed, download if needed
         let installedLocales = await SpeechTranscriber.installedLocales
+        try Task.checkCancellation()
         let isInstalled = installedLocales.map { self.normalizedIdentifier(for: $0) }.contains(localeID)
 
         if !isInstalled {
@@ -70,21 +74,42 @@ final class AppleSpeechAnalyzerProvider: TranscriptionProvider {
             if let downloader = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
                 // Report progress periodically during download
                 let progress = downloader.progress
-                Task {
-                    while !progress.isFinished, !progress.isCancelled {
+                let progressTask = Task {
+                    while !Task.isCancelled, !progress.isFinished, !progress.isCancelled {
                         progressHandler?(progress.fractionCompleted)
                         try? await Task.sleep(for: .milliseconds(100))
                     }
                 }
-                try await downloader.downloadAndInstall()
+                defer { progressTask.cancel() }
+
+                do {
+                    try await withTaskCancellationHandler {
+                        try await downloader.downloadAndInstall()
+                    } onCancel: {
+                        progress.cancel()
+                    }
+                } catch {
+                    let nsError = error as NSError
+                    if Task.isCancelled
+                        || error is CancellationError
+                        || (nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled)
+                    {
+                        throw CancellationError()
+                    }
+                    throw error
+                }
+                try Task.checkCancellation()
+                progressHandler?(1.0)
             }
         }
 
         // 4. Get the best available audio format for conversion
         self.analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber])
+        try Task.checkCancellation()
         self.converter = BufferConverter()
         self.preparedLocale = locale
 
+        try Task.checkCancellation()
         self.isReady = true
 
         // Update cache to reflect that model is now installed (thread-safe)

--- a/Sources/Fluid/Services/ExternalCoreMLModelRegistry.swift
+++ b/Sources/Fluid/Services/ExternalCoreMLModelRegistry.swift
@@ -58,6 +58,8 @@ enum ExternalCoreMLArtifactsValidationError: LocalizedError {
 }
 
 struct ExternalCoreMLASRModelSpec {
+    private static let bundleStampFileName = ".fluid_artifact_bundle_version"
+
     let backend: ExternalCoreMLASRBackend
     let artifactFolderHint: String
     let manifestFileName: String
@@ -101,10 +103,40 @@ struct ExternalCoreMLASRModelSpec {
         (try? self.validateArtifactsOrThrow(at: directory)) != nil
     }
 
+    func validatesInstalledArtifacts(at directory: URL) -> Bool {
+        guard self.validateArtifacts(at: directory) else { return false }
+        return !self.isAppManagedArtifactsDirectory(directory)
+            || self.artifactBundleStampMatches(at: directory)
+    }
+
+    func isAppManagedArtifactsDirectory(_ directory: URL) -> Bool {
+        guard let defaultCacheDirectory = self.defaultCacheDirectory else { return false }
+        return directory.standardizedFileURL.path == defaultCacheDirectory.standardizedFileURL.path
+    }
+
+    func artifactBundleStampMatches(at directory: URL) -> Bool {
+        let stampURL = directory.appendingPathComponent(Self.bundleStampFileName, isDirectory: false)
+        guard
+            let currentStamp = try? String(contentsOf: stampURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            return false
+        }
+        return currentStamp == self.artifactBundleVersion
+    }
+
+    func persistArtifactBundleStamp(at directory: URL) {
+        let stampURL = directory.appendingPathComponent(Self.bundleStampFileName, isDirectory: false)
+        try? self.artifactBundleVersion.write(to: stampURL, atomically: true, encoding: .utf8)
+    }
+
     func missingEntries(at directory: URL) -> [String] {
         self.requiredEntries.filter { entry in
             let url = self.url(for: entry, in: directory)
-            return FileManager.default.fileExists(atPath: url.path) == false
+            return HuggingFaceModelDownloader.artifactIsComplete(
+                at: url,
+                isDirectory: entry.hasSuffix(".mlpackage")
+            ) == false
         }
     }
 

--- a/Sources/Fluid/Services/ExternalCoreMLTranscriptionProvider.swift
+++ b/Sources/Fluid/Services/ExternalCoreMLTranscriptionProvider.swift
@@ -23,6 +23,7 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
     }
 
     func prepare(progressHandler: ((Double) -> Void)? = nil) async throws {
+        try Task.checkCancellation()
         guard self.isReady == false else { return }
 
         let model = self.modelOverride ?? SettingsStore.shared.selectedSpeechModel
@@ -51,8 +52,7 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
             at: directory,
             progressHandler: progressHandler
         )
-
-        progressHandler?(0.85)
+        try Task.checkCancellation()
 
         self.loadedManifest = try spec.loadManifest(at: directory)
         try self.loadCoherePromptConfigurationIfNeeded(at: directory, backend: spec.backend)
@@ -60,7 +60,6 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         switch spec.backend {
         case .cohereTranscribe:
             let manager = CohereTranscribeAsrManager()
-            progressHandler?(0.9)
             try self.invalidateCompiledCohereCacheIfNeeded(at: directory)
             let computeSummary = [
                 String(describing: spec.computeConfiguration.frontend),
@@ -73,16 +72,17 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
                 source: "ExternalCoreML"
             )
             try await manager.loadModels(from: directory, computeConfiguration: spec.computeConfiguration)
+            try Task.checkCancellation()
             self.cohereManager = manager
             self.persistCompiledCohereCacheStamp(at: directory)
         }
 
+        try Task.checkCancellation()
         self.isReady = true
         DebugLogger.shared.info(
             "ExternalCoreML: provider ready for model=\(model.rawValue)",
             source: "ExternalCoreML"
         )
-        progressHandler?(1.0)
     }
 
     func transcribe(_ samples: [Float]) async throws -> ASRTranscriptionResult {
@@ -174,7 +174,7 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         else {
             return false
         }
-        return spec.validateArtifacts(at: directory)
+        return spec.validatesInstalledArtifacts(at: directory)
     }
 
     func clearCache() async throws {
@@ -197,7 +197,7 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
             try FileManager.default.removeItem(at: compiledDirectory)
         }
 
-        if FileManager.default.fileExists(atPath: directory.path), Self.isAppManagedArtifactsDirectory(directory, spec: spec) {
+        if FileManager.default.fileExists(atPath: directory.path), spec.isAppManagedArtifactsDirectory(directory) {
             DebugLogger.shared.info(
                 "ExternalCoreML: removing downloaded artifacts at \(directory.path)",
                 source: "ExternalCoreML"
@@ -228,7 +228,7 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         progressHandler: ((Double) -> Void)?
     ) async throws {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let isManagedDirectory = Self.isAppManagedArtifactsDirectory(directory, spec: spec)
+        let isManagedDirectory = spec.isAppManagedArtifactsDirectory(directory)
 
         // `validateArtifacts` proves the required entries exist and the manifest JSON decodes, but
         // it does NOT byte-check the `.mlpackage` binaries — a network proxy can have returned an
@@ -239,7 +239,7 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         // managed cache is still fully removed even if it is also markup-corrupt, so the bundle
         // is wholly refreshed rather than only the corrupt files re-fetched. See #353.
         if spec.validateArtifacts(at: directory) {
-            if isManagedDirectory, self.artifactBundleStampMatches(spec: spec, directory: directory) == false {
+            if isManagedDirectory, spec.artifactBundleStampMatches(at: directory) == false {
                 DebugLogger.shared.warning(
                     "ExternalCoreML: refreshing managed artifacts for \(directory.lastPathComponent) due to outdated bundle stamp",
                     source: "ExternalCoreML"
@@ -256,18 +256,17 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
                     "ExternalCoreML: artifact validation passed for \(directory.lastPathComponent)",
                     source: "ExternalCoreML"
                 )
-                progressHandler?(0.8)
                 return
             }
         }
 
         if spec.validateArtifacts(at: directory),
-           !Self.cachedArtifactsAreMarkupCorrupt(spec: spec, directory: directory) {
+           !Self.cachedArtifactsAreMarkupCorrupt(spec: spec, directory: directory)
+        {
             DebugLogger.shared.info(
                 "ExternalCoreML: artifact validation passed for \(directory.lastPathComponent)",
                 source: "ExternalCoreML"
             )
-            progressHandler?(0.8)
             return
         }
 
@@ -291,8 +290,11 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
                 "ExternalCoreML: download progress \(Int(progress * 100))% [\(item)]",
                 source: "ExternalCoreML"
             )
-            progressHandler?(progress * 0.8)
+            // The managed-cache stamp below is part of installation truth. Keep the transfer
+            // below 100% until structural validation succeeds and that stamp is persisted.
+            progressHandler?(min(progress, 0.999))
         }
+        try Task.checkCancellation()
 
         do {
             try spec.validateArtifactsOrThrow(at: directory)
@@ -301,9 +303,10 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         }
 
         if isManagedDirectory {
-            self.persistArtifactBundleStamp(spec: spec, directory: directory)
+            spec.persistArtifactBundleStamp(at: directory)
         }
         SettingsStore.shared.setExternalCoreMLArtifactsDirectory(directory, for: model)
+        progressHandler?(1.0)
     }
 
     private static func artifactsDirectory(
@@ -311,14 +314,6 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         spec: ExternalCoreMLASRModelSpec
     ) -> URL? {
         SettingsStore.shared.externalCoreMLArtifactsDirectory(for: model) ?? spec.defaultCacheDirectory
-    }
-
-    private static func isAppManagedArtifactsDirectory(
-        _ directory: URL,
-        spec: ExternalCoreMLASRModelSpec
-    ) -> Bool {
-        guard let defaultCacheDirectory = spec.defaultCacheDirectory else { return false }
-        return directory.standardizedFileURL.path == defaultCacheDirectory.standardizedFileURL.path
     }
 
     /// `true` if any required cached artifact is an HTML/markup payload instead of model data — a
@@ -340,26 +335,6 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
             code: -1,
             userInfo: [NSLocalizedDescriptionKey: description]
         )
-    }
-
-    private func artifactBundleStampMatches(spec: ExternalCoreMLASRModelSpec, directory: URL) -> Bool {
-        let stampURL = Self.artifactBundleStampURL(for: directory)
-        guard
-            let currentStamp = try? String(contentsOf: stampURL, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        else {
-            return false
-        }
-        return currentStamp == spec.artifactBundleVersion
-    }
-
-    private func persistArtifactBundleStamp(spec: ExternalCoreMLASRModelSpec, directory: URL) {
-        let stampURL = Self.artifactBundleStampURL(for: directory)
-        try? spec.artifactBundleVersion.write(to: stampURL, atomically: true, encoding: .utf8)
-    }
-
-    private static func artifactBundleStampURL(for directory: URL) -> URL {
-        directory.appendingPathComponent(".fluid_artifact_bundle_version", isDirectory: false)
     }
 
     private func invalidateCompiledCohereCacheIfNeeded(at directory: URL) throws {

--- a/Sources/Fluid/Services/FluidAudioProvider.swift
+++ b/Sources/Fluid/Services/FluidAudioProvider.swift
@@ -2,18 +2,6 @@ import Foundation
 #if arch(arm64)
 import FluidAudio
 
-private actor DownloadProgressSink {
-    private let handler: ((Double) -> Void)?
-
-    init(handler: ((Double) -> Void)?) {
-        self.handler = handler
-    }
-
-    func emit(_ progress: Double) {
-        self.handler?(progress)
-    }
-}
-
 /// TranscriptionProvider implementation using FluidAudio (optimized for Apple Silicon)
 /// This wraps the existing FluidAudio-based ASR for use on Apple Silicon Macs.
 final class FluidAudioProvider: TranscriptionProvider {
@@ -48,60 +36,70 @@ final class FluidAudioProvider: TranscriptionProvider {
     }
 
     func prepare(progressHandler: ((Double) -> Void)? = nil) async throws {
+        try Task.checkCancellation()
         guard self.isReady == false else { return }
 
         let selectedModel = self.modelOverride ?? SettingsStore.shared.selectedSpeechModel
-        let modelVersion: String = selectedModel == .parakeetTDTv2 ? "v2" : "v3"
+        let asrModelVersion: AsrModelVersion = selectedModel == .parakeetTDTv2 ? .v2 : .v3
+        let modelVersion = selectedModel == .parakeetTDTv2 ? "v2" : "v3"
         let cacheDirectory = AsrModels.defaultCacheDirectory().deletingLastPathComponent()
+        let modelCacheDirectory = AsrModels.defaultCacheDirectory(for: asrModelVersion)
         DebugLogger.shared.info(
             "FluidAudioProvider: Starting model preparation for \(selectedModel.displayName) [version=\(modelVersion)]",
             source: "FluidAudioProvider"
         )
         DebugLogger.shared.debug("FluidAudioProvider: target cache directory=\(cacheDirectory.path)", source: "FluidAudioProvider")
-        let progressSink = DownloadProgressSink(handler: progressHandler)
-        await progressSink.emit(0.05)
-
-        // AsrModels.downloadAndLoad() is a single await without granular callbacks.
-        // Emit synthetic incremental progress so the UI updates smoothly during long downloads.
-        let progressTicker = Task(priority: .utility) {
-            var stagedProgress = 0.05
-            let stageCap = 0.82
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 250_000_000)
-                if Task.isCancelled { break }
-                if stagedProgress >= stageCap { continue }
-
-                let remaining = stageCap - stagedProgress
-                let step = max(0.008, remaining * 0.12)
-                stagedProgress = min(stageCap, stagedProgress + step)
-                await progressSink.emit(stagedProgress)
+        try Task.checkCancellation()
+        if FileManager.default.fileExists(atPath: modelCacheDirectory.path), !self.modelsExistOnDisk() {
+            DebugLogger.shared.warning(
+                "FluidAudioProvider: removing incomplete \(modelVersion) cache before download",
+                source: "FluidAudioProvider"
+            )
+            try FileManager.default.removeItem(at: modelCacheDirectory)
+        }
+        let progressRelay = ModelPreparationProgressRelay(progressHandler)
+        progressRelay.report(0.0)
+        let fluidAudioProgressHandler: DownloadUtils.ProgressHandler = { progress in
+            switch progress.phase {
+            case .listing:
+                progressRelay.report(0.0)
+            case .downloading:
+                progressRelay.report(max(0.0, min(1.0, progress.fractionCompleted * 2.0)))
+            case .compiling:
+                progressRelay.report(1.0)
             }
         }
-        defer { progressTicker.cancel() }
 
         let loadStart = Date()
         // Download and load models
         let models: AsrModels
-        if selectedModel == .parakeetTDTv2 {
-            // Explicitly load v2 (English Only)
-            models = try await AsrModels.downloadAndLoad(version: .v2)
-        } else {
-            // Default to v3 (Multilingual)
-            models = try await AsrModels.downloadAndLoad(version: .v3)
+        do {
+            models = try await AsrModels.downloadAndLoad(
+                version: asrModelVersion,
+                progressHandler: fluidAudioProgressHandler
+            )
+        } catch {
+            let nsError = error as NSError
+            if Task.isCancelled
+                || error is CancellationError
+                || (nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled)
+            {
+                throw CancellationError()
+            }
+            throw error
         }
-        progressTicker.cancel()
+        try Task.checkCancellation()
         DebugLogger.shared.debug(
             "FluidAudioProvider: Models downloadAndLoad returned in \(String(format: "%.2f", Date().timeIntervalSince(loadStart)))s",
             source: "FluidAudioProvider"
         )
-        await progressSink.emit(0.88)
 
         // Streaming manager: lightweight, no vocab boosting → avoids CTC/ANE contention
         // that causes intermittent SIGTRAP crashes during streaming inference.
         let streamingManager = AsrManager(config: ASRConfig.default)
         try await streamingManager.initialize(models: models)
+        try Task.checkCancellation()
         DebugLogger.shared.debug("FluidAudioProvider: Streaming AsrManager initialized", source: "FluidAudioProvider")
-        await progressSink.emit(0.94)
 
         self.isWordBoostingActive = false
         self.boostedVocabularyTermsCount = 0
@@ -137,6 +135,9 @@ final class FluidAudioProvider: TranscriptionProvider {
                     finalManager = streamingManager
                 }
             } catch {
+                if Task.isCancelled || error is CancellationError {
+                    throw CancellationError()
+                }
                 DebugLogger.shared.warning("FluidAudioProvider: Failed to configure vocabulary boosting: \(error)", source: "FluidAudioProvider")
                 finalManager = streamingManager
             }
@@ -150,10 +151,10 @@ final class FluidAudioProvider: TranscriptionProvider {
         self.latestStreamingPreviewText = ""
         self.latestStreamingPreviewSampleCount = 0
         self.latestStreamingPreviewFinishedAt = nil
-        await progressSink.emit(0.98)
 
+        try Task.checkCancellation()
         self.isReady = true
-        await progressSink.emit(1.0)
+        progressRelay.report(1.0)
         DebugLogger.shared.info(
             "FluidAudioProvider: Models ready [isWordBoostingActive=\(self.isWordBoostingActive), terms=\(self.boostedVocabularyTermsCount)]",
             source: "FluidAudioProvider"
@@ -354,15 +355,12 @@ final class FluidAudioProvider: TranscriptionProvider {
     }
 
     func modelsExistOnDisk() -> Bool {
-        let baseCacheDir = AsrModels.defaultCacheDirectory().deletingLastPathComponent()
         let selectedModel = self.modelOverride ?? SettingsStore.shared.selectedSpeechModel
-
-        if selectedModel == .parakeetTDTv2 {
-            let v2CacheDir = baseCacheDir.appendingPathComponent("parakeet-tdt-0.6b-v2-coreml")
-            return FileManager.default.fileExists(atPath: v2CacheDir.path)
-        } else {
-            let v3CacheDir = baseCacheDir.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
-            return FileManager.default.fileExists(atPath: v3CacheDir.path)
+        switch selectedModel {
+        case .parakeetTDT, .parakeetTDTv2:
+            return selectedModel.isInstalled
+        default:
+            return false
         }
     }
 

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -50,7 +50,7 @@ final class GlobalHotkeyManager: NSObject {
     private let asrService: ASRService
     private var primaryShortcuts: [HotkeyShortcut]
     private var promptModeShortcut: HotkeyShortcut
-    private var commandModeShortcut: HotkeyShortcut
+    private var commandModeShortcut: HotkeyShortcut?
     private var rewriteModeShortcut: HotkeyShortcut
     private var promptShortcutAssignments: [(selection: SettingsStore.DictationPromptSelection, shortcut: HotkeyShortcut)]
     private var promptModeShortcutEnabled: Bool
@@ -279,7 +279,7 @@ final class GlobalHotkeyManager: NSObject {
         asrService: ASRService,
         primaryShortcuts: [HotkeyShortcut],
         promptModeShortcut: HotkeyShortcut,
-        commandModeShortcut: HotkeyShortcut,
+        commandModeShortcut: HotkeyShortcut?,
         rewriteModeShortcut: HotkeyShortcut,
         promptShortcutAssignments: [(selection: SettingsStore.DictationPromptSelection, shortcut: HotkeyShortcut)] = [],
         promptModeShortcutEnabled: Bool,
@@ -349,7 +349,7 @@ final class GlobalHotkeyManager: NSObject {
         DebugLogger.shared.info("Updated transcription hotkeys", source: "GlobalHotkeyManager")
     }
 
-    func updateCommandModeShortcut(_ newShortcut: HotkeyShortcut) {
+    func updateCommandModeShortcut(_ newShortcut: HotkeyShortcut?) {
         self.commandModeShortcut = newShortcut
         DebugLogger.shared.info("Updated command mode hotkey", source: "GlobalHotkeyManager")
     }
@@ -700,7 +700,10 @@ final class GlobalHotkeyManager: NSObject {
             if self.handlePromptModeKeyDown(keyCode: keyCode, modifiers: eventModifiers) { return nil }
 
             // Check command mode hotkey first
-            if self.commandModeShortcutEnabled, self.commandModeShortcut.matches(keyCode: keyCode, modifiers: eventModifiers) {
+            if self.commandModeShortcutEnabled,
+               let commandModeShortcut = self.commandModeShortcut,
+               commandModeShortcut.matches(keyCode: keyCode, modifiers: eventModifiers)
+            {
                 switch self.hotkeyMode {
                 case .hold:
                     // Press and hold: start on keyDown, stop on keyUp
@@ -814,7 +817,11 @@ final class GlobalHotkeyManager: NSObject {
 
             // Command mode key up
             // Note: Only check keyCode, not modifiers - user may release modifier before/with main key
-            if self.commandModeShortcutEnabled, self.isCommandModeKeyPressed, keyCode == self.commandModeShortcut.keyCode {
+            if self.commandModeShortcutEnabled,
+               self.isCommandModeKeyPressed,
+               let commandModeShortcut = self.commandModeShortcut,
+               keyCode == commandModeShortcut.keyCode
+            {
                 switch self.hotkeyMode {
                 case .hold:
                     self.isCommandModeKeyPressed = false
@@ -903,37 +910,39 @@ final class GlobalHotkeyManager: NSObject {
 
             if self.handlePromptModeFlagsChanged(keyCode: keyCode, modifiers: eventModifiers) { return nil }
 
-            if self.handleModifierOnlyShortcutFlagsChanged(
-                behavior: .init(
-                    shortcut: self.commandModeShortcut,
-                    isEnabled: self.commandModeShortcutEnabled,
-                    holdModeType: .commandMode,
-                    holdStartCancelledMessage: "Command mode hold start cancelled - key combo detected",
-                    holdStartMessage: "Command mode modifier held (hold mode) - starting after delay",
-                    holdReleaseMessage: "Command mode modifier released (hold mode) - stopping",
-                    toggleIgnoredMessage: "Command mode modifier released but another key was pressed - ignoring",
-                    isModeKeyPressed: { self.isCommandModeKeyPressed },
-                    setModeKeyPressed: { self.isCommandModeKeyPressed = $0 },
-                    onHoldStart: { self.triggerCommandMode() },
-                    onToggleRelease: {
-                        if self.asrService.isRunning {
-                            if self.isCommandRecordingProvider?() ?? false {
-                                DebugLogger.shared.info("Command mode modifier released (toggle, same mode) - stopping", source: "GlobalHotkeyManager")
-                                self.stopRecordingIfNeeded()
-                            } else {
-                                DebugLogger.shared.info("Command mode modifier released (toggle, switch mode) - switching", source: "GlobalHotkeyManager")
-                                self.triggerCommandMode()
-                            }
-                        } else {
-                            DebugLogger.shared.info("Command mode modifier released (toggle) - starting", source: "GlobalHotkeyManager")
-                            self.triggerCommandMode()
-                        }
-                    },
-                    isTargetModeActive: { self.isCommandRecordingProvider?() ?? false }
-                ),
-                keyCode: keyCode,
-                modifiers: eventModifiers
-            ) { return nil }
+            if let commandModeShortcut = self.commandModeShortcut,
+               self.handleModifierOnlyShortcutFlagsChanged(
+                   behavior: .init(
+                       shortcut: commandModeShortcut,
+                       isEnabled: self.commandModeShortcutEnabled,
+                       holdModeType: .commandMode,
+                       holdStartCancelledMessage: "Command mode hold start cancelled - key combo detected",
+                       holdStartMessage: "Command mode modifier held (hold mode) - starting after delay",
+                       holdReleaseMessage: "Command mode modifier released (hold mode) - stopping",
+                       toggleIgnoredMessage: "Command mode modifier released but another key was pressed - ignoring",
+                       isModeKeyPressed: { self.isCommandModeKeyPressed },
+                       setModeKeyPressed: { self.isCommandModeKeyPressed = $0 },
+                       onHoldStart: { self.triggerCommandMode() },
+                       onToggleRelease: {
+                           if self.asrService.isRunning {
+                               if self.isCommandRecordingProvider?() ?? false {
+                                   DebugLogger.shared.info("Command mode modifier released (toggle, same mode) - stopping", source: "GlobalHotkeyManager")
+                                   self.stopRecordingIfNeeded()
+                               } else {
+                                   DebugLogger.shared.info("Command mode modifier released (toggle, switch mode) - switching", source: "GlobalHotkeyManager")
+                                   self.triggerCommandMode()
+                               }
+                           } else {
+                               DebugLogger.shared.info("Command mode modifier released (toggle) - starting", source: "GlobalHotkeyManager")
+                               self.triggerCommandMode()
+                           }
+                       },
+                       isTargetModeActive: { self.isCommandRecordingProvider?() ?? false }
+                   ),
+                   keyCode: keyCode,
+                   modifiers: eventModifiers
+               )
+            { return nil }
 
             if self.handleModifierOnlyShortcutFlagsChanged(
                 behavior: .init(

--- a/Sources/Fluid/Services/NemotronProvider.swift
+++ b/Sources/Fluid/Services/NemotronProvider.swift
@@ -38,7 +38,7 @@ final class NemotronProvider: TranscriptionProvider {
 
     private let repositoryOwner = "BarathwajAnandan"
     private let repositoryRevision = "main"
-    private let requiredFiles = [
+    static let requiredFiles = [
         "metadata.json",
         "preprocessor.mlpackage",
         "encoder.mlpackage",
@@ -76,12 +76,44 @@ final class NemotronProvider: TranscriptionProvider {
 
     func modelsExistOnDisk() -> Bool {
         guard let dir = self.cacheDirectory else { return false }
-        return self.requiredFiles.allSatisfy { entry in
-            FileManager.default.fileExists(atPath: dir.appendingPathComponent(entry).path)
+        return Self.artifactsAreComplete(at: dir)
+    }
+
+    static func artifactsAreComplete(at directory: URL) -> Bool {
+        guard HuggingFaceModelDownloader.artifactsAreComplete(
+            root: directory,
+            items: self.requiredFiles.map {
+                .init(path: $0, isDirectory: $0.hasSuffix(".mlpackage"))
+            }
+        ) else {
+            return false
         }
+
+        let metadataURL = directory.appendingPathComponent("metadata.json")
+        guard
+            let metadataData = try? Data(contentsOf: metadataURL),
+            let metadataObject = try? JSONSerialization.jsonObject(with: metadataData),
+            let metadata = metadataObject as? [String: Any],
+            (metadata["sample_rate"] as? NSNumber)?.intValue == 16_000,
+            ((metadata["max_audio_samples"] as? NSNumber)?.intValue ?? 0) > 0,
+            (metadata["max_audio_seconds"] as? NSNumber).map({ $0.doubleValue > 0 }) ?? true
+        else {
+            return false
+        }
+
+        let tokenizerURL = directory.appendingPathComponent("tokenizer.model")
+        guard
+            let tokenizerAttributes = try? FileManager.default.attributesOfItem(atPath: tokenizerURL.path),
+            tokenizerAttributes[.type] as? FileAttributeType == .typeRegular,
+            ((tokenizerAttributes[.size] as? NSNumber)?.int64Value ?? 0) >= 100_000
+        else {
+            return false
+        }
+        return true
     }
 
     func prepare(progressHandler: ((Double) -> Void)? = nil) async throws {
+        try Task.checkCancellation()
         guard self.isReady == false else { return }
         guard let dir = self.cacheDirectory else {
             throw Self.makeError("Unable to resolve a cache directory for \(self.name).")
@@ -95,13 +127,12 @@ final class NemotronProvider: TranscriptionProvider {
         // via `needsDownload`) instead of being loaded as a model forever. See #353.
         let modelsPresent = self.modelsExistOnDisk()
         let cachedArtifactsCorrupt = modelsPresent
-            && HuggingFaceModelDownloader.cachedPayloadContainsMarkup(root: dir, relativePaths: self.requiredFiles)
-        if modelsPresent && !cachedArtifactsCorrupt {
+            && HuggingFaceModelDownloader.cachedPayloadContainsMarkup(root: dir, relativePaths: Self.requiredFiles)
+        if modelsPresent, !cachedArtifactsCorrupt {
             DebugLogger.shared.info(
                 "Nemotron: artifacts present at \(dir.path); skipping download",
                 source: "Nemotron"
             )
-            progressHandler?(0.8)
         } else {
             if cachedArtifactsCorrupt {
                 DebugLogger.shared.warning(
@@ -117,16 +148,18 @@ final class NemotronProvider: TranscriptionProvider {
                 owner: self.repositoryOwner,
                 repo: self.repositoryName,
                 revision: self.repositoryRevision,
-                requiredItems: self.requiredFiles.map {
+                requiredItems: Self.requiredFiles.map {
                     .init(path: $0, isDirectory: $0.hasSuffix(".mlpackage"))
                 }
             )
             try await downloader.ensureModelsPresent(at: dir) { progress, _ in
-                progressHandler?(progress * 0.8)
+                progressHandler?(min(progress, 0.999))
             }
+            try Task.checkCancellation()
             guard self.modelsExistOnDisk() else {
                 throw Self.makeError("Nemotron artifacts incomplete after download at \(dir.path).")
             }
+            progressHandler?(1.0)
         }
 
         self.maxTranscriptionSamples = Self.loadMaxAudioSamples(from: dir) ?? self.maxTranscriptionSamples
@@ -144,9 +177,9 @@ final class NemotronProvider: TranscriptionProvider {
             manager = try await self.loadManager(modelDirectory: dir, computeUnits: .cpuAndGPU)
         }
         try await self.applySelectedLanguage(to: manager)
+        try Task.checkCancellation()
         self.manager = manager
         self.isReady = true
-        progressHandler?(1.0)
         DebugLogger.shared.info(
             "Nemotron: provider ready [mode=\(self.mode.displayName), lang=\(SettingsStore.shared.selectedNemotronLanguage.rawValue), maxSamples=\(self.maxTranscriptionSamples)]",
             source: "Nemotron"
@@ -294,7 +327,9 @@ final class NemotronProvider: TranscriptionProvider {
             await self.stopComponentProfilingIfNeeded(on: manager)
         }
         if let dir = self.cacheDirectory {
-            try? FileManager.default.removeItem(at: dir)
+            if FileManager.default.fileExists(atPath: dir.path) {
+                try FileManager.default.removeItem(at: dir)
+            }
         }
         self.manager = nil
         self.isReady = false

--- a/Sources/Fluid/Services/ParakeetRealtimeProvider.swift
+++ b/Sources/Fluid/Services/ParakeetRealtimeProvider.swift
@@ -21,6 +21,7 @@ final class ParakeetRealtimeProvider: TranscriptionProvider {
     }
 
     func prepare(progressHandler: ((Double) -> Void)? = nil) async throws {
+        try Task.checkCancellation()
         guard self.isReady == false else { return }
 
         let modelDirectory = self.modelDirectory()
@@ -49,12 +50,32 @@ final class ParakeetRealtimeProvider: TranscriptionProvider {
         configuration.computeUnits = .cpuAndNeuralEngine
         configuration.allowLowPrecisionAccumulationOnGPU = true
 
+        try Task.checkCancellation()
+        if !missingBefore.isEmpty, FileManager.default.fileExists(atPath: modelDirectory.path) {
+            DebugLogger.shared.warning(
+                "ParakeetRealtimeProvider.prepare: removing incomplete Flash cache before download",
+                source: "ParakeetRealtimeProvider"
+            )
+            try FileManager.default.removeItem(at: modelDirectory)
+        }
+
         let engine = StreamingEouAsrManager(configuration: configuration, chunkSize: self.chunkSize)
+        let progressRelay = ModelPreparationProgressRelay(progressHandler)
         do {
             try await engine.loadModelsFromHuggingFace(progressHandler: { progress in
-                progressHandler?(max(0.0, min(1.0, progress.fractionCompleted)))
+                switch progress.phase {
+                case .listing:
+                    progressRelay.report(0.0)
+                case .downloading:
+                    progressRelay.report(max(0.0, min(1.0, progress.fractionCompleted * 2.0)))
+                case .compiling:
+                    progressRelay.report(1.0)
+                }
             })
         } catch {
+            if Task.isCancelled {
+                throw CancellationError()
+            }
             let missingAfterFailure = self.missingRequiredModelFiles()
             DebugLogger.shared.error(
                 "ParakeetRealtimeProvider.prepare: Flash load failed. modelDir=\(modelDirectory.path), missingAfterFailure=\(missingAfterFailure.joined(separator: ", "))",
@@ -66,6 +87,7 @@ final class ParakeetRealtimeProvider: TranscriptionProvider {
             )
             throw error
         }
+        try Task.checkCancellation()
 
         let missingAfter = self.missingRequiredModelFiles()
         guard missingAfter.isEmpty else {
@@ -201,7 +223,11 @@ final class ParakeetRealtimeProvider: TranscriptionProvider {
         return ModelNames.ParakeetEOU.requiredModels
             .sorted()
             .filter { fileName in
-                !FileManager.default.fileExists(atPath: modelDirectory.appendingPathComponent(fileName).path)
+                let artifact = modelDirectory.appendingPathComponent(fileName)
+                return !HuggingFaceModelDownloader.artifactIsComplete(
+                    at: artifact,
+                    isDirectory: fileName.hasSuffix(".mlmodelc")
+                )
             }
     }
 

--- a/Sources/Fluid/Services/TranscriptionProvider.swift
+++ b/Sources/Fluid/Services/TranscriptionProvider.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+/// Bridges provider callbacks into dependencies whose progress handlers are `@Sendable`.
+/// The callback is immutable; callers remain responsible for hopping to their UI actor.
+final class ModelPreparationProgressRelay: @unchecked Sendable {
+    private let handler: ((Double) -> Void)?
+
+    init(_ handler: ((Double) -> Void)?) {
+        self.handler = handler
+    }
+
+    func report(_ progress: Double) {
+        self.handler?(progress)
+    }
+}
+
 // MARK: - Transcription Result
 
 /// Unified result type for ASR transcription across all providers
@@ -58,12 +72,16 @@ protocol TranscriptionProvider {
 
     /// Clear cached models
     func clearCache() async throws
+
+    /// Whether cancellation should discard an incomplete app-managed model cache.
+    var shouldClearCacheAfterCancellation: Bool { get }
 }
 
 // Default implementation for optional methods
 extension TranscriptionProvider {
     func modelsExistOnDisk() -> Bool { return false }
     func clearCache() async throws {}
+    var shouldClearCacheAfterCancellation: Bool { true }
     var prefersNativeFileTranscription: Bool { false }
     func transcribeStreaming(_ samples: [Float]) async throws -> ASRTranscriptionResult {
         try await self.transcribe(samples)

--- a/Sources/Fluid/Services/WhisperProvider.swift
+++ b/Sources/Fluid/Services/WhisperProvider.swift
@@ -59,25 +59,6 @@ final class WhisperProvider: TranscriptionProvider {
         self.modelURL.deletingLastPathComponent()
     }
 
-    private func expectedMinimumModelBytes(for fileName: String) -> Int64? {
-        switch fileName {
-        case "ggml-tiny.bin":
-            return 50 * 1024 * 1024
-        case "ggml-base.bin":
-            return 100 * 1024 * 1024
-        case "ggml-small.bin":
-            return 300 * 1024 * 1024
-        case "ggml-medium.bin":
-            return 1000 * 1024 * 1024
-        // case "ggml-large-v3-turbo.bin": // buggy - so removed temporarily
-        //     return 1200 * 1024 * 1024
-        case "ggml-large-v3.bin":
-            return 2000 * 1024 * 1024
-        default:
-            return nil
-        }
-    }
-
     private func isModelFileValid(at url: URL) -> Bool {
         guard FileManager.default.fileExists(atPath: url.path) else { return false }
         guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
@@ -87,15 +68,14 @@ final class WhisperProvider: TranscriptionProvider {
         }
         let sizeBytes = size.int64Value
         guard sizeBytes > 0 else { return false }
-        if let minBytes = self.expectedMinimumModelBytes(for: url.lastPathComponent),
-           sizeBytes < minBytes
-        {
-            return false
-        }
-        return true
+        let expectedBytes = SettingsStore.SpeechModel.allCases
+            .first { $0.whisperModelFile == url.lastPathComponent }?
+            .expectedDownloadBytes
+        return expectedBytes.map { sizeBytes == $0 } ?? false
     }
 
     func prepare(progressHandler: ((Double) -> Void)? = nil) async throws {
+        try Task.checkCancellation()
         // CRITICAL: Capture the target model at start to use consistently throughout this method.
         // This prevents race conditions where SettingsStore could change after await points.
         let targetModel = self.modelOverride ?? SettingsStore.shared.selectedSpeechModel
@@ -172,6 +152,7 @@ final class WhisperProvider: TranscriptionProvider {
         DebugLogger.shared.info("WhisperProvider: Loading Whisper model...", source: "WhisperProvider")
         self.whisper = Whisper(fromFileURL: self.modelURL)
 
+        try Task.checkCancellation()
         self.loadedModelName = currentModelName
         self.isReady = true
         DebugLogger.shared.info("WhisperProvider: Model ready (\(currentModelName))", source: "WhisperProvider")
@@ -284,6 +265,11 @@ final class WhisperProvider: TranscriptionProvider {
                 DebugLogger.shared.info("WhisperProvider: Model downloaded successfully", source: "WhisperProvider")
                 return
             } catch let error as NSError {
+                if Task.isCancelled
+                    || (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled)
+                {
+                    throw CancellationError()
+                }
                 let isLastAttempt = attempt == maxAttempts
 
                 // Provide user-friendly error messages
@@ -329,95 +315,96 @@ final class WhisperProvider: TranscriptionProvider {
 
     private func downloadFile(from url: URL, to destination: URL, progressHandler: ((Double) -> Void)?) async throws {
         let delegate = DownloadProgressDelegate(onProgress: progressHandler)
-        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        let task = session.downloadTask(with: url)
+        let session = URLSession(configuration: self.urlSession.configuration, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            let lock = NSLock()
-            var didResume = false
+        var temporaryURL: URL?
+        do {
+            let (downloadedURL, response) = try await withTaskCancellationHandler {
+                try await session.download(from: url)
+            } onCancel: {
+                session.invalidateAndCancel()
+            }
+            temporaryURL = downloadedURL
+            try Task.checkCancellation()
 
-            func resumeOnce(_ result: Result<Void, Error>) {
-                lock.lock()
-                defer { lock.unlock() }
-                guard !didResume else { return }
-                didResume = true
-                session.finishTasksAndInvalidate()
-                continuation.resume(with: result)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw NSError(
+                    domain: "WhisperProvider",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Invalid server response"]
+                )
+            }
+            guard httpResponse.statusCode == 200 else {
+                throw NSError(
+                    domain: "WhisperProvider",
+                    code: httpResponse.statusCode,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to download model (HTTP \(httpResponse.statusCode))"]
+                )
             }
 
-            delegate.onFinish = { tempURL, response in
-                do {
-                    guard let httpResponse = response as? HTTPURLResponse else {
-                        throw NSError(
-                            domain: "WhisperProvider",
-                            code: -1,
-                            userInfo: [NSLocalizedDescriptionKey: "Invalid server response"]
-                        )
-                    }
-
-                    guard httpResponse.statusCode == 200 else {
-                        throw NSError(
-                            domain: "WhisperProvider",
-                            code: httpResponse.statusCode,
-                            userInfo: [NSLocalizedDescriptionKey: "Failed to download model (HTTP \(httpResponse.statusCode))"]
-                        )
-                    }
-
-                    if httpResponse.expectedContentLength > 0 {
-                        let attrs = try FileManager.default.attributesOfItem(atPath: tempURL.path)
-                        if let size = attrs[.size] as? NSNumber,
-                           size.int64Value != httpResponse.expectedContentLength
-                        {
-                            throw NSError(
-                                domain: "WhisperProvider",
-                                code: -1,
-                                userInfo: [NSLocalizedDescriptionKey: "Downloaded model size mismatch. Please try again."]
-                            )
-                        }
-                    }
-
-                    try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-                    if FileManager.default.fileExists(atPath: destination.path) {
-                        try FileManager.default.removeItem(at: destination)
-                    }
-                    try FileManager.default.moveItem(at: tempURL, to: destination)
-
-                    if !self.isModelFileValid(at: destination) {
-                        try? FileManager.default.removeItem(at: destination)
-                        throw NSError(
-                            domain: "WhisperProvider",
-                            code: -1,
-                            userInfo: [NSLocalizedDescriptionKey: "Downloaded model is invalid. Please try again."]
-                        )
-                    }
-                    resumeOnce(.success(()))
-                } catch {
-                    resumeOnce(.failure(error))
-                }
+            let attributes = try FileManager.default.attributesOfItem(atPath: downloadedURL.path)
+            let actualBytes = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+            if httpResponse.expectedContentLength > 0,
+               actualBytes != httpResponse.expectedContentLength
+            {
+                throw NSError(
+                    domain: "WhisperProvider",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Downloaded model size mismatch. Please try again."]
+                )
             }
-            delegate.onError = { error in
-                resumeOnce(.failure(error))
+            guard
+                let expectedBytes = SettingsStore.SpeechModel.allCases
+                .first(where: { $0.whisperModelFile == destination.lastPathComponent })?
+                .expectedDownloadBytes,
+                actualBytes == expectedBytes
+            else {
+                throw NSError(
+                    domain: "WhisperProvider",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Downloaded model is invalid. Please try again."]
+                )
             }
-            task.resume()
+
+            try Task.checkCancellation()
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: downloadedURL, to: destination)
+            temporaryURL = nil
+            try Task.checkCancellation()
+        } catch {
+            if let temporaryURL {
+                try? FileManager.default.removeItem(at: temporaryURL)
+            }
+            session.invalidateAndCancel()
+            let nsError = error as NSError
+            if Task.isCancelled
+                || error is CancellationError
+                || (nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled)
+            {
+                throw CancellationError()
+            }
+            throw error
         }
+        try Task.checkCancellation()
+        progressHandler?(1.0)
     }
 
-    private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate {
+    private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
         private let onProgress: ((Double) -> Void)?
-        var onFinish: ((URL, URLResponse) -> Void)?
-        var onError: ((Error) -> Void)?
 
         init(onProgress: ((Double) -> Void)?) {
             self.onProgress = onProgress
         }
 
         func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-            guard let response = downloadTask.response else { return }
-            self.onFinish?(location, response)
-        }
-
-        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-            if let error = error { self.onError?(error) }
+            // The async URLSession API owns completion; this delegate only reports bytes.
         }
 
         func urlSession(
@@ -428,7 +415,7 @@ final class WhisperProvider: TranscriptionProvider {
             totalBytesExpectedToWrite: Int64
         ) {
             guard totalBytesExpectedToWrite > 0 else { return }
-            let pct = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+            let pct = min(0.999, Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
             self.onProgress?(pct)
         }
     }

--- a/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
@@ -6,8 +6,18 @@ import SwiftUI
 final class VoiceEngineSettingsViewModel: ObservableObject {
     let settings: SettingsStore
     private let appServices: AppServices
+    private var cancellables = Set<AnyCancellable>()
 
     var asr: ASRService { self.appServices.asr }
+
+    var areSpeechModelActionsBlocked: Bool {
+        self.asr.isRunning
+            || self.downloadingModel != nil
+            || self.asr.hasActiveModelDownload
+            || self.asr.hasActiveModelPreparation
+            || self.asr.isCancellingModelPreparation
+            || (!self.asr.isAsrReady && (self.asr.isDownloadingModel || self.asr.isLoadingModel))
+    }
 
     @Published var modelSortOption: ModelSortOption = .provider
     @Published var providerFilter: SpeechProviderFilter = .all
@@ -21,10 +31,18 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
     @Published var suppressSpeechProviderSync: Bool = false
     @Published var skipNextSpeechModelSync: Bool = false
 
-    /// The model currently being downloaded (nil if no download in progress)
-    @Published var downloadingModel: SettingsStore.SpeechModel?
-    /// Download progress for the current model (0.0 to 1.0)
-    @Published var downloadProgress: Double = 0.0
+    var downloadingModel: SettingsStore.SpeechModel? {
+        guard let modelID = self.asr.downloadingModelId else { return nil }
+        return SettingsStore.SpeechModel.allCases.first { $0.id == modelID }
+    }
+
+    var downloadProgress: Double {
+        self.asr.downloadProgress ?? 0.0
+    }
+
+    var isCancellingModelDownload: Bool {
+        self.asr.isCancellingModelDownload
+    }
 
     @Published var removeFillerWordsEnabled: Bool
 
@@ -34,6 +52,13 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
         self.previewSpeechModel = settings.selectedSpeechModel
         self.selectedSpeechProvider = settings.selectedSpeechModel.provider
         self.removeFillerWordsEnabled = settings.removeFillerWordsEnabled
+        appServices.objectWillChange
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.objectWillChange.send()
+                }
+            }
+            .store(in: &self.cancellables)
     }
 
     func onAppear() {
@@ -97,7 +122,7 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
     }
 
     func activateSpeechModel(_ model: SettingsStore.SpeechModel) {
-        guard !self.asr.isRunning else { return }
+        guard !self.areSpeechModelActionsBlocked else { return }
         withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
             self.settings.selectedSpeechModel = model
             self.previewSpeechModel = model
@@ -107,6 +132,8 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
         Task {
             do {
                 try await self.asr.ensureAsrReady()
+            } catch is CancellationError {
+                DebugLogger.shared.info("Model activation cancelled: \(model.displayName)", source: "AISettingsView")
             } catch {
                 DebugLogger.shared.error("Failed to prepare model after activation: \(error)", source: "AISettingsView")
                 self.asr.errorTitle = "Model Activation Failed"
@@ -117,46 +144,34 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
     }
 
     func downloadSpeechModel(_ model: SettingsStore.SpeechModel) {
-        guard !self.asr.isRunning else { return }
-        guard self.downloadingModel == nil else { return } // Prevent concurrent downloads
-        self.downloadingModel = model
-        self.downloadProgress = 0.0
-
-        Task {
-            // Mark this model as downloading
-            self.downloadingModel = model
-            self.downloadProgress = 0.0
-
+        guard !self.areSpeechModelActionsBlocked else { return }
+        Task { [weak self] in
+            guard let self else { return }
             do {
-                // Download the model WITHOUT changing the active selection
-                // Capture the model ID to guard against stale progress callbacks
-                let downloadingModelId = model.id
-                try await self.asr.downloadModel(model, progressHandler: { [weak self] progress in
-                    Task { @MainActor in
-                        // Only update progress if we're still downloading this specific model
-                        guard let self, self.downloadingModel?.id == downloadingModelId else { return }
-                        self.downloadProgress = max(self.downloadProgress, progress)
-                    }
-                })
-
+                try await self.asr.downloadModel(model, progressHandler: nil)
                 DebugLogger.shared.info("Model download completed: \(model.displayName)", source: "VoiceEngineVM")
+            } catch is CancellationError {
+                DebugLogger.shared.info("Model download cancelled: \(model.displayName)", source: "VoiceEngineVM")
             } catch {
                 DebugLogger.shared.error("Failed to download model \(model.displayName): \(error)", source: "VoiceEngineVM")
-                await MainActor.run {
-                    self.asr.errorTitle = "Model Download Failed"
-                    self.asr.errorMessage = error.localizedDescription
-                    self.asr.showError = true
-                }
+                self.asr.errorTitle = "Model Download Failed"
+                self.asr.errorMessage = error.localizedDescription
+                self.asr.showError = true
             }
-
-            // Clear downloading state
-            self.downloadingModel = nil
-            self.downloadProgress = 0.0
         }
     }
 
+    func cancelSpeechModelDownload() {
+        guard self.downloadingModel != nil, !self.isCancellingModelDownload else { return }
+        self.asr.cancelModelDownload()
+    }
+
+    func cancelActiveModelPreparation() {
+        self.asr.cancelModelPreparation()
+    }
+
     func deleteSpeechModel(_ model: SettingsStore.SpeechModel) {
-        guard !self.asr.isRunning else { return }
+        guard !self.areSpeechModelActionsBlocked else { return }
         let previousActive = self.settings.selectedSpeechModel
 
         Task {
@@ -219,6 +234,8 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
     func downloadModels() async {
         do {
             try await self.asr.ensureAsrReady()
+        } catch is CancellationError {
+            DebugLogger.shared.info("Model download cancelled", source: "AISettingsView")
         } catch {
             DebugLogger.shared.error("Failed to download models: \(error)", source: "AISettingsView")
             self.asr.errorTitle = "Model Download Failed"

--- a/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
+++ b/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
@@ -308,7 +308,7 @@ extension VoiceEngineSettingsView {
     func speechModelCard(for model: SettingsStore.SpeechModel) -> some View {
         let isSelected = self.viewModel.previewSpeechModel == model
         let isConfiguredActive = self.viewModel.isActiveSpeechModel(model)
-        let isActive = isConfiguredActive && model.isInstalled
+        let isActive = isConfiguredActive && model.isInstalled && self.viewModel.asr.isAsrReady
 
         return HStack(alignment: .top, spacing: 10) {
             Circle()
@@ -361,65 +361,81 @@ extension VoiceEngineSettingsView {
             // Action area: Show progress if THIS model is being downloaded
             if self.viewModel.downloadingModel == model {
                 // This specific model is currently being downloaded
-                VStack(alignment: .trailing, spacing: 4) {
-                    if self.viewModel.downloadProgress >= 0.82 {
-                        HStack(spacing: 6) {
+                HStack(spacing: 8) {
+                    VStack(alignment: .trailing, spacing: 4) {
+                        if self.viewModel.isCancellingModelDownload {
                             ProgressView()
                                 .controlSize(.mini)
-                            Text("Downloading…")
+                            Text("Cancelling…")
+                                .font(self.theme.typography.bodySmall)
+                                .foregroundStyle(self.voiceEngineSecondaryText)
+                        } else {
+                            ProgressView(value: self.viewModel.downloadProgress)
+                                .progressViewStyle(.linear)
+                                .frame(width: 90)
+                            Text("\(Int(self.viewModel.downloadProgress * 100))%")
                                 .font(self.theme.typography.bodySmall)
                                 .foregroundStyle(self.voiceEngineSecondaryText)
                         }
-                    } else {
-                        ProgressView(value: self.viewModel.downloadProgress)
-                            .progressViewStyle(.linear)
-                            .frame(width: 90)
-                        Text("\(Int(self.viewModel.downloadProgress * 100))%")
-                            .font(self.theme.typography.bodySmall)
-                            .foregroundStyle(self.voiceEngineSecondaryText)
                     }
+
+                    Button(self.viewModel.isCancellingModelDownload ? "Cancelling…" : "Cancel") {
+                        self.viewModel.cancelSpeechModelDownload()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(self.viewModel.isCancellingModelDownload)
                 }
-            } else if (self.viewModel.asr.isDownloadingModel || self.viewModel.asr.isLoadingModel) && isConfiguredActive && !self.viewModel.asr.isAsrReady {
+            } else if (self.viewModel.asr.isDownloadingModel
+                || self.viewModel.asr.isLoadingModel
+                || self.viewModel.asr.isCancellingModelPreparation)
+                && isConfiguredActive
+                && !self.viewModel.asr.isAsrReady
+            {
                 // Active model is loading/downloading (for Activate flow)
-                VStack(alignment: .trailing, spacing: 4) {
-                    if let progress = self.viewModel.asr.downloadProgress, self.viewModel.asr.isDownloadingModel {
-                        if progress >= 0.82 {
-                            HStack(spacing: 6) {
-                                ProgressView()
-                                    .controlSize(.mini)
-                                Text("Downloading…")
-                                    .font(self.theme.typography.bodySmall)
-                                    .foregroundStyle(self.voiceEngineSecondaryText)
-                            }
-                        } else {
+                HStack(spacing: 8) {
+                    VStack(alignment: .trailing, spacing: 4) {
+                        if self.viewModel.asr.isCancellingModelPreparation {
+                            ProgressView()
+                                .controlSize(.mini)
+                            Text("Cancelling…")
+                                .font(self.theme.typography.bodySmall)
+                                .foregroundStyle(self.voiceEngineSecondaryText)
+                        } else if let progress = self.viewModel.asr.downloadProgress, self.viewModel.asr.isDownloadingModel {
                             ProgressView(value: progress)
                                 .progressViewStyle(.linear)
                                 .frame(width: 90)
                             Text("\(Int(progress * 100))%")
                                 .font(self.theme.typography.bodySmall)
                                 .foregroundStyle(self.voiceEngineSecondaryText)
+                        } else {
+                            ProgressView()
+                                .controlSize(.mini)
+                            Text(self.viewModel.asr.isLoadingModel ? "Loading…" : "Downloading…")
+                                .font(self.theme.typography.bodySmall)
+                                .foregroundStyle(self.voiceEngineSecondaryText)
                         }
-                    } else {
-                        ProgressView()
-                            .controlSize(.mini)
-                        Text(self.viewModel.asr.isLoadingModel ? "Loading…" : "Downloading…")
-                            .font(self.theme.typography.bodySmall)
-                            .foregroundStyle(self.voiceEngineSecondaryText)
                     }
+
+                    Button(self.viewModel.asr.isCancellingModelPreparation ? "Cancelling…" : "Cancel") {
+                        self.viewModel.cancelActiveModelPreparation()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(self.viewModel.asr.isCancellingModelPreparation)
                 }
             } else if model.isInstalled {
                 HStack(spacing: 8) {
-                    if isConfiguredActive {
-                        let isLoading = (self.viewModel.asr.isLoadingModel || self.viewModel.asr.isDownloadingModel) && !self.viewModel.asr.isAsrReady
+                    if isActive {
                         self.speechModelLanguagePicker(for: model)
-                            .disabled(self.viewModel.asr.isRunning)
+                            .disabled(self.viewModel.areSpeechModelActionsBlocked)
 
-                        Text(isLoading ? "Loading…" : "Active")
+                        Text("Active")
                             .font(self.theme.typography.bodySmallStrong)
                             .padding(.horizontal, 10)
                             .padding(.vertical, 4)
-                            .background(Capsule().fill(isLoading ? .orange.opacity(0.25) : Color.fluidGreen.opacity(0.25)))
-                            .foregroundStyle(isLoading ? .orange : Color.fluidGreen)
+                            .background(Capsule().fill(Color.fluidGreen.opacity(0.25)))
+                            .foregroundStyle(Color.fluidGreen)
                     } else {
                         Button("Activate") {
                             self.viewModel.activateSpeechModel(model)
@@ -429,7 +445,7 @@ extension VoiceEngineSettingsView {
                         .tint(Color.fluidGreen)
                         .fontWeight(.semibold)
                         .shadow(color: Color.fluidGreen.opacity(0.35), radius: 4, x: 0, y: 1)
-                        .disabled(self.viewModel.asr.isRunning || self.viewModel.downloadingModel != nil)
+                        .disabled(self.viewModel.areSpeechModelActionsBlocked)
                     }
 
                     if !model.usesAppleLogo {
@@ -442,7 +458,7 @@ extension VoiceEngineSettingsView {
                                     .foregroundStyle(.red.opacity(0.7))
                             }
                             .buttonStyle(.plain)
-                            .disabled(self.viewModel.asr.isRunning || self.viewModel.downloadingModel != nil)
+                            .disabled(self.viewModel.areSpeechModelActionsBlocked)
                             .offset(x: isSelected ? 0 : 12)
                             .opacity(isSelected ? 1 : 0)
                         }
@@ -461,7 +477,7 @@ extension VoiceEngineSettingsView {
                                 }
                                 .buttonStyle(.plain)
                                 .foregroundStyle(self.voiceEngineTertiaryText)
-                                .disabled(self.viewModel.asr.isRunning || self.viewModel.downloadingModel != nil)
+                                .disabled(self.viewModel.areSpeechModelActionsBlocked)
                             }
 
                             Button("Download") {
@@ -471,7 +487,7 @@ extension VoiceEngineSettingsView {
                             .buttonStyle(.borderedProminent)
                             .controlSize(.small)
                             .tint(.blue)
-                            .disabled(self.viewModel.asr.isRunning || self.viewModel.downloadingModel != nil)
+                            .disabled(self.viewModel.areSpeechModelActionsBlocked)
                         }
                         .offset(x: isSelected ? 0 : 16)
                         .opacity(isSelected ? 1 : 0)
@@ -488,7 +504,7 @@ extension VoiceEngineSettingsView {
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
                         .tint(.blue)
-                        .disabled(self.viewModel.asr.isRunning || self.viewModel.downloadingModel != nil)
+                        .disabled(self.viewModel.areSpeechModelActionsBlocked)
                         .offset(x: isSelected ? 0 : 16)
                         .opacity(isSelected ? 1 : 0)
                     }

--- a/Sources/Fluid/UI/FeedbackView.swift
+++ b/Sources/Fluid/UI/FeedbackView.swift
@@ -22,8 +22,6 @@ struct FeedbackView: View {
     @State private var showFeedbackError: Bool = false
     @State private var feedbackErrorMessage: String = ""
     @State private var appear: Bool = false
-    @State private var showSupportPopover: Bool = false
-    @State private var didCopySupportEmail: Bool = false
 
     var body: some View {
         ScrollView {
@@ -101,24 +99,21 @@ struct FeedbackView: View {
                                     .buttonHoverEffect()
                                 }
 
-                                Button {
-                                    self.showSupportPopover = true
-                                } label: {
-                                    HStack(spacing: 8) {
-                                        Image(systemName: "heart.fill")
-                                        Text("Support FluidVoice")
-                                            .fontWeight(.semibold)
+                                if let sponsorURL = URL(string: "https://github.com/sponsors/altic-dev") {
+                                    Link(destination: sponsorURL) {
+                                        HStack(spacing: 8) {
+                                            Image(systemName: "heart.fill")
+                                            Text("Support FluidVoice")
+                                                .fontWeight(.semibold)
+                                        }
+                                        .font(.system(size: 14))
+                                        .padding(.horizontal, 20)
+                                        .padding(.vertical, 10)
                                     }
-                                    .font(.system(size: 14))
-                                    .padding(.horizontal, 20)
-                                    .padding(.vertical, 10)
+                                    .fluidButton(.glass, size: .medium)
+                                    .buttonHoverEffect()
+                                    .help("Sponsor Altic on GitHub")
                                 }
-                                .fluidButton(.glass, size: .medium)
-                                .buttonHoverEffect()
-                                .popover(isPresented: self.$showSupportPopover, arrowEdge: .bottom) {
-                                    self.supportPopover
-                                }
-                                .help("Show support email")
                             }
                         }
                     }
@@ -224,55 +219,7 @@ struct FeedbackView: View {
         }
     }
 
-    private var supportPopover: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Help make local dictation even better.")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(self.theme.palette.primaryText)
-
-            Text("Please send us an email at alticdev@gmail.com if you'd like to support FluidVoice.")
-                .font(.system(size: 13))
-                .foregroundStyle(self.theme.palette.secondaryText)
-                .fixedSize(horizontal: false, vertical: true)
-
-            HStack(spacing: 8) {
-                Text("alticdev@gmail.com")
-                    .font(.system(size: 13, design: .monospaced))
-                    .foregroundStyle(self.theme.palette.primaryText)
-                    .lineLimit(1)
-                    .textSelection(.enabled)
-
-                Spacer(minLength: 8)
-
-                Button {
-                    self.copySupportEmail()
-                } label: {
-                    Label(self.didCopySupportEmail ? "Copied" : "Copy Email", systemImage: self.didCopySupportEmail ? "checkmark" : "doc.on.doc")
-                        .font(.system(size: 12, weight: .semibold))
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 7)
-                }
-                .fluidButton(.glass, size: .small)
-                .buttonHoverEffect()
-            }
-        }
-        .padding(14)
-        .frame(width: 300)
-    }
-
     // MARK: - Feedback Functions
-
-    private func copySupportEmail() {
-        let email = "alticdev@gmail.com"
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(email, forType: .string)
-        self.didCopySupportEmail = true
-
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 1_600_000_000)
-            self.didCopySupportEmail = false
-        }
-    }
 
     private func sendFeedback() async {
         guard !self.feedbackEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -37,7 +37,7 @@ struct SettingsView: View {
     @Binding var primaryDictationShortcuts: [HotkeyShortcut]
     @Binding var activeShortcutRecordingTarget: ShortcutRecordingTarget?
     @Binding var shortcutRecordingMessage: String?
-    @Binding var commandModeShortcut: HotkeyShortcut
+    @Binding var commandModeShortcut: HotkeyShortcut?
     @Binding var rewriteShortcut: HotkeyShortcut
     @Binding var cancelRecordingShortcut: HotkeyShortcut
     @Binding var commandModeShortcutEnabled: Bool
@@ -703,10 +703,19 @@ struct SettingsView: View {
                                         isAnyRecordingActive: self.isRecordingAnyShortcut,
                                         recordingMessage: self.isRecording(.command) ? self.shortcutRecordingMessage : nil,
                                         isEnabled: self.$commandModeShortcutEnabled,
+                                        requiresShortcutToEnable: true,
                                         onChangePressed: {
                                             DebugLogger.shared.debug("Starting to record new command mode shortcut", source: "SettingsView")
                                             self.shortcutRecordingMessage = nil
                                             self.activeShortcutRecordingTarget = .command
+                                        },
+                                        onRemovePressed: {
+                                            if self.activeShortcutRecordingTarget == .command {
+                                                self.shortcutRecordingMessage = nil
+                                                self.activeShortcutRecordingTarget = nil
+                                            }
+                                            self.commandModeShortcut = nil
+                                            self.commandModeShortcutEnabled = false
                                         }
                                     )
                                     Divider().opacity(0.2).padding(.vertical, 4)
@@ -2201,14 +2210,18 @@ struct SettingsView: View {
     @ViewBuilder
     private func shortcutRow(
         content: ShortcutRowContent,
-        shortcut: HotkeyShortcut,
+        shortcut: HotkeyShortcut?,
         isRecording: Bool,
         isAnyRecordingActive: Bool,
         recordingMessage: String? = nil,
         isEnabled: Binding<Bool>? = nil,
-        onChangePressed: @escaping () -> Void
+        requiresShortcutToEnable: Bool = false,
+        onChangePressed: @escaping () -> Void,
+        onRemovePressed: (() -> Void)? = nil
     ) -> some View {
         let enabledValue = isEnabled?.wrappedValue ?? true
+        let hasShortcut = shortcut != nil
+        let enableToggleDisabled = isAnyRecordingActive || (requiresShortcutToEnable && !hasShortcut)
 
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 10) {
@@ -2233,7 +2246,7 @@ struct SettingsView: View {
                         .toggleStyle(.switch)
                         .tint(self.theme.palette.accent)
                         .labelsHidden()
-                        .disabled(isAnyRecordingActive)
+                        .disabled(enableToggleDisabled)
                 }
             }
 
@@ -2244,7 +2257,7 @@ struct SettingsView: View {
                 if isRecording && enabledValue {
                     self.shortcutCapturePill()
                 } else {
-                    self.shortcutDisplayPill(shortcut.displayString)
+                    self.shortcutDisplayPill(shortcut?.displayString ?? "Not set")
                 }
 
                 Button(isRecording ? "Cancel" : "Change") {
@@ -2257,7 +2270,16 @@ struct SettingsView: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .disabled(!isRecording && (isAnyRecordingActive || !enabledValue))
+                .disabled(!isRecording && (isAnyRecordingActive || (!enabledValue && hasShortcut)))
+
+                if let onRemovePressed {
+                    Button("Remove") {
+                        onRemovePressed()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(!hasShortcut || isAnyRecordingActive)
+                }
 
                 if isRecording, let recordingMessage, !recordingMessage.isEmpty {
                     Text(recordingMessage)

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -29,7 +29,7 @@ struct WelcomeView: View {
     let restartApp: () -> Void
 
     private var commandModeShortcutDisplay: String {
-        self.settings.commandModeHotkeyShortcut.displayString
+        self.settings.commandModeHotkeyShortcut?.displayString ?? "Not set"
     }
 
     private var writeModeShortcutDisplay: String {
@@ -605,6 +605,7 @@ struct OnboardingFlowView: View {
     @State private var isShowingOtherModelRoutes = false
     @State private var preparingModelRouteID: String?
     @State private var uninstallingModelRouteID: String?
+    @State private var modelPreparationTask: Task<Void, Never>?
     @State private var languageSearchText = ""
     @FocusState private var isLanguageSearchFocused: Bool
     @State private var hasPlayedLandingWelcomeSound = false
@@ -791,7 +792,11 @@ struct OnboardingFlowView: View {
         guard self.step == .voiceModel else {
             return false
         }
-        return self.preparingModelRouteID != nil || self.asr.isDownloadingModel || (self.asr.isLoadingModel && !self.asr.isAsrReady)
+        return self.preparingModelRouteID != nil
+            || self.asr.hasActiveModelPreparation
+            || self.asr.isCancellingModelPreparation
+            || self.asr.isDownloadingModel
+            || (self.asr.isLoadingModel && !self.asr.isAsrReady)
     }
 
     private var isMicrophoneReady: Bool {
@@ -887,7 +892,13 @@ struct OnboardingFlowView: View {
             }
         }
         .onChange(of: self.currentStep) { _, _ in
+            if self.step != .voiceModel {
+                self.cancelOnboardingModelPreparation()
+            }
             self.playLandingWelcomeSoundIfNeeded()
+        }
+        .onDisappear {
+            self.cancelOnboardingModelPreparation()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             self.syncOnboardingSelectionFromSettings()
@@ -1555,10 +1566,25 @@ struct OnboardingFlowView: View {
                             }
                             .frame(width: 608)
 
+                            if self.isModelPreparationInProgress {
+                                Label("First setup can take a few minutes. Too long? Cancel and retry.", systemImage: "clock.arrow.circlepath")
+                                    .font(self.theme.typography.captionStrong)
+                                    .foregroundStyle(Color.white.opacity(0.58))
+                                    .labelStyle(.titleAndIcon)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 5)
+                                    .background(
+                                        Capsule()
+                                            .fill(Color.white.opacity(0.06))
+                                            .overlay(Capsule().stroke(Color.white.opacity(0.10), lineWidth: 1))
+                                    )
+                                    .padding(.top, 14)
+                            }
+
                             Text("You can switch models later in Voice Engine settings.")
                                 .font(.system(size: 12, weight: .medium))
                                 .foregroundStyle(Color.white.opacity(0.44))
-                                .padding(.top, 18)
+                                .padding(.top, self.isModelPreparationInProgress ? 8 : 18)
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.top, 30)
@@ -1891,16 +1917,20 @@ struct OnboardingFlowView: View {
     private func prepareOnboardingRoute(_ route: VoiceEngineLanguageRoute) {
         guard !self.asr.isRunning, !self.isModelPreparationInProgress, self.uninstallingModelRouteID == nil else { return }
 
+        self.modelPreparationTask?.cancel()
         self.preparingModelRouteID = route.id
         self.selectOnboardingRoute(route)
 
-        Task { @MainActor in
+        self.modelPreparationTask = Task { @MainActor in
             defer {
                 self.preparingModelRouteID = nil
+                self.modelPreparationTask = nil
             }
 
             do {
                 try await self.asr.ensureAsrReady()
+            } catch is CancellationError {
+                DebugLogger.shared.info("Cancelled onboarding voice model setup for \(route.model.displayName)", source: "OnboardingFlowView")
             } catch {
                 DebugLogger.shared.error("Failed to prepare onboarding voice model \(route.model.displayName): \(error)", source: "OnboardingFlowView")
                 // Surface the failure in the UI instead of only logging it, so the user
@@ -1910,8 +1940,14 @@ struct OnboardingFlowView: View {
                 self.asr.errorMessage = error.localizedDescription
                 self.asr.showError = true
             }
+            guard !Task.isCancelled else { return }
             await self.asr.checkIfModelsExistAsync()
         }
+    }
+
+    private func cancelOnboardingModelPreparation() {
+        self.modelPreparationTask?.cancel()
+        self.asr.cancelModelPreparation()
     }
 
     private func uninstallOnboardingRoute(_ route: VoiceEngineLanguageRoute) {
@@ -2005,35 +2041,19 @@ struct OnboardingFlowView: View {
             }
 
             if isPreparing || isUninstalling {
-                VStack(alignment: .leading, spacing: 7) {
-                    if self.asr.isDownloadingModel, let progress = self.asr.downloadProgress {
-                        ProgressView(value: progress)
-                            .tint(FluidOnboardingLandingColors.blue)
+                HStack(spacing: 8) {
+                    self.onboardingModelPreparationStatus(isUninstalling: isUninstalling)
 
-                        HStack(spacing: 6) {
-                            ZStack {
-                                if progress >= 0.82 {
-                                    ProgressView()
-                                        .controlSize(.mini)
-                                        .fixedSize()
-                                }
-                            }
-                            .frame(width: 14, height: 14)
-                            .opacity(progress >= 0.82 ? 1 : 0)
-
-                            Text("Downloading \(Int(progress * 100))%")
-                                .font(self.theme.typography.captionStrong)
-                                .foregroundStyle(Color.white.opacity(0.56))
-                        }
-                    } else {
-                        HStack(spacing: 8) {
-                            ProgressView()
-                                .controlSize(.small)
-                                .fixedSize()
-
-                            Text(isUninstalling ? "Deleting..." : "Loading model...")
-                                .font(self.theme.typography.captionStrong)
-                                .foregroundStyle(Color.white.opacity(0.62))
+                    if isPreparing {
+                        self.onboardingModelActionButton(
+                            id: "\(route.id)-cancel",
+                            title: self.asr.isCancellingModelPreparation ? "Cancelling…" : "Cancel",
+                            systemImage: "xmark",
+                            tone: .secondary,
+                            width: 104,
+                            isDisabled: self.asr.isCancellingModelPreparation
+                        ) {
+                            self.cancelOnboardingModelPreparation()
                         }
                     }
                 }
@@ -2133,6 +2153,50 @@ struct OnboardingFlowView: View {
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Speed \(Int(model.speedPercent * 100)) percent. Accuracy \(Int(model.accuracyPercent * 100)) percent.")
+    }
+
+    private func onboardingModelPreparationStatus(isUninstalling: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            if self.asr.isCancellingModelPreparation {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .fixedSize()
+
+                    Text("Cancelling...")
+                        .font(self.theme.typography.captionStrong)
+                        .foregroundStyle(Color.white.opacity(0.62))
+                }
+            } else if self.asr.isDownloadingModel, let progress = self.asr.downloadProgress {
+                ProgressView(value: progress)
+                    .tint(FluidOnboardingLandingColors.blue)
+
+                HStack(spacing: 6) {
+                    Text("Downloading \(Int(progress * 100))%")
+                        .font(self.theme.typography.captionStrong)
+                        .foregroundStyle(Color.white.opacity(0.56))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
+            } else {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .fixedSize()
+
+                    Text(
+                        isUninstalling
+                            ? "Deleting..."
+                            : "Loading model..."
+                    )
+                    .font(self.theme.typography.captionStrong)
+                    .foregroundStyle(Color.white.opacity(0.62))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func onboardingModelMetadataRow(badgeText: String?) -> some View {

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -17,7 +17,7 @@ private enum OverlayShortcutResolver {
         case .edit, .write, .rewrite:
             return settings.rewriteModeHotkeyShortcut.displayString
         case .command:
-            return settings.commandModeHotkeyShortcut.displayString
+            return settings.commandModeHotkeyShortcut?.displayString ?? "Not set"
         }
     }
 }

--- a/Sources/Fluid/Views/CommandModeView.swift
+++ b/Sources/Fluid/Views/CommandModeView.swift
@@ -175,7 +175,7 @@ struct CommandModeView: View {
     // MARK: - How To Section
 
     private var shortcutDisplay: String {
-        self.settings.commandModeHotkeyShortcut.displayString
+        self.settings.commandModeHotkeyShortcut?.displayString ?? "Not set"
     }
 
     private var howToSection: some View {


### PR DESCRIPTION
## Description
Adds cancellable voice-model setup/download flows, replaces staged model progress with real byte-backed progress, validates incomplete model artifacts, and routes the Feedback support button to GitHub Sponsors.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issues
- None

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran `sh build_with_FI_incremental.sh` and installed/launched `/Applications/FluidVoice.app`

## Notes
- `RELEASE_NOTES_1.6.1.md` was updated locally and remains ignored by design.
- Public/OSS build script is not available in this checkout; `build.sh` only routes to the private FI build.

## Screenshots / Video 
Not included.