### PR TITLE
add reliable paste for ghostty

### DIFF
--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -225,14 +225,34 @@ final class TypingService {
         return Self.isCurrentlyFocusedElement(element, expectedPID: pid)
     }
 
-    private func isGhosttyTarget(preferredTargetPID: pid_t?) -> Bool {
-        guard let preferredTargetPID, preferredTargetPID > 0,
-              let app = NSRunningApplication(processIdentifier: preferredTargetPID)
+    private func isGhosttyApplication(pid: pid_t) -> Bool {
+        guard pid > 0,
+              let app = NSRunningApplication(processIdentifier: pid)
         else {
             return false
         }
 
         return app.bundleIdentifier == Self.ghosttyBundleIdentifier
+    }
+
+    private func ghosttyTargetPID(preferredTargetPID: pid_t?) -> pid_t? {
+        if let preferredTargetPID, preferredTargetPID > 0 {
+            return self.isGhosttyApplication(pid: preferredTargetPID) ? preferredTargetPID : nil
+        }
+
+        if let focusedPID = self.getSystemFocusedElementAndPID()?.pid,
+           self.isGhosttyApplication(pid: focusedPID)
+        {
+            return focusedPID
+        }
+
+        if let frontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier,
+           self.isGhosttyApplication(pid: frontmostPID)
+        {
+            return frontmostPID
+        }
+
+        return nil
     }
 
     /// Best-effort: activates the app with the given PID, unless it's Fluid itself.
@@ -352,9 +372,11 @@ final class TypingService {
         self.log("[TypingService] insertTextInstantly called with \(text.count) characters")
         self.log("[TypingService] Attempting to type text: \"\(text.prefix(50))\(text.count > 50 ? "..." : "")\"")
 
-        if self.textInsertionMode == .standard, self.isGhosttyTarget(preferredTargetPID: preferredTargetPID) {
-            self.log("[TypingService] Ghostty target detected in standard mode; forcing Reliable Paste path")
-            if self.tryReliablePasteInsertion(text, preferredTargetPID: preferredTargetPID) {
+        if self.textInsertionMode == .standard,
+           let ghosttyTargetPID = self.ghosttyTargetPID(preferredTargetPID: preferredTargetPID)
+        {
+            self.log("[TypingService] Ghostty target detected in standard mode (PID \(ghosttyTargetPID)); forcing Reliable Paste path")
+            if self.tryReliablePasteInsertion(text, preferredTargetPID: ghosttyTargetPID) {
                 self.log("[TypingService] SUCCESS: Ghostty Reliable Paste path completed")
                 return
             }

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -54,6 +54,7 @@ final class TypingService {
     private static let pasteboardSessionSemaphore = DispatchSemaphore(value: 1)
     private static let pasteboardRestoreQueue = DispatchQueue(label: "TypingService.PasteboardRestore", qos: .utility)
     private static var focusSnapshot: FocusSnapshot?
+    private static let ghosttyBundleIdentifier = "com.mitchellh.ghostty"
 
     private var textInsertionMode: SettingsStore.TextInsertionMode {
         SettingsStore.shared.textInsertionMode
@@ -224,6 +225,16 @@ final class TypingService {
         return Self.isCurrentlyFocusedElement(element, expectedPID: pid)
     }
 
+    private func isGhosttyTarget(preferredTargetPID: pid_t?) -> Bool {
+        guard let preferredTargetPID, preferredTargetPID > 0,
+              let app = NSRunningApplication(processIdentifier: preferredTargetPID)
+        else {
+            return false
+        }
+
+        return app.bundleIdentifier == Self.ghosttyBundleIdentifier
+    }
+
     /// Best-effort: activates the app with the given PID, unless it's Fluid itself.
     @discardableResult
     static func activateApp(pid: pid_t) -> Bool {
@@ -340,6 +351,15 @@ final class TypingService {
     private func insertTextInstantly(_ text: String, preferredTargetPID: pid_t?) {
         self.log("[TypingService] insertTextInstantly called with \(text.count) characters")
         self.log("[TypingService] Attempting to type text: \"\(text.prefix(50))\(text.count > 50 ? "..." : "")\"")
+
+        if self.textInsertionMode == .standard, self.isGhosttyTarget(preferredTargetPID: preferredTargetPID) {
+            self.log("[TypingService] Ghostty target detected in standard mode; forcing Reliable Paste path")
+            if self.tryReliablePasteInsertion(text, preferredTargetPID: preferredTargetPID) {
+                self.log("[TypingService] SUCCESS: Ghostty Reliable Paste path completed")
+                return
+            }
+            self.log("[TypingService] Ghostty Reliable Paste path fell through to direct-typing fallbacks")
+        }
 
         if self.textInsertionMode == .reliablePaste {
             self.log("[TypingService] Reliable Paste mode enabled")


### PR DESCRIPTION
## Description
Add a fallback paste method for Ghostty.  Refer #479 for more details for why this fix

## Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issues
#479

## Testing
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 27.0

## Screenshots / Video 
<img width="5744" height="3504" alt="CleanShot 2026-06-30 at 21 53 11@2x" src="https://github.com/user-attachments/assets/c590ac65-3471-47dd-bc3c-29d0bc30e8ba" />

