### PR TITLE
Fix Anthropic temperature 400 for Haiku 4.5

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2667,7 +2667,7 @@ final class SettingsStore: ObservableObject {
 
     /// Whether the model rejects the `temperature` parameter.
     /// Covers reasoning models plus Anthropic models that have deprecated temperature
-    /// (Opus 4.7+, Sonnet 5, Fable/Mythos 5 — Sonnet 4.6 and older still accept it).
+    /// (Opus 4.7+, Sonnet 5, Haiku 4.5, Fable/Mythos 5 — Sonnet 4.6 and older still accept it).
     func isTemperatureUnsupported(_ model: String) -> Bool {
         if self.isReasoningModel(model) { return true }
         // Normalize version separators so dotted IDs (e.g. OpenRouter's
@@ -2676,6 +2676,7 @@ final class SettingsStore: ObservableObject {
         return modelLower.contains("claude-opus-4-7")
             || modelLower.contains("claude-opus-4-8")
             || modelLower.contains("claude-sonnet-5")
+            || modelLower.contains("claude-haiku-4-5")
             || modelLower.contains("claude-fable")
             || modelLower.contains("claude-mythos")
     }

--- a/Tests/FluidDictationIntegrationTests/TemperatureSupportTests.swift
+++ b/Tests/FluidDictationIntegrationTests/TemperatureSupportTests.swift
@@ -2,8 +2,8 @@
 import XCTest
 
 // Regression tests for the Anthropic `temperature` deprecation handling.
-// Newer Anthropic models (Opus 4.7+, Sonnet 5, Fable/Mythos 5) reject the `temperature`
-// parameter with HTTP 400 "`temperature` is deprecated for this model."
+// Newer Anthropic models (Opus 4.7+, Sonnet 5, Haiku 4.5, Fable/Mythos 5) reject the
+// `temperature` parameter with HTTP 400 "`temperature` is deprecated for this model."
 // See https://github.com/altic-dev/FluidVoice/issues/285 (Opus 4.7) — the same failure
 // recurred for Sonnet 5 because the check only matched claude-opus-4-7.
 // Sonnet 4.6 and older still accept `temperature` (verified against the live API)
@@ -18,8 +18,11 @@ final class TemperatureSupportTests: XCTestCase {
             "claude-sonnet-5",
             "claude-fable-5",
             "claude-mythos-5",
+            "claude-haiku-4-5",
+            "claude-haiku-4-5-20251001",
             // Provider-prefixed and dotted IDs (e.g. OpenRouter) must match too
             "anthropic/claude-sonnet-5",
+            "anthropic/claude-haiku-4.5",
             "anthropic/claude-opus-4.7",
             "anthropic/claude-opus-4.8",
             "anthropic/claude-opus-4.8-fast",
@@ -46,6 +49,8 @@ final class TemperatureSupportTests: XCTestCase {
             "gpt-4.1",
             "claude-sonnet-4-6",
             "claude-sonnet-4-20250514",
+            // Haiku 3.5 uses the older claude-3-5-haiku naming and still accepts temperature
+            "claude-3-5-haiku-20241022",
             "gemini-2.5-flash",
             "llama3",
             // Dotted OpenRouter IDs for models that still accept temperature


### PR DESCRIPTION
## Description
Follow-up to #536: Claude Haiku 4.5 has also deprecated the `temperature` parameter. Anthropic's OpenAI-compatible endpoint (`/v1/chat/completions`) now returns `HTTP 400: "temperature" is deprecated for this model` for `claude-haiku-4-5-20251001` (verified against the live API today), so AI Enhancement / Command Mode / Rewrite Mode requests to Haiku 4.5 fail the same way #285/#535 did for Opus 4.7 and Sonnet 5.

- Adds `claude-haiku-4-5` to `SettingsStore.isTemperatureUnsupported(_:)`, same substring style as #536 (the existing dot-normalization covers OpenRouter-style `anthropic/claude-haiku-4.5`, and the substring match covers the dated ID).
- Extends `TemperatureSupportTests` with the Haiku 4.5 variants, and pins `claude-3-5-haiku-20241022` (older naming scheme) as still-supported so the new substring can't accidentally catch it.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Follow-up to #536 / #535 / #285 (no separate issue filed for the Haiku 4.5 case).

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5
- [ ] Ran linter locally: swiftlint not installed on this machine — the change is two added lines in the existing style
- [ ] Ran formatter locally: swiftformat not installed on this machine
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -only-testing:FluidDictationIntegrationTests/TemperatureSupportTests` — all 3 tests pass
- [x] Verified against the live Anthropic API: `claude-haiku-4-5-20251001` with `temperature` returns the 400; without it the request succeeds

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)