### PR TITLE
docs: clarify public source build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,11 @@ open Fluid.xcodeproj
 
 Build and run in Xcode. All dependencies are managed via Swift Package Manager.
 
-For public source builds, use Xcode or the `xcodebuild` command below. The top-level `./build.sh` script is only for the private Fluid Intelligence build setup and is not the public OSS build entrypoint.
+For public source builds from the command line, `./build.sh` skips the private Fluid Intelligence build setup and runs the unsigned macOS build:
+
+```bash
+./build.sh
+```
 
 ### Build Only (No Signing)
 

--- a/README.md
+++ b/README.md
@@ -207,16 +207,10 @@ open Fluid.xcodeproj
 
 Build and run in Xcode. All dependencies are managed via Swift Package Manager.
 
-For public source builds from the command line, `./build.sh` skips the private Fluid Intelligence build setup and runs the unsigned macOS build:
+Run the build using the script: `./build.sh`
 
 ```bash
 ./build.sh
-```
-
-### Build Only (No Signing)
-
-```bash
-xcodebuild -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ open Fluid.xcodeproj
 
 Build and run in Xcode. All dependencies are managed via Swift Package Manager.
 
+For public source builds, use Xcode or the `xcodebuild` command below. The top-level `./build.sh` script is only for the private Fluid Intelligence build setup and is not the public OSS build entrypoint.
+
 ### Build Only (No Signing)
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -1,19 +1,25 @@
 #!/bin/bash
 
 # FluidVoice Build Profile Router
-# Defaults to the private Fluid Intelligence build for local development.
+# Defaults to the public OSS build, which skips private Fluid Intelligence.
 #
 # Usage:
-#   ./build.sh                    # private FI build
+#   ./build.sh                    # public OSS build
+#   ./build.sh public             # public OSS build
 #   ./build.sh fi                 # private FI build
 
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROFILE="${1:-${BUILD_PROFILE:-fi}}"
+PROFILE="${1:-${BUILD_PROFILE:-public}}"
 PRIVATE_FI_BUILD_SCRIPT="${PROJECT_DIR}/build_with_FI_incremental.sh"
 
 case "${PROFILE}" in
+    public|oss|incremental|fast)
+        echo "Running public FluidVoice build without Fluid Intelligence..."
+        cd "${PROJECT_DIR}"
+        exec xcodebuild -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
+        ;;
     fi|private|dev|full)
         if [ ! -x "${PRIVATE_FI_BUILD_SCRIPT}" ]; then
             echo "Private Fluid Intelligence build script is missing:"
@@ -23,14 +29,9 @@ case "${PROFILE}" in
         fi
         exec "${PRIVATE_FI_BUILD_SCRIPT}"
         ;;
-    public|oss|incremental|fast)
-        echo "Public/OSS builds are not available from this repo entrypoint."
-        echo "Use the private Fluid Intelligence build: sh build_with_FI_incremental.sh"
-        exit 1
-        ;;
     *)
         echo "Unknown build profile: ${PROFILE}"
-        echo "Valid profiles: fi/private/dev/full"
+        echo "Valid profiles: public/oss/incremental/fast, fi/private/dev/full"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- add a short note that public source builds should use Xcode or the documented xcodebuild command
- clarify that the top-level ./build.sh script is for the private Fluid Intelligence build setup, not the OSS build path

Closes #471

## Verification
- git diff --check
- reviewed the README diff