### PR TITLE
fix(ai): tolerate a full chat endpoint as a custom provider base URL when refreshing models

### DIFF
--- a/Sources/Fluid/Services/ModelRepository.swift
+++ b/Sources/Fluid/Services/ModelRepository.swift
@@ -249,8 +249,17 @@ final class ModelRepository {
 
         let isAnthropic = providerID == "anthropic" || baseURL.contains("anthropic.com")
 
-        // Construct the models endpoint URL
-        let urlString = baseURL.hasSuffix("/") ? "\(baseURL)models" : "\(baseURL)/models"
+        // Construct the models endpoint URL. Users frequently paste the full chat
+        // endpoint (…/chat/completions or …/responses) as the base URL; append `/models`
+        // to that verbatim and it 404s. Strip a trailing endpoint segment (and slash) so
+        // the list resolves to <root>/models.
+        var normalizedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        for suffix in ["/chat/completions", "/responses"] where normalizedBase.hasSuffix(suffix) {
+            normalizedBase = String(normalizedBase.dropLast(suffix.count))
+            break
+        }
+        while normalizedBase.hasSuffix("/") { normalizedBase = String(normalizedBase.dropLast()) }
+        let urlString = "\(normalizedBase)/models"
         guard let url = URL(string: urlString) else {
             DebugLogger.shared.error(
                 "fetchModels: Invalid URL constructed from baseURL='\(baseURL)' -> '\(urlString)'",


### PR DESCRIPTION
## Description
When a custom AI provider's **base URL** is entered as the full chat endpoint (e.g. `https://host/v1/chat/completions`), the model-refresh button fails. `ModelRepository.fetchModels` appends `/models` verbatim, producing `https://host/v1/chat/completions/models`, which 404s (often returning an HTML page), so the model dropdown never populates:

```
API error (HTTP 404): <!DOCTYPE html> … Not Found …
```

Pasting the full endpoint as the base URL is a very common user mistake, and chat requests were unaffected because `LLMClient` already normalizes the endpoint — so the two paths behaved inconsistently.

This PR normalizes the base URL in `fetchModels` before appending `/models`: it strips a trailing `/chat/completions` or `/responses` segment (and any trailing slash) so the list resolves to `<root>/models`.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #581

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally:

Verified against a live OpenAI-compatible provider: with the base URL saved as `…/v1/chat/completions`, model refresh previously 404'd; after the fix the same saved provider resolves `…/v1/models` and populates the dropdown. Base URLs already ending in `/v1` are unchanged.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Logic-only change in `ModelRepository.fetchModels`; no behavior change for correctly-entered base URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
