### PR TITLE
feat(media): add option to duck media volume instead of pausing

### DIFF
--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -109,6 +109,8 @@ struct SettingsBackupPayload: Codable, Equatable {
     let pauseMediaDuringTranscription: Bool
     let automaticDictionaryLearningEnabled: Bool?
     let pronunciationMatchingEnabled: Bool?
+    let duckMediaInsteadOfPausing: Bool?
+    let duckMediaVolumeLevel: Double?
     let vocabularyBoostingEnabled: Bool
     let customDictionaryEntries: [SettingsStore.CustomDictionaryEntry]
     let selectedDictationPromptID: String?

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -3317,6 +3317,8 @@ final class SettingsStore: ObservableObject {
             pauseMediaDuringTranscription: self.pauseMediaDuringTranscription,
             automaticDictionaryLearningEnabled: self.automaticDictionaryLearningEnabled,
             pronunciationMatchingEnabled: self.pronunciationMatchingEnabled,
+            duckMediaInsteadOfPausing: self.duckMediaInsteadOfPausing,
+            duckMediaVolumeLevel: self.duckMediaVolumeLevel,
             vocabularyBoostingEnabled: self.vocabularyBoostingEnabled,
             customDictionaryEntries: self.customDictionaryEntries,
             selectedDictationPromptID: self.selectedDictationPromptID,
@@ -3493,6 +3495,10 @@ final class SettingsStore: ObservableObject {
         }
         if let pronunciationMatchingEnabled = payload.pronunciationMatchingEnabled {
             self.pronunciationMatchingEnabled = pronunciationMatchingEnabled
+        }
+        self.duckMediaInsteadOfPausing = payload.duckMediaInsteadOfPausing ?? false
+        if let duckLevel = payload.duckMediaVolumeLevel {
+            self.duckMediaVolumeLevel = duckLevel
         }
         self.vocabularyBoostingEnabled = payload.vocabularyBoostingEnabled
         self.customDictionaryEntries = payload.customDictionaryEntries
@@ -4470,6 +4476,29 @@ final class SettingsStore: ObservableObject {
         set {
             objectWillChange.send()
             self.defaults.set(newValue, forKey: Keys.pauseMediaDuringTranscription)
+        }
+    }
+
+    /// When enabled (and `pauseMediaDuringTranscription` is on), lowers the system
+    /// output volume during transcription instead of fully pausing playback.
+    var duckMediaInsteadOfPausing: Bool {
+        get { self.defaults.object(forKey: Keys.duckMediaInsteadOfPausing) as? Bool ?? false }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.duckMediaInsteadOfPausing)
+        }
+    }
+
+    /// Target output volume while ducking, expressed as a fraction (0.05–1.0) of
+    /// the volume at the moment transcription starts. Defaults to 0.2 (20%).
+    var duckMediaVolumeLevel: Double {
+        get {
+            let stored = self.defaults.object(forKey: Keys.duckMediaVolumeLevel) as? Double ?? 0.2
+            return min(1.0, max(0.05, stored))
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(min(1.0, max(0.05, newValue)), forKey: Keys.duckMediaVolumeLevel)
         }
     }
 
@@ -5458,6 +5487,8 @@ private extension SettingsStore {
 
         /// Media Playback Control
         static let pauseMediaDuringTranscription = "PauseMediaDuringTranscription"
+        static let duckMediaInsteadOfPausing = "DuckMediaInsteadOfPausing"
+        static let duckMediaVolumeLevel = "DuckMediaVolumeLevel"
 
         /// Custom Dictation Prompt
         static let customDictationPrompt = "CustomDictationPrompt"

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -96,6 +96,20 @@ final class MediaPlaybackService {
     ///   crash with `EXC_BREAKPOINT` (SIGTRAP) due to double-resume of a
     ///   `CheckedContinuation`.
     func pauseIfPlaying() async -> Bool {
+        // A suppression from a previous session may not have been reverted yet: stop() flips
+        // isRunning false before its (slow) final transcription pass, and only reverts media
+        // afterwards, so a new dictation can start during that window. Don't begin a second
+        // suppression — capturing the already-ducked volume would lose the true original and
+        // could leave the Mac stuck at the ducked level. Report no new action; the in-flight
+        // revert from the prior session restores the original volume.
+        guard self.activeSuppression == nil else {
+            DebugLogger.shared.warning(
+                "MediaPlaybackService: Suppression already active from a prior session, not starting another",
+                source: "MediaPlaybackService"
+            )
+            return false
+        }
+
         return await withCheckedContinuation { continuation in
             let queryStartedAt = DispatchTime.now().uptimeNanoseconds
             let resumeLock = NSLock()

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -134,6 +134,8 @@ final class MediaPlaybackService {
                     return false
                 }
 
+                // Runs exactly once, only for the winning callback, before resuming the
+                // continuation, so suppression cannot be applied by a duplicate callback.
                 beforeResume()
                 continuation.resume(returning: value)
                 return true
@@ -203,8 +205,11 @@ final class MediaPlaybackService {
                 )
 
                 if isPlaying {
-                    self.applySuppression()
-                    resumeOnce(true)
+                    // Gate the suppression behind the same one-shot as the resume.
+                    // MediaRemoteAdapter can fire this callback more than once, and ducking
+                    // is not idempotent (it reads the current volume as the "original"), so a
+                    // duplicate must not re-duck or overwrite `activeSuppression`.
+                    resumeOnce(true) { self.applySuppression() }
                 } else {
                     DebugLogger.shared.debug(
                         """

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -51,9 +51,10 @@ final class MediaPlaybackService {
     private enum ActiveSuppression {
         /// We sent a pause command and should send play() to restore.
         case paused
-        /// We lowered the output volume from `original` to `applied` and should
-        /// raise it back to `original`.
-        case ducked(original: Float, applied: Float)
+        /// We lowered the output volume. `original` is the pre-duck snapshot to
+        /// restore (preserving per-channel balance); `applied` is what the device
+        /// actually snapped to, used to detect user changes mid-dictation.
+        case ducked(original: OutputVolumeSnapshot, applied: OutputVolumeSnapshot)
     }
 
     private var activeSuppression: ActiveSuppression?
@@ -247,17 +248,17 @@ final class MediaPlaybackService {
     private func applySuppression() {
         // Ducking: lower the output volume instead of stopping playback entirely.
         if SettingsStore.shared.duckMediaInsteadOfPausing,
-           let original = self.volumeController.currentOutputVolume()
+           let original = self.volumeController.captureOutputVolume()
         {
             let level = Float(SettingsStore.shared.duckMediaVolumeLevel)
-            let target = original * level
-            if self.volumeController.setOutputVolume(target) {
-                // Read back the level the device actually snapped to (volume can be
+            let target = original.scaled(by: level)
+            if self.volumeController.apply(target) {
+                // Re-capture what the device actually snapped to (volume can be
                 // quantized to coarse steps) so the restore-time change check is accurate.
-                let applied = self.volumeController.currentOutputVolume() ?? target
+                let applied = self.volumeController.captureOutputVolume() ?? target
                 self.activeSuppression = .ducked(original: original, applied: applied)
                 DebugLogger.shared.info(
-                    "MediaPlaybackService: Ducked output volume \(original) -> \(applied) for transcription",
+                    "MediaPlaybackService: Ducked output volume \(original.averageLevel) -> \(applied.averageLevel) for transcription",
                     source: "MediaPlaybackService"
                 )
                 return
@@ -291,17 +292,19 @@ final class MediaPlaybackService {
         case let .ducked(original, applied):
             // Only restore if the volume is still roughly where we left it. If the
             // user adjusted it during dictation, respect their choice and leave it.
-            if let current = self.volumeController.currentOutputVolume(), abs(current - applied) > 0.02 {
+            if let current = self.volumeController.currentAverageLevel(matching: applied),
+               abs(current - applied.averageLevel) > 0.02
+            {
                 DebugLogger.shared.info(
-                    "MediaPlaybackService: Output volume changed during dictation (\(applied) -> \(current)), leaving as-is",
+                    "MediaPlaybackService: Output volume changed during dictation (\(applied.averageLevel) -> \(current)), leaving as-is",
                     source: "MediaPlaybackService"
                 )
             } else {
                 DebugLogger.shared.info(
-                    "MediaPlaybackService: Restoring output volume to \(original) (we ducked it)",
+                    "MediaPlaybackService: Restoring output volume to \(original.averageLevel) (we ducked it)",
                     source: "MediaPlaybackService"
                 )
-                self.volumeController.setOutputVolume(original)
+                self.volumeController.apply(original)
             }
 
         case .none:

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -42,16 +42,31 @@ final class MediaPlaybackService {
     )
 
     private let mediaController: any MediaPlaybackControlling
+    private let volumeController: SystemAudioVolumeController
     private let queryTimeoutSeconds: TimeInterval
     private let timeoutScheduler: TimeoutScheduler
+
+    /// Tracks the action we took for the current transcription session so that
+    /// `resumeIfWePaused(_:)` can revert exactly what was applied.
+    private enum ActiveSuppression {
+        /// We sent a pause command and should send play() to restore.
+        case paused
+        /// We lowered the output volume from `original` to `applied` and should
+        /// raise it back to `original`.
+        case ducked(original: Float, applied: Float)
+    }
+
+    private var activeSuppression: ActiveSuppression?
 
     /// Creates an isolated service with injectable dependencies for deterministic tests.
     init(
         mediaController: any MediaPlaybackControlling,
+        volumeController: SystemAudioVolumeController = SystemAudioVolumeController(),
         queryTimeoutSeconds: TimeInterval,
         timeoutScheduler: @escaping TimeoutScheduler
     ) {
         self.mediaController = mediaController
+        self.volumeController = volumeController
         self.queryTimeoutSeconds = queryTimeoutSeconds
         self.timeoutScheduler = timeoutScheduler
     }
@@ -64,11 +79,16 @@ final class MediaPlaybackService {
     // MARK: - Public API
 
     #if arch(arm64)
-    /// Pauses system media playback if something is currently playing.
+    /// Suppresses system media while transcription is active, if something is
+    /// currently playing.
     ///
-    /// - Returns: `true` if a pause request was issued, `false` if nothing was playing or
-    ///   if we couldn't determine playback state. The media adapter does not acknowledge
-    ///   command completion.
+    /// Depending on `SettingsStore.duckMediaInsteadOfPausing`, this either fully
+    /// pauses playback or lowers the system output volume ("ducking"). The action
+    /// taken is recorded so `resumeIfWePaused(_:)` can revert exactly what was done.
+    ///
+    /// - Returns: `true` if we took an action (pause or duck) that must later be
+    ///   reverted, `false` if nothing was playing or if we couldn't determine
+    ///   playback state. The media adapter does not acknowledge command completion.
     ///
     /// - Note: Uses a local one-shot gate to protect against `MediaRemoteAdapter`
     ///   firing the `getTrackInfo` callback more than once, which would otherwise
@@ -183,16 +203,8 @@ final class MediaPlaybackService {
                 )
 
                 if isPlaying {
-                    resumeOnce(true) {
-                        DebugLogger.shared.info(
-                            """
-                            MediaPlaybackService: Media is playing, sending pause command \
-                            (elapsedMs: \(elapsedMilliseconds()))
-                            """,
-                            source: "MediaPlaybackService"
-                        )
-                        self.mediaController.pause()
-                    }
+                    self.applySuppression()
+                    resumeOnce(true)
                 } else {
                     DebugLogger.shared.debug(
                         """
@@ -207,25 +219,94 @@ final class MediaPlaybackService {
         }
     }
 
-    /// Resumes media playback only if we were the ones who paused it.
+    /// Reverts the media suppression applied for this session — resuming playback
+    /// if we paused it, or restoring the output volume if we ducked it.
     ///
     /// - Parameter wePaused: `true` if `pauseIfPlaying()` returned `true` for this session.
     func resumeIfWePaused(_ wePaused: Bool) async {
         guard wePaused else {
             DebugLogger.shared.debug(
-                "MediaPlaybackService: We didn't pause media, not resuming",
+                "MediaPlaybackService: We didn't suppress media, nothing to revert",
                 source: "MediaPlaybackService"
             )
             return
         }
 
+        self.revertSuppression()
+    }
+
+    // MARK: - Suppression helpers
+
+    /// Either pauses playback or ducks the system output volume, based on the
+    /// user's setting, and records what was done in `activeSuppression`.
+    private func applySuppression() {
+        // Ducking: lower the output volume instead of stopping playback entirely.
+        if SettingsStore.shared.duckMediaInsteadOfPausing,
+           let original = self.volumeController.currentOutputVolume()
+        {
+            let level = Float(SettingsStore.shared.duckMediaVolumeLevel)
+            let target = original * level
+            if self.volumeController.setOutputVolume(target) {
+                // Read back the level the device actually snapped to (volume can be
+                // quantized to coarse steps) so the restore-time change check is accurate.
+                let applied = self.volumeController.currentOutputVolume() ?? target
+                self.activeSuppression = .ducked(original: original, applied: applied)
+                DebugLogger.shared.info(
+                    "MediaPlaybackService: Ducked output volume \(original) -> \(applied) for transcription",
+                    source: "MediaPlaybackService"
+                )
+                return
+            }
+
+            DebugLogger.shared.warning(
+                "MediaPlaybackService: Failed to lower output volume, falling back to pausing media",
+                source: "MediaPlaybackService"
+            )
+        }
+
         DebugLogger.shared.info(
-            "MediaPlaybackService: Resuming media playback (we paused it)",
+            "MediaPlaybackService: Media is playing, sending pause command",
             source: "MediaPlaybackService"
         )
+        self.mediaController.pause()
+        self.activeSuppression = .paused
+    }
 
-        // Use explicit play() command - never toggle
-        self.mediaController.play()
+    /// Reverts whatever `applySuppression()` did for the current session.
+    private func revertSuppression() {
+        switch self.activeSuppression {
+        case .paused:
+            DebugLogger.shared.info(
+                "MediaPlaybackService: Resuming media playback (we paused it)",
+                source: "MediaPlaybackService"
+            )
+            // Use explicit play() command - never toggle
+            self.mediaController.play()
+
+        case let .ducked(original, applied):
+            // Only restore if the volume is still roughly where we left it. If the
+            // user adjusted it during dictation, respect their choice and leave it.
+            if let current = self.volumeController.currentOutputVolume(), abs(current - applied) > 0.02 {
+                DebugLogger.shared.info(
+                    "MediaPlaybackService: Output volume changed during dictation (\(applied) -> \(current)), leaving as-is",
+                    source: "MediaPlaybackService"
+                )
+            } else {
+                DebugLogger.shared.info(
+                    "MediaPlaybackService: Restoring output volume to \(original) (we ducked it)",
+                    source: "MediaPlaybackService"
+                )
+                self.volumeController.setOutputVolume(original)
+            }
+
+        case .none:
+            DebugLogger.shared.debug(
+                "MediaPlaybackService: No active suppression to revert",
+                source: "MediaPlaybackService"
+            )
+        }
+
+        self.activeSuppression = nil
     }
     #else
     // Intel Mac stub - media control not available

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -27,6 +27,13 @@ final class MediaPlaybackService {
         _ action: @escaping @MainActor @Sendable () -> Void
     ) -> Void
 
+    struct SuppressionConfiguration {
+        let duckInsteadOfPausing: Bool
+        let duckVolumeLevel: Float
+    }
+
+    typealias SuppressionConfigurationProvider = @MainActor () -> SuppressionConfiguration
+
     /// The pinned adapter's two-second deadline can occupy roughly 2.1 seconds
     /// in run-loop slices. Leave additional time for process and callback delivery.
     static let nowPlayingQueryTimeoutSeconds: TimeInterval = 2.5
@@ -37,12 +44,21 @@ final class MediaPlaybackService {
 
     static let shared = MediaPlaybackService(
         mediaController: MediaController(),
+        volumeController: SystemAudioVolumeController(),
+        suppressionConfigurationProvider: {
+            let settings = SettingsStore.shared
+            return SuppressionConfiguration(
+                duckInsteadOfPausing: settings.duckMediaInsteadOfPausing,
+                duckVolumeLevel: Float(settings.duckMediaVolumeLevel)
+            )
+        },
         queryTimeoutSeconds: MediaPlaybackService.nowPlayingQueryTimeoutSeconds,
         timeoutScheduler: MediaPlaybackService.productionTimeoutScheduler
     )
 
     private let mediaController: any MediaPlaybackControlling
-    private let volumeController: SystemAudioVolumeController
+    private let volumeController: any SystemAudioVolumeControlling
+    private let suppressionConfigurationProvider: SuppressionConfigurationProvider
     private let queryTimeoutSeconds: TimeInterval
     private let timeoutScheduler: TimeoutScheduler
 
@@ -62,12 +78,14 @@ final class MediaPlaybackService {
     /// Creates an isolated service with injectable dependencies for deterministic tests.
     init(
         mediaController: any MediaPlaybackControlling,
-        volumeController: SystemAudioVolumeController = SystemAudioVolumeController(),
+        volumeController: any SystemAudioVolumeControlling,
+        suppressionConfigurationProvider: @escaping SuppressionConfigurationProvider,
         queryTimeoutSeconds: TimeInterval,
         timeoutScheduler: @escaping TimeoutScheduler
     ) {
         self.mediaController = mediaController
         self.volumeController = volumeController
+        self.suppressionConfigurationProvider = suppressionConfigurationProvider
         self.queryTimeoutSeconds = queryTimeoutSeconds
         self.timeoutScheduler = timeoutScheduler
     }
@@ -109,6 +127,10 @@ final class MediaPlaybackService {
             )
             return false
         }
+
+        // Keep the action stable for this request even if Settings changes while
+        // MediaRemoteAdapter's asynchronous Now Playing query is in flight.
+        let suppressionConfiguration = self.suppressionConfigurationProvider()
 
         return await withCheckedContinuation { continuation in
             let queryStartedAt = DispatchTime.now().uptimeNanoseconds
@@ -224,7 +246,9 @@ final class MediaPlaybackService {
                     // MediaRemoteAdapter can fire this callback more than once, and ducking
                     // is not idempotent (it reads the current volume as the "original"), so a
                     // duplicate must not re-duck or overwrite `activeSuppression`.
-                    resumeOnce(true) { self.applySuppression() }
+                    resumeOnce(true) {
+                        self.applySuppression(configuration: suppressionConfiguration)
+                    }
                 } else {
                     DebugLogger.shared.debug(
                         """
@@ -259,13 +283,12 @@ final class MediaPlaybackService {
 
     /// Either pauses playback or ducks the system output volume, based on the
     /// user's setting, and records what was done in `activeSuppression`.
-    private func applySuppression() {
+    private func applySuppression(configuration: SuppressionConfiguration) {
         // Ducking: lower the output volume instead of stopping playback entirely.
-        if SettingsStore.shared.duckMediaInsteadOfPausing,
+        if configuration.duckInsteadOfPausing,
            let original = self.volumeController.captureOutputVolume()
         {
-            let level = Float(SettingsStore.shared.duckMediaVolumeLevel)
-            let target = original.scaled(by: level)
+            let target = original.scaled(by: configuration.duckVolumeLevel)
             switch self.volumeController.apply(target) {
             case .applied:
                 // Re-read what the device actually snapped to (volume can be quantized to
@@ -326,11 +349,10 @@ final class MediaPlaybackService {
             // Mute is checked separately from the tolerance: a deeply ducked level can
             // sit within 0.02 of zero, and restoring over a mute would turn the user's
             // audio back on against their explicit intent.
-            let current = self.volumeController.reread(applied)?.averageLevel
-            let userMuted = current.map { $0 <= 0.001 && applied.averageLevel > 0.001 } ?? false
-            if let current, userMuted || abs(current - applied.averageLevel) > 0.02 {
+            let currentSnapshot = self.volumeController.reread(applied)
+            if let currentSnapshot, self.userChangedVolume(currentSnapshot, from: applied) {
                 DebugLogger.shared.info(
-                    "MediaPlaybackService: Output volume changed during dictation (\(applied.averageLevel) -> \(current)\(userMuted ? ", muted" : "")), leaving as-is",
+                    "MediaPlaybackService: Output volume changed during dictation (\(applied.averageLevel) -> \(currentSnapshot.averageLevel)), leaving as-is",
                     source: "MediaPlaybackService"
                 )
             } else {
@@ -363,6 +385,22 @@ final class MediaPlaybackService {
         }
 
         self.activeSuppression = nil
+    }
+
+    private func userChangedVolume(
+        _ current: OutputVolumeSnapshot,
+        from applied: OutputVolumeSnapshot
+    ) -> Bool {
+        guard current.channels.count == applied.channels.count else { return true }
+
+        return zip(current.channels, applied.channels).contains { currentChannel, appliedChannel in
+            guard currentChannel.selector == appliedChannel.selector,
+                  currentChannel.element == appliedChannel.element
+            else { return true }
+
+            let userMuted = currentChannel.volume <= 0.001 && appliedChannel.volume > 0.001
+            return userMuted || abs(currentChannel.volume - appliedChannel.volume) > 0.02
+        }
     }
     #else
     // Intel Mac stub - media control not available

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -253,9 +253,9 @@ final class MediaPlaybackService {
             let level = Float(SettingsStore.shared.duckMediaVolumeLevel)
             let target = original.scaled(by: level)
             if self.volumeController.apply(target) {
-                // Re-capture what the device actually snapped to (volume can be
-                // quantized to coarse steps) so the restore-time change check is accurate.
-                let applied = self.volumeController.captureOutputVolume() ?? target
+                // Re-read what the device actually snapped to (volume can be quantized to
+                // coarse steps) so the restore-time change check is accurate.
+                let applied = self.volumeController.reread(target) ?? target
                 self.activeSuppression = .ducked(original: original, applied: applied)
                 DebugLogger.shared.info(
                     "MediaPlaybackService: Ducked output volume \(original.averageLevel) -> \(applied.averageLevel) for transcription",
@@ -292,7 +292,7 @@ final class MediaPlaybackService {
         case let .ducked(original, applied):
             // Only restore if the volume is still roughly where we left it. If the
             // user adjusted it during dictation, respect their choice and leave it.
-            if let current = self.volumeController.currentAverageLevel(matching: applied),
+            if let current = self.volumeController.reread(applied)?.averageLevel,
                abs(current - applied.averageLevel) > 0.02
             {
                 DebugLogger.shared.info(

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -321,7 +321,12 @@ final class MediaPlaybackService {
                     "MediaPlaybackService: Restoring output volume to \(original.averageLevel) (we ducked it)",
                     source: "MediaPlaybackService"
                 )
-                self.volumeController.apply(original)
+                if !self.volumeController.apply(original) {
+                    DebugLogger.shared.warning(
+                        "MediaPlaybackService: Failed to restore output volume — the ducked output device may no longer be available",
+                        source: "MediaPlaybackService"
+                    )
+                }
             }
 
         case .none:

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -306,11 +306,14 @@ final class MediaPlaybackService {
         case let .ducked(original, applied):
             // Only restore if the volume is still roughly where we left it. If the
             // user adjusted it during dictation, respect their choice and leave it.
-            if let current = self.volumeController.reread(applied)?.averageLevel,
-               abs(current - applied.averageLevel) > 0.02
-            {
+            // Mute is checked separately from the tolerance: a deeply ducked level can
+            // sit within 0.02 of zero, and restoring over a mute would turn the user's
+            // audio back on against their explicit intent.
+            let current = self.volumeController.reread(applied)?.averageLevel
+            let userMuted = current.map { $0 <= 0.001 && applied.averageLevel > 0.001 } ?? false
+            if let current, userMuted || abs(current - applied.averageLevel) > 0.02 {
                 DebugLogger.shared.info(
-                    "MediaPlaybackService: Output volume changed during dictation (\(applied.averageLevel) -> \(current)), leaving as-is",
+                    "MediaPlaybackService: Output volume changed during dictation (\(applied.averageLevel) -> \(current)\(userMuted ? ", muted" : "")), leaving as-is",
                     source: "MediaPlaybackService"
                 )
             } else {

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -266,7 +266,8 @@ final class MediaPlaybackService {
         {
             let level = Float(SettingsStore.shared.duckMediaVolumeLevel)
             let target = original.scaled(by: level)
-            if self.volumeController.apply(target) {
+            switch self.volumeController.apply(target) {
+            case .applied:
                 // Re-read what the device actually snapped to (volume can be quantized to
                 // coarse steps) so the restore-time change check is accurate.
                 let applied = self.volumeController.reread(target) ?? target
@@ -276,12 +277,28 @@ final class MediaPlaybackService {
                     source: "MediaPlaybackService"
                 )
                 return
-            }
 
-            DebugLogger.shared.warning(
-                "MediaPlaybackService: Failed to lower output volume, falling back to pausing media",
-                source: "MediaPlaybackService"
-            )
+            case .partial:
+                // Only some channels ducked. Undo before falling back to pausing —
+                // otherwise the device would stay in a mixed left/right state for the
+                // whole session with nothing left to restore it.
+                if self.volumeController.apply(original) != .applied {
+                    DebugLogger.shared.warning(
+                        "MediaPlaybackService: Could not fully undo a partial duck, output channels may be unbalanced",
+                        source: "MediaPlaybackService"
+                    )
+                }
+                DebugLogger.shared.warning(
+                    "MediaPlaybackService: Volume duck only partially applied, falling back to pausing media",
+                    source: "MediaPlaybackService"
+                )
+
+            case .failed:
+                DebugLogger.shared.warning(
+                    "MediaPlaybackService: Failed to lower output volume, falling back to pausing media",
+                    source: "MediaPlaybackService"
+                )
+            }
         }
 
         DebugLogger.shared.info(
@@ -321,11 +338,20 @@ final class MediaPlaybackService {
                     "MediaPlaybackService: Restoring output volume to \(original.averageLevel) (we ducked it)",
                     source: "MediaPlaybackService"
                 )
-                if !self.volumeController.apply(original) {
-                    DebugLogger.shared.warning(
-                        "MediaPlaybackService: Failed to restore output volume — the ducked output device may no longer be available",
-                        source: "MediaPlaybackService"
-                    )
+                if self.volumeController.apply(original) != .applied {
+                    // Some or all raw channel writes failed. Fall back to the HAL virtual
+                    // main volume so a channel isn't left stuck at the ducked level.
+                    if self.volumeController.applyVirtualMainVolume(original) {
+                        DebugLogger.shared.warning(
+                            "MediaPlaybackService: Raw channel restore incomplete, restored via the virtual main volume instead",
+                            source: "MediaPlaybackService"
+                        )
+                    } else {
+                        DebugLogger.shared.warning(
+                            "MediaPlaybackService: Failed to restore output volume — the ducked output device may no longer be available",
+                            source: "MediaPlaybackService"
+                        )
+                    }
                 }
             }
 

--- a/Sources/Fluid/Services/SystemAudioVolumeController.swift
+++ b/Sources/Fluid/Services/SystemAudioVolumeController.swift
@@ -2,6 +2,13 @@ import AudioToolbox
 import CoreAudio
 import Foundation
 
+protocol SystemAudioVolumeControlling {
+    func captureOutputVolume() -> OutputVolumeSnapshot?
+    func apply(_ snapshot: OutputVolumeSnapshot) -> SystemAudioVolumeController.ApplyOutcome
+    func applyVirtualMainVolume(_ snapshot: OutputVolumeSnapshot) -> Bool
+    func reread(_ snapshot: OutputVolumeSnapshot) -> OutputVolumeSnapshot?
+}
+
 /// Thin CoreAudio wrapper for reading and adjusting the **default output device's**
 /// output volume, used to "duck" (temporarily lower) system audio while dictation
 /// is active, as a gentler alternative to fully pausing media.
@@ -16,7 +23,7 @@ import Foundation
 /// unchanged, so the snapshot records each element rather than a single scalar.
 /// When neither the main volume nor the per-channel scalars are settable, it falls back
 /// to the HAL's virtual main volume (the control the macOS volume HUD drives).
-struct SystemAudioVolumeController {
+struct SystemAudioVolumeController: SystemAudioVolumeControlling {
     /// Captures the default output device's current volume so it can later be
     /// restored exactly, preserving per-channel balance.
     ///
@@ -37,14 +44,18 @@ struct SystemAudioVolumeController {
             )
         }
 
-        // Otherwise capture each *settable* stereo channel individually so balance is retained.
-        let channels = self.stereoChannels(device: device).compactMap { element -> OutputVolumeSnapshot.Channel? in
+        // Otherwise capture each settable stereo channel individually so balance is
+        // retained — but only when the *whole* preferred pair is capturable. A partial
+        // pair would duck one channel and leave the other at full volume, with the
+        // all-captured-channels-written check reporting the duck as fully applied.
+        let stereo = self.stereoChannels(device: device)
+        let channels = stereo.compactMap { element -> OutputVolumeSnapshot.Channel? in
             guard self.isVolumeSettable(device: device, selector: kAudioDevicePropertyVolumeScalar, element: element),
                   let volume = self.volume(device: device, selector: kAudioDevicePropertyVolumeScalar, element: element)
             else { return nil }
             return .init(selector: kAudioDevicePropertyVolumeScalar, element: element, volume: volume)
         }
-        if !channels.isEmpty {
+        if channels.count == stereo.count {
             return OutputVolumeSnapshot(deviceID: device, channels: channels)
         }
 

--- a/Sources/Fluid/Services/SystemAudioVolumeController.swift
+++ b/Sources/Fluid/Services/SystemAudioVolumeController.swift
@@ -10,11 +10,11 @@ import Foundation
 /// from the default device, not just a single app's media.
 ///
 /// Volume is captured and restored as an `OutputVolumeSnapshot`, which preserves the
-/// **individual per-channel levels** (or the master element). Some output devices
-/// expose no settable master volume — only per-channel scalars — and a user may have
+/// **individual per-channel levels** (or the main element). Some output devices
+/// expose no settable main volume — only per-channel scalars — and a user may have
 /// a non-centered left/right balance that must survive a duck/restore cycle
 /// unchanged, so the snapshot records each element rather than a single scalar.
-/// When neither the master nor the per-channel scalars are settable, it falls back
+/// When neither the main volume nor the per-channel scalars are settable, it falls back
 /// to the HAL's virtual main volume (the control the macOS volume HUD drives).
 struct SystemAudioVolumeController {
     /// Captures the default output device's current volume so it can later be
@@ -25,15 +25,15 @@ struct SystemAudioVolumeController {
     func captureOutputVolume() -> OutputVolumeSnapshot? {
         guard let device = self.defaultOutputDevice() else { return nil }
 
-        // Prefer the single master element, but only when it is *settable* — otherwise we
-        // could capture a read-only master and then fail to restore it on a device whose
-        // per-channel volumes are the ones that are actually settable.
+        // Prefer the single main element, but only when it is *settable* — otherwise we
+        // could capture a read-only main volume and then fail to restore it on a device
+        // whose per-channel volumes are the ones that are actually settable.
         if self.isVolumeSettable(device: device, selector: kAudioDevicePropertyVolumeScalar, element: kAudioObjectPropertyElementMain),
-           let master = self.volume(device: device, selector: kAudioDevicePropertyVolumeScalar, element: kAudioObjectPropertyElementMain)
+           let mainLevel = self.volume(device: device, selector: kAudioDevicePropertyVolumeScalar, element: kAudioObjectPropertyElementMain)
         {
             return OutputVolumeSnapshot(
                 deviceID: device,
-                channels: [.init(selector: kAudioDevicePropertyVolumeScalar, element: kAudioObjectPropertyElementMain, volume: master)]
+                channels: [.init(selector: kAudioDevicePropertyVolumeScalar, element: kAudioObjectPropertyElementMain, volume: mainLevel)]
             )
         }
 
@@ -65,18 +65,42 @@ struct SystemAudioVolumeController {
         return nil
     }
 
+    /// Outcome of writing a snapshot's channels back to the device. Partial writes
+    /// are surfaced explicitly: treating "one of two channels written" as success
+    /// would let a failed restore leave one channel stuck at the ducked level.
+    enum ApplyOutcome {
+        /// Every captured channel was written.
+        case applied
+        /// Some channel writes failed — the device is in a mixed state.
+        case partial
+        /// No channel could be written.
+        case failed
+    }
+
     /// Writes every channel captured in `snapshot` back to its recorded level.
-    ///
-    /// - Returns: `true` if at least one channel was successfully written.
     @discardableResult
-    func apply(_ snapshot: OutputVolumeSnapshot) -> Bool {
-        var didSet = false
-        for channel in snapshot.channels {
-            if self.setVolume(channel.volume, device: snapshot.deviceID, selector: channel.selector, element: channel.element) {
-                didSet = true
-            }
+    func apply(_ snapshot: OutputVolumeSnapshot) -> ApplyOutcome {
+        let written = snapshot.channels.filter {
+            self.setVolume($0.volume, device: snapshot.deviceID, selector: $0.selector, element: $0.element)
+        }.count
+        switch written {
+        case snapshot.channels.count: return .applied
+        case 0: return .failed
+        default: return .partial
         }
-        return didSet
+    }
+
+    /// Sets the HAL virtual main volume on the snapshot's device to the snapshot's
+    /// average level — a restore fallback for when raw channel writes fail.
+    /// Approximate (the HAL preserves the device's *current* balance, not the
+    /// captured one), but far better than leaving one channel ducked.
+    func applyVirtualMainVolume(_ snapshot: OutputVolumeSnapshot) -> Bool {
+        self.setVolume(
+            snapshot.averageLevel,
+            device: snapshot.deviceID,
+            selector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            element: kAudioObjectPropertyElementMain
+        )
     }
 
     /// Re-reads the current levels of the same device and elements captured in
@@ -184,18 +208,18 @@ struct SystemAudioVolumeController {
     }
 }
 
-/// An immutable capture of an output device's volume — either its master element or
+/// An immutable capture of an output device's volume — either its main element or
 /// its individual stereo channels — so a duck can be reverted without losing the
 /// device's original per-channel (left/right) balance.
 struct OutputVolumeSnapshot {
-    fileprivate struct Channel {
+    struct Channel {
         let selector: AudioObjectPropertySelector
         let element: AudioObjectPropertyElement
         let volume: Float
     }
 
-    fileprivate let deviceID: AudioDeviceID
-    fileprivate let channels: [Channel]
+    let deviceID: AudioDeviceID
+    let channels: [Channel]
 
     /// Average level across the captured channels, used for logging and for
     /// detecting whether the user changed the volume mid-dictation.

--- a/Sources/Fluid/Services/SystemAudioVolumeController.swift
+++ b/Sources/Fluid/Services/SystemAudioVolumeController.swift
@@ -1,3 +1,4 @@
+import AudioToolbox
 import CoreAudio
 import Foundation
 
@@ -13,6 +14,8 @@ import Foundation
 /// expose no settable master volume — only per-channel scalars — and a user may have
 /// a non-centered left/right balance that must survive a duck/restore cycle
 /// unchanged, so the snapshot records each element rather than a single scalar.
+/// When neither the master nor the per-channel scalars are settable, it falls back
+/// to the HAL's virtual main volume (the control the macOS volume HUD drives).
 struct SystemAudioVolumeController {
     /// Captures the default output device's current volume so it can later be
     /// restored exactly, preserving per-channel balance.
@@ -25,24 +28,41 @@ struct SystemAudioVolumeController {
         // Prefer the single master element, but only when it is *settable* — otherwise we
         // could capture a read-only master and then fail to restore it on a device whose
         // per-channel volumes are the ones that are actually settable.
-        if self.isVolumeSettable(device: device, element: kAudioObjectPropertyElementMain),
-           let master = self.scalarVolume(device: device, element: kAudioObjectPropertyElementMain)
+        if self.isVolumeSettable(device: device, selector: kAudioDevicePropertyVolumeScalar, element: kAudioObjectPropertyElementMain),
+           let master = self.volume(device: device, selector: kAudioDevicePropertyVolumeScalar, element: kAudioObjectPropertyElementMain)
         {
             return OutputVolumeSnapshot(
                 deviceID: device,
-                channels: [.init(element: kAudioObjectPropertyElementMain, volume: master)]
+                channels: [.init(selector: kAudioDevicePropertyVolumeScalar, element: kAudioObjectPropertyElementMain, volume: master)]
             )
         }
 
         // Otherwise capture each *settable* stereo channel individually so balance is retained.
         let channels = self.stereoChannels(device: device).compactMap { element -> OutputVolumeSnapshot.Channel? in
-            guard self.isVolumeSettable(device: device, element: element),
-                  let volume = self.scalarVolume(device: device, element: element)
+            guard self.isVolumeSettable(device: device, selector: kAudioDevicePropertyVolumeScalar, element: element),
+                  let volume = self.volume(device: device, selector: kAudioDevicePropertyVolumeScalar, element: element)
             else { return nil }
-            return .init(element: element, volume: volume)
+            return .init(selector: kAudioDevicePropertyVolumeScalar, element: element, volume: volume)
         }
-        guard !channels.isEmpty else { return nil }
-        return OutputVolumeSnapshot(deviceID: device, channels: channels)
+        if !channels.isEmpty {
+            return OutputVolumeSnapshot(deviceID: device, channels: channels)
+        }
+
+        // Last resort: the HAL's *virtual* main volume — the control the macOS volume
+        // HUD drives — which CoreAudio synthesizes for devices whose raw volume scalars
+        // are not settable (some Bluetooth routes, devices with volume on non-stereo
+        // elements). It applies volume while preserving the device's balance itself,
+        // so a single-element snapshot is sufficient.
+        if self.isVolumeSettable(device: device, selector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume, element: kAudioObjectPropertyElementMain),
+           let virtualMain = self.volume(device: device, selector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume, element: kAudioObjectPropertyElementMain)
+        {
+            return OutputVolumeSnapshot(
+                deviceID: device,
+                channels: [.init(selector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume, element: kAudioObjectPropertyElementMain, volume: virtualMain)]
+            )
+        }
+
+        return nil
     }
 
     /// Writes every channel captured in `snapshot` back to its recorded level.
@@ -52,7 +72,7 @@ struct SystemAudioVolumeController {
     func apply(_ snapshot: OutputVolumeSnapshot) -> Bool {
         var didSet = false
         for channel in snapshot.channels {
-            if self.setScalarVolume(channel.volume, device: snapshot.deviceID, element: channel.element) {
+            if self.setVolume(channel.volume, device: snapshot.deviceID, selector: channel.selector, element: channel.element) {
                 didSet = true
             }
         }
@@ -68,8 +88,8 @@ struct SystemAudioVolumeController {
     /// - Returns: An updated snapshot, or `nil` if a captured element is no longer readable.
     func reread(_ snapshot: OutputVolumeSnapshot) -> OutputVolumeSnapshot? {
         let channels = snapshot.channels.compactMap { channel -> OutputVolumeSnapshot.Channel? in
-            guard let volume = self.scalarVolume(device: snapshot.deviceID, element: channel.element) else { return nil }
-            return .init(element: channel.element, volume: volume)
+            guard let volume = self.volume(device: snapshot.deviceID, selector: channel.selector, element: channel.element) else { return nil }
+            return .init(selector: channel.selector, element: channel.element, volume: volume)
         }
         guard channels.count == snapshot.channels.count else { return nil }
         return OutputVolumeSnapshot(deviceID: snapshot.deviceID, channels: channels)
@@ -112,9 +132,9 @@ struct SystemAudioVolumeController {
         return channels
     }
 
-    private func scalarVolume(device: AudioDeviceID, element: AudioObjectPropertyElement) -> Float? {
+    private func volume(device: AudioDeviceID, selector: AudioObjectPropertySelector, element: AudioObjectPropertyElement) -> Float? {
         var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyVolumeScalar,
+            mSelector: selector,
             mScope: kAudioObjectPropertyScopeOutput,
             mElement: element
         )
@@ -127,10 +147,10 @@ struct SystemAudioVolumeController {
         return volume
     }
 
-    /// Whether the volume scalar for `element` exists and can be written.
-    private func isVolumeSettable(device: AudioDeviceID, element: AudioObjectPropertyElement) -> Bool {
+    /// Whether the volume property for `selector`/`element` exists and can be written.
+    private func isVolumeSettable(device: AudioDeviceID, selector: AudioObjectPropertySelector, element: AudioObjectPropertyElement) -> Bool {
         var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyVolumeScalar,
+            mSelector: selector,
             mScope: kAudioObjectPropertyScopeOutput,
             mElement: element
         )
@@ -140,13 +160,14 @@ struct SystemAudioVolumeController {
         return AudioObjectIsPropertySettable(device, &address, &settable) == noErr && settable.boolValue
     }
 
-    private func setScalarVolume(
+    private func setVolume(
         _ volume: Float,
         device: AudioDeviceID,
+        selector: AudioObjectPropertySelector,
         element: AudioObjectPropertyElement
     ) -> Bool {
         var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyVolumeScalar,
+            mSelector: selector,
             mScope: kAudioObjectPropertyScopeOutput,
             mElement: element
         )
@@ -168,6 +189,7 @@ struct SystemAudioVolumeController {
 /// device's original per-channel (left/right) balance.
 struct OutputVolumeSnapshot {
     fileprivate struct Channel {
+        let selector: AudioObjectPropertySelector
         let element: AudioObjectPropertyElement
         let volume: Float
     }
@@ -189,7 +211,7 @@ struct OutputVolumeSnapshot {
         OutputVolumeSnapshot(
             deviceID: self.deviceID,
             channels: self.channels.map {
-                Channel(element: $0.element, volume: max(0.0, min(1.0, $0.volume * factor)))
+                Channel(selector: $0.selector, element: $0.element, volume: max(0.0, min(1.0, $0.volume * factor)))
             }
         )
     }

--- a/Sources/Fluid/Services/SystemAudioVolumeController.swift
+++ b/Sources/Fluid/Services/SystemAudioVolumeController.swift
@@ -22,17 +22,23 @@ struct SystemAudioVolumeController {
     func captureOutputVolume() -> OutputVolumeSnapshot? {
         guard let device = self.defaultOutputDevice() else { return nil }
 
-        // Prefer the single master element when the device exposes it.
-        if let master = self.scalarVolume(device: device, element: kAudioObjectPropertyElementMain) {
+        // Prefer the single master element, but only when it is *settable* — otherwise we
+        // could capture a read-only master and then fail to restore it on a device whose
+        // per-channel volumes are the ones that are actually settable.
+        if self.isVolumeSettable(device: device, element: kAudioObjectPropertyElementMain),
+           let master = self.scalarVolume(device: device, element: kAudioObjectPropertyElementMain)
+        {
             return OutputVolumeSnapshot(
                 deviceID: device,
                 channels: [.init(element: kAudioObjectPropertyElementMain, volume: master)]
             )
         }
 
-        // Otherwise capture each stereo channel individually so balance is retained.
+        // Otherwise capture each *settable* stereo channel individually so balance is retained.
         let channels = self.stereoChannels(device: device).compactMap { element -> OutputVolumeSnapshot.Channel? in
-            guard let volume = self.scalarVolume(device: device, element: element) else { return nil }
+            guard self.isVolumeSettable(device: device, element: element),
+                  let volume = self.scalarVolume(device: device, element: element)
+            else { return nil }
             return .init(element: element, volume: volume)
         }
         guard !channels.isEmpty else { return nil }
@@ -53,14 +59,20 @@ struct SystemAudioVolumeController {
         return didSet
     }
 
-    /// Reads the current average level of the same device and elements captured in
-    /// `snapshot`, for detecting whether the user changed the volume since we set it.
-    func currentAverageLevel(matching snapshot: OutputVolumeSnapshot) -> Float? {
-        let values = snapshot.channels.compactMap {
-            self.scalarVolume(device: snapshot.deviceID, element: $0.element)
+    /// Re-reads the current levels of the same device and elements captured in
+    /// `snapshot`, returning an updated snapshot — used both to learn what the hardware
+    /// actually snapped to (volume can be quantized to coarse steps) and to detect
+    /// whether the user changed the volume since we set it. Operates on the snapshot's
+    /// own device, so it is unaffected if the default output device changes mid-session.
+    ///
+    /// - Returns: An updated snapshot, or `nil` if a captured element is no longer readable.
+    func reread(_ snapshot: OutputVolumeSnapshot) -> OutputVolumeSnapshot? {
+        let channels = snapshot.channels.compactMap { channel -> OutputVolumeSnapshot.Channel? in
+            guard let volume = self.scalarVolume(device: snapshot.deviceID, element: channel.element) else { return nil }
+            return .init(element: channel.element, volume: volume)
         }
-        guard !values.isEmpty else { return nil }
-        return values.reduce(0, +) / Float(values.count)
+        guard channels.count == snapshot.channels.count else { return nil }
+        return OutputVolumeSnapshot(deviceID: snapshot.deviceID, channels: channels)
     }
 
     // MARK: - Private CoreAudio helpers
@@ -113,6 +125,19 @@ struct SystemAudioVolumeController {
         let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &volume)
         guard status == noErr else { return nil }
         return volume
+    }
+
+    /// Whether the volume scalar for `element` exists and can be written.
+    private func isVolumeSettable(device: AudioDeviceID, element: AudioObjectPropertyElement) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: element
+        )
+        guard AudioObjectHasProperty(device, &address) else { return false }
+
+        var settable = DarwinBoolean(false)
+        return AudioObjectIsPropertySettable(device, &address, &settable) == noErr && settable.boolValue
     }
 
     private func setScalarVolume(

--- a/Sources/Fluid/Services/SystemAudioVolumeController.swift
+++ b/Sources/Fluid/Services/SystemAudioVolumeController.swift
@@ -1,0 +1,128 @@
+import CoreAudio
+import Foundation
+
+/// Thin CoreAudio wrapper for reading and adjusting the **default output device's**
+/// master output volume.
+///
+/// This is used to "duck" (temporarily lower) system audio while dictation is
+/// active, as a gentler alternative to fully pausing media. Note that CoreAudio's
+/// output volume is system-wide: ducking lowers *all* output from the default
+/// device, not just a single app's media.
+///
+/// Volume is expressed as a scalar in the `0.0...1.0` range. Some output devices
+/// expose a settable master element (`kAudioObjectPropertyElementMain`), while
+/// others only allow per-channel control; both paths are handled here.
+struct SystemAudioVolumeController {
+    /// Returns the current scalar volume (`0.0...1.0`) of the default output
+    /// device, or `nil` if it can't be determined (e.g. an aggregate device or a
+    /// device that doesn't expose a volume property).
+    func currentOutputVolume() -> Float? {
+        guard let device = self.defaultOutputDevice() else { return nil }
+
+        if let master = self.scalarVolume(device: device, element: kAudioObjectPropertyElementMain) {
+            return master
+        }
+
+        // Fall back to averaging the individual stereo channels.
+        let values = self.stereoChannels(device: device)
+            .compactMap { self.scalarVolume(device: device, element: $0) }
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Float(values.count)
+    }
+
+    /// Sets the default output device volume to `volume` (clamped to `0.0...1.0`).
+    ///
+    /// - Returns: `true` if at least one volume element was successfully written.
+    @discardableResult
+    func setOutputVolume(_ volume: Float) -> Bool {
+        guard let device = self.defaultOutputDevice() else { return false }
+        let clamped = max(0.0, min(1.0, volume))
+
+        if self.setScalarVolume(clamped, device: device, element: kAudioObjectPropertyElementMain) {
+            return true
+        }
+
+        // Fall back to writing each stereo channel individually.
+        var didSet = false
+        for channel in self.stereoChannels(device: device) {
+            if self.setScalarVolume(clamped, device: device, element: channel) {
+                didSet = true
+            }
+        }
+        return didSet
+    }
+
+    // MARK: - Private CoreAudio helpers
+
+    private func defaultOutputDevice() -> AudioDeviceID? {
+        var deviceID = AudioDeviceID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+        )
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    /// The output channel numbers used for stereo, defaulting to `[1, 2]` when the
+    /// device doesn't advertise a preferred pair.
+    private func stereoChannels(device: AudioDeviceID) -> [UInt32] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyPreferredChannelsForStereo,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        guard AudioObjectHasProperty(device, &address) else { return [1, 2] }
+
+        var channels: [UInt32] = [0, 0]
+        var size = UInt32(MemoryLayout<UInt32>.size * channels.count)
+        let status = channels.withUnsafeMutableBytes { buffer -> OSStatus in
+            guard let base = buffer.baseAddress else { return OSStatus(-1) }
+            return AudioObjectGetPropertyData(device, &address, 0, nil, &size, base)
+        }
+        guard status == noErr, channels.allSatisfy({ $0 != 0 }) else { return [1, 2] }
+        return channels
+    }
+
+    private func scalarVolume(device: AudioDeviceID, element: AudioObjectPropertyElement) -> Float? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: element
+        )
+        guard AudioObjectHasProperty(device, &address) else { return nil }
+
+        var volume = Float(0)
+        var size = UInt32(MemoryLayout<Float>.size)
+        let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &volume)
+        guard status == noErr else { return nil }
+        return volume
+    }
+
+    private func setScalarVolume(
+        _ volume: Float,
+        device: AudioDeviceID,
+        element: AudioObjectPropertyElement
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: element
+        )
+        guard AudioObjectHasProperty(device, &address) else { return false }
+
+        var settable = DarwinBoolean(false)
+        guard AudioObjectIsPropertySettable(device, &address, &settable) == noErr, settable.boolValue else {
+            return false
+        }
+
+        var newVolume = max(0.0, min(1.0, volume))
+        let size = UInt32(MemoryLayout<Float>.size)
+        return AudioObjectSetPropertyData(device, &address, 0, nil, size, &newVolume) == noErr
+    }
+}

--- a/Sources/Fluid/Services/SystemAudioVolumeController.swift
+++ b/Sources/Fluid/Services/SystemAudioVolumeController.swift
@@ -2,54 +2,65 @@ import CoreAudio
 import Foundation
 
 /// Thin CoreAudio wrapper for reading and adjusting the **default output device's**
-/// master output volume.
+/// output volume, used to "duck" (temporarily lower) system audio while dictation
+/// is active, as a gentler alternative to fully pausing media.
 ///
-/// This is used to "duck" (temporarily lower) system audio while dictation is
-/// active, as a gentler alternative to fully pausing media. Note that CoreAudio's
-/// output volume is system-wide: ducking lowers *all* output from the default
-/// device, not just a single app's media.
+/// Note that CoreAudio's output volume is system-wide: ducking lowers *all* output
+/// from the default device, not just a single app's media.
 ///
-/// Volume is expressed as a scalar in the `0.0...1.0` range. Some output devices
-/// expose a settable master element (`kAudioObjectPropertyElementMain`), while
-/// others only allow per-channel control; both paths are handled here.
+/// Volume is captured and restored as an `OutputVolumeSnapshot`, which preserves the
+/// **individual per-channel levels** (or the master element). Some output devices
+/// expose no settable master volume — only per-channel scalars — and a user may have
+/// a non-centered left/right balance that must survive a duck/restore cycle
+/// unchanged, so the snapshot records each element rather than a single scalar.
 struct SystemAudioVolumeController {
-    /// Returns the current scalar volume (`0.0...1.0`) of the default output
-    /// device, or `nil` if it can't be determined (e.g. an aggregate device or a
-    /// device that doesn't expose a volume property).
-    func currentOutputVolume() -> Float? {
+    /// Captures the default output device's current volume so it can later be
+    /// restored exactly, preserving per-channel balance.
+    ///
+    /// - Returns: A snapshot, or `nil` if no volume property is available (e.g. an
+    ///   aggregate device).
+    func captureOutputVolume() -> OutputVolumeSnapshot? {
         guard let device = self.defaultOutputDevice() else { return nil }
 
+        // Prefer the single master element when the device exposes it.
         if let master = self.scalarVolume(device: device, element: kAudioObjectPropertyElementMain) {
-            return master
+            return OutputVolumeSnapshot(
+                deviceID: device,
+                channels: [.init(element: kAudioObjectPropertyElementMain, volume: master)]
+            )
         }
 
-        // Fall back to averaging the individual stereo channels.
-        let values = self.stereoChannels(device: device)
-            .compactMap { self.scalarVolume(device: device, element: $0) }
-        guard !values.isEmpty else { return nil }
-        return values.reduce(0, +) / Float(values.count)
+        // Otherwise capture each stereo channel individually so balance is retained.
+        let channels = self.stereoChannels(device: device).compactMap { element -> OutputVolumeSnapshot.Channel? in
+            guard let volume = self.scalarVolume(device: device, element: element) else { return nil }
+            return .init(element: element, volume: volume)
+        }
+        guard !channels.isEmpty else { return nil }
+        return OutputVolumeSnapshot(deviceID: device, channels: channels)
     }
 
-    /// Sets the default output device volume to `volume` (clamped to `0.0...1.0`).
+    /// Writes every channel captured in `snapshot` back to its recorded level.
     ///
-    /// - Returns: `true` if at least one volume element was successfully written.
+    /// - Returns: `true` if at least one channel was successfully written.
     @discardableResult
-    func setOutputVolume(_ volume: Float) -> Bool {
-        guard let device = self.defaultOutputDevice() else { return false }
-        let clamped = max(0.0, min(1.0, volume))
-
-        if self.setScalarVolume(clamped, device: device, element: kAudioObjectPropertyElementMain) {
-            return true
-        }
-
-        // Fall back to writing each stereo channel individually.
+    func apply(_ snapshot: OutputVolumeSnapshot) -> Bool {
         var didSet = false
-        for channel in self.stereoChannels(device: device) {
-            if self.setScalarVolume(clamped, device: device, element: channel) {
+        for channel in snapshot.channels {
+            if self.setScalarVolume(channel.volume, device: snapshot.deviceID, element: channel.element) {
                 didSet = true
             }
         }
         return didSet
+    }
+
+    /// Reads the current average level of the same device and elements captured in
+    /// `snapshot`, for detecting whether the user changed the volume since we set it.
+    func currentAverageLevel(matching snapshot: OutputVolumeSnapshot) -> Float? {
+        let values = snapshot.channels.compactMap {
+            self.scalarVolume(device: snapshot.deviceID, element: $0.element)
+        }
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Float(values.count)
     }
 
     // MARK: - Private CoreAudio helpers
@@ -124,5 +135,37 @@ struct SystemAudioVolumeController {
         var newVolume = max(0.0, min(1.0, volume))
         let size = UInt32(MemoryLayout<Float>.size)
         return AudioObjectSetPropertyData(device, &address, 0, nil, size, &newVolume) == noErr
+    }
+}
+
+/// An immutable capture of an output device's volume — either its master element or
+/// its individual stereo channels — so a duck can be reverted without losing the
+/// device's original per-channel (left/right) balance.
+struct OutputVolumeSnapshot {
+    fileprivate struct Channel {
+        let element: AudioObjectPropertyElement
+        let volume: Float
+    }
+
+    fileprivate let deviceID: AudioDeviceID
+    fileprivate let channels: [Channel]
+
+    /// Average level across the captured channels, used for logging and for
+    /// detecting whether the user changed the volume mid-dictation.
+    var averageLevel: Float {
+        guard !self.channels.isEmpty else { return 0 }
+        return self.channels.map(\.volume).reduce(0, +) / Float(self.channels.count)
+    }
+
+    /// A copy with every channel scaled by `factor` (clamped to `0.0...1.0`).
+    /// Scaling each channel by the same factor lowers the volume while preserving
+    /// the device's left/right balance.
+    func scaled(by factor: Float) -> OutputVolumeSnapshot {
+        OutputVolumeSnapshot(
+            deviceID: self.deviceID,
+            channels: self.channels.map {
+                Channel(element: $0.element, volume: max(0.0, min(1.0, $0.volume * factor)))
+            }
+        )
     }
 }

--- a/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
+++ b/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
@@ -19,7 +19,8 @@ final class TranscriptionSoundPlayer {
         self.play(
             soundName: soundName,
             desiredVolume: settings.transcriptionSoundVolume,
-            independentVolume: settings.transcriptionSoundIndependentVolume
+            independentVolume: settings.transcriptionSoundIndependentVolume,
+            enforceDuckingPrecedence: true
         )
     }
 
@@ -31,7 +32,8 @@ final class TranscriptionSoundPlayer {
         self.play(
             soundName: soundName,
             desiredVolume: settings.transcriptionSoundVolume,
-            independentVolume: settings.transcriptionSoundIndependentVolume
+            independentVolume: settings.transcriptionSoundIndependentVolume,
+            enforceDuckingPrecedence: true
         )
     }
 
@@ -60,7 +62,8 @@ final class TranscriptionSoundPlayer {
     private func play(
         soundName: String,
         desiredVolume: Float,
-        independentVolume: Bool
+        independentVolume: Bool,
+        enforceDuckingPrecedence: Bool = false
     ) {
         let startedAt = ProcessInfo.processInfo.systemUptime
         DebugLogger.shared.benchmark(
@@ -77,7 +80,9 @@ final class TranscriptionSoundPlayer {
         // Media ducking owns system volume during dictation, so the cue must not
         // independently change and asynchronously restore that same volume.
         let settings = SettingsStore.shared
-        let duckingOwnsSystemVolume = settings.pauseMediaDuringTranscription && settings.duckMediaInsteadOfPausing
+        let duckingOwnsSystemVolume = enforceDuckingPrecedence
+            && settings.pauseMediaDuringTranscription
+            && settings.duckMediaInsteadOfPausing
         let useIndependentVolume = independentVolume && !duckingOwnsSystemVolume
 
         self.playbackQueue.async { [weak self] in

--- a/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
+++ b/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
@@ -9,6 +9,11 @@ final class TranscriptionSoundPlayer {
     private var players: [String: AVAudioPlayer] = [:]
     private var savedSystemVolume: Float?
 
+    /// Ducking-precedence decision captured when the start cue plays, reused by the
+    /// stop cue so both cues of one session behave consistently even if the user
+    /// toggles the ducking setting mid-dictation.
+    private var sessionDuckingPrecedence: Bool?
+
     private init() {}
 
     func playStartSound() {
@@ -16,11 +21,12 @@ final class TranscriptionSoundPlayer {
         guard settings.enableTranscriptionSounds else { return }
         let selected = settings.transcriptionStartSound
         guard let soundName = selected.startSoundFileName else { return }
+        let duckingPrecedence = self.duckingOwnsSystemVolume(settings)
+        self.sessionDuckingPrecedence = duckingPrecedence
         self.play(
             soundName: soundName,
             desiredVolume: settings.transcriptionSoundVolume,
-            independentVolume: settings.transcriptionSoundIndependentVolume,
-            enforceDuckingPrecedence: true
+            independentVolume: settings.transcriptionSoundIndependentVolume && !duckingPrecedence
         )
     }
 
@@ -29,11 +35,15 @@ final class TranscriptionSoundPlayer {
         guard settings.enableTranscriptionSounds else { return }
         let selected = settings.transcriptionStartSound
         guard let soundName = selected.stopSoundFileName else { return }
+        // Reuse the decision captured at session start: the ducking revert is keyed to
+        // what MediaPlaybackService actually did when the session began, so a settings
+        // toggle mid-dictation must not re-enable the cue's system-volume override here.
+        let duckingPrecedence = self.sessionDuckingPrecedence ?? self.duckingOwnsSystemVolume(settings)
+        self.sessionDuckingPrecedence = nil
         self.play(
             soundName: soundName,
             desiredVolume: settings.transcriptionSoundVolume,
-            independentVolume: settings.transcriptionSoundIndependentVolume,
-            enforceDuckingPrecedence: true
+            independentVolume: settings.transcriptionSoundIndependentVolume && !duckingPrecedence
         )
     }
 
@@ -59,11 +69,25 @@ final class TranscriptionSoundPlayer {
         )
     }
 
+    /// When "lower volume instead of pausing" (ducking) is enabled, MediaPlaybackService
+    /// owns the system output volume for the duration of a dictation session. The cue's
+    /// independent-volume mode also temporarily sets and *asynchronously* restores the
+    /// system volume, and the two would race: a late cue restore can undo the duck at
+    /// session start, or overwrite the final restore and leave the Mac stuck at the ducked
+    /// level. So for the session start/stop cues, ducking takes precedence — the cue plays
+    /// at its own player volume and leaves the system volume alone. The decision is
+    /// captured at start-cue time (see `sessionDuckingPrecedence`) so a mid-dictation
+    /// settings toggle can't hand the stop cue back the system volume while a duck is
+    /// still active. Settings previews never run during a session, so they always honor
+    /// the independent-volume setting.
+    private func duckingOwnsSystemVolume(_ settings: SettingsStore) -> Bool {
+        settings.pauseMediaDuringTranscription && settings.duckMediaInsteadOfPausing
+    }
+
     private func play(
         soundName: String,
         desiredVolume: Float,
-        independentVolume: Bool,
-        enforceDuckingPrecedence: Bool = false
+        independentVolume: Bool
     ) {
         let startedAt = ProcessInfo.processInfo.systemUptime
         DebugLogger.shared.benchmark(
@@ -77,20 +101,12 @@ final class TranscriptionSoundPlayer {
             return
         }
 
-        // Media ducking owns system volume during dictation, so the cue must not
-        // independently change and asynchronously restore that same volume.
-        let settings = SettingsStore.shared
-        let duckingOwnsSystemVolume = enforceDuckingPrecedence
-            && settings.pauseMediaDuringTranscription
-            && settings.duckMediaInsteadOfPausing
-        let useIndependentVolume = independentVolume && !duckingOwnsSystemVolume
-
         self.playbackQueue.async { [weak self] in
             self?.playOnPlaybackQueue(
                 soundName: soundName,
                 url: url,
                 desiredVolume: desiredVolume,
-                independentVolume: useIndependentVolume,
+                independentVolume: independentVolume,
                 startedAt: startedAt
             )
         }

--- a/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
+++ b/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
@@ -17,6 +17,7 @@ final class TranscriptionSoundPlayer {
     private init() {}
 
     func playStartSound() {
+        self.sessionDuckingPrecedence = nil
         let settings = SettingsStore.shared
         guard settings.enableTranscriptionSounds else { return }
         let selected = settings.transcriptionStartSound
@@ -31,6 +32,8 @@ final class TranscriptionSoundPlayer {
     }
 
     func playStopSound() {
+        let sessionDuckingPrecedence = self.sessionDuckingPrecedence
+        self.sessionDuckingPrecedence = nil
         let settings = SettingsStore.shared
         guard settings.enableTranscriptionSounds else { return }
         let selected = settings.transcriptionStartSound
@@ -38,8 +41,7 @@ final class TranscriptionSoundPlayer {
         // Reuse the decision captured at session start: the ducking revert is keyed to
         // what MediaPlaybackService actually did when the session began, so a settings
         // toggle mid-dictation must not re-enable the cue's system-volume override here.
-        let duckingPrecedence = self.sessionDuckingPrecedence ?? self.duckingOwnsSystemVolume(settings)
-        self.sessionDuckingPrecedence = nil
+        let duckingPrecedence = sessionDuckingPrecedence ?? self.duckingOwnsSystemVolume(settings)
         self.play(
             soundName: soundName,
             desiredVolume: settings.transcriptionSoundVolume,

--- a/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
+++ b/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
@@ -74,12 +74,18 @@ final class TranscriptionSoundPlayer {
             return
         }
 
+        // Media ducking owns system volume during dictation, so the cue must not
+        // independently change and asynchronously restore that same volume.
+        let settings = SettingsStore.shared
+        let duckingOwnsSystemVolume = settings.pauseMediaDuringTranscription && settings.duckMediaInsteadOfPausing
+        let useIndependentVolume = independentVolume && !duckingOwnsSystemVolume
+
         self.playbackQueue.async { [weak self] in
             self?.playOnPlaybackQueue(
                 soundName: soundName,
                 url: url,
                 desiredVolume: desiredVolume,
-                independentVolume: independentVolume,
+                independentVolume: useIndependentVolume,
                 startedAt: startedAt
             )
         }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -940,47 +940,7 @@ struct SettingsView: View {
                                         )
                                     )
 
-                                    if self.settings.pauseMediaDuringTranscription {
-                                        VStack(alignment: .leading, spacing: 10) {
-                                            self.optionToggleRow(
-                                                title: "Lower Volume Instead of Pausing",
-                                                description: "Duck currently playing audio/video to a quieter level while you dictate, then restore it — instead of stopping playback. Affects overall system output volume.",
-                                                isOn: Binding(
-                                                    get: { SettingsStore.shared.duckMediaInsteadOfPausing },
-                                                    set: { SettingsStore.shared.duckMediaInsteadOfPausing = $0 }
-                                                )
-                                            )
-
-                                            if self.settings.duckMediaInsteadOfPausing {
-                                                HStack {
-                                                    VStack(alignment: .leading, spacing: 2) {
-                                                        Text("Volume While Dictating")
-                                                            .font(self.theme.typography.bodyStrong)
-                                                            .foregroundStyle(self.settingsTitleText)
-                                                        Text("Fraction of the current volume to keep while dictation is active.")
-                                                            .font(self.theme.typography.bodySmall)
-                                                            .foregroundStyle(self.settingsSecondaryText)
-                                                    }
-
-                                                    Spacer()
-
-                                                    HStack(spacing: 6) {
-                                                        Slider(value: self.$settings.duckMediaVolumeLevel, in: 0.05 ... 1.0, step: 0.05)
-                                                            .frame(width: 110)
-                                                            .controlSize(.small)
-
-                                                        Text("\(Int((self.settings.duckMediaVolumeLevel * 100).rounded()))%")
-                                                            .font(.caption.monospaced())
-                                                            .foregroundStyle(self.settingsSecondaryText)
-                                                            .frame(width: 44, alignment: .trailing)
-                                                    }
-                                                    .frame(width: 160, alignment: .trailing)
-                                                }
-                                            }
-                                        }
-                                        .padding(.leading, 16)
-                                        .padding(.top, 2)
-                                    }
+                                    self.duckMediaOptions
 
                                     Divider().opacity(0.2)
 
@@ -2989,6 +2949,54 @@ private extension SettingsView {
                 }
                 .padding(.leading, 12)
             }
+        }
+    }
+}
+
+private extension SettingsView {
+    /// Sub-options for "Pause Media During Transcription" — the volume-ducking
+    /// toggle and its level slider, shown only while media pausing is enabled.
+    @ViewBuilder var duckMediaOptions: some View {
+        if self.settings.pauseMediaDuringTranscription {
+            VStack(alignment: .leading, spacing: 10) {
+                self.optionToggleRow(
+                    title: "Lower Volume Instead of Pausing",
+                    description: "Duck currently playing audio/video to a quieter level while you dictate, then restore it — instead of stopping playback. Affects overall system output volume.",
+                    isOn: Binding(
+                        get: { SettingsStore.shared.duckMediaInsteadOfPausing },
+                        set: { SettingsStore.shared.duckMediaInsteadOfPausing = $0 }
+                    )
+                )
+
+                if self.settings.duckMediaInsteadOfPausing {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Volume While Dictating")
+                                .font(self.theme.typography.bodyStrong)
+                                .foregroundStyle(self.settingsTitleText)
+                            Text("Fraction of the current volume to keep while dictation is active.")
+                                .font(self.theme.typography.bodySmall)
+                                .foregroundStyle(self.settingsSecondaryText)
+                        }
+
+                        Spacer()
+
+                        HStack(spacing: 6) {
+                            Slider(value: self.$settings.duckMediaVolumeLevel, in: 0.05...1.0, step: 0.05)
+                                .frame(width: 110)
+                                .controlSize(.small)
+
+                            Text("\(Int((self.settings.duckMediaVolumeLevel * 100).rounded()))%")
+                                .font(.caption.monospaced())
+                                .foregroundStyle(self.settingsSecondaryText)
+                                .frame(width: 44, alignment: .trailing)
+                        }
+                        .frame(width: 160, alignment: .trailing)
+                    }
+                }
+            }
+            .padding(.leading, 16)
+            .padding(.top, 2)
         }
     }
 }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -939,6 +939,49 @@ struct SettingsView: View {
                                             set: { SettingsStore.shared.pauseMediaDuringTranscription = $0 }
                                         )
                                     )
+
+                                    if self.settings.pauseMediaDuringTranscription {
+                                        VStack(alignment: .leading, spacing: 10) {
+                                            self.optionToggleRow(
+                                                title: "Lower Volume Instead of Pausing",
+                                                description: "Duck currently playing audio/video to a quieter level while you dictate, then restore it — instead of stopping playback. Affects overall system output volume.",
+                                                isOn: Binding(
+                                                    get: { SettingsStore.shared.duckMediaInsteadOfPausing },
+                                                    set: { SettingsStore.shared.duckMediaInsteadOfPausing = $0 }
+                                                )
+                                            )
+
+                                            if self.settings.duckMediaInsteadOfPausing {
+                                                HStack {
+                                                    VStack(alignment: .leading, spacing: 2) {
+                                                        Text("Volume While Dictating")
+                                                            .font(self.theme.typography.bodyStrong)
+                                                            .foregroundStyle(self.settingsTitleText)
+                                                        Text("Fraction of the current volume to keep while dictation is active.")
+                                                            .font(self.theme.typography.bodySmall)
+                                                            .foregroundStyle(self.settingsSecondaryText)
+                                                    }
+
+                                                    Spacer()
+
+                                                    HStack(spacing: 6) {
+                                                        Slider(value: self.$settings.duckMediaVolumeLevel, in: 0.05 ... 1.0, step: 0.05)
+                                                            .frame(width: 110)
+                                                            .controlSize(.small)
+
+                                                        Text("\(Int((self.settings.duckMediaVolumeLevel * 100).rounded()))%")
+                                                            .font(.caption.monospaced())
+                                                            .foregroundStyle(self.settingsSecondaryText)
+                                                            .frame(width: 44, alignment: .trailing)
+                                                    }
+                                                    .frame(width: 160, alignment: .trailing)
+                                                }
+                                            }
+                                        }
+                                        .padding(.leading, 16)
+                                        .padding(.top, 2)
+                                    }
+
                                     Divider().opacity(0.2)
 
                                     self.optionToggleRow(

--- a/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
+++ b/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
@@ -1,3 +1,4 @@
+import CoreAudio
 @testable import FluidVoice_Debug
 import Foundation
 #if arch(arm64)
@@ -9,12 +10,12 @@ import XCTest
 @MainActor
 final class MediaPlaybackServiceTests: XCTestCase {
     func testPlayingCallbackBeforeTimeoutRequestsPause() async throws {
-        let (service, controller, scheduler) = self.makeService()
+        let (service, controller, scheduler, _) = self.makeService()
         let pauseTask = Task { await service.pauseIfPlaying() }
 
         await controller.waitUntilQueryRegistered()
         XCTAssertEqual(scheduler.scheduledDelays, [2.5])
-        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
 
         let didPause = await pauseTask.value
         XCTAssertTrue(didPause)
@@ -25,7 +26,7 @@ final class MediaPlaybackServiceTests: XCTestCase {
     }
 
     func testCallbackAfterFormerOneSecondBoundaryStillRequestsPause() async throws {
-        let (service, controller, scheduler) = self.makeService()
+        let (service, controller, scheduler, _) = self.makeService()
         let pauseTask = Task { await service.pauseIfPlaying() }
 
         await controller.waitUntilQueryRegistered()
@@ -33,7 +34,7 @@ final class MediaPlaybackServiceTests: XCTestCase {
         XCTAssertGreaterThan(MediaPlaybackService.nowPlayingQueryTimeoutSeconds, 2)
 
         scheduler.advance(by: 1.1)
-        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
 
         let didPause = await pauseTask.value
         XCTAssertTrue(didPause)
@@ -44,7 +45,7 @@ final class MediaPlaybackServiceTests: XCTestCase {
     }
 
     func testTimeoutThenLatePlayingCallbackNeverPauses() async throws {
-        let (service, controller, scheduler) = self.makeService()
+        let (service, controller, scheduler, volumeController) = self.makeService()
         let pauseTask = Task { await service.pauseIfPlaying() }
 
         await controller.waitUntilQueryRegistered()
@@ -54,12 +55,13 @@ final class MediaPlaybackServiceTests: XCTestCase {
         XCTAssertFalse(didPause)
         XCTAssertEqual(controller.pauseCallCount, 0)
 
-        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
         XCTAssertEqual(controller.pauseCallCount, 0)
+        XCTAssertEqual(volumeController.captureCallCount, 0)
     }
 
     func testDuplicatePlayingCallbacksIssueOnePause() async throws {
-        let (service, controller, _) = self.makeService()
+        let (service, controller, _, _) = self.makeService()
         let pauseTask = Task { await service.pauseIfPlaying() }
         let playingTrack = try self.makeTrackInfo(isPlaying: true, playbackRate: 1)
 
@@ -77,27 +79,33 @@ final class MediaPlaybackServiceTests: XCTestCase {
         XCTAssertFalse(nilResult.didPause)
         XCTAssertEqual(nilResult.pauseCallCount, 0)
 
-        let explicitlyPaused = await self.pauseResult(
-            for: try self.makeTrackInfo(isPlaying: false, playbackRate: 1)
+        let explicitlyPaused = try await self.pauseResult(
+            for: self.makeTrackInfo(isPlaying: false, playbackRate: 1)
         )
         XCTAssertFalse(explicitlyPaused.didPause)
         XCTAssertEqual(explicitlyPaused.pauseCallCount, 0)
 
-        let zeroRate = await self.pauseResult(
-            for: try self.makeTrackInfo(isPlaying: nil, playbackRate: 0)
+        let zeroRate = try await self.pauseResult(
+            for: self.makeTrackInfo(isPlaying: nil, playbackRate: 0)
         )
         XCTAssertFalse(zeroRate.didPause)
         XCTAssertEqual(zeroRate.pauseCallCount, 0)
 
-        let positiveRate = await self.pauseResult(
-            for: try self.makeTrackInfo(isPlaying: nil, playbackRate: 1)
+        let positiveRate = try await self.pauseResult(
+            for: self.makeTrackInfo(isPlaying: nil, playbackRate: 1)
         )
         XCTAssertTrue(positiveRate.didPause)
         XCTAssertEqual(positiveRate.pauseCallCount, 1)
     }
 
-    func testResumeOnlyPlaysWhenPauseOwnershipIsTrue() async {
-        let (service, controller, _) = self.makeService()
+    func testResumeOnlyPlaysWhenPauseOwnershipIsTrue() async throws {
+        let (service, controller, _, _) = self.makeService()
+        let pauseTask = Task { await service.pauseIfPlaying() }
+
+        await controller.waitUntilQueryRegistered()
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+        let didPause = await pauseTask.value
+        XCTAssertTrue(didPause)
 
         await service.resumeIfWePaused(false)
         XCTAssertEqual(controller.playCallCount, 0)
@@ -106,26 +114,175 @@ final class MediaPlaybackServiceTests: XCTestCase {
         XCTAssertEqual(controller.playCallCount, 1)
     }
 
-    private func makeService() -> (
+    func testDuckingScalesAndRestoresEveryChannelWithoutPlaybackCommands() async throws {
+        let original = self.makeSnapshot([0.8, 0.4])
+        let volumeController = FakeSystemAudioVolumeController(capturedSnapshot: original)
+        let (service, controller, _, _) = self.makeService(
+            configuration: .init(duckInsteadOfPausing: true, duckVolumeLevel: 0.2),
+            volumeController: volumeController
+        )
+
+        let suppressionTask = Task { await service.pauseIfPlaying() }
+        await controller.waitUntilQueryRegistered()
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+
+        let didSuppress = await suppressionTask.value
+        XCTAssertTrue(didSuppress)
+        XCTAssertEqual(controller.pauseCallCount, 0)
+        XCTAssertEqual(volumeController.appliedSnapshots.count, 1)
+        XCTAssertEqual(volumeController.appliedSnapshots[0].channels[0].volume, 0.16, accuracy: 0.0001)
+        XCTAssertEqual(volumeController.appliedSnapshots[0].channels[1].volume, 0.08, accuracy: 0.0001)
+
+        await service.resumeIfWePaused(true)
+
+        XCTAssertEqual(controller.playCallCount, 0)
+        XCTAssertEqual(volumeController.appliedSnapshots.count, 2)
+        XCTAssertEqual(volumeController.appliedSnapshots[1].channels[0].volume, 0.8, accuracy: 0.0001)
+        XCTAssertEqual(volumeController.appliedSnapshots[1].channels[1].volume, 0.4, accuracy: 0.0001)
+    }
+
+    func testFailedDuckFallsBackToPauseAndResume() async throws {
+        let volumeController = FakeSystemAudioVolumeController(capturedSnapshot: self.makeSnapshot([0.8, 0.4]))
+        volumeController.applyOutcomes = [.failed]
+        let (service, controller, _, _) = self.makeService(
+            configuration: .init(duckInsteadOfPausing: true, duckVolumeLevel: 0.2),
+            volumeController: volumeController
+        )
+
+        let suppressionTask = Task { await service.pauseIfPlaying() }
+        await controller.waitUntilQueryRegistered()
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+
+        let didSuppress = await suppressionTask.value
+        XCTAssertTrue(didSuppress)
+        XCTAssertEqual(controller.pauseCallCount, 1)
+
+        await service.resumeIfWePaused(true)
+        XCTAssertEqual(controller.playCallCount, 1)
+    }
+
+    func testBalancedAverageDoesNotHidePerChannelUserChange() async throws {
+        let original = self.makeSnapshot([0.8, 0.4])
+        let volumeController = FakeSystemAudioVolumeController(capturedSnapshot: original)
+        let (service, controller, _, _) = self.makeService(
+            configuration: .init(duckInsteadOfPausing: true, duckVolumeLevel: 0.2),
+            volumeController: volumeController
+        )
+
+        let suppressionTask = Task { await service.pauseIfPlaying() }
+        await controller.waitUntilQueryRegistered()
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+        let didSuppress = await suppressionTask.value
+        XCTAssertTrue(didSuppress)
+
+        // Same average as the applied [0.16, 0.08], but the user changed balance.
+        volumeController.currentSnapshot = self.makeSnapshot([0.20, 0.04])
+        await service.resumeIfWePaused(true)
+
+        XCTAssertEqual(volumeController.appliedSnapshots.count, 1)
+        XCTAssertEqual(controller.playCallCount, 0)
+    }
+
+    func testSuppressionConfigurationDoesNotChangeWhileTrackQueryIsInFlight() async throws {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = ManualTimeoutScheduler()
+        let volumeController = FakeSystemAudioVolumeController(capturedSnapshot: self.makeSnapshot([0.8, 0.4]))
+        var configuration = MediaPlaybackService.SuppressionConfiguration(
+            duckInsteadOfPausing: false,
+            duckVolumeLevel: 0.2
+        )
+        let service = MediaPlaybackService(
+            mediaController: controller,
+            volumeController: volumeController,
+            suppressionConfigurationProvider: { configuration },
+            queryTimeoutSeconds: MediaPlaybackService.nowPlayingQueryTimeoutSeconds,
+            timeoutScheduler: scheduler.schedule
+        )
+
+        let suppressionTask = Task { await service.pauseIfPlaying() }
+        await controller.waitUntilQueryRegistered()
+        configuration = .init(duckInsteadOfPausing: true, duckVolumeLevel: 0.2)
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+
+        let didSuppress = await suppressionTask.value
+        XCTAssertTrue(didSuppress)
+        XCTAssertEqual(controller.pauseCallCount, 1)
+        XCTAssertEqual(volumeController.captureCallCount, 0)
+    }
+
+    func testPartialDuckIsUndoneBeforePauseFallback() async throws {
+        let volumeController = FakeSystemAudioVolumeController(capturedSnapshot: self.makeSnapshot([0.8, 0.4]))
+        volumeController.applyOutcomes = [.partial, .applied]
+        let (service, controller, _, _) = self.makeService(
+            configuration: .init(duckInsteadOfPausing: true, duckVolumeLevel: 0.2),
+            volumeController: volumeController
+        )
+
+        let suppressionTask = Task { await service.pauseIfPlaying() }
+        await controller.waitUntilQueryRegistered()
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+
+        let didSuppress = await suppressionTask.value
+        XCTAssertTrue(didSuppress)
+        XCTAssertEqual(volumeController.appliedSnapshots.count, 2)
+        XCTAssertEqual(volumeController.appliedSnapshots[1].channels[0].volume, 0.8, accuracy: 0.0001)
+        XCTAssertEqual(volumeController.appliedSnapshots[1].channels[1].volume, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(controller.pauseCallCount, 1)
+
+        await service.resumeIfWePaused(true)
+        XCTAssertEqual(controller.playCallCount, 1)
+    }
+
+    func testActiveSuppressionRejectsASecondSessionUntilRestore() async throws {
+        let volumeController = FakeSystemAudioVolumeController(capturedSnapshot: self.makeSnapshot([0.8, 0.4]))
+        let (service, controller, _, _) = self.makeService(
+            configuration: .init(duckInsteadOfPausing: true, duckVolumeLevel: 0.2),
+            volumeController: volumeController
+        )
+
+        let firstTask = Task { await service.pauseIfPlaying() }
+        await controller.waitUntilQueryRegistered()
+        try controller.complete(with: self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+        let firstDidSuppress = await firstTask.value
+        XCTAssertTrue(firstDidSuppress)
+
+        let secondDidSuppress = await service.pauseIfPlaying()
+        XCTAssertFalse(secondDidSuppress)
+        XCTAssertEqual(controller.queryCallCount, 1)
+        XCTAssertEqual(volumeController.captureCallCount, 1)
+
+        await service.resumeIfWePaused(true)
+    }
+
+    private func makeService(
+        configuration: MediaPlaybackService.SuppressionConfiguration = .init(
+            duckInsteadOfPausing: false,
+            duckVolumeLevel: 0.2
+        ),
+        volumeController: FakeSystemAudioVolumeController = FakeSystemAudioVolumeController()
+    ) -> (
         service: MediaPlaybackService,
         controller: FakeMediaPlaybackController,
-        scheduler: ManualTimeoutScheduler
+        scheduler: ManualTimeoutScheduler,
+        volumeController: FakeSystemAudioVolumeController
     ) {
         let controller = FakeMediaPlaybackController()
         let scheduler = ManualTimeoutScheduler()
         let service = MediaPlaybackService(
             mediaController: controller,
+            volumeController: volumeController,
+            suppressionConfigurationProvider: { configuration },
             queryTimeoutSeconds: MediaPlaybackService.nowPlayingQueryTimeoutSeconds,
             timeoutScheduler: scheduler.schedule
         )
-        return (service, controller, scheduler)
+        return (service, controller, scheduler, volumeController)
     }
 
     private func pauseResult(for trackInfo: TrackInfo?) async -> (
         didPause: Bool,
         pauseCallCount: Int
     ) {
-        let (service, controller, _) = self.makeService()
+        let (service, controller, _, _) = self.makeService()
         let pauseTask = Task { await service.pauseIfPlaying() }
 
         await controller.waitUntilQueryRegistered()
@@ -145,6 +302,19 @@ final class MediaPlaybackServiceTests: XCTestCase {
         let data = try JSONSerialization.data(withJSONObject: ["payload": payload])
         return try JSONDecoder().decode(TrackInfo.self, from: data)
     }
+
+    private func makeSnapshot(_ volumes: [Float]) -> OutputVolumeSnapshot {
+        OutputVolumeSnapshot(
+            deviceID: 42,
+            channels: volumes.enumerated().map { index, volume in
+                .init(
+                    selector: kAudioDevicePropertyVolumeScalar,
+                    element: AudioObjectPropertyElement(index + 1),
+                    volume: volume
+                )
+            }
+        )
+    }
 }
 
 @MainActor
@@ -153,8 +323,10 @@ private final class FakeMediaPlaybackController: MediaPlaybackControlling {
     private var registrationWaiters: [CheckedContinuation<Void, Never>] = []
     private(set) var pauseCallCount = 0
     private(set) var playCallCount = 0
+    private(set) var queryCallCount = 0
 
     func getTrackInfo(_ onReceive: @escaping (TrackInfo?) -> Void) {
+        self.queryCallCount += 1
         self.callback = onReceive
         let waiters = self.registrationWaiters
         self.registrationWaiters.removeAll()
@@ -182,6 +354,44 @@ private final class FakeMediaPlaybackController: MediaPlaybackControlling {
             self.callback = nil
         }
         callback?(trackInfo)
+    }
+}
+
+private final class FakeSystemAudioVolumeController: SystemAudioVolumeControlling {
+    var capturedSnapshot: OutputVolumeSnapshot?
+    var currentSnapshot: OutputVolumeSnapshot?
+    var applyOutcomes: [SystemAudioVolumeController.ApplyOutcome] = []
+    private(set) var captureCallCount = 0
+    private(set) var appliedSnapshots: [OutputVolumeSnapshot] = []
+    private(set) var virtualMainApplyCallCount = 0
+
+    init(capturedSnapshot: OutputVolumeSnapshot? = nil) {
+        self.capturedSnapshot = capturedSnapshot
+        self.currentSnapshot = capturedSnapshot
+    }
+
+    func captureOutputVolume() -> OutputVolumeSnapshot? {
+        self.captureCallCount += 1
+        return self.capturedSnapshot
+    }
+
+    func apply(_ snapshot: OutputVolumeSnapshot) -> SystemAudioVolumeController.ApplyOutcome {
+        self.appliedSnapshots.append(snapshot)
+        let outcome = self.applyOutcomes.isEmpty ? .applied : self.applyOutcomes.removeFirst()
+        if case .applied = outcome {
+            self.currentSnapshot = snapshot
+        }
+        return outcome
+    }
+
+    func applyVirtualMainVolume(_ snapshot: OutputVolumeSnapshot) -> Bool {
+        self.virtualMainApplyCallCount += 1
+        self.currentSnapshot = snapshot
+        return true
+    }
+
+    func reread(_ snapshot: OutputVolumeSnapshot) -> OutputVolumeSnapshot? {
+        self.currentSnapshot
     }
 }
 


### PR DESCRIPTION
## What

Adds a **"Lower Volume Instead of Pausing"** sub-option under the existing **Pause Media During Transcription** setting. When enabled, FluidVoice lowers the system output volume while you dictate and restores it afterward, instead of fully stopping playback — handy for keeping a video audible but quiet during narration/dictation.

## Why

Today the only choice is to fully pause media during transcription. Some users would rather keep media playing at a lower volume than have it stop and resume.

## Changes

- **`SystemAudioVolumeController`** (new): a small CoreAudio wrapper that reads/sets the default output device's volume (master element with a per-channel fallback).
- **`MediaPlaybackService`**: now either pauses *or* ducks based on the setting, recording which action it took so it reverts exactly what it applied. On restore it:
  - leaves the volume untouched if the user changed it mid-dictation, and
  - falls back to pausing if the volume can't be lowered.
- **Settings** (`SettingsStore` + `BackupService`): adds `duckMediaInsteadOfPausing` (Bool) and `duckMediaVolumeLevel` (fraction of current volume, default **20%**, clamped 5–100%), including backup/restore with backward-compatible decoding.
- **UI** (`SettingsView`): nested toggle + level slider, shown only when media pausing is enabled.

## Notes / trade-offs

- CoreAudio output volume is **system-wide**, so ducking lowers all output from the default device, not just a single app. macOS does not expose per-app media ducking to third-party apps. The UI copy makes this explicit.
- Behavior is **arm64-only**, consistent with the existing pause feature (which relies on `MediaRemoteAdapter` for playback detection). Intel remains a no-op.
- No entitlement changes required (app is not sandboxed).

## Testing

Verified the new CoreAudio file with `swiftc -typecheck` against the macOS SDK, and `swiftc -parse` on all edited files (clean). I was able to run the application using my team id on a M1 Pro chip MacBook Pro and verified the functionality 

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

<img width="952" height="687" alt="image" src="https://github.com/user-attachments/assets/6ecf7740-a21d-47d6-84af-136da12cee94" />

