### PR TITLE
fix(tests): stop Whisper Tiny E2E test from persisting the selected speech model

### DIFF
--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -722,18 +722,10 @@ final class DictationE2ETests: XCTestCase {
 
     func testDictationEndToEnd_whisperTiny_transcribesFixture() async throws {
         // Arrange
-        // App-hosted test writes to the real host UserDefaults; restore the prior
-        // selection so the next app launch doesn't silently come up on Whisper Tiny.
-        let priorSpeechModel = SettingsStore.shared.selectedSpeechModel
-        defer { SettingsStore.shared.selectedSpeechModel = priorSpeechModel }
-
-        SettingsStore.shared.shareAnonymousAnalytics = false
-        SettingsStore.shared.selectedSpeechModel = .whisperTiny
-
         let modelDirectory = Self.modelDirectoryForRun()
         try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
 
-        let provider = WhisperProvider(modelDirectory: modelDirectory)
+        let provider = WhisperProvider(modelDirectory: modelDirectory, modelOverride: .whisperTiny)
 
         // Act
         try await provider.prepare()


### PR DESCRIPTION
## Description
`FluidDictationIntegrationTests` runs hosted inside the real app, so `SettingsStore.shared` writes go to the user's actual `com.FluidApp.app` defaults. The Whisper Tiny E2E test sets `selectedSpeechModel = .whisperTiny` and restores the prior value in a `defer`, but the restore does not reliably stick: on this machine, running the full suite still left `SelectedSpeechModel = whisper-tiny` persisted, so the app silently comes up on Whisper Tiny after a test run.

This change passes the model directly via the existing `WhisperProvider(modelDirectory:modelOverride:)` seam instead of mutating the global selection, so the test still exercises Whisper Tiny end to end without writing the user's settings at all. It also removes the test's `shareAnonymousAnalytics` write for the same reason; the provider-direct path does not read that setting.

Verified before/after on the same machine: full suite on a branch without this change leaves `SelectedSpeechModel = whisper-tiny`; full suite with this change leaves it unchanged at the prior value.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Related to #467.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [ ] Tested on macOS version:
- [x] Ran linter locally: `swiftlint lint Tests/FluidDictationIntegrationTests/DictationE2ETests.swift` (0 violations)
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: targeted `testDictationEndToEnd_whisperTiny_transcribesFixture` passed, and the full integration suite passed with `SelectedSpeechModel` unchanged after the run

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.
