### PR TITLE
Make getting started guide rows clickable

### DIFF
--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -19,6 +19,9 @@ struct WelcomeView: View {
     @Binding var selectedSidebarItem: SidebarItem?
     @Binding var playgroundUsed: Bool
     var isTranscriptionFocused: FocusState<Bool>.Binding
+    @State private var isHowToUseExpanded = false
+    @State private var isCommandModeGuideExpanded = false
+    @State private var isEditModeGuideExpanded = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.theme) private var theme
 
@@ -340,46 +343,45 @@ struct WelcomeView: View {
                     // Secondary guidance
                     ThemedCard(style: .subtle) {
                         VStack(alignment: .leading, spacing: 12) {
-                            DisclosureGroup {
+                            self.guideDisclosureRow(
+                                title: "How to Use",
+                                systemImage: "play.fill",
+                                color: self.theme.palette.accent,
+                                isExpanded: self.$isHowToUseExpanded,
+                                accessories: { EmptyView() }
+                            ) {
                                 VStack(alignment: .leading, spacing: 10) {
                                     self.howToStep(number: 1, title: "Start Recording", description: "Press your hotkey (default: Right Option/Alt) or click the button")
                                     self.howToStep(number: 2, title: "Speak Clearly", description: "Speak naturally - works best in quiet environments")
                                     self.howToStep(number: 3, title: "Auto-Type Result", description: "Transcription is automatically typed into your focused app")
                                 }
-                                .padding(.top, 8)
-                            } label: {
-                                Label("How to Use", systemImage: "play.fill")
-                                    .font(self.theme.typography.sectionTitle)
-                                    .foregroundStyle(self.theme.palette.accent)
                             }
 
                             Divider().opacity(0.2)
 
-                            DisclosureGroup {
+                            self.guideDisclosureRow(
+                                title: "Command Mode",
+                                systemImage: "terminal.fill",
+                                color: self.commandModeColor,
+                                isExpanded: self.$isCommandModeGuideExpanded
+                            ) {
+                                self.featureBadge("New", color: self.commandModeColor)
+                                self.featureBadge("Alpha", color: self.commandModeColor.opacity(0.75))
+                            } content: {
                                 self.commandModeGuide
-                                    .padding(.top, 8)
-                            } label: {
-                                HStack(spacing: 8) {
-                                    Label("Command Mode", systemImage: "terminal.fill")
-                                        .font(self.theme.typography.sectionTitle)
-                                        .foregroundStyle(self.commandModeColor)
-                                    self.featureBadge("New", color: self.commandModeColor)
-                                    self.featureBadge("Alpha", color: self.commandModeColor.opacity(0.75))
-                                }
                             }
 
                             Divider().opacity(0.2)
 
-                            DisclosureGroup {
+                            self.guideDisclosureRow(
+                                title: "Edit Mode",
+                                systemImage: "pencil.and.outline",
+                                color: self.editModeColor,
+                                isExpanded: self.$isEditModeGuideExpanded
+                            ) {
+                                self.featureBadge("New", color: self.editModeColor)
+                            } content: {
                                 self.editModeGuide
-                                    .padding(.top, 8)
-                            } label: {
-                                HStack(spacing: 8) {
-                                    Label("Edit Mode", systemImage: "pencil.and.outline")
-                                        .font(self.theme.typography.sectionTitle)
-                                        .foregroundStyle(self.editModeColor)
-                                    self.featureBadge("New", color: self.editModeColor)
-                                }
                             }
                         }
                         .padding(12)
@@ -402,6 +404,50 @@ struct WelcomeView: View {
     }
 
     // MARK: - Helper Views
+
+    private func guideDisclosureRow<Accessories: View, Content: View>(
+        title: String,
+        systemImage: String,
+        color: Color,
+        isExpanded: Binding<Bool>,
+        @ViewBuilder accessories: () -> Accessories,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(self.reduceMotion ? nil : .easeInOut(duration: 0.16)) {
+                    isExpanded.wrappedValue.toggle()
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.primary.opacity(0.85))
+                        .rotationEffect(.degrees(isExpanded.wrappedValue ? 90 : 0))
+                        .frame(width: 16)
+
+                    Label(title, systemImage: systemImage)
+                        .font(self.theme.typography.sectionTitle)
+                        .foregroundStyle(color)
+
+                    accessories()
+
+                    Spacer(minLength: 0)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Text(title))
+            .accessibilityValue(Text(isExpanded.wrappedValue ? "Expanded" : "Collapsed"))
+
+            if isExpanded.wrappedValue {
+                content()
+                    .padding(.top, 8)
+                    .padding(.leading, 26)
+            }
+        }
+    }
 
     private var commandModeGuide: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -347,9 +347,10 @@ struct WelcomeView: View {
                                 title: "How to Use",
                                 systemImage: "play.fill",
                                 color: self.theme.palette.accent,
-                                isExpanded: self.$isHowToUseExpanded,
-                                accessories: { EmptyView() }
+                                isExpanded: self.$isHowToUseExpanded
                             ) {
+                                EmptyView()
+                            } content: {
                                 VStack(alignment: .leading, spacing: 10) {
                                     self.howToStep(number: 1, title: "Start Recording", description: "Press your hotkey (default: Right Option/Alt) or click the button")
                                     self.howToStep(number: 2, title: "Speak Clearly", description: "Speak naturally - works best in quiet environments")
@@ -440,6 +441,7 @@ struct WelcomeView: View {
             .buttonStyle(.plain)
             .accessibilityLabel(Text(title))
             .accessibilityValue(Text(isExpanded.wrappedValue ? "Expanded" : "Collapsed"))
+            .accessibilityHint(Text("Activates to expand or collapse"))
 
             if isExpanded.wrappedValue {
                 content()


### PR DESCRIPTION
## Description
Fixes the Getting Started guide disclosure rows so clicking the row text/label toggles each section, instead of only the chevron/down-arrow area responding.

This updates the three guide rows in `WelcomeView` to use a reusable button-backed disclosure row. The visual treatment remains the same: chevron, labels, feature badges, section content, reduce-motion animation handling, and accessibility expanded/collapsed values are preserved.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issues
- Not linked

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 26.5.1
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`

Additional verification:
- [x] `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` — 48 tests passed, 0 failures
- [x] `git diff --check`

## Notes
- `swiftlint` and `swiftformat` are not installed in this local environment, so those checks were not run.
- This repository does not currently include a UI test target or SwiftUI view-inspection dependency for automating a row-click regression. The change keeps the interaction localized by making each guide header a full-width SwiftUI `Button`.

## Screenshots / Video
Not included. This is a small interaction-target fix with no intended visual change.
