### PR TITLE
Add Local API settings controls

### DIFF
--- a/Sources/Fluid/Services/LocalAPI/InferenceAPIController.swift
+++ b/Sources/Fluid/Services/LocalAPI/InferenceAPIController.swift
@@ -43,6 +43,21 @@ final class InferenceAPIController: LocalAPIRouteHandler {
     private func transcribe(_ request: LocalAPI.Request) async -> LocalAPI.Response {
         do {
             if let fileURL = try self.decodeFilePath(from: request) {
+                let sampleCount = try LocalAPIAudioDecoder.validateDurationWithinLimit(for: fileURL)
+
+                if LocalAPI.Configuration.current.saveFileTranscriptionsToHistory {
+                    let transcriptionService = MeetingTranscriptionService(asrService: AppServices.shared.asr)
+                    let result = try await transcriptionService.transcribeFile(fileURL)
+                    return LocalAPI.json(
+                        TranscribeResponse(
+                            text: result.text,
+                            confidence: result.confidence,
+                            sampleCount: sampleCount,
+                            provider: SettingsStore.shared.selectedSpeechModel.displayName
+                        )
+                    )
+                }
+
                 let apiResult = try await AppServices.shared.asr.transcribeFileForAPI(fileURL)
                 return LocalAPI.json(
                     TranscribeResponse(

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIAudioDecoder.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIAudioDecoder.swift
@@ -3,12 +3,12 @@ import Foundation
 
 enum LocalAPIAudioDecoder {
     static let sampleRate: Double = 16_000
-    static let maxDurationSeconds: Double = 300
 
     static func samples(from fileURL: URL) throws -> [Float] {
         let file = try AVAudioFile(forReading: fileURL)
         let sourceFormat = file.processingFormat
-        let maxFrames = AVAudioFramePosition(sourceFormat.sampleRate * self.maxDurationSeconds)
+        let maxDurationSeconds = LocalAPI.Configuration.current.fileUploadDurationSeconds
+        let maxFrames = maxDurationSeconds.map { AVAudioFramePosition(sourceFormat.sampleRate * $0) } ?? file.length
         let framesToRead = min(file.length, maxFrames)
         guard framesToRead > 0 else { return [] }
 
@@ -42,13 +42,15 @@ enum LocalAPIAudioDecoder {
             throw NSError(domain: "LocalAPIAudioDecoder", code: -6, userInfo: [NSLocalizedDescriptionKey: "Audio file has an invalid sample rate."])
         }
 
-        let maxFrames = AVAudioFramePosition(sourceFormat.sampleRate * self.maxDurationSeconds)
-        guard file.length <= maxFrames else {
-            throw NSError(
-                domain: "LocalAPIAudioDecoder",
-                code: -5,
-                userInfo: [NSLocalizedDescriptionKey: "Audio file exceeds the \(Int(self.maxDurationSeconds)) second API limit."]
-            )
+        if let maxDurationSeconds = LocalAPI.Configuration.current.fileUploadDurationSeconds {
+            let maxFrames = AVAudioFramePosition(sourceFormat.sampleRate * maxDurationSeconds)
+            guard file.length <= maxFrames else {
+                throw NSError(
+                    domain: "LocalAPIAudioDecoder",
+                    code: -5,
+                    userInfo: [NSLocalizedDescriptionKey: "Audio file exceeds the \(Int(maxDurationSeconds / 60)) minute API limit."]
+                )
+            }
         }
 
         return Int((Double(file.length) * self.sampleRate / sourceFormat.sampleRate).rounded())

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIModels.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIModels.swift
@@ -3,24 +3,48 @@ import Foundation
 enum LocalAPI {
     static let defaultPort: UInt16 = 47_733
     static let maxRequestBytes = 25 * 1024 * 1024
+    static let defaultFileUploadDurationMinutes = 5
+    static let fileUploadDurationMinutesRange = 0...120
+    static let enabledDefaultsKey = "LocalAPIEnabled"
+    static let fileUploadDurationMinutesDefaultsKey = "LocalAPIFileUploadDurationMinutes"
+    static let fileTranscriptionHistoryDefaultsKey = "LocalAPISaveFileTranscriptionsToHistory"
 
     struct Configuration {
         let enabled: Bool
         let port: UInt16
+        let fileUploadDurationMinutes: Int
+        let saveFileTranscriptionsToHistory: Bool
+
+        var fileUploadDurationSeconds: Double? {
+            guard self.fileUploadDurationMinutes > 0 else { return nil }
+            return Double(self.fileUploadDurationMinutes * 60)
+        }
 
         static var current: Configuration {
             let defaults = UserDefaults.standard
             let enabled: Bool
-            if defaults.object(forKey: "LocalAPIEnabled") == nil {
+            if defaults.object(forKey: LocalAPI.enabledDefaultsKey) == nil {
                 enabled = false
             } else {
-                enabled = defaults.bool(forKey: "LocalAPIEnabled")
+                enabled = defaults.bool(forKey: LocalAPI.enabledDefaultsKey)
             }
 
             let rawPort = defaults.integer(forKey: "LocalAPIPort")
             let port = rawPort > 0 && rawPort <= Int(UInt16.max) ? UInt16(rawPort) : LocalAPI.defaultPort
-            return Configuration(enabled: enabled, port: port)
+            let savedDuration = defaults.object(forKey: LocalAPI.fileUploadDurationMinutesDefaultsKey) as? Int
+            let fileUploadDurationMinutes = LocalAPI.clampFileUploadDurationMinutes(savedDuration ?? LocalAPI.defaultFileUploadDurationMinutes)
+            let saveFileTranscriptionsToHistory = defaults.bool(forKey: LocalAPI.fileTranscriptionHistoryDefaultsKey)
+            return Configuration(
+                enabled: enabled,
+                port: port,
+                fileUploadDurationMinutes: fileUploadDurationMinutes,
+                saveFileTranscriptionsToHistory: saveFileTranscriptionsToHistory
+            )
         }
+    }
+
+    static func clampFileUploadDurationMinutes(_ value: Int) -> Int {
+        min(max(value, self.fileUploadDurationMinutesRange.lowerBound), self.fileUploadDurationMinutesRange.upperBound)
     }
 
     struct Request {

--- a/Sources/Fluid/Services/LocalAPI/LocalAPIServer.swift
+++ b/Sources/Fluid/Services/LocalAPI/LocalAPIServer.swift
@@ -79,6 +79,11 @@ final class LocalAPIServer {
         self.listener = nil
     }
 
+    func reload() {
+        self.stop()
+        self.start()
+    }
+
     private func handleState(_ state: NWListener.State) {
         switch state {
         case .ready:

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -64,6 +64,10 @@ struct SettingsView: View {
     @State private var isRollingBack: Bool = false
     @State private var audioHistoryBudgetText: String = Self.audioBudgetText(for: SettingsStore.shared.audioHistoryBudgetGB)
     @State private var audioHistoryUsageBytes: Int64 = DictationAudioHistoryStore.shared.audioUsageBytes()
+    @State private var localAPIEnabled = LocalAPI.Configuration.current.enabled
+    @State private var localAPIFileUploadDurationMinutes = LocalAPI.Configuration.current.fileUploadDurationMinutes
+    @State private var localAPIFileUploadDurationText = String(LocalAPI.Configuration.current.fileUploadDurationMinutes)
+    @State private var localAPISavesFileTranscriptionsToHistory = LocalAPI.Configuration.current.saveFileTranscriptionsToHistory
 
     let hotkeyManager: GlobalHotkeyManager?
     let menuBarManager: MenuBarManager
@@ -1455,6 +1459,8 @@ struct SettingsView: View {
                         .padding(16)
                 }
 
+                self.localAPISettingsCard
+
                 // Debug Settings Card
                 ThemedCard(style: .standard) {
                     VStack(alignment: .leading, spacing: 14) {
@@ -1593,6 +1599,23 @@ struct SettingsView: View {
         }
         .onChange(of: self.visualizerNoiseThreshold) { _, newValue in
             SettingsStore.shared.visualizerNoiseThreshold = newValue
+        }
+        .onChange(of: self.localAPIEnabled) { _, enabled in
+            UserDefaults.standard.set(enabled, forKey: LocalAPI.enabledDefaultsKey)
+            LocalAPIServer.shared.reload()
+        }
+        .onChange(of: self.localAPIFileUploadDurationMinutes) { _, minutes in
+            UserDefaults.standard.set(
+                LocalAPI.clampFileUploadDurationMinutes(minutes),
+                forKey: LocalAPI.fileUploadDurationMinutesDefaultsKey
+            )
+        }
+        .onChange(of: self.localAPIFileUploadDurationText) { _, text in
+            guard let minutes = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) else { return }
+            self.localAPIFileUploadDurationMinutes = LocalAPI.clampFileUploadDurationMinutes(minutes)
+        }
+        .onChange(of: self.localAPISavesFileTranscriptionsToHistory) { _, enabled in
+            UserDefaults.standard.set(enabled, forKey: LocalAPI.fileTranscriptionHistoryDefaultsKey)
         }
     }
 
@@ -2518,6 +2541,17 @@ struct FlowLayout: Layout {
 }
 
 private extension SettingsView {
+    var localAPIFileUploadDurationBinding: Binding<Int> {
+        Binding(
+            get: { self.localAPIFileUploadDurationMinutes },
+            set: { minutes in
+                let clampedMinutes = LocalAPI.clampFileUploadDurationMinutes(minutes)
+                self.localAPIFileUploadDurationMinutes = clampedMinutes
+                self.localAPIFileUploadDurationText = String(clampedMinutes)
+            }
+        )
+    }
+
     var lowLatencyAudioCaptureToggle: some View {
         Group {
             self.settingsToggleRow(
@@ -2538,6 +2572,73 @@ private extension SettingsView {
             .disabled(self.asr.isRunning)
 
             Divider().padding(.vertical, 8)
+        }
+    }
+}
+
+private extension SettingsView {
+    var localAPISettingsCard: some View {
+        ThemedCard(style: .standard) {
+            VStack(alignment: .leading, spacing: 14) {
+                Label("Local API", systemImage: "network")
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    self.settingsToggleRow(
+                        title: "Enable Local API",
+                        description: "Allow other apps on this Mac to use FluidVoice transcription and text processing.",
+                        footnote: "The API only accepts connections from this Mac at http://127.0.0.1:\(LocalAPI.defaultPort).",
+                        isOn: self.$localAPIEnabled
+                    )
+
+                    Divider().padding(.vertical, 4)
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Maximum file duration")
+                                .font(self.theme.typography.bodyStrong)
+                                .foregroundStyle(self.settingsTitleText)
+                            Text("Set 0 for no limit, or enter a limit in minutes.")
+                                .font(self.theme.typography.bodySmall)
+                                .foregroundStyle(self.settingsSecondaryText)
+                        }
+
+                        Spacer()
+
+                        HStack(spacing: 4) {
+                            TextField("", text: self.$localAPIFileUploadDurationText)
+                                .textFieldStyle(.roundedBorder)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: 48)
+                                .onSubmit {
+                                    self.localAPIFileUploadDurationText = String(self.localAPIFileUploadDurationMinutes)
+                                }
+
+                            Stepper(
+                                "",
+                                value: self.localAPIFileUploadDurationBinding,
+                                in: LocalAPI.fileUploadDurationMinutesRange
+                            )
+                            .labelsHidden()
+
+                            Text(self.localAPIFileUploadDurationMinutes == 0 ? "unlimited" : "min")
+                                .font(self.theme.typography.bodySmall)
+                                .foregroundStyle(self.settingsSecondaryText)
+                        }
+                    }
+
+                    Divider().padding(.vertical, 4)
+
+                    self.settingsToggleRow(
+                        title: "Save API file transcriptions to history",
+                        description: "Show successful API file-path transcriptions in File Transcriptions history.",
+                        footnote: "Raw and base64 audio requests are not saved.",
+                        isOn: self.$localAPISavesFileTranscriptionsToHistory
+                    )
+                }
+            }
+            .padding(16)
         }
     }
 }


### PR DESCRIPTION
## Description
Adds a compact Local API Settings section. Users can enable or disable the existing localhost-only API, set the maximum duration for audio files submitted for API transcription (`0` for no limit, otherwise 1–120 minutes; default: 5), and opt in to saving successful API file-path transcriptions in the existing File Transcriptions history. The enable switch reloads the listener immediately; no endpoints, authentication model, or network exposure change.

## Type of Change
- [x] ✨ New feature
- [ ] 🐞 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Implements the proposal in https://github.com/altic-dev/FluidVoice/discussions/639.

## Testing
- [x] Tested manually on Apple Silicon Mac
- [x] Verified the Local API with a file-path transcription request
- [x] Verified the duration input, including `0` for unlimited duration
- [x] Verified opt-in saving of API file-path transcriptions to File Transcriptions history
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Tested on Intel Mac
- [ ] Ran tests locally

## Screenshots / Video
Demo video recorded locally; attach the supplied MP4 here through GitHub’s PR editor.

https://github.com/user-attachments/assets/04f94661-9c74-45d6-8ef8-22d6d9ff6e62



## Notes
History is off by default. It applies to requests that provide a local file path; raw and base64 audio requests remain stateless. The branch is based directly on tag `v1.6.4` (`6174aa7`) and contains one focused commit.