### PR TITLE
fix(hotkey): apply primary dictation shortcut change to live event tap

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1091,7 +1091,17 @@ struct ContentView: View {
                 shortcuts.append(shortcut)
             }
         }
-        self.primaryDictationShortcuts = shortcuts
+
+        // Persist and push the normalized list to the running event tap right here, mirroring the
+        // other shortcut types in applyRecordedShortcut(_:to:). GlobalHotkeyManager matches primary
+        // dictation against its cached `primaryShortcuts` array, so the previous shortcut keeps
+        // firing until this update runs. Doing it directly (instead of relying solely on the
+        // .onChange(of:) side effect, which is driven from the NSEvent capture callback) makes the
+        // replacement take effect without an app restart. (#470)
+        SettingsStore.shared.primaryDictationShortcuts = shortcuts
+        let storedShortcuts = SettingsStore.shared.primaryDictationShortcuts
+        self.primaryDictationShortcuts = storedShortcuts
+        self.hotkeyManager?.updatePrimaryShortcuts(storedShortcuts)
     }
 
     private func setShortcutTargetEnabled(_ enabled: Bool, for target: ShortcutRecordingTarget) {


### PR DESCRIPTION
## Description
Changing the **Primary Dictation** shortcut saved the new shortcut to `SettingsStore` but did not push it to the running `GlobalHotkeyManager`, so the previously registered shortcut kept triggering dictation until the app was restarted.

`GlobalHotkeyManager` matches primary dictation against its in-memory `primaryShortcuts` cache, refreshed only via `updatePrimaryShortcuts(_:)`. The secondary/command/edit shortcut types call that update **directly** in `applyRecordedShortcut(_:to:)`, but the primary path (`applyPrimaryDictationShortcut(_:edit:)`) only mutated `@State` and relied on the `.onChange(of:)` side effect — driven from the `NSEvent` shortcut-capture callback — to both persist and refresh the manager. When that refresh did not run, the event tap kept matching the old shortcut.

The fix persists and calls `updatePrimaryShortcuts(_:)` directly in `applyPrimaryDictationShortcut(_:edit:)`, mirroring the other shortcut types, so a replacement (or an added shortcut) takes effect immediately without a restart. It is idempotent with the existing `.onChange(of:)` handler.

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issues
- Closes #470

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS Tahoe 26
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` (0 violations)
- [x] Built unsigned: `xcodebuild -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO` → **BUILD SUCCEEDED**

Manual repro (from the issue): Settings → Global Shortcuts → **Change** the Primary Dictation shortcut (e.g. `⇧+\`` → `Hyper+\``). After the fix only the new shortcut triggers dictation, immediately, with no app restart.

## Notes
- One-line behavioral change in `applyPrimaryDictationShortcut(_:edit:)`; no public API or settings-schema changes.
- Also resolves the same staleness for the **Add shortcut** flow, which shares the same method.
- A focused unit test was not added because the defect is in the SwiftUI propagation inside `ContentView` (not unit-testable without invasive hooks); `GlobalHotkeyManager.updatePrimaryShortcuts(_:)` already replaces the cached set correctly, so a manager-level test would pass both before and after and would not guard this regression.
