### PR TITLE
Fix main window stranded on unreachable Space in menu-bar-only mode

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7C5AF14C2F15041600DE21B0 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7C9A71022F58B00000FB7CAF /* TranscribeCpp in Frameworks */ = {isa = PBXBuildFile; productRef = 7C9A71012F58B00000FB7CAF /* TranscribeCpp */; };
 		7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */; };
+		7C91B0AA2F42AA0100C0DEAA /* WindowRevealTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0AB2F42AA0100C0DEAB /* WindowRevealTests.swift */; };
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
 		86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */; };
@@ -51,6 +52,7 @@
 		7C078D8F2E3B339200FB7CAC /* FluidVoice Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FluidVoice Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidDictationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
+		7C91B0AB2F42AA0100C0DEAB /* WindowRevealTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowRevealTests.swift; sourceTree = "<group>"; };
 		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
 		343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMClientRequestBodyTests.swift; sourceTree = "<group>"; };
 		980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSupportTests.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				7CDB0A272F3C4D5600FB7CAD /* Resources */,
 				7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */,
 				7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */,
+				7C91B0AB2F42AA0100C0DEAB /* WindowRevealTests.swift */,
 				343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */,
 				980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */,
 				A62300000000000000000001 /* AudioBufferConverterTests.swift */,
@@ -283,6 +286,7 @@
 				7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */,
 				7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */,
 				7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */,
+				7C91B0AA2F42AA0100C0DEAA /* WindowRevealTests.swift in Sources */,
 				86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */,
 				272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */,
 				A62300000000000000000002 /* AudioBufferConverterTests.swift in Sources */,

--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -310,11 +310,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     @discardableResult
     private func bringMainWindowToFrontIfPresent() -> Bool {
         if let mainWindow = NSApp.windows.first(where: self.isMainWindow) {
-            if mainWindow.alphaValue <= 0.01 {
-                mainWindow.alphaValue = 1
-            }
-            mainWindow.orderFrontRegardless()
-            mainWindow.makeKeyAndOrderFront(nil)
+            mainWindow.revealOnActiveSpace()
             DebugLogger.shared.debug("Brought main window to front", source: "AppDelegate")
             return true
         }

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -944,10 +944,6 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
 
     private func bringToFront(_ window: NSWindow) {
         // Keep ordering explicit to avoid "opened but behind other apps" behavior.
-        if window.alphaValue <= 0.01 {
-            window.alphaValue = 1
-        }
-        window.orderFrontRegardless()
-        window.makeKeyAndOrderFront(nil)
+        window.revealOnActiveSpace()
     }
 }

--- a/Sources/Fluid/UI/NSWindow+ActiveSpaceReveal.swift
+++ b/Sources/Fluid/UI/NSWindow+ActiveSpaceReveal.swift
@@ -1,0 +1,19 @@
+import AppKit
+
+extension NSWindow {
+    /// Reveal the window on the Space the user is currently viewing.
+    ///
+    /// The window server can leave the main window bound to another Space — including a
+    /// defunct one left over from a previous session. When the app runs as an accessory
+    /// (hidden from Dock and Cmd+Tab), the user has no way to travel to that Space, and a
+    /// plain `orderFrontRegardless()` "succeeds" invisibly there. `.moveToActiveSpace`
+    /// makes every reveal collect the window onto the active Space instead.
+    func revealOnActiveSpace() {
+        self.collectionBehavior.insert(.moveToActiveSpace)
+        if self.alphaValue <= 0.01 {
+            self.alphaValue = 1
+        }
+        self.orderFrontRegardless()
+        self.makeKeyAndOrderFront(nil)
+    }
+}

--- a/Sources/Fluid/UI/NSWindow+ActiveSpaceReveal.swift
+++ b/Sources/Fluid/UI/NSWindow+ActiveSpaceReveal.swift
@@ -7,13 +7,20 @@ extension NSWindow {
     /// defunct one left over from a previous session. When the app runs as an accessory
     /// (hidden from Dock and Cmd+Tab), the user has no way to travel to that Space, and a
     /// plain `orderFrontRegardless()` "succeeds" invisibly there. `.moveToActiveSpace`
-    /// makes every reveal collect the window onto the active Space instead.
+    /// makes the reveal collect the window onto the active Space instead.
+    ///
+    /// The behavior is scoped to this reveal: it is restored on the next runloop pass so
+    /// direct ordering calls elsewhere keep the window's normal Space affinity.
     func revealOnActiveSpace() {
+        let originalBehavior = self.collectionBehavior
         self.collectionBehavior.insert(.moveToActiveSpace)
         if self.alphaValue <= 0.01 {
             self.alphaValue = 1
         }
         self.orderFrontRegardless()
         self.makeKeyAndOrderFront(nil)
+        DispatchQueue.main.async { [weak self] in
+            self?.collectionBehavior = originalBehavior
+        }
     }
 }

--- a/Tests/FluidDictationIntegrationTests/WindowRevealTests.swift
+++ b/Tests/FluidDictationIntegrationTests/WindowRevealTests.swift
@@ -1,0 +1,26 @@
+import AppKit
+@testable import FluidVoice_Debug
+import XCTest
+
+final class WindowRevealTests: XCTestCase {
+    /// Regression: the main window could be stranded on another (even defunct) Space,
+    /// where accessory-mode reveals succeeded invisibly. Every reveal must opt the
+    /// window into collecting onto the user's active Space.
+    @MainActor
+    func testRevealOnActiveSpaceAdoptsMoveToActiveSpaceBehavior() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: true
+        )
+        window.isReleasedWhenClosed = false
+        window.alphaValue = 0
+
+        window.revealOnActiveSpace()
+
+        XCTAssertTrue(window.collectionBehavior.contains(.moveToActiveSpace))
+        XCTAssertEqual(window.alphaValue, 1)
+        window.close()
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/WindowRevealTests.swift
+++ b/Tests/FluidDictationIntegrationTests/WindowRevealTests.swift
@@ -17,10 +17,19 @@ final class WindowRevealTests: XCTestCase {
         window.isReleasedWhenClosed = false
         window.alphaValue = 0
 
+        let originalBehavior = window.collectionBehavior
         window.revealOnActiveSpace()
 
         XCTAssertTrue(window.collectionBehavior.contains(.moveToActiveSpace))
         XCTAssertEqual(window.alphaValue, 1)
+
+        // The behavior is scoped to the reveal and restored on the next runloop pass.
+        let restored = expectation(description: "collection behavior restored")
+        DispatchQueue.main.async {
+            XCTAssertEqual(window.collectionBehavior, originalBehavior)
+            restored.fulfill()
+        }
+        wait(for: [restored], timeout: 2)
         window.close()
     }
 }


### PR DESCRIPTION
## Description
The window server can leave the main window bound to another Space — including a defunct one from a previous session — where `orderFrontRegardless()` "succeeds" invisibly. In menu-bar-only mode (Hide from Dock & App Switcher) the user has no Dock icon or Cmd+Tab to recover it, so the app appears windowless: launch shows nothing, and menu bar → Settings... does nothing, while the log claims "Brought main window to front".

Fix: add `NSWindow.revealOnActiveSpace()` which inserts `.moveToActiveSpace` into the window's collection behavior before ordering front, so every reveal collects the window onto the Space the user is currently viewing. Used in both reveal paths: `AppDelegate.bringMainWindowToFrontIfPresent()` (launch/reopen/notification) and `MenuBarManager.bringToFront(_:)` (menu bar → Settings/openMainWindow).

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #646

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26 (Darwin 25.5)
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: `FluidDictationIntegrationTests/WindowRevealTests` (new regression test) — passed

Live verification: with the app in accessory mode, stranded the main window on another Space, then clicked menu bar → Settings... — the window is collected onto the current Space. Reproduced the pre-fix failure the same way.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
No pixel-level UI changes — the fix changes *where* the window appears (always the user's active Space). A screenshot cannot capture Space collection; the Testing section describes the live repro/verification instead. Side benefit: opening from the menu bar now brings the window to the user's current Space rather than relying on macOS to switch Spaces.