### PR TITLE
docs: link fluidvoice-cli companion CLI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,18 @@ Anonymous analytics are enabled by default to track app health and feature usage
 
 ---
 
+## Developer Tools
+
+FluidVoice exposes a **Local API** for scripting and automation. Enable it in **Settings → Advanced → Local API**.
+
+Community companion CLI (MIT-licensed, separate from the app):
+
+- **[fluidvoice-cli](https://github.com/EBay1992/fluidvoice-cli)** — batch transcription, history export, dictionary management, and `--json` output for CI. Install from [releases](https://github.com/EBay1992/fluidvoice-cli/releases/latest).
+
+Discussion: [#529](https://github.com/altic-dev/FluidVoice/issues/529)
+
+---
+
 ## Community
 
 Join our Discord: https://discord.gg/VUPHaKSvYV

--- a/README.md
+++ b/README.md
@@ -292,7 +292,14 @@ Anonymous analytics are enabled by default to track app health and feature usage
 
 ## Developer Tools
 
-FluidVoice exposes a **Local API** for scripting and automation. Enable it in **Settings → Advanced → Local API**.
+FluidVoice includes a loopback-only **Local API** at `http://127.0.0.1:47733/v1/` for scripting and automation (see `Sources/Fluid/Services/LocalAPI/`).
+
+The server starts only when the `LocalAPIEnabled` UserDefaults key is set for bundle ID `com.FluidApp.app`. **There is currently no Settings UI toggle** for this flag in 1.6.x — enable it from Terminal, then restart FluidVoice:
+
+```bash
+defaults write com.FluidApp.app LocalAPIEnabled -bool true
+curl http://127.0.0.1:47733/v1/health
+```
 
 Community companion CLI (MIT-licensed, separate from the app):
 


### PR DESCRIPTION
## Description
Adds a **Developer Tools** section to the README that documents the loopback Local API (`http://127.0.0.1:47733/v1/`) and links to [fluidvoice-cli](https://github.com/EBay1992/fluidvoice-cli), a MIT-licensed community companion CLI for batch transcription, history export, and scripting.

**Follow-up to Codex review:** The first draft incorrectly said *Settings → Advanced → Local API*. That UI does not exist in 1.6.x — confirmed by searching the repo (`LocalAPIEnabled` is only read in `LocalAPIModels.swift`). The README now documents the actual enable path via `defaults write com.FluidApp.app LocalAPIEnabled -bool true` and a `curl` health check.

## Type of Change
- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [x] 📝 Documentation update

## Related Issue or Discussion
Companion to #529 (adoption discussion for fluidvoice-cli).

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: Sequoia (15.x)
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally:
- [x] Verified Local API enable path: `defaults write com.FluidApp.app LocalAPIEnabled -bool true` + `curl http://127.0.0.1:47733/v1/health`
- [x] Verified companion CLI: `fluidvoice doctor` against live FluidVoice 1.6.x

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
- The Local API server code lives under `Sources/Fluid/Services/LocalAPI/` and only binds to loopback.
- A future Settings toggle for `LocalAPIEnabled` would be a great follow-up feature; this PR only documents current behavior.
- Happy to adjust wording or move the section. See [ADOPT.md](https://github.com/EBay1992/fluidvoice-cli/blob/main/ADOPT.md) for co-maintenance options.