### PR TITLE
Fix login launch (#520), volume spike (#522), add spoken Enter keystr…

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -8,6 +8,7 @@
 import AppKit
 import Carbon
 import PromiseKit
+import ServiceManagement
 import SwiftUI
 import UserNotifications
 
@@ -94,6 +95,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if self.shouldSuppressNextReopenActivation {
             self.shouldSuppressNextReopenActivation = false
+            // This reopen came from our own silent login-launch fallback. The reopen
+            // realizes the SwiftUI main window, so immediately boot it hidden instead of
+            // letting it flash on screen until the launch retry loop catches it (#520).
+            DispatchQueue.main.async { [weak self] in
+                _ = self?.bootMainWindowHiddenIfPresent()
+            }
             return true
         }
 
@@ -135,10 +142,31 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         if ProcessInfo.processInfo.environment["FLUID_SIMULATE_LOGIN_LAUNCH"] == "1" {
             return true
         }
-        guard let event = NSAppleEventManager.shared().currentAppleEvent else { return false }
-        return event.eventID == AEEventID(kAEOpenApplication)
-            && event.paramDescriptor(forKeyword: AEKeyword(keyAEPropData))?.enumCodeValue
-            == OSType(keyAELaunchedAsLogInItem)
+
+        if let event = NSAppleEventManager.shared().currentAppleEvent,
+           event.eventID == AEEventID(kAEOpenApplication),
+           event.paramDescriptor(forKeyword: AEKeyword(keyAEPropData))?.enumCodeValue
+           == OSType(keyAELaunchedAsLogInItem)
+        {
+            return true
+        }
+
+        // SMAppService login launches on modern macOS frequently arrive WITHOUT the
+        // legacy login-item Apple Event flag, which made the app treat login launches
+        // as manual ones and show the main window on every reboot (issue #520).
+        // Heuristic fallback: FluidVoice is registered as a login item and the process
+        // started shortly after boot - a manual launch that early is very unlikely.
+        if SMAppService.mainApp.status == .enabled,
+           ProcessInfo.processInfo.systemUptime < 300
+        {
+            DebugLogger.shared.info(
+                "Login-item launch inferred (SMAppService enabled, uptime \(Int(ProcessInfo.processInfo.systemUptime))s)",
+                source: "AppDelegate"
+            )
+            return true
+        }
+
+        return false
     }
 
     /// Apply the user's dock-visibility preference ("Hide from dock", issue #162).

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -77,6 +77,8 @@ struct SettingsBackupPayload: Codable, Equatable {
     let gaavModeEnabled: Bool
     let gaavLowercaseFirstLetterEnabled: Bool?
     let gaavRemoveTrailingPeriodEnabled: Bool?
+    let pressEnterPhraseEnabled: Bool?
+    let pressEnterTriggerPhrase: String?
     let continuousDictationModeEnabled: Bool?
     let continuousDictationSpacingEnabled: Bool?
     let contextAwareCapitalizationEnabled: Bool?

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1286,14 +1286,14 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Show the main window when macOS launches FluidVoice at login (default: ON, matching
-    /// current behavior). When off, login launches boot silently in the menu bar. Manual
-    /// launches always show the window. Default-true semantics so existing installs keep
-    /// their current behavior.
+    /// Show the main window when macOS launches FluidVoice at login (default: OFF, issue
+    /// #520 - login launches should start silently in the menu bar without any GUI window).
+    /// When off, login launches boot silently in the menu bar. Manual launches always show
+    /// the window.
     var showMainWindowAtLoginLaunch: Bool {
         get {
             let value = self.defaults.object(forKey: Keys.showMainWindowAtLoginLaunch)
-            if value == nil { return true }
+            if value == nil { return false }
             return self.defaults.bool(forKey: Keys.showMainWindowAtLoginLaunch)
         }
         set {
@@ -2860,6 +2860,8 @@ final class SettingsStore: ObservableObject {
             gaavModeEnabled: self.gaavModeEnabled,
             gaavLowercaseFirstLetterEnabled: self.gaavLowercaseFirstLetterEnabled,
             gaavRemoveTrailingPeriodEnabled: self.gaavRemoveTrailingPeriodEnabled,
+            pressEnterPhraseEnabled: self.pressEnterPhraseEnabled,
+            pressEnterTriggerPhrase: self.pressEnterTriggerPhrase,
             continuousDictationModeEnabled: self.continuousDictationModeEnabled,
             continuousDictationSpacingEnabled: self.continuousDictationSpacingEnabled,
             contextAwareCapitalizationEnabled: self.contextAwareCapitalizationEnabled,
@@ -2932,7 +2934,7 @@ final class SettingsStore: ObservableObject {
         }
         self.showThinkingTokens = payload.showThinkingTokens
         self.hideFromDockAndAppSwitcher = payload.hideFromDockAndAppSwitcher
-        self.showMainWindowAtLoginLaunch = payload.showMainWindowAtLoginLaunch ?? true
+        self.showMainWindowAtLoginLaunch = payload.showMainWindowAtLoginLaunch ?? false
         self.accentColorOption = payload.accentColorOption
         self.transcriptionStartSound = payload.transcriptionStartSound
         self.transcriptionSoundVolume = payload.transcriptionSoundVolume
@@ -2972,6 +2974,8 @@ final class SettingsStore: ObservableObject {
         self.gaavModeEnabled = restoredGaavModeEnabled
         self.gaavLowercaseFirstLetterEnabled = payload.gaavLowercaseFirstLetterEnabled ?? restoredGaavModeEnabled
         self.gaavRemoveTrailingPeriodEnabled = payload.gaavRemoveTrailingPeriodEnabled ?? restoredGaavModeEnabled
+        self.pressEnterPhraseEnabled = payload.pressEnterPhraseEnabled ?? false
+        self.pressEnterTriggerPhrase = payload.pressEnterTriggerPhrase ?? "press enter"
         self.continuousDictationModeEnabled = restoredContinuousDictationModeEnabled
         self.continuousDictationSpacingEnabled = payload.continuousDictationSpacingEnabled ?? restoredContinuousDictationModeEnabled
         self.contextAwareCapitalizationEnabled = payload.contextAwareCapitalizationEnabled ?? restoredContinuousDictationModeEnabled
@@ -3595,6 +3599,35 @@ final class SettingsStore: ObservableObject {
         set {
             objectWillChange.send()
             self.defaults.set(newValue, forKey: Keys.gaavRemoveTrailingPeriodEnabled)
+        }
+    }
+
+    // MARK: - Press Enter by Voice (issue #523)
+
+    /// When enabled, saying the trigger phrase (default "press enter") during dictation
+    /// posts a real Return keystroke instead of inserting text. Unlike pasting a "\n",
+    /// a native keystroke also submits in terminals where bracketed paste treats pasted
+    /// newlines as literal characters.
+    var pressEnterPhraseEnabled: Bool {
+        get { self.defaults.object(forKey: Keys.pressEnterPhraseEnabled) as? Bool ?? false }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.pressEnterPhraseEnabled)
+        }
+    }
+
+    /// The spoken phrase that triggers a Return keystroke. Falls back to "press enter"
+    /// when unset or whitespace-only, so the feature can never be armed with an empty trigger.
+    var pressEnterTriggerPhrase: String {
+        get {
+            let stored = self.defaults.string(forKey: Keys.pressEnterTriggerPhrase)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let stored, !stored.isEmpty else { return "press enter" }
+            return stored
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.pressEnterTriggerPhrase)
         }
     }
 
@@ -4524,6 +4557,8 @@ private extension SettingsStore {
         static let gaavModeEnabled = "GAAVModeEnabled"
         static let gaavLowercaseFirstLetterEnabled = "GAAVLowercaseFirstLetterEnabled"
         static let gaavRemoveTrailingPeriodEnabled = "GAAVRemoveTrailingPeriodEnabled"
+        static let pressEnterPhraseEnabled = "PressEnterPhraseEnabled"
+        static let pressEnterTriggerPhrase = "PressEnterTriggerPhrase"
 
         /// Continuous Dictation Mode (append trailing space + smart caps for chaining)
         static let continuousDictationModeEnabled = "ContinuousDictationModeEnabled"

--- a/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
+++ b/Sources/Fluid/Services/TranscriptionSoundPlayer.swift
@@ -47,12 +47,27 @@ final class TranscriptionSoundPlayer {
         let settings = SettingsStore.shared
         let desiredVolume = overrideVolume ?? settings.transcriptionSoundVolume
 
+        var playerVolume = desiredVolume
+        var needsSystemVolumeBoost = false
+        var systemVolumeBeforeBoost: Float = 1.0
+
         if settings.transcriptionSoundIndependentVolume {
             let currentSystemVol = Self.getSystemVolume()
             guard currentSystemVol > 0.001 else { return }
-            // Save current system volume and temporarily set it to desired level
-            self.savedSystemVolume = currentSystemVol
-            Self.setSystemVolume(desiredVolume)
+            // Perceived loudness is playerVolume x systemVolume. Whenever the
+            // desired level fits under the current system volume, compensate
+            // inside the player and leave the system volume alone - changing it
+            // spikes any other audio that happens to be playing (issue #522).
+            if desiredVolume <= currentSystemVol {
+                playerVolume = desiredVolume / currentSystemVol
+            } else {
+                // Louder than the system volume allows: the system volume must be
+                // raised, but only as far as needed and ramped smoothly so the
+                // change never lands as a sudden spike.
+                playerVolume = 1.0
+                needsSystemVolumeBoost = true
+                systemVolumeBeforeBoost = currentSystemVol
+            }
         }
 
         do {
@@ -66,25 +81,31 @@ final class TranscriptionSoundPlayer {
             }
 
             player.currentTime = 0
-            if settings.transcriptionSoundIndependentVolume {
-                player.volume = 1.0
-            } else {
-                player.volume = desiredVolume
+            player.volume = playerVolume
+
+            if needsSystemVolumeBoost {
+                // If a previous boost is still pending restore, keep its saved
+                // (pre-boost) value so overlapping sounds never adopt a boosted
+                // level as the volume to restore.
+                self.savedSystemVolume = self.savedSystemVolume ?? systemVolumeBeforeBoost
+                Self.rampSystemVolume(to: desiredVolume)
             }
+
             player.play()
 
             // Restore system volume after the sound finishes
-            if settings.transcriptionSoundIndependentVolume, let saved = self.savedSystemVolume {
+            if needsSystemVolumeBoost {
                 let duration = player.duration
                 DispatchQueue.main.asyncAfter(deadline: .now() + duration + 0.05) { [weak self] in
-                    Self.setSystemVolume(saved)
-                    self?.savedSystemVolume = nil
+                    guard let self, let saved = self.savedSystemVolume else { return }
+                    Self.rampSystemVolume(to: saved)
+                    self.savedSystemVolume = nil
                 }
             }
         } catch {
             // Restore system volume on error
             if let saved = self.savedSystemVolume {
-                Self.setSystemVolume(saved)
+                Self.rampSystemVolume(to: saved)
                 self.savedSystemVolume = nil
             }
             DebugLogger.shared.error(
@@ -96,7 +117,30 @@ final class TranscriptionSoundPlayer {
 
     // MARK: - System Volume via CoreAudio
 
-    private static func getDefaultOutputDeviceID() -> AudioObjectID? {
+    /// Moves the system output volume to `target` in small steps instead of a
+    /// single jump, so any other audio playing changes level smoothly rather
+    /// than spiking (issue #522).
+    private nonisolated static func rampSystemVolume(
+        to target: Float,
+        duration: TimeInterval = 0.12,
+        steps: Int = 8
+    ) {
+        let start = self.getSystemVolume()
+        guard abs(start - target) > 0.001 else { return }
+
+        let stepDelayMicros = useconds_t((duration / Double(steps)) * 1_000_000)
+        DispatchQueue.global(qos: .userInteractive).async {
+            for step in 1...steps {
+                let fraction = Float(step) / Float(steps)
+                self.setSystemVolume(start + (target - start) * fraction)
+                if step < steps {
+                    usleep(stepDelayMicros)
+                }
+            }
+        }
+    }
+
+    private nonisolated static func getDefaultOutputDeviceID() -> AudioObjectID? {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultOutputDevice,
             mScope: kAudioObjectPropertyScopeGlobal,
@@ -116,7 +160,7 @@ final class TranscriptionSoundPlayer {
         return deviceID
     }
 
-    static func getSystemVolume() -> Float {
+    nonisolated static func getSystemVolume() -> Float {
         guard let deviceID = getDefaultOutputDeviceID() else { return 1.0 }
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
@@ -130,7 +174,7 @@ final class TranscriptionSoundPlayer {
         return volume
     }
 
-    private static func setSystemVolume(_ volume: Float) {
+    private nonisolated static func setSystemVolume(_ volume: Float) {
         guard let deviceID = getDefaultOutputDeviceID() else { return }
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -241,6 +241,142 @@ final class TypingService {
         return app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
     }
 
+    // MARK: - Spoken Enter command (issue #523)
+
+    /// A piece of dictated output: either literal text to insert, or a native
+    /// Return keystroke triggered by the spoken phrase (e.g. "press enter").
+    enum SpokenOutputSegment: Equatable {
+        case text(String)
+        case pressEnter
+    }
+
+    /// Splits `text` on the configured spoken Enter trigger phrase. Returns nil when the
+    /// feature is disabled or the phrase does not occur, so callers fall back to the
+    /// plain insertion path. Punctuation the transcriber attaches around the phrase
+    /// (e.g. "…, press enter.") is swallowed together with the phrase.
+    static func splitSpokenEnterCommands(_ text: String) -> [SpokenOutputSegment]? {
+        guard SettingsStore.shared.pressEnterPhraseEnabled else { return nil }
+        let phrase = SettingsStore.shared.pressEnterTriggerPhrase
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !phrase.isEmpty else { return nil }
+
+        // Allow any whitespace between the words of the phrase.
+        let words = phrase.split(whereSeparator: { $0.isWhitespace })
+            .map { NSRegularExpression.escapedPattern(for: String($0)) }
+        guard !words.isEmpty else { return nil }
+        let phrasePattern = words.joined(separator: "\\s+")
+        let pattern = "(?:[,.;:!?]\\s*)?\\b" + phrasePattern + "\\b[,.;:!?]?"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return nil
+        }
+
+        let nsText = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+        guard !matches.isEmpty else { return nil }
+
+        var segments: [SpokenOutputSegment] = []
+        var cursor = 0
+        for match in matches {
+            let before = nsText
+                .substring(with: NSRange(location: cursor, length: match.range.location - cursor))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !before.isEmpty {
+                segments.append(.text(before))
+            }
+            segments.append(.pressEnter)
+            cursor = match.range.location + match.range.length
+        }
+        let tail = nsText.substring(from: cursor).trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tail.isEmpty {
+            segments.append(.text(tail))
+        }
+        return segments
+    }
+
+    /// Posts a real Return keystroke (kVK_Return). Unlike inserting a "\n" character via
+    /// paste, a native keystroke submits in terminals where bracketed paste mode treats
+    /// pasted newlines as literal characters (issue #523).
+    func pressReturnKey(preferredTargetPID: pid_t?) {
+        let returnKeyCode: CGKeyCode = 36 // kVK_Return
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
+        else {
+            self.log("[TypingService] ERROR: Failed to create Return key CGEvents")
+            return
+        }
+
+        let targetPID = preferredTargetPID.flatMap { $0 > 0 ? $0 : nil }
+            ?? self.getSystemFocusedElementAndPID()?.pid
+
+        if let targetPID {
+            keyDown.postToPid(targetPID)
+            usleep(10_000)
+            keyUp.postToPid(targetPID)
+            self.log("[TypingService] Return keystroke posted to PID \(targetPID)")
+        } else {
+            keyDown.post(tap: .cghidEventTap)
+            usleep(10_000)
+            keyUp.post(tap: .cghidEventTap)
+            self.log("[TypingService] Return keystroke posted via HID tap")
+        }
+    }
+
+    /// Types text/Return segments sequentially. Mirrors the guards of typeTextInstantly,
+    /// then inserts each text chunk and emits native Return keystrokes between them.
+    private func typeSegmentsInstantly(
+        _ segments: [SpokenOutputSegment],
+        preferredTargetPID: pid_t?
+    ) {
+        guard !segments.isEmpty else { return }
+
+        guard !self.isCurrentlyTyping else {
+            self.log("[TypingService] WARNING: Skipping segment injection - already in progress")
+            return
+        }
+
+        guard AXIsProcessTrusted() else {
+            self.log("[TypingService] ERROR: Accessibility permissions required for segment injection")
+            return
+        }
+
+        self.isCurrentlyTyping = true
+
+        let mode = self.textInsertionMode
+        let settleDelayMs: Int = {
+            if mode == .reliablePaste {
+                return preferredTargetPID == nil ? 80 : 0
+            }
+            return preferredTargetPID == nil ? 200 : 0
+        }()
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { self.isCurrentlyTyping = false }
+
+            if settleDelayMs > 0 {
+                usleep(useconds_t(settleDelayMs * 1000))
+            }
+
+            for (index, segment) in segments.enumerated() {
+                switch segment {
+                case .text(let chunk):
+                    self.insertTextInstantly(chunk, preferredTargetPID: preferredTargetPID)
+                    // Paste-based insertion is dispatched asynchronously by the target
+                    // app; give the text time to land before a following Return so the
+                    // keystroke doesn't submit an empty line.
+                    if index < segments.count - 1 {
+                        usleep(300_000)
+                    }
+                case .pressEnter:
+                    self.pressReturnKey(preferredTargetPID: preferredTargetPID)
+                    if index < segments.count - 1 {
+                        usleep(120_000)
+                    }
+                }
+            }
+            self.log("[TypingService] Completed spoken-command segment injection (\(segments.count) segments)")
+        }
+    }
+
     // MARK: - Public API
 
     func typeTextInstantly(_ text: String) {
@@ -270,6 +406,17 @@ final class TypingService {
         )
         self.log("[TypingService] ENTRY: typeTextInstantly called with text length: \(text.count)")
         self.log("[TypingService] Text preview: \"\(String(text.prefix(100)))\"")
+
+        // Spoken Enter command (issue #523): when the transcript contains the trigger
+        // phrase, route through the segment pipeline so a native Return keystroke is
+        // emitted where the phrase was spoken. Checked before the empty guard so a
+        // transcript consisting only of the phrase still presses Enter.
+        if let segments = Self.splitSpokenEnterCommands(text) {
+            self.bench("request_segments count=\(segments.count)")
+            self.log("[TypingService] Spoken Enter command detected, typing \(segments.count) segment(s)")
+            self.typeSegmentsInstantly(segments, preferredTargetPID: preferredTargetPID)
+            return
+        }
 
         guard text.isEmpty == false else {
             self.bench("request_return reason=empty_text")

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -365,7 +365,7 @@ struct SettingsView: View {
                                 self.settingsToggleRow(
                                     title: "Independent Volume",
                                     description: "Sound volume stays constant regardless of system volume. Mute is still respected.",
-                                    footnote: "Temporarily changes system volume during playback, which may briefly affect other audio.",
+                                    footnote: "Only adjusts system volume when the cue is louder than the current system volume, ramping smoothly to avoid sudden spikes.",
                                     isOn: Binding(
                                         get: { SettingsStore.shared.transcriptionSoundIndependentVolume },
                                         set: { SettingsStore.shared.transcriptionSoundIndependentVolume = $0 }
@@ -967,6 +967,35 @@ struct SettingsView: View {
                                             set: { SettingsStore.shared.pauseMediaDuringTranscription = $0 }
                                         )
                                     )
+                                    Divider().opacity(0.2)
+
+                                    self.optionToggleRow(
+                                        title: "Press Enter by Voice",
+                                        description: "Say the trigger phrase while dictating to send a real Return keystroke. Unlike inserting a newline, this also submits in terminals.",
+                                        isOn: Binding(
+                                            get: { SettingsStore.shared.pressEnterPhraseEnabled },
+                                            set: { SettingsStore.shared.pressEnterPhraseEnabled = $0 }
+                                        )
+                                    )
+
+                                    if SettingsStore.shared.pressEnterPhraseEnabled {
+                                        HStack {
+                                            Text("Trigger phrase")
+                                                .font(self.theme.typography.bodySmall)
+                                                .foregroundStyle(self.settingsSecondaryText)
+                                                .padding(.leading, 30)
+
+                                            Spacer()
+
+                                            TextField("press enter", text: Binding(
+                                                get: { SettingsStore.shared.pressEnterTriggerPhrase },
+                                                set: { SettingsStore.shared.pressEnterTriggerPhrase = $0 }
+                                            ))
+                                            .textFieldStyle(.roundedBorder)
+                                            .frame(width: 190)
+                                        }
+                                        .padding(.top, 2)
+                                    }
                                     Divider().opacity(0.2)
 
                                     self.optionToggleRow(


### PR DESCRIPTION
## Description
Addresses three issues in one focused change set (6 files):

**#523 – Native Enter keypress emulation via spoken phrase.** New opt-in setting "Press Enter by Voice" with a configurable trigger phrase (default `press enter`; falls back to the default if left empty, so the empty-replacement problem from the dictionary workaround in #380 can't occur). When the transcript contains the phrase, `TypingService` splits the output into segments and posts a real `kVK_Return` CGEvent keystroke (targeted at the focused app's PID, HID tap fallback) where the phrase was spoken, instead of pasting a `\n`. Because it is a genuine keystroke, zsh/bash with bracketed paste execute the command — this works in terminals as well as chat apps. Matching is case-insensitive, swallows punctuation the transcriber attaches around the phrase, handles a transcript consisting only of the phrase, and waits ~300 ms after paste-based insertion so the Return never fires before the text lands. The new settings round-trip through backup export/import.

**#522 – Independent volume selection causes system volume spike.** `TranscriptionSoundPlayer` previously always set the system volume to the cue's level and played at full player volume, spiking any other audio. Now, when the desired cue level fits under the current system volume (the common case), the system volume is never touched — loudness is compensated inside the player (`playerVolume = desired / systemVolume`). Only when the cue is louder than the system volume does it boost, and the boost now ramps in 8 small steps over ~120 ms up and back down instead of jumping. Overlapping sounds no longer clobber the saved pre-boost volume, so restores can't get stuck at a boosted level. Settings footnote updated accordingly.

**#520 – Persistent & invisible background launch on system startup.** Login-launch detection relied on the legacy `keyAELaunchedAsLogInItem` Apple Event, which SMAppService login launches on modern macOS often don't carry — so every reboot looked like a manual launch and the main window appeared. Detection now falls back to a heuristic: the app is registered as a login item and the process started within 5 minutes of boot. The default for "Show window when launched at login" is flipped to OFF so login launches start silently in the menu bar (manual launches always show the window), and the LaunchServices reopen fallback now boots the window hidden immediately instead of flashing it until the retry loop catches it.

## Type of Change
- [x] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #520
Closes #522
Closes #523

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [ ] Tested on macOS version:
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally:

## Screenshots / Video
This PR does change Settings UI: two new rows ("Press Enter by Voice" toggle + "Trigger phrase" field) and an updated footnote on "Independent Volume".

<img width="1148" height="927" alt="image" src="https://github.com/user-attachments/assets/f80d32ed-a192-4111-b93a-007befa4b12b" />


Note: `SettingsStore.swift` is flagged by the policy check but contains only persistence changes (new UserDefaults keys, backup fields, a default-value flip) — no visual code. The visual changes are the `SettingsView.swift` rows shown above.

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes
- The `showMainWindowAtLoginLaunch` default flip means existing installs that never touched the toggle will now start silently at login (per #520's expected behavior); users can re-enable the window in App Settings.
- The login-launch heuristic (SMAppService enabled + uptime < 300 s) can classify a manual launch made within 5 minutes of boot as a login launch; the trade-off favors never flashing the window on reboot.
- "Press Enter by Voice" is off by default, so no behavior changes unless a user opts in.