### PR TITLE
fix: require a modifier key for keyboard shortcut recording

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -757,6 +757,19 @@ struct ContentView: View {
         let newShortcut = HotkeyShortcut(keyCode: keyCode, modifierFlags: self.pendingModifierFlags.union(eventModifiers))
         DebugLogger.shared.debug("NSEvent monitor: Recording new shortcut: \(newShortcut.displayString)", source: "ContentView")
 
+        // A bare key with no modifiers (e.g. "F") registers as a global hotkey and would
+        // intercept that key everywhere, breaking normal typing in every app. Require at
+        // least one modifier for global keyboard shortcuts, mirroring the guard the mouse
+        // recorder already applies (isUnmodifiedLeftOrRightClick "needs a modifier key").
+        // The cancel shortcut is exempt: it only applies while recording is active and
+        // legitimately defaults to a bare Escape.
+        if let recordingTarget, recordingTarget != .cancel, newShortcut.relevantModifierFlags.isEmpty {
+            self.shortcutRecordingMessage = "\(newShortcut.displayString) needs a modifier key"
+            self.resetPendingShortcutState()
+            DebugLogger.shared.debug("NSEvent monitor: Rejected modifier-less keyboard shortcut while recording", source: "ContentView")
+            return nil
+        }
+
         if let recordingTarget,
            let conflictMessage = self.shortcutConflictMessage(for: newShortcut, target: recordingTarget)
         {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -757,13 +757,13 @@ struct ContentView: View {
         let newShortcut = HotkeyShortcut(keyCode: keyCode, modifierFlags: self.pendingModifierFlags.union(eventModifiers))
         DebugLogger.shared.debug("NSEvent monitor: Recording new shortcut: \(newShortcut.displayString)", source: "ContentView")
 
-        // A bare key with no modifiers (e.g. "F") registers as a global hotkey and would
-        // intercept that key everywhere, breaking normal typing in every app. Require at
-        // least one modifier for global keyboard shortcuts, mirroring the guard the mouse
-        // recorder already applies (isUnmodifiedLeftOrRightClick "needs a modifier key").
-        // The cancel shortcut is exempt: it only applies while recording is active and
-        // legitimately defaults to a bare Escape.
-        if let recordingTarget, recordingTarget != .cancel, newShortcut.relevantModifierFlags.isEmpty {
+        // A bare key with no real modifier (e.g. "F", or an arrow key — whose events carry
+        // an auto-injected .function flag) registers as a global hotkey and would intercept
+        // that key everywhere, breaking normal typing in every app. Require a modifier,
+        // mirroring the guard the mouse recorder already applies (isUnmodifiedLeftOrRightClick
+        // "needs a modifier key"). The cancel shortcut is exempt: it is only consumed while
+        // dictation is active and legitimately defaults to a bare Escape.
+        if let recordingTarget, recordingTarget != .cancel, newShortcut.isUnmodifiedKeyboardKey {
             self.shortcutRecordingMessage = "\(newShortcut.displayString) needs a modifier key"
             self.resetPendingShortcutState()
             DebugLogger.shared.debug("NSEvent monitor: Rejected modifier-less keyboard shortcut while recording", source: "ContentView")

--- a/Sources/Fluid/Models/HotkeyShortcut.swift
+++ b/Sources/Fluid/Models/HotkeyShortcut.swift
@@ -220,6 +220,29 @@ extension HotkeyShortcut {
         return (mouseButton == 0 || mouseButton == 1) && self.relevantModifierFlags.isEmpty
     }
 
+    /// Key codes in the keyboard's function section (F-keys, navigation keys, arrows).
+    /// macOS auto-sets the `.function` modifier flag on key events for these keys even
+    /// when the Fn key is not held, so that flag alone does not indicate a real modifier.
+    static let functionSectionKeyCodes: Set<UInt16> = [
+        122, 120, 99, 118, 96, 97, 98, 100, 101, 109, 103, 111, // F1–F12
+        105, 107, 113, 106, 64, 79, 80, 90, // F13–F20
+        114, 115, 116, 117, 119, 121, // Help, Home, Page Up, Forward Delete, End, Page Down
+        123, 124, 125, 126, // Left, Right, Down, Up
+    ]
+
+    /// True for a keyboard shortcut that would fire on a bare key press with no real
+    /// modifier held — the keyboard analogue of `isUnmodifiedLeftOrRightClick`. The
+    /// auto-injected `.function` flag on function-section keys does not count as a
+    /// modifier; modifier-only shortcuts (e.g. Right ⌥) are never bare.
+    var isUnmodifiedKeyboardKey: Bool {
+        guard !self.isMouseShortcut, self.modifierTriggerFlag == nil else { return false }
+        var meaningfulModifiers = self.relevantModifierFlags
+        if Self.functionSectionKeyCodes.contains(self.keyCode) {
+            meaningfulModifiers.subtract(.function)
+        }
+        return meaningfulModifiers.isEmpty
+    }
+
     var normalizedModifierKeyCodes: [UInt16] {
         guard !self.isMouseShortcut else { return [] }
         let normalized = Self.normalizedModifierKeyCodes(from: self.modifierKeyCodes)

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -60,6 +60,43 @@ final class HotkeyShortcutTests: XCTestCase {
         XCTAssertTrue(modifiedLeftClick.matchesMouse(button: 0, modifiers: [.control]))
     }
 
+    func testUnmodifiedKeyboardKeysRequireModifiers() {
+        let bareLetter = HotkeyShortcut(keyCode: 3, modifierFlags: []) // F
+        let commandLetter = HotkeyShortcut(keyCode: 3, modifierFlags: [.command]) // ⌘F
+        let fnLetter = HotkeyShortcut(keyCode: 3, modifierFlags: [.function]) // real Fn + F
+        let bareSpace = HotkeyShortcut(keyCode: 49, modifierFlags: []) // Space
+
+        XCTAssertTrue(bareLetter.isUnmodifiedKeyboardKey)
+        XCTAssertFalse(commandLetter.isUnmodifiedKeyboardKey)
+        XCTAssertFalse(fnLetter.isUnmodifiedKeyboardKey)
+        XCTAssertTrue(bareSpace.isUnmodifiedKeyboardKey)
+    }
+
+    func testAutoInjectedFunctionFlagDoesNotCountAsModifier() {
+        // macOS sets .function automatically on events for function-section keys, so a
+        // bare arrow, F-key, or navigation key press arrives carrying that flag even
+        // though no modifier is held.
+        let bareLeftArrow = HotkeyShortcut(keyCode: 123, modifierFlags: [.function])
+        let bareF5 = HotkeyShortcut(keyCode: 96, modifierFlags: [.function])
+        let bareHome = HotkeyShortcut(keyCode: 115, modifierFlags: [.function])
+        let shiftedArrow = HotkeyShortcut(keyCode: 123, modifierFlags: [.function, .shift])
+
+        XCTAssertTrue(bareLeftArrow.isUnmodifiedKeyboardKey)
+        XCTAssertTrue(bareF5.isUnmodifiedKeyboardKey)
+        XCTAssertTrue(bareHome.isUnmodifiedKeyboardKey)
+        XCTAssertFalse(shiftedArrow.isUnmodifiedKeyboardKey)
+    }
+
+    func testModifierOnlyAndMouseShortcutsAreNeverUnmodifiedKeyboardKeys() {
+        let optionOnly = HotkeyShortcut(keyCode: 61, modifierFlags: []) // Right ⌥
+        let fnOnly = HotkeyShortcut(keyCode: 63, modifierFlags: []) // Fn
+        let mouseClick = HotkeyShortcut(mouseButton: 0, modifierFlags: [])
+
+        XCTAssertFalse(optionOnly.isUnmodifiedKeyboardKey)
+        XCTAssertFalse(fnOnly.isUnmodifiedKeyboardKey)
+        XCTAssertFalse(mouseClick.isUnmodifiedKeyboardKey)
+    }
+
     func testMouseShortcutDisplayIncludesModifiers() {
         let shortcut = HotkeyShortcut(mouseButton: 0, modifierFlags: [.control, .shift])
 


### PR DESCRIPTION
<!--
PRs that do not follow this template will be blocked by the PR Policy check.
If the missing information is not fixed after 48 hours, the PR may be closed.
-->

## Description
The keyboard shortcut recorder in `handleShortcutKeyDownEvent` (`Sources/Fluid/ContentView.swift`) currently accepts a bare key with no modifier (e.g. pressing `F` alone, keyCode 3) as a valid global hotkey. Once saved, that key is intercepted system-wide by the app's global event monitor, breaking normal typing of that key in every other app, with no UI path to remove the offending shortcut.

The mouse-click recorder already guards against this exact class of bug (`isUnmodifiedLeftOrRightClick` → "needs a modifier key"). This PR adds the equivalent guard for keyboard shortcuts.

**Design note — the `.function` flag subtlety:** a naive `relevantModifierFlags.isEmpty` check is not enough. macOS auto-sets the `.function` modifier flag on key events for function-section keys (arrows, F1–F20, Home/End/Page Up/Page Down, Forward Delete) even when the Fn key is not held — and the global event tap maps `.maskSecondaryFn` back to `.function` the same way, so a bare arrow key recorded under that check would still be intercepted system-wide. The guard therefore lives on the model as `HotkeyShortcut.isUnmodifiedKeyboardKey` (the keyboard analogue of `isUnmodifiedLeftOrRightClick`): it ignores the auto-injected `.function` flag for function-section key codes, while still honoring a genuine Fn chord on typing keys (e.g. Fn+F) and excluding modifier-only shortcuts (e.g. Right ⌥), which are legitimate.

The cancel shortcut is exempt: the global tap only consumes it while dictation is running or a cancel callback handles it (`GlobalHotkeyManager`), and it legitimately defaults to a bare Escape.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #556

## Testing
My environment has Xcode Command Line Tools only (no full Xcode), so I could not run `xcodebuild` or the XCTest suite locally, and `swiftlint --strict` fails locally for lack of `sourcekitd`. This PR stays in draft so the repo's `Build and Test` CI can confirm compilation, lint, and tests before it's marked ready for review.

What was verified locally:
- `Sources/Fluid/Models/HotkeyShortcut.swift` compiles standalone with `swiftc` against the macOS SDK, and a 15-assertion harness exercising `isUnmodifiedKeyboardKey` (bare letters/Space rejected; ⌘F and genuine Fn+F accepted; bare arrows/F5/Home/Forward Delete rejected despite their auto-injected `.function` flag; ⇧+arrow accepted; modifier-only and mouse shortcuts excluded) passes in full.
- Unit tests covering the same cases were added to the existing `Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift` for CI to run; the file passes `swiftc -parse`.
- `swiftformat --lint` reports byte-identical findings on the touched files before and after the change (all pre-existing elsewhere in the files) — no new formatting issues introduced.
- Every symbol the ContentView hunk touches was verified against the current source and mirrors the neighboring mouse-shortcut guard.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

This changes rejection behavior of an existing recorder, not any visual layout — the same "needs a modifier key" message/style the mouse recorder already shows is reused as-is.

## Notes
**Open question for maintainers:** as implemented, bare F-keys (F1–F20) are rejected along with bare typing keys, arrows, and navigation keys — consistent with the PR title, and matching how the `.function` flag actually behaves (an earlier revision of this PR believed bare F-keys were blocked while arrows were the open question; the auto-injected `.function` flag made the opposite true). If you'd prefer to allow bare F-keys as global shortcuts (they collide less with normal typing than letters or arrows), it's a one-line change: drop the F-key codes from `HotkeyShortcut.functionSectionKeyCodes` so their `.function` flag counts as a real modifier again. Happy to adjust.

**Possible follow-up (out of scope here):** users who already saved a modifier-less shortcut before this fix still have it persisted in settings (and it survives backup/restore). They can now recover by re-recording, but a one-time sanitization on settings load that strips modifier-less keyboard shortcuts for non-cancel targets would auto-heal existing installs. Can open a separate issue/PR if wanted.
