### PR TITLE
feat(settings): add Clipboard Only text insertion mode

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2288,9 +2288,10 @@ struct ContentView: View {
 
         // When FluidVoice itself is frontmost, the bound editor already receives `finalText`.
         // Avoid re-inserting or overwriting the clipboard in that self-target case.
+        let isClipboardOnlyMode = SettingsStore.shared.textInsertionMode == .clipboardOnly
         let shouldCopyToClipboard = shouldPersistOutputs &&
-            SettingsStore.shared.copyTranscriptionToClipboard &&
-            !isFluidFrontmost
+            !isFluidFrontmost &&
+            (SettingsStore.shared.copyTranscriptionToClipboard || isClipboardOnlyMode)
 
         if shouldCopyToClipboard {
             ClipboardService.copyToClipboard(finalText)
@@ -2304,7 +2305,7 @@ struct ContentView: View {
         }
 
         var didTypeExternally = false
-        let shouldTypeExternally = shouldPersistOutputs && !isFluidFrontmost
+        let shouldTypeExternally = shouldPersistOutputs && !isFluidFrontmost && !isClipboardOnlyMode
 
         DebugLogger.shared.debug(
             "Typing decision → frontmost: \(frontmostName), fluidFrontmost: \(isFluidFrontmost), editorFocused: \(self.isTranscriptionFocused), willTypeExternally: \(shouldTypeExternally)",
@@ -2354,7 +2355,7 @@ struct ContentView: View {
                 NotchOverlayManager.shared.hide()
             }
         } else if shouldPersistOutputs,
-                  SettingsStore.shared.copyTranscriptionToClipboard == false,
+                  !shouldCopyToClipboard,
                   SettingsStore.shared.saveTranscriptionHistory
         {
             AnalyticsService.shared.capture(

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2671,8 +2671,13 @@ struct ContentView: View {
         if !self.rewriteModeService.rewrittenText.isEmpty {
             DebugLogger.shared.info("Rewrite successful, typing result (chars: \(self.rewriteModeService.rewrittenText.count))", source: "ContentView")
 
+            // In clipboard-only mode the delivery below already writes the pasteboard and emits a
+            // single `.clipboard` event, so skip the backup copy to avoid double-counting that
+            // delivery — mirroring how the dictation path collapses these into one event. (#481)
+            let isClipboardOnlyMode = SettingsStore.shared.textInsertionMode == .clipboardOnly
+
             // Copy to clipboard as backup
-            if SettingsStore.shared.copyTranscriptionToClipboard {
+            if SettingsStore.shared.copyTranscriptionToClipboard, !isClipboardOnlyMode {
                 ClipboardService.copyToClipboard(self.rewriteModeService.rewrittenText)
                 AnalyticsService.shared.capture(
                     .outputDelivered,
@@ -2686,7 +2691,6 @@ struct ContentView: View {
             // Deliver the rewritten text. In clipboard-only mode the insertion machinery writes to
             // the pasteboard instead of typing, so report the matching analytics method rather than
             // unconditionally claiming a typed insertion. (#481)
-            let isClipboardOnlyMode = SettingsStore.shared.textInsertionMode == .clipboardOnly
             let typingTarget = self.resolveTypingTargetPID()
             if typingTarget.shouldRestoreOriginalFocus {
                 await self.restoreFocusToRecordingTarget()

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2289,9 +2289,13 @@ struct ContentView: View {
         // When FluidVoice itself is frontmost, the bound editor already receives `finalText`.
         // Avoid re-inserting or overwriting the clipboard in that self-target case.
         let isClipboardOnlyMode = SettingsStore.shared.textInsertionMode == .clipboardOnly
+        // Clipboard-only is the primary delivery method, so it must write even when FluidVoice is
+        // frontmost — suppressing it there would leave the user with nothing on the clipboard. The
+        // backup-copy checkbox keeps its `!isFluidFrontmost` guard, since the bound editor already
+        // holds the text in that self-target case.
         let shouldCopyToClipboard = shouldPersistOutputs &&
-            !isFluidFrontmost &&
-            (SettingsStore.shared.copyTranscriptionToClipboard || isClipboardOnlyMode)
+            (isClipboardOnlyMode ||
+                (!isFluidFrontmost && SettingsStore.shared.copyTranscriptionToClipboard))
 
         if shouldCopyToClipboard {
             ClipboardService.copyToClipboard(finalText)
@@ -2679,7 +2683,10 @@ struct ContentView: View {
                 )
             }
 
-            // Type the rewritten text
+            // Deliver the rewritten text. In clipboard-only mode the insertion machinery writes to
+            // the pasteboard instead of typing, so report the matching analytics method rather than
+            // unconditionally claiming a typed insertion. (#481)
+            let isClipboardOnlyMode = SettingsStore.shared.textInsertionMode == .clipboardOnly
             let typingTarget = self.resolveTypingTargetPID()
             if typingTarget.shouldRestoreOriginalFocus {
                 await self.restoreFocusToRecordingTarget()
@@ -2692,7 +2699,9 @@ struct ContentView: View {
                 .outputDelivered,
                 properties: [
                     "mode": AnalyticsMode.rewrite.rawValue,
-                    "method": AnalyticsOutputMethod.typed.rawValue,
+                    "method": isClipboardOnlyMode
+                        ? AnalyticsOutputMethod.clipboard.rawValue
+                        : AnalyticsOutputMethod.typed.rawValue,
                 ]
             )
 

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -4480,7 +4480,7 @@ extension SettingsStore {
             case .reliablePaste:
                 return "Clipboard Paste"
             case .clipboardOnly:
-                return "Clipboard Only"
+                return "Copy to Clipboard Only"
             }
         }
 

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -4467,6 +4467,7 @@ extension SettingsStore {
     enum TextInsertionMode: String, CaseIterable, Identifiable, Codable {
         case standard
         case reliablePaste
+        case clipboardOnly
 
         var id: String {
             self.rawValue
@@ -4478,6 +4479,8 @@ extension SettingsStore {
                 return "Clipboard Free Insert"
             case .reliablePaste:
                 return "Clipboard Paste"
+            case .clipboardOnly:
+                return "Clipboard Only"
             }
         }
 
@@ -4487,6 +4490,8 @@ extension SettingsStore {
                 return "Fastest path. Inserts text without changing the clipboard, with paste fallback if direct insertion is unavailable."
             case .reliablePaste:
                 return "Compatibility path. Uses a temporary clipboard paste, so clipboard history apps may briefly record dictated text."
+            case .clipboardOnly:
+                return "Copies transcribed text to the clipboard without inserting it. Useful for remote desktop workflows or when you prefer to paste manually."
             }
         }
     }

--- a/Sources/Fluid/Services/RewriteModeService.swift
+++ b/Sources/Fluid/Services/RewriteModeService.swift
@@ -164,11 +164,16 @@ final class RewriteModeService: ObservableObject {
         NSApp.hide(nil) // Restore focus to the previous app
         self.typingService.typeTextInstantly(self.rewrittenText)
 
+        // Clipboard-only mode routes the delivery to the pasteboard instead of typing, so report the
+        // method that actually happened rather than always claiming a typed insertion. (#481)
+        let isClipboardOnlyMode = SettingsStore.shared.textInsertionMode == .clipboardOnly
         AnalyticsService.shared.capture(
             .outputDelivered,
             properties: [
                 "mode": AnalyticsMode.rewrite.rawValue,
-                "method": AnalyticsOutputMethod.typed.rawValue,
+                "method": isClipboardOnlyMode
+                    ? AnalyticsOutputMethod.clipboard.rawValue
+                    : AnalyticsOutputMethod.typed.rawValue,
             ]
         )
     }

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -277,6 +277,14 @@ final class TypingService {
             return
         }
 
+        // Clipboard-only mode: skip all insertion machinery and write to clipboard directly.
+        // This avoids the accessibility-permission requirement and settle delay entirely. (#481)
+        if mode == .clipboardOnly {
+            self.bench("request_return reason=clipboard_only")
+            ClipboardService.copyToClipboard(text)
+            return
+        }
+
         // Prevent concurrent typing operations
         guard !self.isCurrentlyTyping else {
             self.bench("request_return reason=already_typing")


### PR DESCRIPTION
## Description

Adds a **Clipboard Only** option to the Text Insertion Mode picker in Settings. When selected, dictated text is written directly to the system clipboard without any keyboard simulation or Accessibility API insertion.

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issues
- Closes #481

## How It Works

A new `clipboardOnly` case is added to `SettingsStore.TextInsertionMode`. In `TypingService.typeTextInstantly`, an early-return guard detects this mode before any accessibility check or threading overhead fires — it calls `ClipboardService.copyToClipboard(_:)` and returns immediately.

**No changes to the Settings UI are required** — the mode picker already uses `ForEach(TextInsertionMode.allCases)` and picks up the new case automatically.

## Use Case

Remote desktop workflows (e.g. Sunshine/Moonlight) where a synced clipboard carries the text to the remote machine. Also useful for users who prefer to keep FluidVoice as a pure transcription-to-clipboard tool and paste manually.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 15.5 Sequoia
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — **0 violations**
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`

## Notes

- The mode skips the `AXIsProcessTrusted()` guard entirely — clipboard writes don't need accessibility permission.
- The existing `copyTranscriptionToClipboard` setting remains independent. If both are active, the text is written to the clipboard twice (second write is a no-op since it's the same content).
- No settings migration needed — `textInsertionMode` falls back to `.standard` for any unrecognised raw value, so existing installs are unaffected.