### PR TITLE
fix(audio): sequence engine rebuild behind retired-engine teardown to stop launch freeze (#620)

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -618,7 +618,7 @@ final class ASRService: ObservableObject {
         self.directAudioInput != nil || self.hasWarmAudioEngine
     }
 
-    private func retireAudioEngine(reason: String) {
+    private func retireAudioEngine(reason: String, onDrained: (@Sendable () -> Void)? = nil) {
         self.audioEngineStandbyTask?.cancel()
         self.audioEngineStandbyTask = nil
 
@@ -649,9 +649,38 @@ final class ASRService: ObservableObject {
         if self.engineStorage != nil {
             let retired = RetiredAudioEngineReference(self.engineStorage)
             self.engineStorage = nil
-            retired.scheduleRelease()
+            retired.scheduleRelease(onDrained: onDrained)
+        } else {
+            // Nothing retained; follow-up work can run right away.
+            onDrained?()
         }
         DebugLogger.shared.debug("Audio engine retired (\(reason))", source: "ASRService")
+    }
+
+    /// Retires the engine and suspends (cooperatively — the main thread stays
+    /// responsive) until its final release has completed on the drain queue.
+    /// Returns false if the teardown did not finish within the timeout.
+    private func retireAudioEngineAndAwaitDrain(reason: String) async -> Bool {
+        let (drainStream, drainContinuation) = AsyncStream.makeStream(of: Void.self)
+        self.retireAudioEngine(reason: reason, onDrained: {
+            drainContinuation.yield()
+            drainContinuation.finish()
+        })
+
+        let timeoutNanoseconds = self.audioEngineDrainTimeoutNanoseconds
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await _ in drainStream { return true }
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                return false
+            }
+            let drainWonTheRace = await group.next() ?? false
+            group.cancelAll()
+            return drainWonTheRace
+        }
     }
 
     private func scheduleAudioEngineStandbyRetirement() {
@@ -994,6 +1023,10 @@ final class ASRService: ObservableObject {
     private var engineConfigurationChangeObserver: NSObjectProtocol?
     private var audioRouteRecoveryTask: Task<Void, Never>?
     private let audioRouteRecoveryDelayNanoseconds: UInt64 = 1_000_000_000
+    /// Bumped on every idle route change so a burst of them collapses into a
+    /// single engine rebuild once the newest teardown has drained.
+    private var idleEngineRebuildGeneration = 0
+    private let audioEngineDrainTimeoutNanoseconds: UInt64 = 5_000_000_000
     private var audioEngineStandbyTask: Task<Void, Never>?
     private let audioEngineStandbyNanoseconds: UInt64 = 8_000_000_000
     private var isEngineTapInstalled = false
@@ -2365,8 +2398,20 @@ final class ASRService: ObservableObject {
         guard self.isRunning else {
             self.audioLevelSubject.send(0.0)
             if self.hasPreparedAudioCapture {
-                self.retireAudioEngine(reason: "idle_route_change:\(reason)")
-                self.prewarmAudioEngineIfPossible(reason: "idle_route_change")
+                // Rebuild only after the retired engine has fully deallocated:
+                // -[AVAudioEngine dealloc] on the drain queue and inputNode/
+                // prepare() on a fresh engine serialize inside the HAL, and
+                // overlapping them can park the main thread behind the teardown
+                // for good (#620). The generation check collapses route-change
+                // bursts into one rebuild of the newest configuration.
+                self.idleEngineRebuildGeneration &+= 1
+                let generation = self.idleEngineRebuildGeneration
+                self.retireAudioEngine(reason: "idle_route_change:\(reason)", onDrained: { [weak self] in
+                    Task { @MainActor [weak self] in
+                        guard let self, self.idleEngineRebuildGeneration == generation else { return }
+                        self.prewarmAudioEngineIfPossible(reason: "idle_route_change")
+                    }
+                })
             }
             return
         }
@@ -2407,7 +2452,27 @@ final class ASRService: ObservableObject {
 
         self.stopMonitoringDevice()
         self.stopActiveAudioCapture()
-        self.retireAudioEngine(reason: "audio_route_recovery")
+
+        // Same HAL serialization hazard as the idle path (#620): never build the
+        // replacement capture stack while the retired engine is still tearing
+        // down. If the drain wedges, fail the recovery cleanly instead of racing.
+        let drained = await self.retireAudioEngineAndAwaitDrain(reason: "audio_route_recovery")
+        guard drained else {
+            self.audioCapturePipeline.setRecordingEnabled(false)
+            DebugLogger.shared.error(
+                "Audio route recovery aborted: engine teardown did not complete in time",
+                source: "ASRService"
+            )
+            await self.stopWithoutTranscription()
+            NotificationCenter.default.post(
+                name: NSNotification.Name("ASRServiceDeviceDisconnected"),
+                object: nil,
+                userInfo: ["errorMessage": "Recording stopped because the audio device changed."]
+            )
+            return
+        }
+        // The drain suspends; recording can legitimately stop while it runs.
+        guard self.isRunning else { return }
 
         do {
             self.audioCapturePipeline.setRecordingEnabled(
@@ -3743,6 +3808,11 @@ private extension ASRService {
 /// `@unchecked Sendable`: created on the main thread, then handed off and touched
 /// exactly once by the draining block; the dispatch provides the ordering.
 private final nonisolated class RetiredAudioEngineReference: @unchecked Sendable {
+    /// One serial queue for every retired engine: drains can never overlap each
+    /// other, and callers can order bring-up work behind a drain via
+    /// `onDrained` (#620).
+    private static let drainQueue = DispatchQueue(label: "com.fluidapp.audio-engine-drain", qos: .utility)
+
     private var engine: AnyObject?
 
     init(_ engine: AnyObject?) {
@@ -3751,8 +3821,13 @@ private final nonisolated class RetiredAudioEngineReference: @unchecked Sendable
 
     /// Schedules the retained engine's release off the main thread. Keeping the
     /// actual drain private prevents callers from bypassing this queue hop.
-    func scheduleRelease() {
-        DispatchQueue.global(qos: .utility).async { self.drain() }
+    /// `onDrained` runs on the drain queue after `-[AVAudioEngine dealloc]` has
+    /// fully completed.
+    func scheduleRelease(onDrained: (@Sendable () -> Void)? = nil) {
+        Self.drainQueue.async {
+            self.drain()
+            onDrained?()
+        }
     }
 
     private func drain() {

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -619,6 +619,18 @@ final class ASRService: ObservableObject {
     }
 
     private func retireAudioEngine(reason: String) {
+        if let retired = self.detachAudioEngineForRetirement(reason: reason) {
+            self.scheduleRetiredEngineDrain(retired)
+        }
+    }
+
+    /// Tears the capture stack down and returns the holder carrying the
+    /// engine's final reference WITHOUT scheduling its release. The start-retry
+    /// loop keeps the holder alive until its synchronous rebuild is done —
+    /// postponing dealloc past bring-up satisfies the same "never overlap"
+    /// invariant as the drain fence where awaiting is impossible (#620). All
+    /// other callers go through retireAudioEngine, which drains immediately.
+    private func detachAudioEngineForRetirement(reason: String) -> RetiredAudioEngineReference? {
         self.audioEngineStandbyTask?.cancel()
         self.audioEngineStandbyTask = nil
 
@@ -646,18 +658,23 @@ final class ASRService: ObservableObject {
         // block finishes before this function returns, the local's release
         // becomes the final one and dealloc lands back on main. The holder keeps
         // the engine out of main-thread locals entirely.
+        var retired: RetiredAudioEngineReference?
         if self.engineStorage != nil {
-            let retired = RetiredAudioEngineReference(self.engineStorage)
+            retired = RetiredAudioEngineReference(self.engineStorage)
             self.engineStorage = nil
-            self.pendingEngineDrainCount += 1
-            retired.scheduleRelease(onDrained: { [weak self] in
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    self.pendingEngineDrainCount = max(0, self.pendingEngineDrainCount - 1)
-                }
-            })
         }
         DebugLogger.shared.debug("Audio engine retired (\(reason))", source: "ASRService")
+        return retired
+    }
+
+    private func scheduleRetiredEngineDrain(_ retired: RetiredAudioEngineReference) {
+        self.pendingEngineDrainCount += 1
+        retired.scheduleRelease(onDrained: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.pendingEngineDrainCount = max(0, self.pendingEngineDrainCount - 1)
+            }
+        })
     }
 
     /// Resolves once every drain scheduled so far has finished, or returns
@@ -2280,6 +2297,16 @@ final class ASRService: ObservableObject {
         DebugLogger.shared.debug("🚀 startEngine() - ENTERED", source: "ASRService")
         var attempts = 0
         var lastError: Error?
+        // Engines retired by failed attempts are held here and drained only on
+        // exit, so a retry's configureSession()/prepare() can never run against
+        // an in-flight dealloc (#620). This loop is synchronous, so the async
+        // drain fence is not usable here; postponing the drain is equivalent.
+        var enginesRetiredDuringRetry: [RetiredAudioEngineReference] = []
+        defer {
+            for retired in enginesRetiredDuringRetry {
+                self.scheduleRetiredEngineDrain(retired)
+            }
+        }
 
         while attempts < 3 {
             do {
@@ -2335,7 +2362,9 @@ final class ASRService: ObservableObject {
                 // If this isn't the last attempt, recreate engine and reconfigure
                 if attempts < 3 {
                     DebugLogger.shared.debug("⚠️ Start failed, recreating engine for retry...", source: "ASRService")
-                    self.retireAudioEngine(reason: "start_retry")
+                    if let retired = self.detachAudioEngineForRetirement(reason: "start_retry") {
+                        enginesRetiredDuringRetry.append(retired)
+                    }
                     // Need to reconfigure the new engine
                     try? self.configureSession()
                     DebugLogger.shared.debug("✅ Engine recreated and reconfigured, will retry", source: "ASRService")

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -902,7 +902,16 @@ final class ASRService: ObservableObject {
     private func startCompatibilityAudioCapture(reason: String) throws {
         self.benchmarkLog("audio_backend kind=av_audio_engine_fallback reason=\(reason)")
         try self.configureSession()
-        try self.startEngine()
+        // Engines retired by failed start attempts stay referenced until the
+        // whole bring-up — including tap installation — has finished, so their
+        // dealloc can never overlap any of it (#620).
+        var enginesRetiredDuringRetry: [RetiredAudioEngineReference] = []
+        defer {
+            for retired in enginesRetiredDuringRetry {
+                self.scheduleRetiredEngineDrain(retired)
+            }
+        }
+        try self.startEngine(holdingRetiredEnginesIn: &enginesRetiredDuringRetry)
         try self.setupEngineTap()
         self.activeAudioCaptureBackend = .audioEngine
     }
@@ -2293,20 +2302,15 @@ final class ASRService: ObservableObject {
         }
     }
 
-    private func startEngine() throws {
+    /// Retry attempts detach the failed engine into `retiredEngines` instead
+    /// of draining it: this loop and the tap setup that follows are
+    /// synchronous, so the async drain fence cannot be awaited here. The
+    /// caller schedules the drains once the entire bring-up has completed,
+    /// which preserves the same never-overlap invariant (#620).
+    private func startEngine(holdingRetiredEnginesIn retiredEngines: inout [RetiredAudioEngineReference]) throws {
         DebugLogger.shared.debug("🚀 startEngine() - ENTERED", source: "ASRService")
         var attempts = 0
         var lastError: Error?
-        // Engines retired by failed attempts are held here and drained only on
-        // exit, so a retry's configureSession()/prepare() can never run against
-        // an in-flight dealloc (#620). This loop is synchronous, so the async
-        // drain fence is not usable here; postponing the drain is equivalent.
-        var enginesRetiredDuringRetry: [RetiredAudioEngineReference] = []
-        defer {
-            for retired in enginesRetiredDuringRetry {
-                self.scheduleRetiredEngineDrain(retired)
-            }
-        }
 
         while attempts < 3 {
             do {
@@ -2363,7 +2367,7 @@ final class ASRService: ObservableObject {
                 if attempts < 3 {
                     DebugLogger.shared.debug("⚠️ Start failed, recreating engine for retry...", source: "ASRService")
                     if let retired = self.detachAudioEngineForRetirement(reason: "start_retry") {
-                        enginesRetiredDuringRetry.append(retired)
+                        retiredEngines.append(retired)
                     }
                     // Need to reconfigure the new engine
                     try? self.configureSession()

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -618,7 +618,7 @@ final class ASRService: ObservableObject {
         self.directAudioInput != nil || self.hasWarmAudioEngine
     }
 
-    private func retireAudioEngine(reason: String, onDrained: (@Sendable () -> Void)? = nil) {
+    private func retireAudioEngine(reason: String) {
         self.audioEngineStandbyTask?.cancel()
         self.audioEngineStandbyTask = nil
 
@@ -649,38 +649,54 @@ final class ASRService: ObservableObject {
         if self.engineStorage != nil {
             let retired = RetiredAudioEngineReference(self.engineStorage)
             self.engineStorage = nil
-            retired.scheduleRelease(onDrained: onDrained)
-        } else {
-            // Nothing retained; follow-up work can run right away.
-            onDrained?()
+            self.pendingEngineDrainCount += 1
+            retired.scheduleRelease(onDrained: { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.pendingEngineDrainCount = max(0, self.pendingEngineDrainCount - 1)
+                }
+            })
         }
         DebugLogger.shared.debug("Audio engine retired (\(reason))", source: "ASRService")
     }
 
-    /// Retires the engine and suspends (cooperatively — the main thread stays
-    /// responsive) until its final release has completed on the drain queue.
-    /// Returns false if the teardown did not finish within the timeout.
-    private func retireAudioEngineAndAwaitDrain(reason: String) async -> Bool {
-        let (drainStream, drainContinuation) = AsyncStream.makeStream(of: Void.self)
-        self.retireAudioEngine(reason: reason, onDrained: {
-            drainContinuation.yield()
-            drainContinuation.finish()
-        })
-
-        let timeoutNanoseconds = self.audioEngineDrainTimeoutNanoseconds
+    /// Resolves once every drain scheduled so far has finished, or returns
+    /// false at the timeout. Cooperative — the main thread stays responsive.
+    private func awaitEngineDrainFence(timeoutNanoseconds: UInt64) async -> Bool {
+        let (fenceStream, fenceContinuation) = AsyncStream.makeStream(of: Void.self)
+        RetiredAudioEngineReference.notifyAfterPendingDrains {
+            fenceContinuation.yield()
+            fenceContinuation.finish()
+        }
         return await withTaskGroup(of: Bool.self) { group in
             group.addTask {
-                for await _ in drainStream { return true }
+                for await _ in fenceStream { return true }
                 return true
             }
             group.addTask {
                 try? await Task.sleep(nanoseconds: timeoutNanoseconds)
                 return false
             }
-            let drainWonTheRace = await group.next() ?? false
+            let fenceWonTheRace = await group.next() ?? false
             group.cancelAll()
-            return drainWonTheRace
+            return fenceWonTheRace
         }
+    }
+
+    /// Suspends until no retired engine is still deallocating, so bring-up can
+    /// never enter the HAL against an in-flight teardown (#620). Returns false
+    /// if teardown does not settle within `audioEngineDrainTimeoutNanoseconds`.
+    private func awaitPendingEngineDrains() async -> Bool {
+        let deadline = DispatchTime.now().uptimeNanoseconds + self.audioEngineDrainTimeoutNanoseconds
+        while self.pendingEngineDrainCount > 0 {
+            let now = DispatchTime.now().uptimeNanoseconds
+            guard now < deadline else { return false }
+            guard await self.awaitEngineDrainFence(timeoutNanoseconds: deadline - now) else { return false }
+            // The count decrements via a MainActor hop; yield so it can land
+            // before the next check.
+            await Task.yield()
+        }
+        return true
     }
 
     private func scheduleAudioEngineStandbyRetirement() {
@@ -736,6 +752,19 @@ final class ASRService: ObservableObject {
         }
         guard self.hasPreparedAudioCapture == false else {
             DebugLogger.shared.debug("Audio capture prewarm skipped - backend already prepared", source: "ASRService")
+            return
+        }
+        guard self.pendingEngineDrainCount == 0 else {
+            // A retired engine is still deallocating; bring-up must not enter
+            // the HAL until it finishes (#620). Re-attempt once the drains
+            // settle — repeat deferrals self-coalesce through the prepared
+            // guard above.
+            DebugLogger.shared.debug("Audio engine prewarm deferred - engine drain pending (\(reason))", source: "ASRService")
+            RetiredAudioEngineReference.notifyAfterPendingDrains { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.prewarmAudioEngineIfPossible(reason: reason)
+                }
+            }
             return
         }
 
@@ -1023,9 +1052,9 @@ final class ASRService: ObservableObject {
     private var engineConfigurationChangeObserver: NSObjectProtocol?
     private var audioRouteRecoveryTask: Task<Void, Never>?
     private let audioRouteRecoveryDelayNanoseconds: UInt64 = 1_000_000_000
-    /// Bumped on every idle route change so a burst of them collapses into a
-    /// single engine rebuild once the newest teardown has drained.
-    private var idleEngineRebuildGeneration = 0
+    /// Retired engines whose dealloc is still running on the drain queue.
+    /// Every engine bring-up path must wait for this to reach zero (#620).
+    private var pendingEngineDrainCount = 0
     private let audioEngineDrainTimeoutNanoseconds: UInt64 = 5_000_000_000
     private var audioEngineStandbyTask: Task<Void, Never>?
     private let audioEngineStandbyNanoseconds: UInt64 = 8_000_000_000
@@ -1369,6 +1398,19 @@ final class ASRService: ObservableObject {
         self.isDictionaryTrainingCaptureActive = false
 
         do {
+            // A route change just before this start may still be draining the
+            // retired engine; entering the HAL against that teardown is the
+            // #620 freeze. The common path pays nothing — the count is only
+            // non-zero for the few milliseconds a dealloc is in flight.
+            if self.pendingEngineDrainCount > 0 {
+                guard await self.awaitPendingEngineDrains() else {
+                    throw NSError(
+                        domain: "ASRService",
+                        code: -1101,
+                        userInfo: [NSLocalizedDescriptionKey: "The previous audio engine is still shutting down."]
+                    )
+                }
+            }
             try self.startPreferredAudioCapture()
             self.isDictionaryTrainingCaptureActive = forDictionaryTraining
             self.isRunning = true
@@ -2398,20 +2440,11 @@ final class ASRService: ObservableObject {
         guard self.isRunning else {
             self.audioLevelSubject.send(0.0)
             if self.hasPreparedAudioCapture {
-                // Rebuild only after the retired engine has fully deallocated:
-                // -[AVAudioEngine dealloc] on the drain queue and inputNode/
-                // prepare() on a fresh engine serialize inside the HAL, and
-                // overlapping them can park the main thread behind the teardown
-                // for good (#620). The generation check collapses route-change
-                // bursts into one rebuild of the newest configuration.
-                self.idleEngineRebuildGeneration &+= 1
-                let generation = self.idleEngineRebuildGeneration
-                self.retireAudioEngine(reason: "idle_route_change:\(reason)", onDrained: { [weak self] in
-                    Task { @MainActor [weak self] in
-                        guard let self, self.idleEngineRebuildGeneration == generation else { return }
-                        self.prewarmAudioEngineIfPossible(reason: "idle_route_change")
-                    }
-                })
+                // prewarmAudioEngineIfPossible defers itself behind the drain
+                // this retire just scheduled, so the rebuild can never enter
+                // the HAL while the old engine is still deallocating (#620).
+                self.retireAudioEngine(reason: "idle_route_change:\(reason)")
+                self.prewarmAudioEngineIfPossible(reason: "idle_route_change")
             }
             return
         }
@@ -2456,7 +2489,8 @@ final class ASRService: ObservableObject {
         // Same HAL serialization hazard as the idle path (#620): never build the
         // replacement capture stack while the retired engine is still tearing
         // down. If the drain wedges, fail the recovery cleanly instead of racing.
-        let drained = await self.retireAudioEngineAndAwaitDrain(reason: "audio_route_recovery")
+        self.retireAudioEngine(reason: "audio_route_recovery")
+        let drained = await self.awaitPendingEngineDrains()
         guard drained else {
             self.audioCapturePipeline.setRecordingEnabled(false)
             DebugLogger.shared.error(
@@ -3808,15 +3842,22 @@ private extension ASRService {
 /// `@unchecked Sendable`: created on the main thread, then handed off and touched
 /// exactly once by the draining block; the dispatch provides the ordering.
 private final nonisolated class RetiredAudioEngineReference: @unchecked Sendable {
-    /// One serial queue for every retired engine: drains can never overlap each
-    /// other, and callers can order bring-up work behind a drain via
-    /// `onDrained` (#620).
+    /// One shared serial queue across all retired engines: drains can never
+    /// overlap each other, and `notifyAfterPendingDrains` can fence bring-up
+    /// work behind every teardown scheduled so far (#620).
     private static let drainQueue = DispatchQueue(label: "com.fluidapp.audio-engine-drain", qos: .utility)
 
     private var engine: AnyObject?
 
     init(_ engine: AnyObject?) {
         self.engine = engine
+    }
+
+    /// Runs `completion` on the drain queue after every drain scheduled so far
+    /// has finished — a fence over pending teardowns, regardless of which
+    /// retirement scheduled them.
+    static func notifyAfterPendingDrains(_ completion: @escaping @Sendable () -> Void) {
+        self.drainQueue.async { completion() }
     }
 
     /// Schedules the retained engine's release off the main thread. Keeping the

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -104,6 +104,9 @@ final class ASRService: ObservableObject {
     private(set) var dictionaryTrainingAudioGeneration = 0
 
     private var isStarting: Bool = false // Guard against re-entrant start() calls
+    // Set by abortStartIfPending() while start() is suspended at the engine-
+    // drain fence; the stop paths gate on isRunning, which is still false there.
+    private var startAbortRequested = false
     private var hasCompletedFirstTranscription: Bool = false // Track if model has warmed up with first transcription
     private var lastBoostHitTerm: String?
     private var hasPendingParakeetVocabularyReload: Bool = false
@@ -1349,6 +1352,18 @@ final class ASRService: ObservableObject {
         }
     }
 
+    /// Cancels an in-flight `start()` that is suspended at the engine-drain
+    /// fence. During that suspension `isRunning` is still false, so the stop
+    /// paths would silently drop the request and capture would come up after
+    /// the user already released the hotkey (#620). Returns `true` when a
+    /// pending start will abort; no-op otherwise.
+    @discardableResult
+    func abortStartIfPending() -> Bool {
+        guard self.isStarting, self.isRunning == false else { return false }
+        self.startAbortRequested = true
+        return true
+    }
+
     /// Starts the speech recognition session.
     ///
     /// This method initiates audio capture and real-time processing. The service will:
@@ -1420,7 +1435,10 @@ final class ASRService: ObservableObject {
         DebugLogger.shared.debug("✅ Buffers cleared", source: "ASRService")
 
         self.isStarting = true
-        defer { self.isStarting = false }
+        defer {
+            self.isStarting = false
+            self.startAbortRequested = false
+        }
         self.isDictionaryTrainingCaptureActive = false
 
         do {
@@ -1436,6 +1454,15 @@ final class ASRService: ObservableObject {
                         userInfo: [NSLocalizedDescriptionKey: "The previous audio engine is still shutting down."]
                     )
                 }
+            }
+            // The fence above is the only suspension before isRunning is set;
+            // a stop that landed during it must cancel the session here or
+            // recording would begin after the user already let go.
+            if self.startAbortRequested {
+                self.audioCapturePipeline.setRecordingEnabled(false)
+                self.benchmarkLog("recording_start_aborted reason=stop_during_engine_drain")
+                DebugLogger.shared.info("🛑 START() aborted - stop requested while awaiting engine teardown", source: "ASRService")
+                return
             }
             try self.startPreferredAudioCapture()
             self.isDictionaryTrainingCaptureActive = forDictionaryTraining

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -1812,6 +1812,10 @@ final class GlobalHotkeyManager: NSObject {
             }
 
             guard self.asrService.isRunning else {
+                // start() may still be suspended at its engine-drain fence
+                // with isRunning false; mark the session aborted so capture
+                // does not come up after the key was already released.
+                self.asrService.abortStartIfPending()
                 return
             }
 


### PR DESCRIPTION
## Description

Fixes the permanent launch-time freeze reported in #620 (1.6.4 build 15).

**What the spindump shows.** The main thread is parked in `kevent_id` — a dispatch workloop sync-wait — and the kernel's turnstile marks it as blocked on an in-process worker (`0xcd437a`) that is itself parked forever in `psynch_cvwait`. A second worker (`0xcd438f`) is also stuck in a condition wait, and every CoreAudio/AudioToolbox thread (caulk messengers, `AUScheduledParameterRefresher`) went idle at the same instant, ~15 s after launch. That is a main-thread-waits-on-audio-workloop deadlock, the same family as #542.

**Root cause.** Since the #542 fix, a retired `AVAudioEngine`'s final release always drains on a background queue — but the idle route-change path immediately builds the replacement engine on the main thread in the same call:

```swift
self.retireAudioEngine(reason: "idle_route_change:\(reason)")   // dealloc drains concurrently on a global queue
self.prewarmAudioEngineIfPossible(reason: "idle_route_change")  // new engine inputNode/prepare() on main, right now
```

`-[AVAudioEngine dealloc]` and `inputNode`/`prepare()` on a fresh engine both serialize inside the HAL. When they interleave badly, the main thread's bring-up parks behind the wedged teardown — permanently. Route changes fire in bursts right after launch (Bluetooth devices reconnecting, default device settling), which is why the freeze presents as "opens … freezes" and survives a reinstall: it needs only a route change while the app is idle with a prewarmed engine. The mid-recording recovery path (`recoverAudioRoute`) has the same overlap.

**The fix — never overlap engine teardown with engine bring-up:**

- Retired engines now drain on a single **serial** queue (drains can no longer race each other either), and `scheduleRelease(onDrained:)` lets callers order follow-up work strictly after `dealloc` has completed.
- Idle route change: the rebuild moves into the drain completion. A generation counter collapses a burst of route changes into one rebuild of the newest configuration.
- Mid-recording recovery: cooperatively awaits the drain (bounded at 5 s; the main thread stays responsive — this is a suspension, not a block). If the teardown ever wedges, recording stops cleanly through the existing device-disconnected path instead of racing a new engine against it. `isRunning` is re-checked after the suspension since recording can legitimately stop while the drain runs.

### Verified live

With the app idle and the engine prewarmed, programmatically flipping the macOS default output device (aggregate-device wrap → restore) triggers the exact code path. Before, retire and rebuild ran in the same instant; now the log shows the rebuild strictly after the drain, and the app stays fully responsive across repeated flips:

```
[16:35:33.489] Audio engine retired (idle_route_change:default output changed)
[16:35:33.518] audio_engine_prewarm reason=idle_route_change elapsedMs=6   ← ~30 ms later, after dealloc completed
[16:35:38.489] Audio engine retired (idle_route_change:default output changed)
[16:35:38.520] audio_engine_prewarm reason=idle_route_change elapsedMs=6
```

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #620

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — 0 violations
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: full `xcodebuild test` suite with CI's invocation — all suites pass

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
- The reporter's spindump has truncated app frames, so the exact wedge point inside the HAL can't be read off it — but the turnstile chain (main → workloop sync-wait → in-process servicer in a condition wait, second worker also in a condition wait) matches this teardown/bring-up overlap, which is demonstrably present in the code and demonstrably eliminated by the sequencing. If the reporter can attach a full spindump, the frames should confirm.
- Behavior cost is nil in practice: the idle rebuild lands ~30 ms later than before (after dealloc), and recording recovery adds a drain await that normally completes in milliseconds inside its existing 1 s debounce window.
