### PR TITLE
fix(providers): allow plain-HTTP custom endpoints blocked by ATS (#499)

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
 		86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */; };
+		C2E85A710B463D97C4F21E88 /* InsecureEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D94B37C25E80A614F7C3A902 /* InsecureEndpointTests.swift */; };
 		7CDB0A2F2F3C4D5600FB7CAD /* dictation_fixture.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */; };
 		7CDB0A302F3C4D5600FB7CAD /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */; };
 		7CE006BD2E80EBE600DDCCD6 /* AppUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = 7CE006BC2E80EBE600DDCCD6 /* AppUpdater */; };
@@ -36,6 +37,7 @@
 		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
 		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
 		343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMClientRequestBodyTests.swift; sourceTree = "<group>"; };
+		D94B37C25E80A614F7C3A902 /* InsecureEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsecureEndpointTests.swift; sourceTree = "<group>"; };
 		7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFixtureLoader.swift; sourceTree = "<group>"; };
 		7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = dictation_fixture.wav; sourceTree = "<group>"; };
 		7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -106,6 +108,7 @@
 				7CDB0A272F3C4D5600FB7CAD /* Resources */,
 				7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */,
 				7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */,
+				D94B37C25E80A614F7C3A902 /* InsecureEndpointTests.swift */,
 				343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
@@ -261,6 +264,7 @@
 				7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */,
 				7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */,
 				7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */,
+				C2E85A710B463D97C4F21E88 /* InsecureEndpointTests.swift in Sources */,
 				86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Info.plist
+++ b/Info.plist
@@ -28,6 +28,16 @@
 	<false/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>FluidVoice needs permission to control system events for managing launch at startup settings.</string>
+	<!-- Custom AI providers are user-configured at runtime (local proxies such as
+	     Ollama, LM Studio, cliproxyapi often run plain HTTP on LAN hosts), so their
+	     domains cannot be enumerated as ATS exceptions at build time. All bundled
+	     endpoints remain HTTPS; the provider settings UI warns before using a
+	     non-loopback HTTP endpoint. -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>POSTHOG_API_KEY</key>
 	<string>phc_coNu37345O2bgaAeQMD3tezkg1rDCbDS9Y3pOVvp2VM</string>
 	<key>POSTHOG_HOST</key>

--- a/Sources/Fluid/Services/ModelRepository.swift
+++ b/Sources/Fluid/Services/ModelRepository.swift
@@ -152,6 +152,22 @@ final class ModelRepository {
         return false
     }
 
+    /// Check if a URL sends traffic unencrypted beyond this machine: plain HTTP
+    /// to any non-loopback host. Loopback (localhost/127.x/::1) never leaves the
+    /// device, so it is exempt; other LAN hosts are not, since that traffic is
+    /// observable on the network.
+    func isInsecureRemoteEndpoint(_ urlString: String) -> Bool {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              url.scheme?.lowercased() == "http",
+              let host = url.host?.lowercased()
+        else { return false }
+        if host == "localhost" || host == "::1" || host.hasPrefix("127.") {
+            return false
+        }
+        return true
+    }
+
     /// Returns the list of built-in providers for UI pickers
     /// - Parameter includeAppleIntelligence: Whether to include Apple Intelligence
     /// - Parameter appleIntelligenceAvailable: Whether Apple Intelligence is available on this device

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -1232,6 +1232,9 @@ extension AIEnhancementSettingsView {
                         TextField("https://api.yourprovider.com/v1", text: baseURLBinding)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(size: 13, design: .monospaced))
+                        if ModelRepository.shared.isInsecureRemoteEndpoint(baseURLBinding.wrappedValue) {
+                            self.insecureEndpointWarning
+                        }
                     }
                 }
 
@@ -2429,6 +2432,9 @@ extension AIEnhancementSettingsView {
                     TextField("https://api.yourprovider.com/v1", text: self.$viewModel.newProviderBaseURL)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(size: 13, design: .monospaced))
+                    if ModelRepository.shared.isInsecureRemoteEndpoint(self.viewModel.newProviderBaseURL) {
+                        self.insecureEndpointWarning
+                    }
                 }
 
                 VStack(alignment: .leading, spacing: 6) {
@@ -2491,5 +2497,17 @@ extension AIEnhancementSettingsView {
 
     func saveNewProvider() {
         self.viewModel.saveNewProvider()
+    }
+
+    var insecureEndpointWarning: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+            Text("Unencrypted HTTP endpoint — prompts, transcripts, and the API key are sent as plain text. Use only on networks you trust.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -1931,6 +1931,9 @@ extension AIEnhancementSettingsView {
                             TextField("e.g., http://localhost:11434/v1", text: self.$viewModel.editProviderBaseURL)
                                 .textFieldStyle(.roundedBorder)
                                 .font(.system(size: 13, design: .monospaced))
+                            if ModelRepository.shared.isInsecureRemoteEndpoint(self.viewModel.editProviderBaseURL) {
+                                self.insecureEndpointWarning
+                            }
                         }
                     }
                 }

--- a/Tests/FluidDictationIntegrationTests/InsecureEndpointTests.swift
+++ b/Tests/FluidDictationIntegrationTests/InsecureEndpointTests.swift
@@ -1,0 +1,30 @@
+@testable import FluidVoice_Debug
+import Foundation
+import XCTest
+
+final class InsecureEndpointTests: XCTestCase {
+    private let repository = ModelRepository.shared
+
+    func testPlainHTTPToRemoteHostsIsInsecure() {
+        XCTAssertTrue(self.repository.isInsecureRemoteEndpoint("http://mars-main.box:8317/v1"))
+        XCTAssertTrue(self.repository.isInsecureRemoteEndpoint("http://192.168.1.20:8080/v1"))
+        XCTAssertTrue(self.repository.isInsecureRemoteEndpoint("http://proxy.example.com/v1"))
+        XCTAssertTrue(self.repository.isInsecureRemoteEndpoint("  http://proxy.example.com/v1  "))
+        XCTAssertTrue(self.repository.isInsecureRemoteEndpoint("HTTP://proxy.example.com/v1"))
+    }
+
+    func testLoopbackHTTPIsNotFlagged() {
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint("http://localhost:11434/v1"))
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint("http://LOCALHOST:11434/v1"))
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint("http://127.0.0.1:1234/v1"))
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint("http://127.1.2.3:1234/v1"))
+    }
+
+    func testHTTPSAndInvalidInputAreNotFlagged() {
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint("https://api.example.com/v1"))
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint("https://mars-main.box:8317/v1"))
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint(""))
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint("   "))
+        XCTAssertFalse(self.repository.isInsecureRemoteEndpoint("api.example.com/v1"))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #499. Custom providers pointed at a plain-HTTP endpoint — e.g. the reporter's `http://mars-main.box:8317/v1`, or local LLM proxies like cliproxyapi/new-api that have no TLS cert — fail every request (model refresh, verification, enhancement) with:

> Network error: The resource could not be loaded because the App Transport Security policy requires the use of a secure connection. (Error code: -1022)

## Root cause

The app bundle had no `NSAppTransportSecurity` configuration, so macOS applies the default ATS policy: cleartext HTTP is blocked at the CFNetwork layer for every host except loopback. The provider form itself accepts `http://` URLs (`saveNewProvider` only checks for non-empty), so users could configure an endpoint that could never work, and the failure only surfaced later as error -1022.

## Why `NSAllowsArbitraryLoads`

- **`NSExceptionDomains`** requires the hosts to be known at build time; custom provider hosts are user-configured at runtime.
- **`NSAllowsLocalNetworking`** only exempts local-network names (single-label, `.local`); it does not cover multi-label private DNS names like the reporter's `mars-main.box`, nor self-hosted proxies reached across networks.

So a global allowance is the only mechanism that actually covers the reported setups. Every endpoint the app itself ships with (model downloads, updater, analytics) remains HTTPS — this change only permits endpoints the user explicitly configures.

## Keeping the choice informed

Both custom provider forms (add and edit) now show a warning under the Base URL field when it is plain HTTP to a non-loopback host:

> ⚠️ Unencrypted HTTP endpoint — prompts, transcripts, and the API key are sent as plain text. Use only on networks you trust.

Classification lives in `ModelRepository.isInsecureRemoteEndpoint`: loopback (`localhost`/`127.x`/`::1`) is exempt since that traffic never leaves the machine; other LAN hosts are not, since that traffic is observable on the network.

## Out of scope

HTTPS endpoints with self-signed/invalid certificates still fail TLS validation — that is certificate trust, not ATS, and would need a separate opt-in trust override if wanted.

## Changes

- `Info.plist` — `NSAppTransportSecurity` → `NSAllowsArbitraryLoads`, with a comment documenting the rationale.
- `ModelRepository` — `isInsecureRemoteEndpoint(_:)` helper next to the existing `isLocalEndpoint`.
- `AISettingsView+AIConfiguration` — shared warning row under the Base URL field in the add and edit provider forms.
- Tests — `InsecureEndpointTests` covering remote-HTTP flagging (including the reporter's URL shape), loopback exemption, HTTPS, and invalid input.

## Testing

- `swiftlint --strict` — 0 violations.
- Full `xcodebuild test` suite — 57/57 passing.
- Verified the built app bundle's `Info.plist` contains the ATS key (`plutil -p`).

Closes #499