### PR TITLE
fix: do not persist a deleted speech model as the active selection

### DIFF
--- a/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
@@ -28,8 +28,6 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
     @Published var selectedSpeechProvider: SettingsStore.SpeechModel.Provider
     @Published var previewSpeechModel: SettingsStore.SpeechModel
     @Published var showAdvancedSpeechInfo: Bool = false
-    @Published var suppressSpeechProviderSync: Bool = false
-    @Published var skipNextSpeechModelSync: Bool = false
 
     var downloadingModel: SettingsStore.SpeechModel? {
         guard let modelID = self.asr.downloadingModelId else { return nil }
@@ -72,11 +70,6 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
     }
 
     func handleSelectedSpeechModelChange(_ newValue: SettingsStore.SpeechModel) {
-        if self.skipNextSpeechModelSync {
-            self.skipNextSpeechModelSync = false
-            return
-        }
-        guard !self.suppressSpeechProviderSync else { return }
         self.previewSpeechModel = newValue
         self.setSelectedSpeechProvider(newValue.provider)
     }
@@ -170,34 +163,19 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
         self.asr.cancelModelPreparation()
     }
 
-    func deleteSpeechModel(_ model: SettingsStore.SpeechModel) {
+    func deleteSpeechModel(_ model: SettingsStore.SpeechModel) async {
         guard !self.areSpeechModelActionsBlocked else { return }
-        let previousActive = self.settings.selectedSpeechModel
-
-        Task {
-            let shouldRestore = previousActive != model
-            await MainActor.run {
-                if shouldRestore {
-                    self.suppressSpeechProviderSync = true
-                }
-                self.settings.selectedSpeechModel = model
-                self.asr.resetTranscriptionProvider()
-            }
-
-            defer {
-                Task { @MainActor in
-                    guard shouldRestore else { return }
-                    self.skipNextSpeechModelSync = true
-                    self.settings.selectedSpeechModel = previousActive
-                    self.asr.resetTranscriptionProvider()
-                    if self.previewSpeechModel == model {
-                        self.previewSpeechModel = model
-                    }
-                    self.suppressSpeechProviderSync = false
-                }
-            }
-
-            await self.deleteModels()
+        do {
+            try await self.asr.clearModelCache(for: model)
+            // Refresh installed-model state so the model cards reflect the deletion for
+            // every model, not only the active one (clearModelCache(for:) re-checks only
+            // when deleting the selected model).
+            await self.asr.checkIfModelsExistAsync()
+        } catch {
+            DebugLogger.shared.error(
+                "Failed to delete model \(model.displayName): \(error)",
+                source: "VoiceEngineVM"
+            )
         }
     }
 

--- a/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
+++ b/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
@@ -462,7 +462,9 @@ extension VoiceEngineSettingsView {
                     if !model.usesAppleLogo {
                         if isSelected {
                             Button {
-                                self.viewModel.deleteSpeechModel(model)
+                                Task {
+                                    await self.viewModel.deleteSpeechModel(model)
+                                }
                             } label: {
                                 Image(systemName: "trash")
                                     .font(.system(size: 15))

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -2335,6 +2335,59 @@ final class DictationE2ETests: XCTestCase {
     }
 }
 
+// Speech-model management regression coverage. Kept in an extension so it does not add to
+// the main `DictationE2ETests` class body, which is at the `type_body_length` limit.
+extension DictationE2ETests {
+    func testDeleteNonActiveSpeechModel_doesNotBounceSelectionThroughDeletedModel() async throws {
+        // Regression: deleting a non-active speech model used to temporarily persist the
+        // deleted model as `selectedSpeechModel`, then restore the real selection through an
+        // un-awaited `defer { Task { ... } }`. If the process exited during that window (app
+        // quit, crash, or update relaunch) the user was left with a model they never chose.
+        // Use a built-in no-cache model here so the hosted test can catch the selection bounce
+        // without deleting a real downloaded speech model from the developer's machine.
+        let defaults = UserDefaults.standard
+        let key = "SelectedSpeechModel"
+        let snapshot = defaults.object(forKey: key)
+        defer {
+            if let snapshot {
+                defaults.set(snapshot, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        let settings = SettingsStore.shared
+        let activeModel: SettingsStore.SpeechModel = .whisperTiny
+        let modelToDelete: SettingsStore.SpeechModel = .appleSpeech
+        XCTAssertNotEqual(activeModel, modelToDelete)
+
+        settings.selectedSpeechModel = activeModel
+        XCTAssertEqual(settings.selectedSpeechModel, activeModel)
+
+        // Record every value the persisted selection takes during the delete so a transient
+        // write of the deleted model is caught directly, not masked by the async restore.
+        let recorder = PersistedSpeechModelRecorder(defaults: defaults, key: key)
+        defer { recorder.stop() }
+
+        let viewModel = VoiceEngineSettingsViewModel(settings: settings, appServices: AppServices.shared)
+        XCTAssertFalse(viewModel.areSpeechModelActionsBlocked)
+        await viewModel.deleteSpeechModel(modelToDelete)
+
+        XCTAssertEqual(
+            settings.selectedSpeechModel,
+            activeModel,
+            "Deleting a non-active model must leave the user's selection unchanged."
+        )
+        XCTAssertFalse(
+            recorder.recordedRawValues.contains(modelToDelete.rawValue),
+            """
+            Deleting a non-active model must never persist it as the selection, even transiently. \
+            Recorded writes: \(recorder.recordedRawValues)
+            """
+        )
+    }
+}
+
 extension DictationE2ETests {
     func testSpokenFormattingActionsUseSharedPrefix() {
         self.withRestoredDefaults(keys: self.punctuationFormattingDefaultsKeys) {
@@ -2566,3 +2619,40 @@ final class SimpleUpdaterTests: XCTestCase {
         XCTAssertTrue(gate.begin())
     }
 }
+
+// Classic key-path KVO is required here: an arbitrary UserDefaults key has no Swift `KeyPath`
+// for the block-based API, and the change dictionary is delivered synchronously with the exact
+// new value, which a coalescing `UserDefaults.didChangeNotification` cannot guarantee.
+// swiftlint:disable block_based_kvo discouraged_optional_collection
+
+/// Records every value written to a UserDefaults key via KVO, so a transient write that is
+/// later reverted can still be observed. Used to catch the non-active speech-model delete race,
+/// where the deleted model was momentarily persisted as the selection before being restored.
+private final class PersistedSpeechModelRecorder: NSObject {
+    private let defaults: UserDefaults
+    private let key: String
+    private(set) var recordedRawValues: [String] = []
+
+    init(defaults: UserDefaults, key: String) {
+        self.defaults = defaults
+        self.key = key
+        super.init()
+        defaults.addObserver(self, forKeyPath: key, options: [.new], context: nil)
+    }
+
+    func stop() {
+        self.defaults.removeObserver(self, forKeyPath: self.key)
+    }
+
+    override func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey: Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        guard keyPath == self.key, let rawValue = change?[.newKey] as? String else { return }
+        self.recordedRawValues.append(rawValue)
+    }
+}
+
+// swiftlint:enable block_based_kvo discouraged_optional_collection


### PR DESCRIPTION
## Description
Deleting a non-active speech model used to briefly persist the model being deleted as `selectedSpeechModel`, then restore the real selection through an un-awaited async restore. If the app quit, crashed, or relaunched during that window, the deleted model could become the saved active model.

This routes per-model deletion through an awaitable `ASRService.clearModelCache(for:)` call, which clears the target model without changing the saved selection. It also refreshes installed-model state after deletion so the model cards update without relying on a temporary selection change.

The removed `suppressSpeechProviderSync` and `skipNextSpeechModelSync` flags were only needed for the old selection bounce. With the bounce removed, the speech provider and preview state can stay directly synced to the actual selected model. The view-model method is now awaitable, so the regression test does not rely on a fixed sleep.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📝 Documentation update

## Related Issue or Discussion
Related to #467. This fixes the delete-non-active-model persistence path only; it does not claim to close every possible path that could reset the active speech model.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 15.7.7
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources Tests/FluidDictationIntegrationTests/DictationE2ETests.swift`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Built locally: `xcodebuild build-for-testing -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Added `DictationE2ETests.testDeleteNonActiveSpeechModel_doesNotBounceSelectionThroughDeletedModel`. The test records every write to `SelectedSpeechModel` and fails if deleting `.appleSpeech` while `.whisperTiny` is active ever persists the deleted value, even transiently.

The test intentionally uses a built-in no-cache model so it can catch the selection-bounce regression without deleting a real downloaded speech model from the developer's machine.

## Notes
This is intentionally narrow. It removes one concrete race in model deletion without changing model activation, update behavior, or broader speech-model fallback logic.

Full hosted test execution was not run locally because the installed FluidVoice app was open; the hosted test runner can hang in that state. `build-for-testing` compiled the app and test target, and CI should run the full hosted suite after the branch update.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.
