### PR TITLE
Fix VoiceOver: hide recording overlays and pass through system hotkeys

### DIFF
--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -592,6 +592,19 @@ final class GlobalHotkeyManager: NSObject {
             return tapRecoveryResult
         }
 
+        // Fast path: pass through system shortcuts (Cmd+Tab, Cmd+Shift+Tab, Cmd+Space, etc.)
+        // to avoid adding latency to app switching, especially with VoiceOver.
+        if type == .keyDown || type == .keyUp {
+            let flags = event.flags
+            if flags.contains(.maskCommand) {
+                let kc = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+                // Tab(48), Space(49), Backtick(50 — Cmd+` for window cycling)
+                if kc == 48 || kc == 49 || kc == 50 {
+                    return Unmanaged.passUnretained(event)
+                }
+            }
+        }
+
         if self.isShortcutCaptureActiveProvider?() ?? false {
             self.resetModifierOnlyShortcutTracking()
             return Unmanaged.passUnretained(event)

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -556,6 +556,11 @@ final class GlobalHotkeyManager: NSObject {
         if self.promptShortcutAssignments.contains(where: { $0.shortcut.matches(keyCode: keyCode, modifiers: modifiers) }) {
             return true
         }
+        if self.promptModeShortcutEnabled,
+           self.promptModeShortcut.matches(keyCode: keyCode, modifiers: modifiers)
+        {
+            return true
+        }
         if self.commandModeShortcutEnabled,
            let commandModeShortcut = self.commandModeShortcut,
            commandModeShortcut.matches(keyCode: keyCode, modifiers: modifiers)

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -528,6 +528,51 @@ final class GlobalHotkeyManager: NSObject {
         self.otherKeyPressedDuringModifier = true
     }
 
+    /// Maps a `CGEventFlags` bitmask to the `NSEvent.ModifierFlags` used for shortcut
+    /// matching. Single source of truth for the flag translation.
+    private static func modifierFlags(from flags: CGEventFlags) -> NSEvent.ModifierFlags {
+        var modifiers: NSEvent.ModifierFlags = []
+        if flags.contains(.maskSecondaryFn) { modifiers.insert(.function) }
+        if flags.contains(.maskCommand) { modifiers.insert(.command) }
+        if flags.contains(.maskAlternate) { modifiers.insert(.option) }
+        if flags.contains(.maskControl) { modifiers.insert(.control) }
+        if flags.contains(.maskShift) { modifiers.insert(.shift) }
+        return modifiers
+    }
+
+    /// Whether a key event matches any shortcut the user has configured. The
+    /// system-shortcut fast-path consults this so it never silently swallows a real
+    /// binding that happens to use the same chord (e.g. Cmd+Space bound to a Fluid action).
+    private func eventMatchesAnyConfiguredShortcut(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> Bool {
+        if SettingsStore.shared.cancelRecordingHotkeyShortcut.matches(keyCode: keyCode, modifiers: modifiers) {
+            return true
+        }
+        if SettingsStore.shared.pasteLastTranscriptionShortcutEnabled,
+           let paste = SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut,
+           paste.matches(keyCode: keyCode, modifiers: modifiers)
+        {
+            return true
+        }
+        if self.promptShortcutAssignments.contains(where: { $0.shortcut.matches(keyCode: keyCode, modifiers: modifiers) }) {
+            return true
+        }
+        if self.commandModeShortcutEnabled,
+           let commandModeShortcut = self.commandModeShortcut,
+           commandModeShortcut.matches(keyCode: keyCode, modifiers: modifiers)
+        {
+            return true
+        }
+        if self.rewriteModeShortcutEnabled,
+           self.rewriteModeShortcut.matches(keyCode: keyCode, modifiers: modifiers)
+        {
+            return true
+        }
+        if self.primaryShortcuts.contains(where: { $0.matches(keyCode: keyCode, modifiers: modifiers) }) {
+            return true
+        }
+        return false
+    }
+
     private func mouseButton(from event: CGEvent) -> Int {
         Int(event.getIntegerValueField(.mouseEventButtonNumber))
     }
@@ -592,15 +637,28 @@ final class GlobalHotkeyManager: NSObject {
             return tapRecoveryResult
         }
 
-        // Fast path: pass through system shortcuts (Cmd+Tab, Cmd+Shift+Tab, Cmd+Space, etc.)
-        // to avoid adding latency to app switching, especially with VoiceOver.
+        // Fast path: pass the macOS system shortcuts Cmd+Tab (app switcher) and
+        // Cmd+Space (Spotlight / input-source) straight through with minimal work, to
+        // avoid adding latency to app/space switching — especially with VoiceOver, whose
+        // event handling is latency-sensitive. Skipped when the user has bound one of
+        // Fluid's own shortcuts to the same chord, so real bindings are never swallowed.
+        //
+        // Only Tab(48) and Space(49) are handled: both are layout-stable hardware
+        // keycodes. Cmd+` is deliberately excluded because its keycode differs across
+        // ANSI/ISO keyboard layouts, so a hardcoded value would match the wrong key.
         if type == .keyDown || type == .keyUp {
             let flags = event.flags
             if flags.contains(.maskCommand) {
                 let kc = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
-                // Tab(48), Space(49), Backtick(50 — Cmd+` for window cycling)
-                if kc == 48 || kc == 49 || kc == 50 {
-                    return Unmanaged.passUnretained(event)
+                if kc == 48 || kc == 49 {
+                    let modifiers = Self.modifierFlags(from: flags)
+                    if !self.eventMatchesAnyConfiguredShortcut(keyCode: kc, modifiers: modifiers) {
+                        // Preserve modifier-only bookkeeping: a system chord pressed while
+                        // a modifier-only Fluid shortcut is held must count as "other input"
+                        // so the later modifier release isn't mistaken for a clean tap.
+                        if type == .keyDown { self.markOtherInputDuringModifierOnly() }
+                        return Unmanaged.passUnretained(event)
+                    }
                 }
             }
         }
@@ -613,12 +671,7 @@ final class GlobalHotkeyManager: NSObject {
         let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
         let flags = event.flags
 
-        var eventModifiers: NSEvent.ModifierFlags = []
-        if flags.contains(.maskSecondaryFn) { eventModifiers.insert(.function) }
-        if flags.contains(.maskCommand) { eventModifiers.insert(.command) }
-        if flags.contains(.maskAlternate) { eventModifiers.insert(.option) }
-        if flags.contains(.maskControl) { eventModifiers.insert(.control) }
-        if flags.contains(.maskShift) { eventModifiers.insert(.shift) }
+        let eventModifiers = Self.modifierFlags(from: flags)
 
         switch type {
         case .keyDown:

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -339,6 +339,8 @@ final class BottomOverlayWindowController {
         panel.isMovableByWindowBackground = false
         panel.hidesOnDeactivate = false
         panel.animationBehavior = .none
+        panel.setAccessibilityElement(false)
+        panel.setAccessibilityRole(.unknown)
 
         let contentView = BottomOverlayView()
         let hostingView = BottomOverlayHostingView(rootView: contentView)
@@ -611,6 +613,8 @@ final class BottomOverlayPromptMenuController {
         panel.isMovableByWindowBackground = false
         panel.hidesOnDeactivate = false
         panel.animationBehavior = .none
+        panel.setAccessibilityElement(false)
+        panel.setAccessibilityRole(.unknown)
 
         let contentView = BottomOverlayPromptMenuView(
             promptMode: self.resolvedPromptMode(),
@@ -888,6 +892,8 @@ final class BottomOverlayModeMenuController {
         panel.isMovableByWindowBackground = false
         panel.hidesOnDeactivate = false
         panel.animationBehavior = .none
+        panel.setAccessibilityElement(false)
+        panel.setAccessibilityRole(.unknown)
 
         let contentView = BottomOverlayModeMenuView(
             maxWidth: self.menuMaxWidth,
@@ -1152,6 +1158,8 @@ final class BottomOverlayActionsMenuController {
         panel.isMovableByWindowBackground = false
         panel.hidesOnDeactivate = false
         panel.animationBehavior = .none
+        panel.setAccessibilityElement(false)
+        panel.setAccessibilityRole(.unknown)
 
         let contentView = BottomOverlayActionsMenuView(
             maxWidth: self.menuMaxWidth,
@@ -3088,6 +3096,7 @@ struct BottomOverlayView: View {
         //         NotchOverlayManager.shared.onNotchClicked?()
         //     }
         // }
+        .accessibilityHidden(true)
     }
 }
 


### PR DESCRIPTION
## Description
Two accessibility fixes for VoiceOver users:

- **`GlobalHotkeyManager`** — a fast-path in the CGEvent tap that passes the macOS system shortcuts **Cmd+Tab** and **Cmd+Space** straight through, so the tap doesn't add latency to app/space switching while the dictation hotkey is active. This is especially noticeable with VoiceOver, whose own event handling is latency-sensitive. The fast-path is skipped when the user has bound one of Fluid's own shortcuts to the same chord, and it preserves the modifier-only bookkeeping so a system chord pressed mid-hold isn't mistaken for a clean tap.
- **`BottomOverlayView`** — `setAccessibilityElement(false)` + `setAccessibilityRole(.unknown)` on all four recording-overlay panels, and `.accessibilityHidden(true)` on the SwiftUI body, so VoiceOver doesn't announce the overlays or shift focus to them.

Both match behavior the repo's `CLAUDE.md` already documents as intended (overlay panels must hide from VoiceOver; the event tap must pass system shortcuts through immediately).

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Addresses #401 (*VoiceOver: dictation overlay steals focus and Cmd+Tab becomes sluggish*).

This PR fixes the two root causes in **this** repo:
1. `BottomOverlayView` panels being discoverable by VoiceOver (overlay focus stealing).
2. Cmd+Tab / Cmd+Space sluggishness from the CGEvent tap.

The third root cause noted in #401 — `DynamicNotchKit`'s `DynamicNotchPanel` overriding `canBecomeKey`/`canBecomeMain` — lives in the separate DynamicNotchKit dependency and is out of scope here; it only affects the non-default notch overlay and would need a fix in that repo. This PR covers the default **bottom** overlay path, so #401 is intentionally *addressed*, not auto-closed.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2 (Apple Silicon)
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally:

Manually verified: pressing the dictation hotkey with VoiceOver active no longer delays Cmd+Tab / Cmd+Space; the recording overlays are no longer announced by or focusable in VoiceOver.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

The overlay change only sets accessibility attributes (`setAccessibilityElement`, `setAccessibilityRole`, `.accessibilityHidden`) — it does not alter rendering in any way.

## Notes
Tested locally against the current `main`. The hotkey fast-path is limited to Cmd+Tab and Cmd+Space (both layout-stable hardware keycodes) to avoid the ANSI/ISO ambiguity of the backtick key.
