### PR TITLE
1.6.3: prompt existing users for MLX upgrade

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -17,6 +17,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var didRequestMainWindowReopen = false
     private var shouldSuppressNextReopenActivation = false
     private var wasLaunchedAsLoginItem = false
+    private var hasDeferredMLXUpgradeOffer = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Bring up file logging + crash handlers immediately during launch.
@@ -32,6 +33,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         // Initialize app settings (dock visibility, etc.)
         SettingsStore.shared.initializeAppSettings()
+        let shouldOfferMLXUpgrade = PrivateAIMLXUpgradeCoordinator.prepareOfferIfNeeded()
         LocalAPIServer.shared.start()
 
         // Record first-open synchronously before async analytics bootstrap so
@@ -57,6 +59,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         // Login Items can launch hidden; reveal the real SwiftUI window so ContentView startup runs.
         self.openMainWindowOnLaunch()
+
+        if shouldOfferMLXUpgrade {
+            if self.wasLaunchedAsLoginItem, !SettingsStore.shared.showMainWindowAtLoginLaunch {
+                self.hasDeferredMLXUpgradeOffer = true
+            } else {
+                self.scheduleMLXUpgradeOffer()
+            }
+        }
 
         // Note: App UI is designed with dark color scheme in mind
         // All gradients and effects are optimized for dark mode
@@ -122,6 +132,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         sender.activate(ignoringOtherApps: true)
 
         return !self.bringMainWindowToFrontIfPresent()
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        guard self.hasDeferredMLXUpgradeOffer else { return }
+        self.hasDeferredMLXUpgradeOffer = false
+        self.scheduleMLXUpgradeOffer()
     }
 
     func userNotificationCenter(
@@ -202,6 +218,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                     self.requestMainWindowReopenIfNeeded(activate: revealWindow)
                 }
             }
+        }
+    }
+
+    private func scheduleMLXUpgradeOffer() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
+            self?.showMLXUpgradeOffer()
+        }
+    }
+
+    @MainActor
+    private func showMLXUpgradeOffer() {
+        let alert = NSAlert()
+        alert.messageText = "Fluid-1 is now 2.2x faster"
+        alert.informativeText = "A new 3.77 GB MLX model is available for Apple silicon. Continue to AI Enhancement to download and verify it. Your current slower model will keep working unless you choose to upgrade."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Continue to Download")
+        alert.addButton(withTitle: "Keep Current Model")
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            PrivateAIMLXUpgradeCoordinator.beginUpgrade()
+            AppNavigationRouter.shared.request(.aiEnhancements)
+            self.bringMainWindowToFront()
+        } else {
+            PrivateAIMLXUpgradeCoordinator.keepCurrentModel()
         }
     }
 

--- a/Sources/Fluid/Services/PrivateAIIntegrationService.swift
+++ b/Sources/Fluid/Services/PrivateAIIntegrationService.swift
@@ -1,5 +1,188 @@
 import Foundation
 
+enum PrivateAIMLXUpgradeCoordinator {
+    private static let offerVersion = "1.6.3"
+    private static let offerHandledKey = "FluidIntelligenceMLXUpgrade163OfferHandled"
+    private static let offerPreparedKey = "FluidIntelligenceMLXUpgrade163OfferPrepared"
+    private static let upgradePendingKey = "FluidIntelligenceMLXUpgrade163Pending"
+    private static let previousVerificationKey = "FluidIntelligenceMLXUpgrade163PreviousVerification"
+    private static let legacyLlamaFilenames = ["fluid-1-q4_k_m.gguf", "Fluid-1-Q4_K_M.gguf"]
+
+    static func prepareOfferIfNeeded(
+        settings: SettingsStore = .shared,
+        defaults: UserDefaults = .standard,
+        modelDirectoryURL: URL = PrivateAIIntegrationService.modelDirectoryURL,
+        isAppleSilicon: Bool = CPUArchitecture.isAppleSilicon,
+        appVersion: String = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String ?? ""
+    ) -> Bool {
+        if defaults.bool(forKey: self.upgradePendingKey) {
+            self.restorePreviousLlama(settings: settings, defaults: defaults)
+            return false
+        }
+
+        guard appVersion == self.offerVersion else {
+            defaults.set(false, forKey: self.offerPreparedKey)
+            return false
+        }
+
+        if defaults.bool(forKey: self.offerPreparedKey),
+           !defaults.bool(forKey: self.offerHandledKey)
+        {
+            let rawBackend = defaults.string(forKey: SettingsStore.privateAIBackendPreferenceDefaultsKey)
+            guard self.shouldResumePreparedOffer(
+                hasPrivateProvider: PrivateFeatures.privateAIProvider,
+                isAppleSilicon: isAppleSilicon,
+                appVersion: appVersion,
+                backendPreference: rawBackend.flatMap(SettingsStore.PrivateAIBackendPreference.init(rawValue:)),
+                hasLegacyLlamaModel: self.hasLegacyLlamaModel(in: modelDirectoryURL),
+                hasMLXModel: PrivateAIIntegrationService.hasInactiveInstalledModel(
+                    keeping: PrivateAIModelRegistry.defaultModel
+                )
+            ) else {
+                defaults.set(false, forKey: self.offerPreparedKey)
+                return false
+            }
+
+            settings.privateAIBackendPreference = .llama
+            self.migrateLegacyVerificationToLlama(settings: settings)
+            return true
+        }
+
+        guard self.shouldOffer(
+            hasPrivateProvider: PrivateFeatures.privateAIProvider,
+            isAppleSilicon: isAppleSilicon,
+            appVersion: appVersion,
+            backendPreferenceWasSet: defaults.object(
+                forKey: SettingsStore.privateAIBackendPreferenceDefaultsKey
+            ) != nil,
+            hasLegacyLlamaModel: self.hasLegacyLlamaModel(in: modelDirectoryURL),
+            hasMLXModel: PrivateAIIntegrationService.isModelInstalled(PrivateAIModelRegistry.defaultModel),
+            offerWasHandled: defaults.bool(forKey: self.offerHandledKey)
+        ) else {
+            return false
+        }
+
+        settings.privateAIBackendPreference = .llama
+        self.migrateLegacyVerificationToLlama(settings: settings)
+        defaults.set(true, forKey: self.offerPreparedKey)
+        return true
+    }
+
+    static func beginUpgrade(
+        settings: SettingsStore = .shared,
+        defaults: UserDefaults = .standard
+    ) {
+        let key = self.privateProviderKey
+        if let verification = settings.verifiedProviderFingerprints[key] {
+            defaults.set(verification, forKey: self.previousVerificationKey)
+        } else {
+            defaults.removeObject(forKey: self.previousVerificationKey)
+        }
+
+        defaults.set(true, forKey: self.offerHandledKey)
+        defaults.set(false, forKey: self.offerPreparedKey)
+        defaults.set(true, forKey: self.upgradePendingKey)
+        settings.privateAIBackendPreference = .mlx
+        settings.verifiedProviderFingerprints.removeValue(forKey: key)
+        defaults.removeObject(forKey: PrivateAIIntegrationService.localModelPathDefaultsKey)
+    }
+
+    static func keepCurrentModel(defaults: UserDefaults = .standard) {
+        defaults.set(true, forKey: self.offerHandledKey)
+        defaults.set(false, forKey: self.offerPreparedKey)
+        defaults.set(false, forKey: self.upgradePendingKey)
+        defaults.removeObject(forKey: self.previousVerificationKey)
+    }
+
+    static func completeUpgrade(defaults: UserDefaults = .standard) {
+        defaults.set(false, forKey: self.upgradePendingKey)
+        defaults.removeObject(forKey: self.previousVerificationKey)
+    }
+
+    static func restorePreviousLlama(
+        settings: SettingsStore = .shared,
+        defaults: UserDefaults = .standard
+    ) {
+        settings.privateAIBackendPreference = .llama
+        var fingerprints = settings.verifiedProviderFingerprints
+        if let verification = defaults.string(forKey: self.previousVerificationKey), !verification.isEmpty {
+            fingerprints[self.privateProviderKey] = verification
+        } else {
+            fingerprints.removeValue(forKey: self.privateProviderKey)
+        }
+        settings.verifiedProviderFingerprints = fingerprints
+        defaults.set(false, forKey: self.upgradePendingKey)
+        defaults.removeObject(forKey: self.previousVerificationKey)
+        defaults.removeObject(forKey: PrivateAIIntegrationService.localModelPathDefaultsKey)
+    }
+
+    static func isUpgradePending(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: self.upgradePendingKey)
+    }
+
+    static func shouldOffer(
+        hasPrivateProvider: Bool,
+        isAppleSilicon: Bool,
+        appVersion: String,
+        backendPreferenceWasSet: Bool,
+        hasLegacyLlamaModel: Bool,
+        hasMLXModel: Bool,
+        offerWasHandled: Bool
+    ) -> Bool {
+        hasPrivateProvider &&
+            isAppleSilicon &&
+            appVersion == self.offerVersion &&
+            !backendPreferenceWasSet &&
+            hasLegacyLlamaModel &&
+            !hasMLXModel &&
+            !offerWasHandled
+    }
+
+    static func shouldResumePreparedOffer(
+        hasPrivateProvider: Bool,
+        isAppleSilicon: Bool,
+        appVersion: String,
+        backendPreference: SettingsStore.PrivateAIBackendPreference?,
+        hasLegacyLlamaModel: Bool,
+        hasMLXModel: Bool
+    ) -> Bool {
+        hasPrivateProvider &&
+            isAppleSilicon &&
+            appVersion == self.offerVersion &&
+            backendPreference == .llama &&
+            hasLegacyLlamaModel &&
+            !hasMLXModel
+    }
+
+    private static var privateProviderKey: String {
+        let providerID = PrivateAIProviderFeature.shared.providerID
+        if ModelRepository.shared.isBuiltIn(providerID) || providerID.hasPrefix("custom:") {
+            return providerID
+        }
+        return "custom:\(providerID)"
+    }
+
+    private static func hasLegacyLlamaModel(in directoryURL: URL) -> Bool {
+        self.legacyLlamaFilenames.contains {
+            FileManager.default.fileExists(atPath: directoryURL.appendingPathComponent($0).path)
+        }
+    }
+
+    private static func migrateLegacyVerificationToLlama(settings: SettingsStore) {
+        let key = self.privateProviderKey
+        let legacyFingerprint = "private-ai-provider|\(PrivateAIProviderFeature.shared.defaultModelID)"
+        guard settings.verifiedProviderFingerprints[key] == legacyFingerprint else { return }
+
+        var fingerprints = settings.verifiedProviderFingerprints
+        fingerprints[key] = PrivateAIProviderFeature.verificationFingerprint(
+            for: PrivateAIProviderFeature.shared.defaultModelID
+        )
+        settings.verifiedProviderFingerprints = fingerprints
+    }
+}
+
 actor PrivateAIIntegrationService {
     static let shared = PrivateAIIntegrationService()
 
@@ -85,6 +268,10 @@ actor PrivateAIIntegrationService {
         return !targetURLs.isEmpty
     }
 
+    nonisolated static func hasInactiveInstalledModel(keeping model: PrivateAIRegisteredModel) -> Bool {
+        !self.provider.inactiveInstalledModelURLs(keeping: model).isEmpty
+    }
+
     nonisolated static func removeInstalledModel(_ model: PrivateAIRegisteredModel) throws {
         let requestedURLs = self.provider.installedModelURLs(for: model)
         guard !requestedURLs.isEmpty else { return }
@@ -160,6 +347,12 @@ actor PrivateAIIntegrationService {
         let status = try await Self.provider.loadModel(model)
         guard status.state == .ready else { return status }
 
+        guard !PrivateAIMLXUpgradeCoordinator.isUpgradePending() else { return status }
+        await self.removeInactiveInstalledModels(keeping: model)
+        return status
+    }
+
+    func removeInactiveInstalledModels(keeping model: PrivateAIRegisteredModel) async {
         do {
             try Self.removeInactiveInstalledModels(keeping: model)
         } catch {
@@ -170,7 +363,6 @@ actor PrivateAIIntegrationService {
                 )
             }
         }
-        return status
     }
 
     private nonisolated static func errorMessage(for error: Error) -> String {

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsView.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsView.swift
@@ -101,6 +101,10 @@ struct AIEnhancementSettingsView: View {
                 self.viewModel.onAppear()
                 self.privateAISelectedModelID = PrivateAIIntegrationService.configuredModelID
                 self.refreshPrivateAILoadState()
+                if PrivateAIMLXUpgradeCoordinator.isUpgradePending() {
+                    self.selectedConfigurationSection = .providers
+                    self.expandedProviderID = PrivateAIProviderFeature.shared.providerID
+                }
             }
             .onChange(of: self.viewModel.connectionStatus) { oldValue, newValue in
                 if oldValue == .success && newValue != .success {

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -1019,21 +1019,39 @@ extension AIEnhancementSettingsView {
                 guard self.privateAISelectedModelID == model.id else { return }
                 if verified {
                     self.privateAILoadState = .loaded(modelID: model.id, latencyMilliseconds: latencyMilliseconds)
+                    if PrivateAIMLXUpgradeCoordinator.isUpgradePending() {
+                        PrivateAIMLXUpgradeCoordinator.completeUpgrade()
+                        await PrivateAIIntegrationService.shared.removeInactiveInstalledModels(keeping: model)
+                    }
                 } else {
                     let message = self.viewModel.connectionErrorMessage.isEmpty
                         ? "Model downloaded, but verification failed."
                         : self.viewModel.connectionErrorMessage
-                    self.privateAILoadState = .failed(modelID: model.id, message: message)
+                    self.restoreLlamaAfterFailedMLXUpgrade(message: message, modelID: model.id)
                 }
             } catch {
                 guard self.privateAISelectedModelID == model.id else { return }
-                self.privateAILoadState = .failed(
-                    modelID: model.id,
-                    message: Self.errorMessage(for: error)
+                self.restoreLlamaAfterFailedMLXUpgrade(
+                    message: Self.errorMessage(for: error),
+                    modelID: model.id
                 )
             }
             self.viewModel.refreshProviderItems()
         }
+    }
+
+    private func restoreLlamaAfterFailedMLXUpgrade(message: String, modelID: String) {
+        guard PrivateAIMLXUpgradeCoordinator.isUpgradePending() else {
+            self.privateAILoadState = .failed(modelID: modelID, message: message)
+            return
+        }
+
+        PrivateAIMLXUpgradeCoordinator.restorePreviousLlama()
+        self.viewModel.onAppear()
+        self.privateAILoadState = .failed(
+            modelID: modelID,
+            message: "MLX upgrade failed. Your previous llama.cpp model is still active. \(message)"
+        )
     }
 
     private func verifyPrivateAIConnection(_ model: PrivateAIRegisteredModel) {
@@ -1906,7 +1924,7 @@ extension AIEnhancementSettingsView {
         return nil
     }
 
-    private func selectProvider(_ providerID: String) {
+    func selectProvider(_ providerID: String) {
         self.viewModel.selectProvider(providerID)
     }
 

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -1880,6 +1880,106 @@ final class DictationE2ETests: XCTestCase {
         }
     }
 
+    func testMLXUpgradeOfferOnlyTargetsLegacyAppleSiliconInstalls() {
+        let eligible = PrivateAIMLXUpgradeCoordinator.shouldOffer(
+            hasPrivateProvider: true,
+            isAppleSilicon: true,
+            appVersion: "1.6.3",
+            backendPreferenceWasSet: false,
+            hasLegacyLlamaModel: true,
+            hasMLXModel: false,
+            offerWasHandled: false
+        )
+        XCTAssertTrue(eligible)
+
+        XCTAssertFalse(PrivateAIMLXUpgradeCoordinator.shouldOffer(
+            hasPrivateProvider: true,
+            isAppleSilicon: false,
+            appVersion: "1.6.3",
+            backendPreferenceWasSet: false,
+            hasLegacyLlamaModel: true,
+            hasMLXModel: false,
+            offerWasHandled: false
+        ))
+        XCTAssertFalse(PrivateAIMLXUpgradeCoordinator.shouldOffer(
+            hasPrivateProvider: true,
+            isAppleSilicon: true,
+            appVersion: "1.6.3",
+            backendPreferenceWasSet: true,
+            hasLegacyLlamaModel: true,
+            hasMLXModel: false,
+            offerWasHandled: false
+        ))
+        XCTAssertFalse(PrivateAIMLXUpgradeCoordinator.shouldOffer(
+            hasPrivateProvider: true,
+            isAppleSilicon: true,
+            appVersion: "1.6.3",
+            backendPreferenceWasSet: false,
+            hasLegacyLlamaModel: false,
+            hasMLXModel: false,
+            offerWasHandled: false
+        ))
+        XCTAssertFalse(PrivateAIMLXUpgradeCoordinator.shouldOffer(
+            hasPrivateProvider: true,
+            isAppleSilicon: true,
+            appVersion: "1.6.3",
+            backendPreferenceWasSet: false,
+            hasLegacyLlamaModel: true,
+            hasMLXModel: true,
+            offerWasHandled: false
+        ))
+        XCTAssertFalse(PrivateAIMLXUpgradeCoordinator.shouldOffer(
+            hasPrivateProvider: true,
+            isAppleSilicon: true,
+            appVersion: "1.6.3",
+            backendPreferenceWasSet: false,
+            hasLegacyLlamaModel: true,
+            hasMLXModel: false,
+            offerWasHandled: true
+        ))
+        for version in ["1.6.2", "1.6.4", "2.0.0", ""] {
+            XCTAssertFalse(PrivateAIMLXUpgradeCoordinator.shouldOffer(
+                hasPrivateProvider: true,
+                isAppleSilicon: true,
+                appVersion: version,
+                backendPreferenceWasSet: false,
+                hasLegacyLlamaModel: true,
+                hasMLXModel: false,
+                offerWasHandled: false
+            ))
+        }
+    }
+
+    func testMLXUpgradePreparedOfferIsRevalidatedBeforeResuming() {
+        XCTAssertTrue(PrivateAIMLXUpgradeCoordinator.shouldResumePreparedOffer(
+            hasPrivateProvider: true,
+            isAppleSilicon: true,
+            appVersion: "1.6.3",
+            backendPreference: .llama,
+            hasLegacyLlamaModel: true,
+            hasMLXModel: false
+        ))
+
+        for state in [
+            (true, true, "1.6.3", SettingsStore.PrivateAIBackendPreference.mlx, true, false),
+            (true, true, "1.6.3", SettingsStore.PrivateAIBackendPreference.llama, false, false),
+            (true, true, "1.6.3", SettingsStore.PrivateAIBackendPreference.llama, true, true),
+            (true, true, "1.6.4", SettingsStore.PrivateAIBackendPreference.llama, true, false),
+            (true, false, "1.6.3", SettingsStore.PrivateAIBackendPreference.llama, true, false),
+            (false, true, "1.6.3", SettingsStore.PrivateAIBackendPreference.llama, true, false),
+            (true, true, "1.6.3", nil, true, false),
+        ] {
+            XCTAssertFalse(PrivateAIMLXUpgradeCoordinator.shouldResumePreparedOffer(
+                hasPrivateProvider: state.0,
+                isAppleSilicon: state.1,
+                appVersion: state.2,
+                backendPreference: state.3,
+                hasLegacyLlamaModel: state.4,
+                hasMLXModel: state.5
+            ))
+        }
+    }
+
     func testPrivateAIProviderDoesNotConfigureCommandMode() {
         guard PrivateFeatures.privateAIProvider else { return }
 


### PR DESCRIPTION
## Description
Adds a one-time 1.6.3 upgrade prompt for existing Apple silicon users with the legacy llama.cpp Fluid-1 model. Users can keep the verified legacy backend, or switch to MLX only after the replacement model downloads and verifies successfully.

The migration is limited to 1.6.3, defers silent login-item prompts until FluidVoice becomes active, revalidates persisted offers, and restores llama.cpp after failed, cancelled, or interrupted upgrades.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Follow-up to #591.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: `testMLXUpgradeOfferOnlyTargetsLegacyAppleSiliconInstalls`, `testMLXUpgradePreparedOfferIsRevalidatedBeforeResuming`

Private Fluid Intelligence build succeeded, installed to `/Applications/FluidVoice.app`, and remained running with the MLX helper and required frameworks embedded.

## Screenshots / Video
This reuses the native macOS alert and existing AI Enhancement settings UI without layout or styling changes.

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
The offer is hard-gated to app version 1.6.3 and never runs on Intel, fresh installs, explicit backend selections, or completed MLX installs. The legacy model is removed only after MLX verification succeeds. Intel runtime was not tested as part of this PR.