### PR TITLE
fix(asr): unload idle speech model to release wired memory (#548)

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
 		86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */; };
 		272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */; };
+		80465DE1A77810B54487CD0E /* SpeechModelIdleUnloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE1E8B230CB0C06897E51E9 /* SpeechModelIdleUnloadTests.swift */; };
 		7CDB0A2F2F3C4D5600FB7CAD /* dictation_fixture.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */; };
 		7CDB0A302F3C4D5600FB7CAD /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */; };
 		7CE006BD2E80EBE600DDCCD6 /* AppUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = 7CE006BC2E80EBE600DDCCD6 /* AppUpdater */; };
@@ -38,6 +39,7 @@
 		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
 		343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMClientRequestBodyTests.swift; sourceTree = "<group>"; };
 		980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSupportTests.swift; sourceTree = "<group>"; };
+		4CE1E8B230CB0C06897E51E9 /* SpeechModelIdleUnloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechModelIdleUnloadTests.swift; sourceTree = "<group>"; };
 		7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFixtureLoader.swift; sourceTree = "<group>"; };
 		7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = dictation_fixture.wav; sourceTree = "<group>"; };
 		7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -109,6 +111,7 @@
 				7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */,
 				7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */,
 				343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */,
+				4CE1E8B230CB0C06897E51E9 /* SpeechModelIdleUnloadTests.swift */,
 				980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
@@ -265,6 +268,7 @@
 				7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */,
 				7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */,
 				86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */,
+				80465DE1A77810B54487CD0E /* SpeechModelIdleUnloadTests.swift in Sources */,
 				272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -75,6 +75,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let weekendsDontBreakStreak: Bool
     let fillerWords: [String]
     let removeFillerWordsEnabled: Bool
+    let speechModelIdleUnloadMinutes: Int?
     let autoConvertPunctuationEnabled: Bool?
     let literalDictationFormattingEnabled: Bool?
     let punctuationDictionaryPrefix: String?

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -5206,21 +5206,28 @@ extension SettingsStore {
 
     /// Minutes of dictation inactivity after which the loaded speech model is
     /// unloaded to reclaim memory. 0 keeps the model loaded until quit.
+    /// Clamped to at most 24 hours so stored or restored values can never
+    /// overflow the nanosecond arithmetic that arms the unload timer.
     var speechModelIdleUnloadMinutes: Int {
         get {
             guard let value = self.defaults.object(forKey: Keys.speechModelIdleUnloadMinutes) as? Int else {
                 return Self.defaultSpeechModelIdleUnloadMinutes
             }
-            return max(0, value)
+            return Self.clampedSpeechModelIdleUnloadMinutes(value)
         }
         set {
             objectWillChange.send()
-            self.defaults.set(max(0, newValue), forKey: Keys.speechModelIdleUnloadMinutes)
+            self.defaults.set(Self.clampedSpeechModelIdleUnloadMinutes(newValue), forKey: Keys.speechModelIdleUnloadMinutes)
             NotificationCenter.default.post(name: .speechModelIdleUnloadPolicyDidChange, object: nil)
         }
     }
 
     static let defaultSpeechModelIdleUnloadMinutes = 30
+    static let maxSpeechModelIdleUnloadMinutes = 24 * 60
+
+    static func clampedSpeechModelIdleUnloadMinutes(_ minutes: Int) -> Int {
+        min(max(0, minutes), Self.maxSpeechModelIdleUnloadMinutes)
+    }
 
     var selectedCohereLanguage: CohereLanguage {
         get {

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2995,6 +2995,7 @@ final class SettingsStore: ObservableObject {
             weekendsDontBreakStreak: self.weekendsDontBreakStreak,
             fillerWords: self.fillerWords,
             removeFillerWordsEnabled: self.removeFillerWordsEnabled,
+            speechModelIdleUnloadMinutes: self.speechModelIdleUnloadMinutes,
             autoConvertPunctuationEnabled: self.autoConvertPunctuationEnabled,
             literalDictationFormattingEnabled: self.literalDictationFormattingEnabled,
             punctuationDictionaryPrefix: self.punctuationDictionaryPrefix,
@@ -3114,6 +3115,9 @@ final class SettingsStore: ObservableObject {
         self.weekendsDontBreakStreak = payload.weekendsDontBreakStreak
         self.fillerWords = payload.fillerWords
         self.removeFillerWordsEnabled = payload.removeFillerWordsEnabled
+        if let speechModelIdleUnloadMinutes = payload.speechModelIdleUnloadMinutes {
+            self.speechModelIdleUnloadMinutes = speechModelIdleUnloadMinutes
+        }
         if let autoConvertPunctuationEnabled = payload.autoConvertPunctuationEnabled {
             self.autoConvertPunctuationEnabled = autoConvertPunctuationEnabled
         }
@@ -4377,6 +4381,20 @@ final class SettingsStore: ObservableObject {
             }
         }
 
+        /// Whether transcription runs on weights loaded into FluidVoice's own
+        /// process memory. Apple engines run in system services, so there is
+        /// no in-process model to unload when idle.
+        var holdsModelInProcessMemory: Bool {
+            switch self {
+            case .appleSpeech, .appleSpeechAnalyzer:
+                return false
+            case .parakeetTDT, .parakeetTDTv2, .parakeetRealtime, .qwen3Asr, .cohereTranscribeSixBit,
+                 .nemotronOffline, .nemotronStreaming, .nemotronStreaming320,
+                 .whisperTiny, .whisperBase, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperLarge:
+                return true
+            }
+        }
+
         /// Warning text for models with high memory requirements, nil if no warning needed
         var memoryWarning: String? {
             switch self {
@@ -4927,6 +4945,7 @@ private extension SettingsStore {
 
         /// Unified Speech Model (replaces above two)
         static let selectedSpeechModel = "SelectedSpeechModel"
+        static let speechModelIdleUnloadMinutes = "SpeechModelIdleUnloadMinutes"
         static let selectedCohereLanguage = "SelectedCohereLanguage"
         static let selectedNemotronLanguage = "SelectedNemotronLanguage"
         static let selectedAppleSpeechLocaleIdentifier = "SelectedAppleSpeechLocaleIdentifier"
@@ -5184,6 +5203,24 @@ extension SettingsStore {
             self.defaults.set(model.rawValue, forKey: Keys.selectedSpeechModel)
         }
     }
+
+    /// Minutes of dictation inactivity after which the loaded speech model is
+    /// unloaded to reclaim memory. 0 keeps the model loaded until quit.
+    var speechModelIdleUnloadMinutes: Int {
+        get {
+            guard let value = self.defaults.object(forKey: Keys.speechModelIdleUnloadMinutes) as? Int else {
+                return Self.defaultSpeechModelIdleUnloadMinutes
+            }
+            return max(0, value)
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(max(0, newValue), forKey: Keys.speechModelIdleUnloadMinutes)
+            NotificationCenter.default.post(name: .speechModelIdleUnloadPolicyDidChange, object: nil)
+        }
+    }
+
+    static let defaultSpeechModelIdleUnloadMinutes = 30
 
     var selectedCohereLanguage: CohereLanguage {
         get {

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -85,6 +85,22 @@ final class ASRService: ObservableObject {
         failureCount >= 3
     }
 
+    nonisolated static func canUnloadIdleSpeechModel(
+        isAsrReady: Bool,
+        isRunning: Bool,
+        isStarting: Bool,
+        hasActiveModelPreparation: Bool,
+        hasActiveModelDownload: Bool,
+        activeSpeechModelUseCount: Int
+    ) -> Bool {
+        isAsrReady
+            && !isRunning
+            && !isStarting
+            && !hasActiveModelPreparation
+            && !hasActiveModelDownload
+            && activeSpeechModelUseCount == 0
+    }
+
     @Published var isRunning: Bool = false
     @Published var finalText: String = ""
     @Published var partialTranscription: String = ""
@@ -205,6 +221,8 @@ final class ASRService: ObservableObject {
         await self.providerResetDrain?.task.value
         await self.transcriptionExecutor.cancelAndAwaitPending()
 
+        self.modelIdleUnloadTask?.cancel()
+        self.modelIdleUnloadTask = nil
         self.fluidAudioProvider = nil
         self.parakeetRealtimeProvider = nil
         self.externalCoreMLProvider = nil
@@ -557,9 +575,12 @@ final class ASRService: ObservableObject {
         self.wordBoostStatusText = "Word boost: off"
 
         // Reset cached providers to force re-initialization with new settings
+        self.modelIdleUnloadTask?.cancel()
+        self.modelIdleUnloadTask = nil
         self.fluidAudioProvider = nil
         self.parakeetRealtimeProvider = nil
         self.externalCoreMLProvider = nil
+        self.nemotronProviders.removeAll()
         self.whisperProvider = nil
         self.appleSpeechProvider = nil
         self._appleSpeechAnalyzerProvider = nil
@@ -577,6 +598,85 @@ final class ASRService: ObservableObject {
             }
             DebugLogger.shared.info("ASRService: Provider reset complete, will initialize '\(newModel.displayName)' on next use", source: "ASRService")
         }
+    }
+
+    // MARK: - Idle Speech Model Unload
+
+    /// Marks the loaded speech model as in use so an idle unload cannot fire
+    /// mid-operation. Every call must be balanced with `endSpeechModelUse()`.
+    func beginSpeechModelUse() {
+        self.activeSpeechModelUseCount += 1
+        self.modelIdleUnloadTask?.cancel()
+        self.modelIdleUnloadTask = nil
+    }
+
+    /// Balances `beginSpeechModelUse()` and re-arms the idle unload countdown
+    /// once the model is no longer in use.
+    func endSpeechModelUse() {
+        self.activeSpeechModelUseCount = max(0, self.activeSpeechModelUseCount - 1)
+        if self.activeSpeechModelUseCount == 0 {
+            self.scheduleModelIdleUnloadIfEnabled(reason: "model_use_ended")
+        }
+    }
+
+    private func scheduleModelIdleUnloadIfEnabled(reason: String) {
+        self.modelIdleUnloadTask?.cancel()
+        self.modelIdleUnloadTask = nil
+
+        let minutes = SettingsStore.shared.speechModelIdleUnloadMinutes
+        guard minutes > 0,
+              self.isAsrReady,
+              SettingsStore.shared.selectedSpeechModel.holdsModelInProcessMemory
+        else { return }
+
+        DebugLogger.shared.debug(
+            "Speech model idle unload armed for \(minutes)min (\(reason))",
+            source: "ASRService"
+        )
+        let delay = UInt64(minutes) * 60 * 1_000_000_000
+        self.modelIdleUnloadTask = Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: delay)
+            } catch {
+                return
+            }
+            self?.unloadIdleSpeechModel()
+        }
+    }
+
+    /// Releases every cached in-process speech model once the idle window has
+    /// elapsed with no dictation. Disk caches are untouched; the existing
+    /// `ensureAsrReady()` paths reload the model on next use, exactly like the
+    /// first dictation after app launch.
+    private func unloadIdleSpeechModel() {
+        self.modelIdleUnloadTask = nil
+        guard Self.canUnloadIdleSpeechModel(
+            isAsrReady: self.isAsrReady,
+            isRunning: self.isRunning,
+            isStarting: self.isStarting,
+            hasActiveModelPreparation: self.ensureReadyTask != nil,
+            hasActiveModelDownload: self.modelDownloadTask != nil,
+            activeSpeechModelUseCount: self.activeSpeechModelUseCount
+        ) else {
+            self.scheduleModelIdleUnloadIfEnabled(reason: "unload_deferred")
+            return
+        }
+
+        DebugLogger.shared.info(
+            "Unloading idle speech model to reclaim memory; it reloads on next dictation",
+            source: "ASRService"
+        )
+        self.fluidAudioProvider = nil
+        self.parakeetRealtimeProvider = nil
+        self.externalCoreMLProvider = nil
+        self.nemotronProviders.removeAll()
+        self.whisperProvider = nil
+        self.isAsrReady = false
+        self.hasCompletedFirstTranscription = false
+        self.isLoadingModel = false
+        self.modelPreparationPhase = nil
+        self.lastBoostHitTerm = nil
+        self.refreshWordBoostStatus()
     }
 
     // CRITICAL FIX (launch-time crash mitigation):
@@ -996,6 +1096,14 @@ final class ASRService: ObservableObject {
     private let audioRouteRecoveryDelayNanoseconds: UInt64 = 1_000_000_000
     private var audioEngineStandbyTask: Task<Void, Never>?
     private let audioEngineStandbyNanoseconds: UInt64 = 8_000_000_000
+
+    /// Countdown that releases the loaded speech model after the configured
+    /// idle window, so multi-GB model weights do not stay resident forever.
+    private var modelIdleUnloadTask: Task<Void, Never>?
+    /// Number of in-flight operations (final transcription, Local API calls,
+    /// file transcription) that must block an idle unload while they run.
+    private var activeSpeechModelUseCount = 0
+    private var idleUnloadPolicyObserver: NSObjectProtocol?
     private var isEngineTapInstalled = false
     private var isRecoveringAudioRoute = false
 
@@ -1079,6 +1187,15 @@ final class ASRService: ObservableObject {
                 self?.handleParakeetVocabularyDidChange()
             }
         }
+        self.idleUnloadPolicyObserver = NotificationCenter.default.addObserver(
+            forName: .speechModelIdleUnloadPolicyDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleModelIdleUnloadIfEnabled(reason: "policy_changed")
+            }
+        }
     }
 
     deinit {
@@ -1087,6 +1204,9 @@ final class ASRService: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
         }
         if let observer = self.engineConfigurationChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = self.idleUnloadPolicyObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }
@@ -1470,9 +1590,11 @@ final class ASRService: ObservableObject {
             return ""
         }
         let useDictionaryTrainingPath = forDictionaryTraining || self.isDictionaryTrainingCaptureActive
+        self.beginSpeechModelUse()
         defer {
             self.applyPendingParakeetVocabularyReloadIfNeeded()
             self.isDictionaryTrainingCaptureActive = false
+            self.endSpeechModelUse()
         }
 
         self.audioRouteRecoveryTask?.cancel()
@@ -1727,6 +1849,8 @@ final class ASRService: ObservableObject {
     }
 
     func transcribeSamplesForAPI(_ inputSamples: [Float]) async throws -> ASRTranscriptionResult {
+        self.beginSpeechModelUse()
+        defer { self.endSpeechModelUse() }
         var samples = inputSamples
         guard !samples.isEmpty else {
             return ASRTranscriptionResult(text: "", confidence: 0)
@@ -1764,6 +1888,8 @@ final class ASRService: ObservableObject {
     }
 
     func transcribeFileForAPI(_ fileURL: URL) async throws -> (result: ASRTranscriptionResult, sampleCount: Int) {
+        self.beginSpeechModelUse()
+        defer { self.endSpeechModelUse() }
         guard FileManager.default.isReadableFile(atPath: fileURL.path) else {
             throw NSError(
                 domain: "ASRService",
@@ -1809,9 +1935,11 @@ final class ASRService: ObservableObject {
 
     func stopWithoutTranscription() async {
         guard self.isRunning else { return }
+        self.beginSpeechModelUse()
         defer {
             self.applyPendingParakeetVocabularyReloadIfNeeded()
             self.isDictionaryTrainingCaptureActive = false
+            self.endSpeechModelUse()
         }
 
         self.audioRouteRecoveryTask?.cancel()
@@ -3003,6 +3131,7 @@ final class ASRService: ObservableObject {
             self.isAsrReady = true
             self.isCancellingModelPreparation = false
             self.refreshWordBoostStatus()
+            self.scheduleModelIdleUnloadIfEnabled(reason: "model_ready")
         } catch is CancellationError {
             DebugLogger.shared.info("ASR initialization cancelled", source: "ASRService")
             if provider.shouldClearCacheAfterCancellation,
@@ -4194,4 +4323,8 @@ private final nonisolated class AudioCapturePipeline: @unchecked Sendable {
         vDSP_vsdiv(mono, 1, &div, &mono, 1, vDSP_Length(frameCount))
         return mono
     }
+}
+
+extension Notification.Name {
+    static let speechModelIdleUnloadPolicyDidChange = Notification.Name("SpeechModelIdleUnloadPolicyDidChange")
 }

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1490,9 +1490,13 @@ final class ASRService: ObservableObject {
             // Only start streaming for models that support it (large Whisper models are too slow)
             let model = SettingsStore.shared.selectedSpeechModel
             if model.supportsStreaming, !forDictionaryTraining {
-                DebugLogger.shared.debug("📡 Starting streaming transcription...", source: "ASRService")
-                self.benchmarkLog("streaming_timer_start intervalMs=\(Int((self.streamingChunkDurationSeconds * 1000).rounded())) minSamples=\(self.minimumStreamingPreviewSamples)")
-                self.startStreamingTranscription()
+                if self.isAsrReady {
+                    DebugLogger.shared.debug("📡 Starting streaming transcription...", source: "ASRService")
+                    self.benchmarkLog("streaming_timer_start intervalMs=\(Int((self.streamingChunkDurationSeconds * 1000).rounded())) minSamples=\(self.minimumStreamingPreviewSamples)")
+                    self.startStreamingTranscription()
+                } else {
+                    self.attachStreamingTranscriptionWhenModelLoads()
+                }
             } else if forDictionaryTraining {
                 DebugLogger.shared.debug("⏸️ Skipping streaming for dictionary training sample", source: "ASRService")
             } else {
@@ -3357,6 +3361,33 @@ final class ASRService: ObservableObject {
     }
 
     // MARK: - Timer-based Streaming Transcription (No VAD)
+
+    /// The model can be absent when capture starts (idle unload, or app launch
+    /// before the startup auto-load finishes). Reload it during capture and
+    /// attach the live streaming preview to the same session once it is ready,
+    /// instead of losing streaming for the whole dictation.
+    private func attachStreamingTranscriptionWhenModelLoads() {
+        let sessionID = self.benchmarkSessionID
+        DebugLogger.shared.debug("📡 Streaming deferred - loading model during capture...", source: "ASRService")
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.ensureAsrReady()
+            } catch {
+                DebugLogger.shared.debug(
+                    "Streaming attach abandoned - model load failed: \(error.localizedDescription)",
+                    source: "ASRService"
+                )
+                return
+            }
+            guard self.isRunning,
+                  self.benchmarkSessionID == sessionID,
+                  SettingsStore.shared.selectedSpeechModel.supportsStreaming
+            else { return }
+            self.benchmarkLog("streaming_timer_start intervalMs=\(Int((self.streamingChunkDurationSeconds * 1000).rounded())) minSamples=\(self.minimumStreamingPreviewSamples) deferred=true")
+            self.startStreamingTranscription()
+        }
+    }
 
     private func startStreamingTranscription() {
         self.streamingTask?.cancel()

--- a/Sources/Fluid/Services/MeetingTranscriptionService.swift
+++ b/Sources/Fluid/Services/MeetingTranscriptionService.swift
@@ -163,10 +163,14 @@ final class MeetingTranscriptionService: ObservableObject {
         error = nil
         self.progress = 0.0
         let startTime = Date()
+        // Long file jobs reuse the ASR provider outside ASRService's own
+        // flows, so hold the model in memory until this run finishes.
+        self.asrService.beginSpeechModelUse()
 
         defer {
             isTranscribing = false
             progress = 0.0
+            self.asrService.endSpeechModelUse()
         }
 
         do {

--- a/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/VoiceEngineSettingsViewModel.swift
@@ -45,6 +45,7 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
     }
 
     @Published var removeFillerWordsEnabled: Bool
+    @Published var speechModelIdleUnloadMinutes: Int
 
     init(settings: SettingsStore, appServices: AppServices) {
         self.settings = settings
@@ -52,6 +53,7 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
         self.previewSpeechModel = settings.selectedSpeechModel
         self.selectedSpeechProvider = settings.selectedSpeechModel.provider
         self.removeFillerWordsEnabled = settings.removeFillerWordsEnabled
+        self.speechModelIdleUnloadMinutes = settings.speechModelIdleUnloadMinutes
         appServices.objectWillChange
             .sink { [weak self] _ in
                 Task { @MainActor in
@@ -65,6 +67,7 @@ final class VoiceEngineSettingsViewModel: ObservableObject {
         self.previewSpeechModel = self.settings.selectedSpeechModel
         self.selectedSpeechProvider = self.settings.selectedSpeechModel.provider
         self.removeFillerWordsEnabled = self.settings.removeFillerWordsEnabled
+        self.speechModelIdleUnloadMinutes = self.settings.speechModelIdleUnloadMinutes
 
         Task {
             await self.asr.checkIfModelsExistAsync()

--- a/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
+++ b/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
@@ -154,10 +154,14 @@ extension VoiceEngineSettingsView {
                         // Filler Words Section
                         self.fillerWordsSection
 
-                        Divider().padding(.vertical, 4)
+                        // Apple engines run in system services and hold no
+                        // in-process model, so there is nothing to unload.
+                        if self.settings.selectedSpeechModel.holdsModelInProcessMemory {
+                            Divider().padding(.vertical, 4)
 
-                        // Model Memory Section
-                        self.modelMemorySection
+                            // Model Memory Section
+                            self.modelMemorySection
+                        }
                     }
                 }
             }
@@ -799,6 +803,8 @@ extension VoiceEngineSettingsView {
         switch minutes {
         case 0:
             return "Never"
+        case 1:
+            return "After 1 minute"
         case 60:
             return "After 1 hour"
         default:

--- a/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
+++ b/Sources/Fluid/UI/AISettingsView+SpeechRecognition.swift
@@ -153,6 +153,11 @@ extension VoiceEngineSettingsView {
 
                         // Filler Words Section
                         self.fillerWordsSection
+
+                        Divider().padding(.vertical, 4)
+
+                        // Model Memory Section
+                        self.modelMemorySection
                     }
                 }
             }
@@ -745,6 +750,59 @@ extension VoiceEngineSettingsView {
             if self.viewModel.removeFillerWordsEnabled {
                 FillerWordsEditor()
             }
+        }
+    }
+
+    // MARK: - Model Memory Section
+
+    private static let idleUnloadMinuteOptions = [0, 5, 15, 30, 60]
+
+    var modelMemorySection: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Unload Model When Inactive")
+                    .font(self.theme.typography.bodyStrong)
+                    .foregroundStyle(self.voiceEngineTitleText)
+                Text("Free memory by unloading the voice model after a period without dictation. It reloads automatically on the next dictation.")
+                    .font(self.theme.typography.bodySmall)
+                    .foregroundStyle(self.voiceEngineSecondaryText)
+            }
+            Spacer()
+            Menu {
+                ForEach(Self.idleUnloadMinuteOptions, id: \.self) { minutes in
+                    Button(Self.idleUnloadOptionLabel(minutes)) {
+                        self.viewModel.speechModelIdleUnloadMinutes = minutes
+                    }
+                }
+            } label: {
+                Text(Self.idleUnloadOptionLabel(self.viewModel.speechModelIdleUnloadMinutes))
+                    .font(self.theme.typography.bodySmallStrong)
+                    .foregroundStyle(self.voiceEngineTitleText)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 9)
+                            .fill(self.theme.palette.cardBackground.opacity(0.8))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 9)
+                                    .stroke(self.theme.palette.cardBorder.opacity(0.5), lineWidth: 1)
+                            )
+                    )
+            }
+            .onChange(of: self.viewModel.speechModelIdleUnloadMinutes) { _, newValue in
+                self.settings.speechModelIdleUnloadMinutes = newValue
+            }
+        }
+    }
+
+    private static func idleUnloadOptionLabel(_ minutes: Int) -> String {
+        switch minutes {
+        case 0:
+            return "Never"
+        case 60:
+            return "After 1 hour"
+        default:
+            return "After \(minutes) minutes"
         }
     }
 

--- a/Tests/FluidDictationIntegrationTests/SpeechModelIdleUnloadTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpeechModelIdleUnloadTests.swift
@@ -1,0 +1,118 @@
+@testable import FluidVoice_Debug
+import Foundation
+import XCTest
+
+final class SpeechModelIdleUnloadTests: XCTestCase {
+    private let idleUnloadMinutesKey = "SpeechModelIdleUnloadMinutes"
+
+    func testCanUnloadOnlyWhenServiceIsFullyIdle() {
+        XCTAssertTrue(ASRService.canUnloadIdleSpeechModel(
+            isAsrReady: true,
+            isRunning: false,
+            isStarting: false,
+            hasActiveModelPreparation: false,
+            hasActiveModelDownload: false,
+            activeSpeechModelUseCount: 0
+        ))
+    }
+
+    func testCannotUnloadWithoutLoadedModel() {
+        XCTAssertFalse(ASRService.canUnloadIdleSpeechModel(
+            isAsrReady: false,
+            isRunning: false,
+            isStarting: false,
+            hasActiveModelPreparation: false,
+            hasActiveModelDownload: false,
+            activeSpeechModelUseCount: 0
+        ))
+    }
+
+    func testCannotUnloadWhileRecordingOrStarting() {
+        XCTAssertFalse(ASRService.canUnloadIdleSpeechModel(
+            isAsrReady: true,
+            isRunning: true,
+            isStarting: false,
+            hasActiveModelPreparation: false,
+            hasActiveModelDownload: false,
+            activeSpeechModelUseCount: 0
+        ))
+        XCTAssertFalse(ASRService.canUnloadIdleSpeechModel(
+            isAsrReady: true,
+            isRunning: false,
+            isStarting: true,
+            hasActiveModelPreparation: false,
+            hasActiveModelDownload: false,
+            activeSpeechModelUseCount: 0
+        ))
+    }
+
+    func testCannotUnloadDuringModelPreparationOrDownload() {
+        XCTAssertFalse(ASRService.canUnloadIdleSpeechModel(
+            isAsrReady: true,
+            isRunning: false,
+            isStarting: false,
+            hasActiveModelPreparation: true,
+            hasActiveModelDownload: false,
+            activeSpeechModelUseCount: 0
+        ))
+        XCTAssertFalse(ASRService.canUnloadIdleSpeechModel(
+            isAsrReady: true,
+            isRunning: false,
+            isStarting: false,
+            hasActiveModelPreparation: false,
+            hasActiveModelDownload: true,
+            activeSpeechModelUseCount: 0
+        ))
+    }
+
+    func testCannotUnloadWhileTranscriptionWorkHoldsTheModel() {
+        // Final transcription in stop(), Local API requests, and long file
+        // transcription jobs all hold a use token that must block unload.
+        XCTAssertFalse(ASRService.canUnloadIdleSpeechModel(
+            isAsrReady: true,
+            isRunning: false,
+            isStarting: false,
+            hasActiveModelPreparation: false,
+            hasActiveModelDownload: false,
+            activeSpeechModelUseCount: 1
+        ))
+    }
+
+    func testOnlyAppleModelsHoldNoInProcessMemory() {
+        for model in SettingsStore.SpeechModel.allCases {
+            let isAppleManaged = model == .appleSpeech || model == .appleSpeechAnalyzer
+            XCTAssertEqual(
+                model.holdsModelInProcessMemory,
+                !isAppleManaged,
+                "Unexpected in-process memory classification for \(model.rawValue)"
+            )
+        }
+    }
+
+    func testIdleUnloadMinutesDefaultAndClamping() {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: self.idleUnloadMinutesKey)
+        defer {
+            if let original {
+                defaults.set(original, forKey: self.idleUnloadMinutesKey)
+            } else {
+                defaults.removeObject(forKey: self.idleUnloadMinutesKey)
+            }
+        }
+
+        defaults.removeObject(forKey: self.idleUnloadMinutesKey)
+        XCTAssertEqual(
+            SettingsStore.shared.speechModelIdleUnloadMinutes,
+            SettingsStore.defaultSpeechModelIdleUnloadMinutes
+        )
+
+        SettingsStore.shared.speechModelIdleUnloadMinutes = 15
+        XCTAssertEqual(SettingsStore.shared.speechModelIdleUnloadMinutes, 15)
+
+        SettingsStore.shared.speechModelIdleUnloadMinutes = 0
+        XCTAssertEqual(SettingsStore.shared.speechModelIdleUnloadMinutes, 0)
+
+        SettingsStore.shared.speechModelIdleUnloadMinutes = -5
+        XCTAssertEqual(SettingsStore.shared.speechModelIdleUnloadMinutes, 0)
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/SpeechModelIdleUnloadTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpeechModelIdleUnloadTests.swift
@@ -114,5 +114,19 @@ final class SpeechModelIdleUnloadTests: XCTestCase {
 
         SettingsStore.shared.speechModelIdleUnloadMinutes = -5
         XCTAssertEqual(SettingsStore.shared.speechModelIdleUnloadMinutes, 0)
+
+        // Oversized stored values (e.g. from a hand-edited or corrupt backup)
+        // must clamp instead of overflowing the timer's nanosecond math.
+        SettingsStore.shared.speechModelIdleUnloadMinutes = Int.max
+        XCTAssertEqual(
+            SettingsStore.shared.speechModelIdleUnloadMinutes,
+            SettingsStore.maxSpeechModelIdleUnloadMinutes
+        )
+
+        defaults.set(Int.max, forKey: self.idleUnloadMinutesKey)
+        XCTAssertEqual(
+            SettingsStore.shared.speechModelIdleUnloadMinutes,
+            SettingsStore.maxSpeechModelIdleUnloadMinutes
+        )
     }
 }


### PR DESCRIPTION
## Description

Fixes the voice-engine side of the wired-memory pinning reported in #548: once a speech model is loaded, FluidVoice never releases it. (The reporter's specific 3.43 GB `fluid-1-q4_k_m.gguf` is the Fluid Intelligence runtime — same missing-idle-unload defect, separate code path; see the Related Issue section and PR discussion.) `ASRService` caches every provider instance (`FluidAudioProvider` alone holds two to three `AsrManager` CoreML models, `WhisperProvider` a Metal-backed GGUF session) and only drops them on app quit or model switch — there is no time-based offload anywhere in the codebase. Combined with the startup auto-load in `initialize()`, a multi-GB model stays resident from launch until quit, which matches the reporter's measurements (wired stayed at ~5.6–5.8 GB for 10+ idle hours and only returned to baseline on quit) and freezes 8 GB Macs.

This PR adds an idle unload for the speech model, mirroring the existing audio-engine standby pattern:

- After a configurable window with no dictation (default **30 minutes**; Never / 5 / 15 / 30 / 60 min under Settings → Voice Engine), `ASRService` drops all cached in-process providers and frees the model memory. Disk caches are untouched.
- Reload is transparent: recording start is unaffected (audio capture starts immediately, and `startRecording()` already pre-loads the model in the background), while `stop()` awaits `ensureAsrReady()` — exactly the same path as the first dictation after app launch.
- A use-count token (`beginSpeechModelUse()` / `endSpeechModelUse()`) guarantees the unload can never fire while a final transcription, a Local API request, or a long file-transcription job is in flight; recording, preparation, and download states are re-checked at fire time via the pure decision function `canUnloadIdleSpeechModel(...)`.
- Apple Speech engines are excluded (`holdsModelInProcessMemory == false`) — they run in system services and hold no in-process weights, so there is nothing to unload.
- Changing the setting re-arms or cancels the countdown immediately (NotificationCenter, same pattern as `parakeetVocabularyDidChange`), and the value participates in settings backup/restore.

Also fixes a latent leak in the same lifecycle: `resetTranscriptionProvider()` cleared every cached provider **except** `nemotronProviders`, so switching away from a Nemotron model kept its CoreML models in memory forever (`shutdownForTermination()` already removed them; the reset path now matches).

### Verified end-to-end

Release build, `whisper-tiny`, unload window set to 1 minute:

```
[14:15:36.660] [INFO]  [ASRService] === ASR INITIALIZATION COMPLETE ===
[14:15:36.660] [DEBUG] [ASRService] Speech model idle unload armed for 1min (model_ready)
[14:16:36.811] [INFO]  [ASRService] Unloading idle speech model to reclaim memory; it reloads on next dictation
```

Process RSS dropped from 236.7 MB to 160.6 MB the moment the unload fired (whisper-tiny is only a 46 MB GGUF; with the ~3.4 GB model from the report this is multi-GB of wired memory). The app stays fully functional afterwards — the next dictation reloads through the existing `ensureAsrReady()` flow.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Part of #548 — this PR fixes the voice-engine side of the leak (ASR providers are never released while the app runs, and `resetTranscriptionProvider()` additionally leaks `nemotronProviders` on model switch). The reporter's specific 3.43 GB file (`fluid-1-q4_k_m.gguf`) is the Fluid Intelligence runtime, which has the same missing idle-unload and needs the same policy applied — happy to extend this PR or send it as a follow-up, whichever is preferred (see PR discussion).

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — 0 violations
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: full `xcodebuild test` suite (same invocation as CI) — all green, including the new `SpeechModelIdleUnloadTests` (7 tests covering the unload decision truth table, the in-process-memory model classification, and the setting's default/clamping)

## Screenshots / Video

New "Unload Model When Inactive" row in Settings → Voice Engine (below Remove Filler Words):

![Unload Model When Inactive setting row](https://raw.githubusercontent.com/devzahirul/FluidVoice/assets/548-screenshots/voice-engine-idle-unload-section.png)

<details><summary>Full Voice Engine card showing placement (below Remove Filler Words)</summary>

![Full Voice Engine settings card](https://raw.githubusercontent.com/devzahirul/FluidVoice/assets/548-screenshots/voice-engine-card-full.png)

</details>

## Notes
- Default is 30 minutes because idle offload appears to be the intended behavior (see maintainer comment in #548). Users who prefer the old always-resident behavior can select "Never". Frequent dictation never hits the unload — every model use re-arms the countdown.
- Worst case after an idle unload: a dictation shorter than the model load time waits at `stop()` for the reload, identical to the first dictation after app launch. For most models this is a few seconds; the background pre-load during recording absorbs it entirely for normal-length dictations.
- swiftformat 0.62.1 reformats ~60 files that this PR does not touch (the checked-in tree is not clean under it), so formatting was verified for the changed files only to keep the diff atomic and reviewable.
