### PR TITLE
Allow empty custom-dictionary replacements to delete text

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -2982,8 +2982,13 @@ final class ASRService: ObservableObject {
                 guard !trigger.isEmpty else { continue }
 
                 let escapedTrigger = NSRegularExpression.escapedPattern(for: trigger)
+                // Only apply `\b` word boundaries where the trigger edge is a word
+                // character. Punctuation-only triggers (e.g. "¿") have no adjacent
+                // word boundary, so `\b…\b` would never match them.
+                let leadingBoundary = (trigger.first?.isWordCharacter ?? false) ? "\\b" : ""
+                let trailingBoundary = (trigger.last?.isWordCharacter ?? false) ? "\\b" : ""
                 guard let regex = try? NSRegularExpression(
-                    pattern: "\\b" + escapedTrigger + "\\b",
+                    pattern: leadingBoundary + escapedTrigger + trailingBoundary,
                     options: .caseInsensitive
                 ) else { continue }
 
@@ -3130,6 +3135,12 @@ private extension Character {
         default:
             return false
         }
+    }
+
+    /// Matches the regex `\w` class (letters, digits, or underscore) so we only
+    /// wrap dictionary triggers in `\b` boundaries where they actually apply.
+    var isWordCharacter: Bool {
+        self == "_" || self.isLetter || self.isNumber
     }
 }
 

--- a/Sources/Fluid/UI/CustomDictionaryView.swift
+++ b/Sources/Fluid/UI/CustomDictionaryView.swift
@@ -192,8 +192,8 @@ struct CustomDictionaryView: View {
     }
 
     private var canAddManualReplacement: Bool {
+        // An empty replacement is allowed: it deletes the trigger from the transcript.
         !self.manualTriggers.isEmpty &&
-            !self.manualReplacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
             self.manualDuplicateTriggers.isEmpty
     }
 
@@ -2221,8 +2221,8 @@ struct EditDictionaryEntrySheet: View {
     }
 
     private var canSave: Bool {
+        // An empty replacement is allowed: it deletes the trigger from the transcript.
         !self.parseTriggers().isEmpty &&
-            !self.replacement.trimmingCharacters(in: .whitespaces).isEmpty &&
             self.duplicateTriggers.isEmpty
     }
 


### PR DESCRIPTION
## What & why

The Custom Dictionary can currently only **rewrite** text — every add/edit path requires a non-empty replacement. This PR lets a user map a trigger to an **empty** replacement so the matched text is simply **removed** from the transcript.

Motivating use case: removing the Spanish inverted marks `¿` / `¡` (map `¿` → empty) so they never appear in output.

## The two blockers

1. **Validation.** The Manual Add composer (`canAddManualReplacement`) and `EditDictionaryEntrySheet.canSave` both required a non-empty replacement. They now require only at least one (non-duplicate) trigger.

2. **A latent matching bug.** `ASRService.rebuildDictionaryCache` compiled every trigger as `\b<trigger>\b`. ICU `\b` word boundaries never match around punctuation, so a punctuation-only trigger such as `¿` matched **nothing** — meaning even after relaxing validation, `¿ → (empty)` would silently do nothing. Boundaries are now applied **conditionally**: a leading `\b` only when the trigger's first character is a word character, a trailing `\b` only when its last is. 

   - Word triggers (`cant`, `fluid voice`) keep the exact current `\b…\b` behavior — no regression.
   - Punctuation triggers (`¿`, `¡`, `...`) now match and can be replaced/removed.
   - Only previously-dead punctuation entries change behavior; nothing that worked before is affected.

An empty replacement already produces an empty `escapedTemplate`, i.e. deletion, so no change to the apply loop was needed.

## Scope

Deliberately minimal — three focused edits. Left untouched: the whitespace around a removed standalone word (literal delete), the LocalAPI replacement validation, and the voice-training merge path (training teaches a *spelling*, so an empty target stays disallowed there).

## Verification

Validated the matching logic against the real `NSRegularExpression`/ICU engine:

| Input | Rule | Output |
|---|---|---|
| `¿Cómo estás?` | `¿` → ∅ | `Cómo estás?` |
| `Hola ¿cómo? ¡genial!` | `¿`,`¡` → ∅ | `Hola cómo? genial!` |
| `I use fluid voice daily` | `fluid voice` → `FluidVoice` | `I use FluidVoice daily` |
| `I cant cantina` | `cant` → ∅ | `I  cantina` (boundary respected, `cantina` untouched) |

Note: I couldn't run a full app build in my environment (local Xcode toolchain issue unrelated to the change), so a maintainer build/CI check is welcome.