### PR TITLE
fix(build): embed MediaRemoteAdapter.framework so the built app is relocatable

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		7C1C72F22EECBD1300E3BF4D /* SwiftWhisper in Frameworks */ = {isa = PBXBuildFile; productRef = 7C1C72F12EECBD1300E3BF4D /* SwiftWhisper */; };
 		7C3697892ED70F9C005874CE /* DynamicNotchKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7C3697882ED70F9C005874CE /* DynamicNotchKit */; };
 		7C5AF14B2F15041600DE21B0 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */; };
+		7C5AF14C2F15041600DE21B0 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */; };
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
@@ -73,6 +74,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		7C5AF14D2F15041600DE21B0 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				7C5AF14C2F15041600DE21B0 /* MediaRemoteAdapter in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXGroup section */
 		7C078D862E3B339200FB7CAC = {
@@ -148,6 +163,7 @@
 				7C078D8B2E3B339200FB7CAC /* Sources */,
 				7C078D8C2E3B339200FB7CAC /* Frameworks */,
 				7C078D8D2E3B339200FB7CAC /* Resources */,
+				7C5AF14D2F15041600DE21B0 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
## Description
The `MediaRemoteAdapter` Swift package product is linked but the app target has no **Embed Frameworks** build phase. As a result, `xcodebuild build` leaves the dynamic framework in DerivedData's `PackageFrameworks/` and the app resolves it only via a dev-time rpath. The built `.app` runs in place but crashes as soon as it is copied elsewhere (e.g. to `/Applications`):

```
dyld: Library not loaded: @rpath/MediaRemoteAdapter.framework/Versions/A/MediaRemoteAdapter
```

Archive-based builds embed the framework implicitly, which is why this is not seen when distributing via Organizer — but a plain `build` product is not relocatable.

This PR adds an **Embed Frameworks** copy-files phase (Embed & Sign / `CodeSignOnCopy`) so `MediaRemoteAdapter.framework` is packaged into `Contents/Frameworks/` and the build product is self-contained and relocatable.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #580

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally:

Verified: a clean `xcodebuild -configuration Release build` now produces `FluidVoice.app/Contents/Frameworks/MediaRemoteAdapter.framework`, `codesign --verify --deep --strict` passes, and the app launches with **no dyld errors** after being copied to `/Applications` (previously crashed on launch there).

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Project-file-only change: adds one `PBXCopyFilesBuildPhase` (`dstSubfolderSpec = 10`) plus its `PBXBuildFile` (with `CodeSignOnCopy`) and wires it into the app target's `buildPhases`. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
