### PR TITLE
feat: Paste Last Transcription (clipboard-free) via hotkey + overlay

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -117,7 +117,12 @@ enum ShortcutRecordingTarget: Hashable {
     }
 
     var allowsMouseShortcut: Bool {
-        self.isPrimaryDictation
+        switch self {
+        case .primaryDictation, .pasteLast:
+            return true
+        case .secondaryDictation, .command, .edit, .cancel, .dictationPrompt, .newPrompt:
+            return false
+        }
     }
 
     var isPrimaryDictation: Bool {
@@ -993,7 +998,7 @@ struct ContentView: View {
     private func shortcutConflictMessage(for shortcut: HotkeyShortcut, target: ShortcutRecordingTarget) -> String? {
         if shortcut.isMouseShortcut {
             guard target.allowsMouseShortcut else {
-                return "Mouse clicks can only be assigned to Primary Dictation Shortcut"
+                return "Mouse clicks can only be assigned to Primary Dictation or Paste Last Transcription"
             }
 
             if shortcut.isUnmodifiedLeftOrRightClick, let mouseButton = shortcut.mouseButton {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2528,6 +2528,13 @@ struct ContentView: View {
         }
 
         Task { @MainActor in
+            // The hotkey fires on key-down while its own modifier keys (e.g. ⌘⌃) are still
+            // physically held. Synthesizing text in that state makes the target app treat the
+            // characters as keyboard shortcuts and drop them, so wait for the modifiers to be
+            // released before inserting. (Dictation never hits this because by the time it types,
+            // no keys are held.)
+            await Self.waitForHotkeyModifiersReleased(timeout: 0.6)
+
             let typingTarget = self.resolveTypingTargetPID()
             guard typingTarget.pid != nil else {
                 DebugLogger.shared.info("Actions: Paste skipped - no external target field available", source: "ContentView")
@@ -2538,6 +2545,20 @@ struct ContentView: View {
             }
             self.asr.typeTextToActiveField(text, preferredTargetPID: typingTarget.pid)
             DebugLogger.shared.info("Actions: Pasted latest transcription into focused field", source: "ContentView")
+        }
+    }
+
+    /// Polls until the keyboard modifier keys are released (or the timeout elapses). Used before
+    /// synthesizing a paste so the inserted characters aren't swallowed as modifier+key shortcuts.
+    private static func waitForHotkeyModifiersReleased(timeout: TimeInterval) async {
+        let relevant: CGEventFlags = [.maskCommand, .maskControl, .maskAlternate, .maskShift, .maskSecondaryFn]
+        let start = Date()
+        while Date().timeIntervalSince(start) < timeout {
+            let flags = CGEventSource.flagsState(.combinedSessionState)
+            if flags.isDisjoint(with: relevant) {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 15_000_000) // 15ms
         }
     }
 

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2528,6 +2528,17 @@ struct ContentView: View {
         }
 
         Task { @MainActor in
+            // Only one paste may be pending at a time. Because the paste waits for the modifier keys
+            // to release, a quick double/triple-tap of the chord would otherwise queue several Tasks
+            // that all insert at once on release. This collapses them to a single paste while still
+            // allowing a deliberate repeat (press, it lands, then press again).
+            guard !Self.isPasteLastInProgress else {
+                DebugLogger.shared.info("Actions: Paste skipped - a paste is already pending", source: "ContentView")
+                return
+            }
+            Self.isPasteLastInProgress = true
+            defer { Self.isPasteLastInProgress = false }
+
             // The hotkey fires on key-down while its own modifier keys (e.g. ⌘⌃) are still
             // physically held. Synthesizing text in that state makes the target app treat the
             // characters as keyboard shortcuts and drop them, so the paste lands once the keys are
@@ -2558,6 +2569,12 @@ struct ContentView: View {
             DebugLogger.shared.info("Actions: Pasted latest transcription into focused field", source: "ContentView")
         }
     }
+
+    /// Guards against overlapping paste insertions: only one "paste last transcription" may be
+    /// pending at a time (see pasteLastDictationFromHistory). A rapid re-tap while one is still
+    /// waiting for the modifier keys to release is ignored rather than queuing a duplicate insert.
+    /// Only ever touched on the main actor.
+    private static var isPasteLastInProgress = false
 
     /// Polls until the keyboard modifier keys are released, returning `true` once they are, or
     /// `false` if the timeout elapses with keys still held. Used before synthesizing a paste so the

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2532,8 +2532,19 @@ struct ContentView: View {
             // physically held. Synthesizing text in that state makes the target app treat the
             // characters as keyboard shortcuts and drop them, so wait for the modifiers to be
             // released before inserting. (Dictation never hits this because by the time it types,
-            // no keys are held.)
-            await Self.waitForHotkeyModifiersReleased(timeout: 0.6)
+            // no keys are held.) If they never release (stuck/held), abort rather than typing a
+            // corrupted — and possibly destructive — shortcut sequence; the user can retrigger.
+            guard await Self.waitForHotkeyModifiersReleased(timeout: 0.6) else {
+                DebugLogger.shared.info("Actions: Paste aborted - modifier keys still held", source: "ContentView")
+                return
+            }
+
+            // Re-check here rather than only at the hotkey trigger: the overlay menu entry point
+            // has no pre-check, and the wait above may have elapsed since the trigger fired.
+            guard !self.asr.isRunning else {
+                DebugLogger.shared.info("Actions: Paste skipped - recording in progress", source: "ContentView")
+                return
+            }
 
             let typingTarget = self.resolveTypingTargetPID()
             guard typingTarget.pid != nil else {
@@ -2548,18 +2559,20 @@ struct ContentView: View {
         }
     }
 
-    /// Polls until the keyboard modifier keys are released (or the timeout elapses). Used before
-    /// synthesizing a paste so the inserted characters aren't swallowed as modifier+key shortcuts.
-    private static func waitForHotkeyModifiersReleased(timeout: TimeInterval) async {
+    /// Polls until the keyboard modifier keys are released, returning `true` once they are, or
+    /// `false` if the timeout elapses with keys still held. Used before synthesizing a paste so the
+    /// inserted characters aren't swallowed as modifier+key shortcuts.
+    private static func waitForHotkeyModifiersReleased(timeout: TimeInterval) async -> Bool {
         let relevant: CGEventFlags = [.maskCommand, .maskControl, .maskAlternate, .maskShift, .maskSecondaryFn]
         let start = Date()
         while Date().timeIntervalSince(start) < timeout {
             let flags = CGEventSource.flagsState(.combinedSessionState)
             if flags.isDisjoint(with: relevant) {
-                return
+                return true
             }
             try? await Task.sleep(nanoseconds: 15_000_000) // 15ms
         }
+        return false
     }
 
     private func undoLastAIProcessingFromHistory() {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -77,6 +77,7 @@ enum ShortcutRecordingTarget: Hashable {
     case command
     case edit
     case cancel
+    case pasteLast
     case dictationPrompt(String)
     case newPrompt
 
@@ -92,6 +93,8 @@ enum ShortcutRecordingTarget: Hashable {
             return "Edit Mode"
         case .cancel:
             return "Cancel Recording"
+        case .pasteLast:
+            return "Paste Last Transcription"
         case .dictationPrompt:
             return "Prompt Shortcut"
         case .newPrompt:
@@ -101,7 +104,7 @@ enum ShortcutRecordingTarget: Hashable {
 
     var enablesFeatureOnAssignment: Bool {
         switch self {
-        case .secondaryDictation, .command, .edit:
+        case .secondaryDictation, .command, .edit, .pasteLast:
             return true
         case .primaryDictation, .cancel, .dictationPrompt, .newPrompt:
             return false
@@ -182,6 +185,8 @@ struct ContentView: View {
     @State private var commandModeHotkeyShortcut: HotkeyShortcut? = SettingsStore.shared.commandModeHotkeyShortcut
     @State private var rewriteModeHotkeyShortcut: HotkeyShortcut = SettingsStore.shared.rewriteModeHotkeyShortcut
     @State private var cancelRecordingHotkeyShortcut: HotkeyShortcut = SettingsStore.shared.cancelRecordingHotkeyShortcut
+    @State private var pasteLastTranscriptionHotkeyShortcut: HotkeyShortcut? = SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut
+    @State private var isPasteLastTranscriptionShortcutEnabled: Bool = SettingsStore.shared.pasteLastTranscriptionShortcutEnabled
     @State private var isPromptModeShortcutEnabled: Bool = SettingsStore.shared.promptModeShortcutEnabled
     @State private var isCommandModeShortcutEnabled: Bool = SettingsStore.shared.commandModeShortcutEnabled
     @State private var isRewriteModeShortcutEnabled: Bool = SettingsStore.shared.rewriteModeShortcutEnabled
@@ -456,6 +461,20 @@ struct ContentView: View {
             .onChange(of: self.isRewriteModeShortcutEnabled) { newValue in
                 self.handleRewriteShortcutEnabledChange(newValue)
             }
+            .onChange(of: self.pasteLastTranscriptionHotkeyShortcut) { _, newValue in
+                // The hotkey manager reads this value live from SettingsStore, so persisting is enough.
+                SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut = newValue
+            }
+            .onChange(of: self.isPasteLastTranscriptionShortcutEnabled) { newValue in
+                self.handlePasteLastTranscriptionShortcutEnabledChange(newValue)
+            }
+    }
+
+    private func handlePasteLastTranscriptionShortcutEnabledChange(_ isEnabled: Bool) {
+        SettingsStore.shared.pasteLastTranscriptionShortcutEnabled = isEnabled
+        if !isEnabled, self.activeShortcutRecordingTarget == .pasteLast {
+            self.clearShortcutRecordingMode()
+        }
     }
 
     private func handlePromptShortcutEnabledChange(_ isEnabled: Bool) {
@@ -999,6 +1018,7 @@ struct ContentView: View {
         ]
         let optionalConfiguredShortcuts: [(ShortcutRecordingTarget, HotkeyShortcut?)] = [
             (.command, self.commandModeHotkeyShortcut),
+            (.pasteLast, self.pasteLastTranscriptionHotkeyShortcut),
         ]
 
         for (otherTarget, configuredShortcut) in configuredShortcuts where otherTarget != target {
@@ -1064,6 +1084,10 @@ struct ContentView: View {
         case .cancel:
             self.cancelRecordingHotkeyShortcut = shortcut
             SettingsStore.shared.cancelRecordingHotkeyShortcut = shortcut
+        case .pasteLast:
+            // The hotkey manager reads this shortcut directly from SettingsStore, so no manager update is needed.
+            self.pasteLastTranscriptionHotkeyShortcut = shortcut
+            SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut = shortcut
         case let .dictationPrompt(key):
             guard let selection = SettingsStore.shared.dictationPromptSelection(forConfigurationKey: key) else { return }
             var configuration = SettingsStore.shared.dictationPromptConfiguration(for: selection)
@@ -1108,6 +1132,9 @@ struct ContentView: View {
             self.isRewriteModeShortcutEnabled = enabled
             SettingsStore.shared.rewriteModeShortcutEnabled = enabled
             self.hotkeyManager?.updateRewriteModeShortcutEnabled(enabled)
+        case .pasteLast:
+            self.isPasteLastTranscriptionShortcutEnabled = enabled
+            SettingsStore.shared.pasteLastTranscriptionShortcutEnabled = enabled
         case .primaryDictation, .cancel, .dictationPrompt, .newPrompt:
             break
         }
@@ -1435,8 +1462,10 @@ struct ContentView: View {
             commandModeShortcut: self.$commandModeHotkeyShortcut,
             rewriteShortcut: self.$rewriteModeHotkeyShortcut,
             cancelRecordingShortcut: self.$cancelRecordingHotkeyShortcut,
+            pasteLastTranscriptionShortcut: self.$pasteLastTranscriptionHotkeyShortcut,
             commandModeShortcutEnabled: self.$isCommandModeShortcutEnabled,
             rewriteShortcutEnabled: self.$isRewriteModeShortcutEnabled,
+            pasteLastTranscriptionShortcutEnabled: self.$isPasteLastTranscriptionShortcutEnabled,
             hotkeyManagerInitialized: self.$hotkeyManagerInitialized,
             hotkeyMode: self.$hotkeyMode,
             enableStreamingPreview: self.$enableStreamingPreview,
@@ -2478,6 +2507,40 @@ struct ContentView: View {
         DebugLogger.shared.info("Actions: Copied latest transcription to clipboard", source: "ContentView")
     }
 
+    /// Re-inserts the most recent transcription into the focused text field using the same
+    /// clipboard-free insertion path as live dictation. Unlike copy, this never touches the
+    /// system clipboard, and unlike reprocess, it pastes the existing text verbatim (no new
+    /// history entry, no reformatting). Useful when the original auto-insert dropped the tail.
+    private func pasteLastDictationFromHistory() {
+        guard let last = TranscriptionHistoryStore.shared.entries.first else {
+            DebugLogger.shared.info("Actions: Paste requested but history is empty", source: "ContentView")
+            return
+        }
+
+        // Prefer the processed text (what was actually delivered, possibly AI-enhanced),
+        // falling back to raw for older entries or when enhancement was off.
+        let processed = last.processedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let raw = last.rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = processed.isEmpty ? raw : processed
+        guard !text.isEmpty else {
+            DebugLogger.shared.info("Actions: Paste skipped because latest history text is empty", source: "ContentView")
+            return
+        }
+
+        Task { @MainActor in
+            let typingTarget = self.resolveTypingTargetPID()
+            guard typingTarget.pid != nil else {
+                DebugLogger.shared.info("Actions: Paste skipped - no external target field available", source: "ContentView")
+                return
+            }
+            if typingTarget.shouldRestoreOriginalFocus {
+                await self.restoreFocusToRecordingTarget()
+            }
+            self.asr.typeTextToActiveField(text, preferredTargetPID: typingTarget.pid)
+            DebugLogger.shared.info("Actions: Pasted latest transcription into focused field", source: "ContentView")
+        }
+    }
+
     private func undoLastAIProcessingFromHistory() {
         guard let last = TranscriptionHistoryStore.shared.entries.first else {
             DebugLogger.shared.info("Actions: Undo AI requested but history is empty", source: "ContentView")
@@ -2999,6 +3062,9 @@ struct ContentView: View {
         NotchContentState.shared.onCopyLastRequested = {
             self.copyLastDictationFromHistory()
         }
+        NotchContentState.shared.onPasteLastRequested = {
+            self.pasteLastDictationFromHistory()
+        }
         NotchContentState.shared.onUndoLastAIRequested = {
             self.undoLastAIProcessingFromHistory()
         }
@@ -3167,6 +3233,11 @@ struct ContentView: View {
             }
 
             return handled
+        }
+
+        // Re-insert the most recent transcription on demand (no clipboard involved).
+        self.hotkeyManager?.setPasteLastTranscriptionCallback {
+            self.pasteLastDictationFromHistory()
         }
 
         // Monitor initialization status

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2530,12 +2530,12 @@ struct ContentView: View {
         Task { @MainActor in
             // The hotkey fires on key-down while its own modifier keys (e.g. ⌘⌃) are still
             // physically held. Synthesizing text in that state makes the target app treat the
-            // characters as keyboard shortcuts and drop them, so wait for the modifiers to be
-            // released before inserting. (Dictation never hits this because by the time it types,
-            // no keys are held.) If they never release (stuck/held), abort rather than typing a
-            // corrupted — and possibly destructive — shortcut sequence; the user can retrigger.
-            guard await Self.waitForHotkeyModifiersReleased(timeout: 0.6) else {
-                DebugLogger.shared.info("Actions: Paste aborted - modifier keys still held", source: "ContentView")
+            // characters as keyboard shortcuts and drop them, so the paste lands once the keys are
+            // released — effectively "paste when you let go". The timeout is generous so a normal
+            // hold (or a quick repeated press) still pastes on release; it only aborts if a modifier
+            // is genuinely stuck, rather than typing a corrupted/destructive shortcut sequence.
+            guard await Self.waitForHotkeyModifiersReleased(timeout: 5) else {
+                DebugLogger.shared.info("Actions: Paste aborted - modifier keys still held after timeout", source: "ContentView")
                 return
             }
 

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -37,6 +37,9 @@ struct SettingsBackupPayload: Codable, Equatable {
     let rewriteModeSelectedProviderID: String
     let rewriteModeLinkedToGlobal: Bool
     let cancelRecordingHotkeyShortcut: HotkeyShortcut
+    // Optional so older backup files (which predate this setting) still decode.
+    let pasteLastTranscriptionHotkeyShortcut: HotkeyShortcut?
+    let pasteLastTranscriptionShortcutEnabled: Bool?
     let showThinkingTokens: Bool
     let hideFromDockAndAppSwitcher: Bool
     let showMainWindowAtLoginLaunch: Bool?

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2855,7 +2855,11 @@ final class SettingsStore: ObservableObject {
         self.rewriteModeSelectedProviderID = payload.rewriteModeSelectedProviderID
         self.rewriteModeLinkedToGlobal = payload.rewriteModeLinkedToGlobal
         self.cancelRecordingHotkeyShortcut = payload.cancelRecordingHotkeyShortcut
-        self.pasteLastTranscriptionHotkeyShortcut = payload.pasteLastTranscriptionHotkeyShortcut
+        // Both guarded so restoring an older backup (which predates these fields) doesn't wipe a
+        // currently-configured shortcut or leave the feature enabled with no shortcut bound.
+        if let pasteLastTranscriptionHotkeyShortcut = payload.pasteLastTranscriptionHotkeyShortcut {
+            self.pasteLastTranscriptionHotkeyShortcut = pasteLastTranscriptionHotkeyShortcut
+        }
         if let pasteLastTranscriptionShortcutEnabled = payload.pasteLastTranscriptionShortcutEnabled {
             self.pasteLastTranscriptionShortcutEnabled = pasteLastTranscriptionShortcutEnabled
         }

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2399,6 +2399,43 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    // MARK: - Paste Last Transcription Settings
+
+    /// Whether the "Paste Last Transcription" global hotkey is active. Opt-in and off by default.
+    var pasteLastTranscriptionShortcutEnabled: Bool {
+        get {
+            let value = self.defaults.object(forKey: Keys.pasteLastTranscriptionShortcutEnabled)
+            return value as? Bool ?? false
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.pasteLastTranscriptionShortcutEnabled)
+        }
+    }
+
+    /// The shortcut that re-inserts the most recent transcription into the focused field.
+    /// Unbound (nil) by default so it never collides with an existing shortcut until the user assigns one.
+    var pasteLastTranscriptionHotkeyShortcut: HotkeyShortcut? {
+        get {
+            if let data = defaults.data(forKey: Keys.pasteLastTranscriptionHotkeyShortcut),
+               let shortcut = try? JSONDecoder().decode(HotkeyShortcut.self, from: data)
+            {
+                return shortcut
+            }
+            return nil
+        }
+        set {
+            objectWillChange.send()
+            guard let newValue else {
+                self.defaults.removeObject(forKey: Keys.pasteLastTranscriptionHotkeyShortcut)
+                return
+            }
+            if let data = try? JSONEncoder().encode(newValue) {
+                self.defaults.set(data, forKey: Keys.pasteLastTranscriptionHotkeyShortcut)
+            }
+        }
+    }
+
     var commandModeConfirmBeforeExecute: Bool {
         get {
             // Default to true (safer - ask before running commands)
@@ -2725,6 +2762,8 @@ final class SettingsStore: ObservableObject {
             rewriteModeSelectedProviderID: self.rewriteModeSelectedProviderID,
             rewriteModeLinkedToGlobal: self.rewriteModeLinkedToGlobal,
             cancelRecordingHotkeyShortcut: self.cancelRecordingHotkeyShortcut,
+            pasteLastTranscriptionHotkeyShortcut: self.pasteLastTranscriptionHotkeyShortcut,
+            pasteLastTranscriptionShortcutEnabled: self.pasteLastTranscriptionShortcutEnabled,
             showThinkingTokens: self.showThinkingTokens,
             hideFromDockAndAppSwitcher: self.hideFromDockAndAppSwitcher,
             showMainWindowAtLoginLaunch: self.showMainWindowAtLoginLaunch,
@@ -2816,6 +2855,10 @@ final class SettingsStore: ObservableObject {
         self.rewriteModeSelectedProviderID = payload.rewriteModeSelectedProviderID
         self.rewriteModeLinkedToGlobal = payload.rewriteModeLinkedToGlobal
         self.cancelRecordingHotkeyShortcut = payload.cancelRecordingHotkeyShortcut
+        self.pasteLastTranscriptionHotkeyShortcut = payload.pasteLastTranscriptionHotkeyShortcut
+        if let pasteLastTranscriptionShortcutEnabled = payload.pasteLastTranscriptionShortcutEnabled {
+            self.pasteLastTranscriptionShortcutEnabled = pasteLastTranscriptionShortcutEnabled
+        }
         self.showThinkingTokens = payload.showThinkingTokens
         self.hideFromDockAndAppSwitcher = payload.hideFromDockAndAppSwitcher
         self.showMainWindowAtLoginLaunch = payload.showMainWindowAtLoginLaunch ?? true
@@ -4367,6 +4410,8 @@ private extension SettingsStore {
         static let commandModeHotkeyShortcut = "CommandModeHotkeyShortcut"
         static let commandModeConfirmBeforeExecute = "CommandModeConfirmBeforeExecute"
         static let cancelRecordingHotkeyShortcut = "CancelRecordingHotkeyShortcut"
+        static let pasteLastTranscriptionHotkeyShortcut = "PasteLastTranscriptionHotkeyShortcut"
+        static let pasteLastTranscriptionShortcutEnabled = "PasteLastTranscriptionShortcutEnabled"
         static let commandModeLinkedToGlobal = "CommandModeLinkedToGlobal"
         static let commandModeShortcutEnabled = "CommandModeShortcutEnabled"
 

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -659,7 +659,10 @@ final class GlobalHotkeyManager: NSObject {
                let pasteShortcut = SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut,
                pasteShortcut.matches(keyCode: keyCode, modifiers: eventModifiers)
             {
-                self.triggerPasteLastTranscription()
+                // Holding the chord emits auto-repeat key-downs; because the paste waits for the
+                // modifiers to release, every repeat would otherwise queue another insertion and
+                // paste N times. triggerPasteLastTranscription ignores repeats.
+                self.triggerPasteLastTranscription(isAutorepeat: event.getIntegerValueField(.keyboardEventAutorepeat) != 0)
                 return nil
             }
 
@@ -1666,9 +1669,11 @@ final class GlobalHotkeyManager: NSObject {
         }
     }
 
-    private func triggerPasteLastTranscription() {
+    private func triggerPasteLastTranscription(isAutorepeat: Bool) {
         Task { @MainActor [weak self] in
             guard let self = self else { return }
+            // Holding the chord auto-repeats the key-down; act only on the initial press.
+            guard !isAutorepeat else { return }
             guard self.canTriggerRecordingAction("Paste last transcription hotkey") else { return }
             // Re-pasting mid-recording would be surprising; ignore while capture is active.
             guard !self.asrService.isRunning else {

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -902,18 +902,14 @@ final class GlobalHotkeyManager: NSObject {
 
         case .leftMouseDown, .rightMouseDown, .otherMouseDown:
             self.markOtherInputDuringModifierOnly()
-            let mouseButton = self.mouseButton(from: event)
-            if self.primaryShortcuts.contains(where: { $0.matchesMouse(button: mouseButton, modifiers: eventModifiers) }) {
-                guard self.beginPrimaryShortcutPress(.mouse(mouseButton)) else { return nil }
-                self.handlePrimaryDictationTriggerDown()
+            if self.handleMouseShortcutDown(event, modifiers: eventModifiers) {
                 return nil
             }
 
         case .leftMouseUp, .rightMouseUp, .otherMouseUp:
-            let mouseButton = self.mouseButton(from: event)
-            guard self.finishPrimaryShortcutPress(.mouse(mouseButton)) else { break }
-            self.handlePrimaryDictationTriggerUp()
-            return nil
+            if self.handleMouseShortcutUp(event) {
+                return nil
+            }
 
         case .flagsChanged:
             if HotkeyShortcut.modifierFlag(forKeyCode: keyCode) != nil {
@@ -1667,6 +1663,47 @@ final class GlobalHotkeyManager: NSObject {
             )
             await self.rewriteModeCallback?()
         }
+    }
+
+    /// Handles a mouse-button down event against the configured mouse shortcuts. Returns true when
+    /// the event was consumed. "Paste Last Transcription" is a one-shot trigger (mirrors the keyboard
+    /// path); primary dictation begins a press here and ends it on mouse-up.
+    private func handleMouseShortcutDown(_ event: CGEvent, modifiers eventModifiers: NSEvent.ModifierFlags) -> Bool {
+        let mouseButton = self.mouseButton(from: event)
+
+        if SettingsStore.shared.pasteLastTranscriptionShortcutEnabled,
+           let pasteShortcut = SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut,
+           pasteShortcut.matchesMouse(button: mouseButton, modifiers: eventModifiers)
+        {
+            self.triggerPasteLastTranscription(isAutorepeat: false)
+            return true
+        }
+
+        if self.primaryShortcuts.contains(where: { $0.matchesMouse(button: mouseButton, modifiers: eventModifiers) }) {
+            guard self.beginPrimaryShortcutPress(.mouse(mouseButton)) else { return true }
+            self.handlePrimaryDictationTriggerDown()
+            return true
+        }
+
+        return false
+    }
+
+    /// Handles a mouse-button up event. Swallows the up that pairs with a consumed paste mouse-down
+    /// so the focused app never sees an orphaned mouse-up; otherwise ends a primary dictation press.
+    private func handleMouseShortcutUp(_ event: CGEvent) -> Bool {
+        let mouseButton = self.mouseButton(from: event)
+
+        if SettingsStore.shared.pasteLastTranscriptionShortcutEnabled,
+           let pasteShortcut = SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut,
+           pasteShortcut.isMouseShortcut,
+           pasteShortcut.mouseButton == mouseButton
+        {
+            return true
+        }
+
+        guard self.finishPrimaryShortcutPress(.mouse(mouseButton)) else { return false }
+        self.handlePrimaryDictationTriggerUp()
+        return true
     }
 
     private func triggerPasteLastTranscription(isAutorepeat: Bool) {

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -69,6 +69,7 @@ final class GlobalHotkeyManager: NSObject {
     private var isRewriteRecordingProvider: (() -> Bool)?
     private var isShortcutCaptureActiveProvider: (() -> Bool)?
     private var cancelCallback: (() -> Bool)? // Returns true if handled
+    private var pasteLastTranscriptionCallback: (() -> Void)?
     private var hotkeyMode: HotkeyActivationMode = SettingsStore.shared.hotkeyMode
     private let automaticTapThresholdSeconds: TimeInterval = 0.4
 
@@ -414,6 +415,10 @@ final class GlobalHotkeyManager: NSObject {
         self.cancelCallback = callback
     }
 
+    func setPasteLastTranscriptionCallback(_ callback: @escaping () -> Void) {
+        self.pasteLastTranscriptionCallback = callback
+    }
+
     private func setupGlobalHotkeyWithRetry() {
         for attempt in 1...self.maxRetryAttempts {
             DebugLogger.shared.debug("Setup attempt \(attempt)/\(self.maxRetryAttempts)", source: "GlobalHotkeyManager")
@@ -647,6 +652,15 @@ final class GlobalHotkeyManager: NSObject {
                 if handled {
                     return nil // Consume event only if we did something
                 }
+            }
+
+            // Check the "paste last transcription" shortcut (a one-shot action, like cancel).
+            if SettingsStore.shared.pasteLastTranscriptionShortcutEnabled,
+               let pasteShortcut = SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut,
+               pasteShortcut.matches(keyCode: keyCode, modifiers: eventModifiers)
+            {
+                self.triggerPasteLastTranscription()
+                return nil
             }
 
             if let assignment = self.promptShortcutAssignments.first(where: { $0.shortcut.matches(keyCode: keyCode, modifiers: eventModifiers) }) {
@@ -1649,6 +1663,23 @@ final class GlobalHotkeyManager: NSObject {
                 source: "GlobalHotkeyManager"
             )
             await self.rewriteModeCallback?()
+        }
+    }
+
+    private func triggerPasteLastTranscription() {
+        Task { @MainActor [weak self] in
+            guard let self = self else { return }
+            guard self.canTriggerRecordingAction("Paste last transcription hotkey") else { return }
+            // Re-pasting mid-recording would be surprising; ignore while capture is active.
+            guard !self.asrService.isRunning else {
+                DebugLogger.shared.info(
+                    "Paste last transcription hotkey ignored - recording in progress",
+                    source: "GlobalHotkeyManager"
+                )
+                return
+            }
+            DebugLogger.shared.info("Paste last transcription hotkey triggered", source: "GlobalHotkeyManager")
+            self.pasteLastTranscriptionCallback?()
         }
     }
 

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -2285,7 +2285,7 @@ struct SettingsView: View {
                 Color.clear
                     .frame(width: 20)
 
-                if isRecording && enabledValue {
+                if isRecording {
                     self.shortcutCapturePill()
                 } else {
                     self.shortcutDisplayPill(shortcut?.displayString ?? "Not set")

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -40,8 +40,10 @@ struct SettingsView: View {
     @Binding var commandModeShortcut: HotkeyShortcut?
     @Binding var rewriteShortcut: HotkeyShortcut
     @Binding var cancelRecordingShortcut: HotkeyShortcut
+    @Binding var pasteLastTranscriptionShortcut: HotkeyShortcut?
     @Binding var commandModeShortcutEnabled: Bool
     @Binding var rewriteShortcutEnabled: Bool
+    @Binding var pasteLastTranscriptionShortcutEnabled: Bool
     @Binding var hotkeyManagerInitialized: Bool
     @Binding var hotkeyMode: HotkeyActivationMode
     @Binding var enableStreamingPreview: Bool
@@ -755,6 +757,35 @@ struct SettingsView: View {
                                             DebugLogger.shared.debug("Starting to record new cancel shortcut", source: "SettingsView")
                                             self.shortcutRecordingMessage = nil
                                             self.activeShortcutRecordingTarget = .cancel
+                                        }
+                                    )
+                                    Divider().opacity(0.2).padding(.vertical, 4)
+
+                                    self.shortcutRow(
+                                        content: .init(
+                                            icon: "arrow.down.doc",
+                                            iconColor: .secondary,
+                                            title: "Paste Last Transcription",
+                                            description: "Re-insert your most recent transcription without using the clipboard"
+                                        ),
+                                        shortcut: self.pasteLastTranscriptionShortcut,
+                                        isRecording: self.isRecording(.pasteLast),
+                                        isAnyRecordingActive: self.isRecordingAnyShortcut,
+                                        recordingMessage: self.isRecording(.pasteLast) ? self.shortcutRecordingMessage : nil,
+                                        isEnabled: self.$pasteLastTranscriptionShortcutEnabled,
+                                        requiresShortcutToEnable: true,
+                                        onChangePressed: {
+                                            DebugLogger.shared.debug("Starting to record new paste last transcription shortcut", source: "SettingsView")
+                                            self.shortcutRecordingMessage = nil
+                                            self.activeShortcutRecordingTarget = .pasteLast
+                                        },
+                                        onRemovePressed: {
+                                            if self.activeShortcutRecordingTarget == .pasteLast {
+                                                self.shortcutRecordingMessage = nil
+                                                self.activeShortcutRecordingTarget = nil
+                                            }
+                                            self.pasteLastTranscriptionShortcut = nil
+                                            self.pasteLastTranscriptionShortcutEnabled = false
                                         }
                                     )
                                 }

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -1539,6 +1539,10 @@ private struct BottomOverlayActionsMenuView: View {
         return !(processed.isEmpty && raw.isEmpty)
     }
 
+    private var canPasteLast: Bool {
+        self.canCopyLast
+    }
+
     private var canUndoLastAI: Bool {
         guard !self.contentState.isProcessing else { return false }
         guard let latest = self.latestEntry else { return false }
@@ -1627,6 +1631,15 @@ private struct BottomOverlayActionsMenuView: View {
                 enabled: self.canCopyLast
             ) {
                 self.contentState.onCopyLastRequested?()
+            }
+
+            self.actionRow(
+                title: "Paste Last Transcription",
+                icon: "arrow.down.doc",
+                rowID: "paste_last",
+                enabled: self.canPasteLast
+            ) {
+                self.contentState.onPasteLastRequested?()
             }
 
             Divider()

--- a/Sources/Fluid/Views/NotchContentViews.swift
+++ b/Sources/Fluid/Views/NotchContentViews.swift
@@ -157,6 +157,8 @@ class NotchContentState: ObservableObject {
     var onReprocessLastRequested: (() -> Void)?
     /// Called when the user requests copying the latest saved transcription entry.
     var onCopyLastRequested: (() -> Void)?
+    /// Called when the user requests re-pasting the latest saved transcription entry.
+    var onPasteLastRequested: (() -> Void)?
     /// Called when the user requests undoing AI processing for the latest entry.
     var onUndoLastAIRequested: (() -> Void)?
     /// Called when the user requests opening Preferences.

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -143,6 +143,18 @@ final class HotkeyShortcutTests: XCTestCase {
         }
     }
 
+    func testPasteLastTranscriptionShortcutSupportsMouseButton() throws {
+        try self.withRestoredDefaults(keys: [self.pasteLastTranscriptionShortcutKey]) {
+            let mouseShortcut = HotkeyShortcut(mouseButton: 3, modifierFlags: [.option])
+            SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut = mouseShortcut
+
+            let stored = SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut
+            XCTAssertEqual(stored, mouseShortcut)
+            XCTAssertTrue(stored?.isMouseShortcut ?? false)
+            XCTAssertTrue(stored?.matchesMouse(button: 3, modifiers: [.option]) ?? false)
+        }
+    }
+
     private func withRestoredDefaults(keys: [String], run: () throws -> Void) rethrows {
         let defaults = UserDefaults.standard
         var snapshot: [String: Any] = [:]

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -6,6 +6,8 @@ import XCTest
 final class HotkeyShortcutTests: XCTestCase {
     private let legacyHotkeyShortcutKey = "HotkeyShortcutKey"
     private let primaryDictationShortcutsKey = "PrimaryDictationShortcuts"
+    private let pasteLastTranscriptionShortcutKey = "PasteLastTranscriptionHotkeyShortcut"
+    private let pasteLastTranscriptionEnabledKey = "PasteLastTranscriptionShortcutEnabled"
 
     func testLegacyKeyboardShortcutPayloadDefaultsToKeyboardKind() throws {
         let json = #"{"keyCode":61,"modifierFlagsRawValue":0}"#
@@ -107,6 +109,37 @@ final class HotkeyShortcutTests: XCTestCase {
                 SettingsStore.shared.primaryDictationShortcutDisplayString,
                 "\(mouseShortcut.displayString) / \(keyboardShortcut.displayString)"
             )
+        }
+    }
+
+    func testPasteLastTranscriptionShortcutDefaultsToUnboundAndDisabled() throws {
+        try self.withRestoredDefaults(keys: [
+            self.pasteLastTranscriptionShortcutKey,
+            self.pasteLastTranscriptionEnabledKey,
+        ]) {
+            UserDefaults.standard.removeObject(forKey: self.pasteLastTranscriptionShortcutKey)
+            UserDefaults.standard.removeObject(forKey: self.pasteLastTranscriptionEnabledKey)
+
+            XCTAssertNil(SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut)
+            XCTAssertFalse(SettingsStore.shared.pasteLastTranscriptionShortcutEnabled)
+        }
+    }
+
+    func testPasteLastTranscriptionShortcutPersistsAndClears() throws {
+        try self.withRestoredDefaults(keys: [
+            self.pasteLastTranscriptionShortcutKey,
+            self.pasteLastTranscriptionEnabledKey,
+        ]) {
+            let shortcut = HotkeyShortcut(keyCode: 9, modifierFlags: [.command, .shift])
+            SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut = shortcut
+            SettingsStore.shared.pasteLastTranscriptionShortcutEnabled = true
+
+            XCTAssertEqual(SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut, shortcut)
+            XCTAssertTrue(SettingsStore.shared.pasteLastTranscriptionShortcutEnabled)
+
+            // Removing the shortcut returns to the unbound state.
+            SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut = nil
+            XCTAssertNil(SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut)
         }
     }
 


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/cc852e52-8a53-4490-a124-2ef7c61f78cd

Shows assigning the shortcut in Settings → Shortcuts and re-pasting the last transcription into a focused field (clipboard untouched).

## Description

Adds a **"Paste Last Transcription"** action that re-inserts the most recent transcription into the focused text field using FluidVoice's existing **clipboard-free** insertion path (`TypingService` standard mode). Unlike "Copy Last Transcription," it never writes to the system clipboard, so it works for users who intentionally keep `Copy transcription to clipboard` disabled. Useful when auto-insert drops the tail of a dictation or the text lands in the wrong place.

It's exposed two ways, both routed through a single `ContentView.pasteLastDictationFromHistory()`:
- A **configurable global hotkey**, **unbound and disabled by default** (opt-in; assigned in Settings, same default-off model as Command/Edit mode), so it never collides with an existing shortcut until the user sets one.
- An item in the overlay actions menu beside the existing "Copy Last Transcription."

The action re-inserts the last entry's `processedText` (falling back to `rawText`), creates no new history entry, and does no reformatting — it's a faithful re-paste. It reuses `resolveTypingTargetPID()` / `restoreFocusToRecordingTarget()` so it targets the right field in both the hotkey case (insert at the current cursor) and the menu case (restore focus to the prior app first). It's ignored while a recording is in progress, and no-ops with a debug log when history is empty.

## Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issues
- Closes #487

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac (macOS 26)
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Manually verified end-to-end on a signed local build: record shortcut → dictate → re-paste into a focused field with the clipboard untouched.

Added `HotkeyShortcutTests` cases covering the new setting's default (unbound + disabled) and persistence/clear round-trip.

Two fixes landed after exercising the feature on a real build:
1. **Shortcut-recording feedback** (`shortcutRow`): the "press keys…" capture pill was gated on `isRecording && enabledValue`, so for an opt-in row whose toggle is still off, clicking "Change" started recording but kept showing "Not set" — it looked unresponsive. Now the pill shows whenever recording. **Note: this also improves the existing Command Mode row** (same helper), which had the same first-record blind spot — flagging in case that's unexpected.
2. **Modifier-held paste drop**: the hotkey fires on key-down while its own modifiers are still held, so synthesized characters were interpreted by the target app as shortcuts and dropped. The paste now waits for the modifier keys to release before inserting.

## Notes
- **Default-off / unbound by design.** The hotkey ships with no binding and disabled; it activates only after the user records a shortcut in Settings → Shortcuts. This avoids clobbering app shortcuts (e.g. ⌘⇧V "paste & match style").
- **No new dependencies.** Mirrors the existing Command/Cancel hotkey patterns; the manager reads the shortcut live from `SettingsStore` (like the Cancel shortcut), so there's no extra plumbing through the `GlobalHotkeyManager` initializer.
- **Backup/restore.** The new shortcut + enabled flag are added to `SettingsBackupPayload` as optionals, so older backup files still decode.
- **Clipboard behavior unchanged.** Honors the user's `textInsertionMode`: `standard` inserts with no clipboard involvement; `reliablePaste` uses the existing temporary-clipboard-then-restore mechanism. The independent `copyTranscriptionToClipboard` setting is untouched.

## Screenshots / Video
See the **Demo** at the top — it walks through assigning the shortcut in Settings and re-pasting the last transcription into a focused field with the clipboard untouched.
