### PR TITLE
fix(ai): preserve custom model IDs across refresh

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -50,11 +50,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		7C078D8F2E3B339200FB7CAC /* FluidVoice Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FluidVoice Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidDictationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
 		A60100000000000000000001 /* AIModelRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIModelRefreshTests.swift; sourceTree = "<group>"; };
-		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
 		343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMClientRequestBodyTests.swift; sourceTree = "<group>"; };
 		980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSupportTests.swift; sourceTree = "<group>"; };
 		A62300000000000000000001 /* AudioBufferConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioBufferConverterTests.swift; sourceTree = "<group>"; };

--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7C5AF14C2F15041600DE21B0 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7C9A71022F58B00000FB7CAF /* TranscribeCpp in Frameworks */ = {isa = PBXBuildFile; productRef = 7C9A71012F58B00000FB7CAF /* TranscribeCpp */; };
 		7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */; };
+		A60100000000000000000002 /* AIModelRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60100000000000000000001 /* AIModelRefreshTests.swift */; };
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
 		86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */; };
@@ -49,6 +50,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7C078D8F2E3B339200FB7CAC /* FluidVoice Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FluidVoice Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidDictationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
+		A60100000000000000000001 /* AIModelRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIModelRefreshTests.swift; sourceTree = "<group>"; };
+		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
 		343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMClientRequestBodyTests.swift; sourceTree = "<group>"; };
 		980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSupportTests.swift; sourceTree = "<group>"; };
 		A62300000000000000000001 /* AudioBufferConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioBufferConverterTests.swift; sourceTree = "<group>"; };
@@ -124,6 +130,7 @@
 			children = (
 				7CDB0A262F3C4D5600FB7CAD /* Helpers */,
 				7CDB0A272F3C4D5600FB7CAD /* Resources */,
+				A60100000000000000000001 /* AIModelRefreshTests.swift */,
 				7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */,
 				7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */,
 				343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */,
@@ -281,6 +288,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A60100000000000000000002 /* AIModelRefreshTests.swift in Sources */,
 				7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */,
 				7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */,
 				7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */,

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -11,6 +11,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let selectedProviderID: String
     let selectedModelByProvider: [String: String]
     // Optional so backups created before custom model persistence still decode.
+    // swiftlint:disable:next discouraged_optional_collection
     let customModelsByProvider: [String: [String]]?
     let savedProviders: [SettingsStore.SavedProvider]
     let modelReasoningConfigs: [String: SettingsStore.ModelReasoningConfig]

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -10,6 +10,8 @@ struct BackupFileVersion: Codable, Equatable {
 struct SettingsBackupPayload: Codable, Equatable {
     let selectedProviderID: String
     let selectedModelByProvider: [String: String]
+    // Optional so backups created before custom model persistence still decode.
+    let customModelsByProvider: [String: [String]]?
     let savedProviders: [SettingsStore.SavedProvider]
     let modelReasoningConfigs: [String: SettingsStore.ModelReasoningConfig]
     let privateAIPrefixKVCacheEnabled: Bool?

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1511,11 +1511,28 @@ final class SettingsStore: ObservableObject {
         )
     }
 
-    func prepareLegacyModelCatalogRestore() {
+    func prepareLegacyModelCatalogRestore(savedProviders: [SavedProvider]) {
         self.availableModels = []
-        self.availableModelsByProvider = [:]
+        self.availableModelsByProvider = Self.availableModelsAfterRestore(
+            customModelsByProvider: [:],
+            savedProviders: savedProviders
+        )
         self.clearStoredCustomModelsByProvider()
         self.clearStoredLegacyModelCandidatesByProvider()
+    }
+
+    func customModelsByProviderForBackup() -> [String: [String]] {
+        guard !self.hasStoredCustomModelsByProvider else {
+            return self.customModelsByProvider
+        }
+        let savedModelsByProvider = Dictionary(
+            self.savedProviders.map { ($0.id, $0.models) },
+            uniquingKeysWith: { _, newer in newer }
+        )
+        return AIModelCatalog.migratedLegacyCustomModels(
+            cachedModelsByProvider: self.availableModelsByProvider,
+            savedModelsByProvider: savedModelsByProvider
+        )
     }
 
     var enableDebugLogs: Bool {
@@ -3100,7 +3117,7 @@ final class SettingsStore: ObservableObject {
         SettingsBackupPayload(
             selectedProviderID: self.selectedProviderID,
             selectedModelByProvider: self.selectedModelByProvider,
-            customModelsByProvider: self.customModelsByProvider,
+            customModelsByProvider: self.customModelsByProviderForBackup(),
             savedProviders: self.savedProviders,
             modelReasoningConfigs: self.modelReasoningConfigs,
             privateAIPrefixKVCacheEnabled: self.privateAIPrefixKVCacheEnabled,
@@ -3208,7 +3225,7 @@ final class SettingsStore: ObservableObject {
                 savedProviders: self.savedProviders
             )
         } else {
-            self.prepareLegacyModelCatalogRestore()
+            self.prepareLegacyModelCatalogRestore(savedProviders: self.savedProviders)
         }
         self.modelReasoningConfigs = payload.modelReasoningConfigs
         if let privateAIPrefixKVCacheEnabled = payload.privateAIPrefixKVCacheEnabled {

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -3137,8 +3137,6 @@ final class SettingsStore: ObservableObject {
         self.clearStoredLegacyModelCandidatesByProvider()
         if let customModelsByProvider = payload.customModelsByProvider {
             self.customModelsByProvider = customModelsByProvider
-        } else {
-            self.clearStoredCustomModelsByProvider()
         }
         self.modelReasoningConfigs = payload.modelReasoningConfigs
         if let privateAIPrefixKVCacheEnabled = payload.privateAIPrefixKVCacheEnabled {

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1412,6 +1412,14 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    var customModelsByProvider: [String: [String]] {
+        get { (self.defaults.dictionary(forKey: Keys.customModelsByProvider) as? [String: [String]]) ?? [:] }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.customModelsByProvider)
+        }
+    }
+
     var enableDebugLogs: Bool {
         get {
             let value = self.defaults.object(forKey: Keys.enableDebugLogs)
@@ -4872,6 +4880,7 @@ private extension SettingsStore {
         static let enableDebugLogs = "EnableDebugLogs"
         static let availableAIModels = "AvailableAIModels"
         static let availableModelsByProvider = "AvailableModelsByProvider"
+        static let customModelsByProvider = "CustomModelsByProvider"
         static let selectedAIModel = "SelectedAIModel"
         static let selectedModelByProvider = "SelectedModelByProvider"
         static let selectedProviderID = "SelectedProviderID"

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -23,6 +23,7 @@ final class SettingsStore: ObservableObject {
     static let privateAIDictationRoundTripTokenCost = 2.75
     static let privateAIBackendPreferenceDefaultsKey = "FluidIntelligenceBackendPreference"
     static let customModelsByProviderDefaultsKey = "CustomModelsByProvider"
+    static let legacyModelCandidatesByProviderDefaultsKey = "LegacyModelCandidatesByProvider"
     private static let forcedOnboardingResetIntroducedAt = Date(timeIntervalSince1970: 1_782_091_732)
     private let defaults = UserDefaults.standard
     private let keychain = KeychainService.shared
@@ -1430,6 +1431,23 @@ final class SettingsStore: ObservableObject {
     func clearStoredCustomModelsByProvider() {
         objectWillChange.send()
         self.defaults.removeObject(forKey: Self.customModelsByProviderDefaultsKey)
+    }
+
+    var legacyModelCandidatesByProvider: [String: [String]] {
+        get {
+            (self.defaults.dictionary(
+                forKey: Self.legacyModelCandidatesByProviderDefaultsKey
+            ) as? [String: [String]]) ?? [:]
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Self.legacyModelCandidatesByProviderDefaultsKey)
+        }
+    }
+
+    func clearStoredLegacyModelCandidatesByProvider() {
+        objectWillChange.send()
+        self.defaults.removeObject(forKey: Self.legacyModelCandidatesByProviderDefaultsKey)
     }
 
     var enableDebugLogs: Bool {
@@ -3116,6 +3134,7 @@ final class SettingsStore: ObservableObject {
         self.savedProviders = payload.savedProviders
         self.selectedProviderID = payload.selectedProviderID
         self.selectedModelByProvider = payload.selectedModelByProvider
+        self.clearStoredLegacyModelCandidatesByProvider()
         if let customModelsByProvider = payload.customModelsByProvider {
             self.customModelsByProvider = customModelsByProvider
         } else {

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1423,6 +1423,10 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    var hasStoredCustomModelsByProvider: Bool {
+        self.defaults.object(forKey: Self.customModelsByProviderDefaultsKey) != nil
+    }
+
     var enableDebugLogs: Bool {
         get {
             let value = self.defaults.object(forKey: Keys.enableDebugLogs)
@@ -3005,6 +3009,7 @@ final class SettingsStore: ObservableObject {
         SettingsBackupPayload(
             selectedProviderID: self.selectedProviderID,
             selectedModelByProvider: self.selectedModelByProvider,
+            customModelsByProvider: self.customModelsByProvider,
             savedProviders: self.savedProviders,
             modelReasoningConfigs: self.modelReasoningConfigs,
             privateAIPrefixKVCacheEnabled: self.privateAIPrefixKVCacheEnabled,
@@ -3106,6 +3111,7 @@ final class SettingsStore: ObservableObject {
         self.savedProviders = payload.savedProviders
         self.selectedProviderID = payload.selectedProviderID
         self.selectedModelByProvider = payload.selectedModelByProvider
+        self.customModelsByProvider = payload.customModelsByProvider ?? [:]
         self.modelReasoningConfigs = payload.modelReasoningConfigs
         if let privateAIPrefixKVCacheEnabled = payload.privateAIPrefixKVCacheEnabled {
             self.privateAIPrefixKVCacheEnabled = privateAIPrefixKVCacheEnabled

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1450,6 +1450,74 @@ final class SettingsStore: ObservableObject {
         self.defaults.removeObject(forKey: Self.legacyModelCandidatesDefaultsKey)
     }
 
+    static func availableModelsAfterRestore(
+        customModelsByProvider: [String: [String]],
+        savedProviders: [SavedProvider]
+    ) -> [String: [String]] {
+        func normalized(_ models: [String]) -> [String] {
+            var seen: Set<String> = []
+            return models.compactMap { model in
+                let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { return nil }
+                return trimmed
+            }
+        }
+
+        func providerKey(_ providerID: String) -> String {
+            let trimmed = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return "" }
+            let lower = trimmed.lowercased()
+            if ModelRepository.shared.isBuiltIn(lower) {
+                return lower
+            }
+            return trimmed.hasPrefix("custom:") ? trimmed : "custom:\(trimmed)"
+        }
+
+        var restored: [String: [String]] = [:]
+        for provider in savedProviders {
+            let key = providerKey(provider.id)
+            let models = normalized(provider.models)
+            if !key.isEmpty, !models.isEmpty {
+                restored[key] = models
+            }
+        }
+
+        for (providerID, customModels) in customModelsByProvider {
+            let key = providerKey(providerID)
+            guard !key.isEmpty else { continue }
+            let defaults = ModelRepository.shared.isBuiltIn(key)
+                ? ModelRepository.shared.defaultModels(for: key)
+                : restored[key] ?? []
+            let models = normalized(defaults + customModels)
+            if models.isEmpty {
+                restored.removeValue(forKey: key)
+            } else {
+                restored[key] = models
+            }
+        }
+        return restored
+    }
+
+    func restoreModelCatalogState(
+        customModelsByProvider: [String: [String]],
+        savedProviders: [SavedProvider]
+    ) {
+        self.availableModels = []
+        self.clearStoredLegacyModelCandidatesByProvider()
+        self.customModelsByProvider = customModelsByProvider
+        self.availableModelsByProvider = Self.availableModelsAfterRestore(
+            customModelsByProvider: customModelsByProvider,
+            savedProviders: savedProviders
+        )
+    }
+
+    func prepareLegacyModelCatalogRestore() {
+        self.availableModels = []
+        self.availableModelsByProvider = [:]
+        self.clearStoredCustomModelsByProvider()
+        self.clearStoredLegacyModelCandidatesByProvider()
+    }
+
     var enableDebugLogs: Bool {
         get {
             let value = self.defaults.object(forKey: Keys.enableDebugLogs)
@@ -3134,13 +3202,13 @@ final class SettingsStore: ObservableObject {
         self.savedProviders = payload.savedProviders
         self.selectedProviderID = payload.selectedProviderID
         self.selectedModelByProvider = payload.selectedModelByProvider
-        self.clearStoredLegacyModelCandidatesByProvider()
         if let customModelsByProvider = payload.customModelsByProvider {
-            self.customModelsByProvider = customModelsByProvider
+            self.restoreModelCatalogState(
+                customModelsByProvider: customModelsByProvider,
+                savedProviders: self.savedProviders
+            )
         } else {
-            // Legacy backups predate the dedicated custom-model store. Remove
-            // local state so the restored provider catalogs can be migrated.
-            self.clearStoredCustomModelsByProvider()
+            self.prepareLegacyModelCatalogRestore()
         }
         self.modelReasoningConfigs = payload.modelReasoningConfigs
         if let privateAIPrefixKVCacheEnabled = payload.privateAIPrefixKVCacheEnabled {

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1427,6 +1427,11 @@ final class SettingsStore: ObservableObject {
         self.defaults.object(forKey: Self.customModelsByProviderDefaultsKey) != nil
     }
 
+    func clearStoredCustomModelsByProvider() {
+        objectWillChange.send()
+        self.defaults.removeObject(forKey: Self.customModelsByProviderDefaultsKey)
+    }
+
     var enableDebugLogs: Bool {
         get {
             let value = self.defaults.object(forKey: Keys.enableDebugLogs)
@@ -3111,7 +3116,11 @@ final class SettingsStore: ObservableObject {
         self.savedProviders = payload.savedProviders
         self.selectedProviderID = payload.selectedProviderID
         self.selectedModelByProvider = payload.selectedModelByProvider
-        self.customModelsByProvider = payload.customModelsByProvider ?? [:]
+        if let customModelsByProvider = payload.customModelsByProvider {
+            self.customModelsByProvider = customModelsByProvider
+        } else {
+            self.clearStoredCustomModelsByProvider()
+        }
         self.modelReasoningConfigs = payload.modelReasoningConfigs
         if let privateAIPrefixKVCacheEnabled = payload.privateAIPrefixKVCacheEnabled {
             self.privateAIPrefixKVCacheEnabled = privateAIPrefixKVCacheEnabled

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -22,6 +22,7 @@ final class SettingsStore: ObservableObject {
     static let privateAIDictationMinimumOutputTokens = 256
     static let privateAIDictationRoundTripTokenCost = 2.75
     static let privateAIBackendPreferenceDefaultsKey = "FluidIntelligenceBackendPreference"
+    static let customModelsByProviderDefaultsKey = "CustomModelsByProvider"
     private static let forcedOnboardingResetIntroducedAt = Date(timeIntervalSince1970: 1_782_091_732)
     private let defaults = UserDefaults.standard
     private let keychain = KeychainService.shared
@@ -1413,10 +1414,12 @@ final class SettingsStore: ObservableObject {
     }
 
     var customModelsByProvider: [String: [String]] {
-        get { (self.defaults.dictionary(forKey: Keys.customModelsByProvider) as? [String: [String]]) ?? [:] }
+        get {
+            (self.defaults.dictionary(forKey: Self.customModelsByProviderDefaultsKey) as? [String: [String]]) ?? [:]
+        }
         set {
             objectWillChange.send()
-            self.defaults.set(newValue, forKey: Keys.customModelsByProvider)
+            self.defaults.set(newValue, forKey: Self.customModelsByProviderDefaultsKey)
         }
     }
 
@@ -4880,7 +4883,6 @@ private extension SettingsStore {
         static let enableDebugLogs = "EnableDebugLogs"
         static let availableAIModels = "AvailableAIModels"
         static let availableModelsByProvider = "AvailableModelsByProvider"
-        static let customModelsByProvider = "CustomModelsByProvider"
         static let selectedAIModel = "SelectedAIModel"
         static let selectedModelByProvider = "SelectedModelByProvider"
         static let selectedProviderID = "SelectedProviderID"

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1433,6 +1433,16 @@ final class SettingsStore: ObservableObject {
         self.defaults.removeObject(forKey: Self.customModelsByProviderDefaultsKey)
     }
 
+    func restoreCustomModelsByProvider(_ models: [String: [String]]?) {
+        if let models {
+            self.customModelsByProvider = models
+        } else {
+            // Legacy backups predate the dedicated custom-model store. Remove
+            // local state so the restored provider catalogs can be migrated.
+            self.clearStoredCustomModelsByProvider()
+        }
+    }
+
     var legacyModelCandidatesByProvider: [String: [String]] {
         get {
             (self.defaults.dictionary(
@@ -3135,9 +3145,7 @@ final class SettingsStore: ObservableObject {
         self.selectedProviderID = payload.selectedProviderID
         self.selectedModelByProvider = payload.selectedModelByProvider
         self.clearStoredLegacyModelCandidatesByProvider()
-        if let customModelsByProvider = payload.customModelsByProvider {
-            self.customModelsByProvider = customModelsByProvider
-        }
+        self.restoreCustomModelsByProvider(payload.customModelsByProvider)
         self.modelReasoningConfigs = payload.modelReasoningConfigs
         if let privateAIPrefixKVCacheEnabled = payload.privateAIPrefixKVCacheEnabled {
             self.privateAIPrefixKVCacheEnabled = privateAIPrefixKVCacheEnabled

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -23,7 +23,7 @@ final class SettingsStore: ObservableObject {
     static let privateAIDictationRoundTripTokenCost = 2.75
     static let privateAIBackendPreferenceDefaultsKey = "FluidIntelligenceBackendPreference"
     static let customModelsByProviderDefaultsKey = "CustomModelsByProvider"
-    static let legacyModelCandidatesByProviderDefaultsKey = "LegacyModelCandidatesByProvider"
+    static let legacyModelCandidatesDefaultsKey = "LegacyModelCandidatesByProvider"
     private static let forcedOnboardingResetIntroducedAt = Date(timeIntervalSince1970: 1_782_091_732)
     private let defaults = UserDefaults.standard
     private let keychain = KeychainService.shared
@@ -1436,18 +1436,18 @@ final class SettingsStore: ObservableObject {
     var legacyModelCandidatesByProvider: [String: [String]] {
         get {
             (self.defaults.dictionary(
-                forKey: Self.legacyModelCandidatesByProviderDefaultsKey
+                forKey: Self.legacyModelCandidatesDefaultsKey
             ) as? [String: [String]]) ?? [:]
         }
         set {
             objectWillChange.send()
-            self.defaults.set(newValue, forKey: Self.legacyModelCandidatesByProviderDefaultsKey)
+            self.defaults.set(newValue, forKey: Self.legacyModelCandidatesDefaultsKey)
         }
     }
 
     func clearStoredLegacyModelCandidatesByProvider() {
         objectWillChange.send()
-        self.defaults.removeObject(forKey: Self.legacyModelCandidatesByProviderDefaultsKey)
+        self.defaults.removeObject(forKey: Self.legacyModelCandidatesDefaultsKey)
     }
 
     var enableDebugLogs: Bool {

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1433,16 +1433,6 @@ final class SettingsStore: ObservableObject {
         self.defaults.removeObject(forKey: Self.customModelsByProviderDefaultsKey)
     }
 
-    func restoreCustomModelsByProvider(_ models: [String: [String]]?) {
-        if let models {
-            self.customModelsByProvider = models
-        } else {
-            // Legacy backups predate the dedicated custom-model store. Remove
-            // local state so the restored provider catalogs can be migrated.
-            self.clearStoredCustomModelsByProvider()
-        }
-    }
-
     var legacyModelCandidatesByProvider: [String: [String]] {
         get {
             (self.defaults.dictionary(
@@ -3145,7 +3135,13 @@ final class SettingsStore: ObservableObject {
         self.selectedProviderID = payload.selectedProviderID
         self.selectedModelByProvider = payload.selectedModelByProvider
         self.clearStoredLegacyModelCandidatesByProvider()
-        self.restoreCustomModelsByProvider(payload.customModelsByProvider)
+        if let customModelsByProvider = payload.customModelsByProvider {
+            self.customModelsByProvider = customModelsByProvider
+        } else {
+            // Legacy backups predate the dedicated custom-model store. Remove
+            // local state so the restored provider catalogs can be migrated.
+            self.clearStoredCustomModelsByProvider()
+        }
         self.modelReasoningConfigs = payload.modelReasoningConfigs
         if let privateAIPrefixKVCacheEnabled = payload.privateAIPrefixKVCacheEnabled {
             self.privateAIPrefixKVCacheEnabled = privateAIPrefixKVCacheEnabled

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -109,6 +109,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let customModels: [String]
     }
 
+    struct ManualModelDeletion: Equatable {
+        let visibleModels: [String]
+        let customModels: [String]
+        let selectedModel: String
+    }
+
     @Published var cachedProviderItems: [ProviderItemData] = []
     @Published var cachedVerifiedProviderItems: [ProviderItemData] = []
     @Published var cachedUnverifiedProviderItems: [ProviderItemData] = []
@@ -1306,46 +1312,86 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.invalidateVerification(for: self.selectedProviderID)
     }
 
-    func deleteSelectedModel() {
-        let key = self.providerKey(for: self.selectedProviderID)
-        self.customModelsByProvider[key]?.removeAll { $0 == self.selectedModel }
-        self.legacyModelCandidatesByProvider[key]?.removeAll { $0 == self.selectedModel }
-        if self.customModelsByProvider[key]?.isEmpty == true {
+    func deleteSelectedModel(for providerID: String) {
+        let key = self.providerKey(for: providerID)
+        let selectedModel = self.selectedModelByProvider[key] ?? ""
+        let visibleModels = self.availableModelsByProvider[key] ?? []
+        guard let deletion = Self.manualModelDeletion(
+            selectedModel,
+            visibleModels: visibleModels,
+            customModels: self.customModelsByProvider[key] ?? [],
+            fallbackModels: ModelRepository.shared.defaultModels(for: key)
+        ) else { return }
+
+        if deletion.customModels.isEmpty {
             self.customModelsByProvider.removeValue(forKey: key)
+        } else {
+            self.customModelsByProvider[key] = deletion.customModels
         }
+        self.legacyModelCandidatesByProvider[key]?.removeAll { $0 == selectedModel }
         if self.legacyModelCandidatesByProvider[key]?.isEmpty == true {
             self.legacyModelCandidatesByProvider.removeValue(forKey: key)
         }
         self.settings.customModelsByProvider = self.customModelsByProvider
         self.settings.legacyModelCandidatesByProvider = self.legacyModelCandidatesByProvider
 
-        var list = self.availableModelsByProvider[key] ?? self.availableModels
-        list.removeAll { $0 == self.selectedModel }
-        if list.isEmpty { list = ModelRepository.shared.defaultModels(for: key) }
-        self.availableModelsByProvider[key] = list
+        self.availableModelsByProvider[key] = deletion.visibleModels
         self.settings.availableModelsByProvider = self.availableModelsByProvider
 
-        if let providerIndex = savedProviders.firstIndex(where: { $0.id == selectedProviderID }) {
+        if let providerIndex = savedProviders.firstIndex(where: { $0.id == providerID }) {
             let updatedProvider = SettingsStore.SavedProvider(
                 id: self.savedProviders[providerIndex].id,
                 name: self.savedProviders[providerIndex].name,
                 baseURL: self.savedProviders[providerIndex].baseURL,
-                models: list
+                models: deletion.visibleModels
             )
             self.savedProviders[providerIndex] = updatedProvider
             self.saveSavedProviders()
         }
 
-        self.availableModels = list
-        self.selectedModel = list.first ?? ""
-        self.selectedModelByProvider[key] = self.selectedModel
+        self.selectedModelByProvider[key] = deletion.selectedModel
         self.settings.selectedModelByProvider = self.selectedModelByProvider
+        if self.selectedProviderID == providerID {
+            self.availableModels = deletion.visibleModels
+            self.selectedModel = deletion.selectedModel
+        }
+    }
+
+    func deleteSelectedModel() {
+        self.deleteSelectedModel(for: self.selectedProviderID)
+    }
+
+    func canDeleteSelectedModel(for providerID: String) -> Bool {
+        let key = self.providerKey(for: providerID)
+        guard let selectedModel = self.selectedModelByProvider[key] else { return false }
+        return self.customModelsByProvider[key]?.contains(selectedModel) == true
     }
 
     func canDeleteSelectedModel() -> Bool {
-        let key = self.providerKey(for: self.selectedProviderID)
-        return !ModelRepository.shared.isBuiltIn(self.selectedProviderID) ||
-            (self.customModelsByProvider[key]?.contains(self.selectedModel) == true)
+        self.canDeleteSelectedModel(for: self.selectedProviderID)
+    }
+
+    static func manualModelDeletion(
+        _ selectedModel: String,
+        visibleModels: [String],
+        customModels: [String],
+        fallbackModels: [String]
+    ) -> ManualModelDeletion? {
+        let customModels = AIModelCatalog.normalized(customModels)
+        guard customModels.contains(selectedModel) else { return nil }
+
+        let remainingCustomModels = customModels.filter { $0 != selectedModel }
+        var remainingVisibleModels = AIModelCatalog.normalized(
+            visibleModels.filter { $0 != selectedModel }
+        )
+        if remainingVisibleModels.isEmpty {
+            remainingVisibleModels = AIModelCatalog.normalized(fallbackModels)
+        }
+        return ManualModelDeletion(
+            visibleModels: remainingVisibleModels,
+            customModels: remainingCustomModels,
+            selectedModel: remainingVisibleModels.first ?? ""
+        )
     }
 
     func fetchModelsForCurrentProvider() async {

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -703,9 +703,22 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         return AIModelCatalog.normalized(legacyModels).filter { !discovered.contains($0) }
     }
 
+    static func visibleModelsForManualAddition(
+        _ cachedModels: [String],
+        providerKey: String
+    ) -> [String] {
+        self.modelsByMergingCustomModels(
+            cachedModels,
+            customModels: [],
+            providerKey: providerKey,
+            useDefaultModels: cachedModels.isEmpty
+        )
+    }
+
     func addNewModel() {
         let key = self.providerKey(for: self.selectedProviderID)
-        let visibleModels = self.availableModelsByProvider[key] ?? self.availableModels
+        let cachedModels = self.availableModelsByProvider[key] ?? self.availableModels
+        let visibleModels = Self.visibleModelsForManualAddition(cachedModels, providerKey: key)
         let customModels = self.customModelsByProvider[key] ?? []
         guard let addition = Self.manualModelAddition(
             self.newModelName,

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -229,10 +229,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             )
         }
         for (key, customModels) in normalizedCustom {
+            let hasDiscoveredModels = normalized[key] != nil
             normalized[key] = Self.modelsByMergingCustomModels(
-                normalized[key],
+                normalized[key] ?? [],
                 customModels: customModels,
-                providerKey: key
+                providerKey: key,
+                useDefaultModels: !hasDiscoveredModels
             )
         }
         self.availableModelsByProvider = normalized
@@ -679,15 +681,16 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     }
 
     static func modelsByMergingCustomModels(
-        _ discoveredModels: [String]?,
+        _ discoveredModels: [String],
         customModels: [String],
-        providerKey: String
+        providerKey: String,
+        useDefaultModels: Bool
     ) -> [String] {
-        let discoveredFallback = ModelRepository.shared.isBuiltIn(providerKey)
+        let discoveredFallback = useDefaultModels && ModelRepository.shared.isBuiltIn(providerKey)
             ? ModelRepository.shared.defaultModels(for: providerKey)
-            : []
+            : discoveredModels
         return AIModelCatalog.merged(
-            discoveredModels: discoveredModels ?? discoveredFallback,
+            discoveredModels: discoveredFallback,
             customModels: customModels
         )
     }

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -229,9 +229,10 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             )
         }
         for (key, customModels) in normalizedCustom {
-            normalized[key] = AIModelCatalog.merged(
-                discoveredModels: normalized[key] ?? [],
-                customModels: customModels
+            normalized[key] = Self.modelsByMergingCustomModels(
+                normalized[key],
+                customModels: customModels,
+                providerKey: key
             )
         }
         self.availableModelsByProvider = normalized
@@ -671,32 +672,24 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         cachedModelsByProvider: [String: [String]],
         savedModelsByProvider: [String: [String]]
     ) -> [String: [String]] {
-        var candidates: [String: [String]] = [:]
+        self.migratedLegacyCustomModels(
+            cachedModelsByProvider: cachedModelsByProvider,
+            savedModelsByProvider: savedModelsByProvider
+        )
+    }
 
-        func providerKey(_ providerID: String) -> String {
-            let trimmed = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return "" }
-            let lower = trimmed.lowercased()
-            if ModelRepository.shared.isBuiltIn(lower) {
-                return lower
-            }
-            return trimmed.hasPrefix("custom:") ? trimmed : "custom:\(trimmed)"
-        }
-
-        for source in [cachedModelsByProvider, savedModelsByProvider] {
-            for (providerID, models) in source {
-                let key = providerKey(providerID)
-                let normalized = AIModelCatalog.normalized(models)
-                if !key.isEmpty, !normalized.isEmpty {
-                    candidates[key] = AIModelCatalog.merged(
-                        discoveredModels: candidates[key] ?? [],
-                        customModels: normalized
-                    )
-                }
-            }
-        }
-
-        return candidates
+    static func modelsByMergingCustomModels(
+        _ discoveredModels: [String]?,
+        customModels: [String],
+        providerKey: String
+    ) -> [String] {
+        let discoveredFallback = ModelRepository.shared.isBuiltIn(providerKey)
+            ? ModelRepository.shared.defaultModels(for: providerKey)
+            : []
+        return AIModelCatalog.merged(
+            discoveredModels: discoveredModels ?? discoveredFallback,
+            customModels: customModels
+        )
     }
 
     static func reconciledLegacyCustomModels(

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -703,6 +703,23 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         return AIModelCatalog.normalized(legacyModels).filter { !discovered.contains($0) }
     }
 
+    static func customModelsAfterReconcilingLegacyCandidates(
+        customModels: [String],
+        legacyCandidates: [String],
+        discoveredModels: [String]
+    ) -> [String] {
+        let candidates = Set(AIModelCatalog.normalized(legacyCandidates))
+        let retainedCustomModels = AIModelCatalog.normalized(customModels).filter {
+            !candidates.contains($0)
+        }
+        return AIModelCatalog.normalized(
+            retainedCustomModels + self.reconciledLegacyCustomModels(
+                legacyModels: legacyCandidates,
+                discoveredModels: discoveredModels
+            )
+        )
+    }
+
     static func visibleModelsForManualAddition(
         _ cachedModels: [String],
         providerKey: String
@@ -1279,15 +1296,15 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         providerKey: String
     ) -> [String] {
         if let legacyModels = self.legacyModelCandidatesByProvider.removeValue(forKey: providerKey) {
-            let reconciled = Self.reconciledLegacyCustomModels(
-                legacyModels: legacyModels,
+            let reconciledCustomModels = Self.customModelsAfterReconcilingLegacyCandidates(
+                customModels: self.customModelsByProvider[providerKey] ?? [],
+                legacyCandidates: legacyModels,
                 discoveredModels: discoveredModels
             )
-            if !reconciled.isEmpty {
-                self.customModelsByProvider[providerKey] = AIModelCatalog.merged(
-                    discoveredModels: self.customModelsByProvider[providerKey] ?? [],
-                    customModels: reconciled
-                )
+            if reconciledCustomModels.isEmpty {
+                self.customModelsByProvider.removeValue(forKey: providerKey)
+            } else {
+                self.customModelsByProvider[providerKey] = reconciledCustomModels
             }
             self.settings.legacyModelCandidatesByProvider = self.legacyModelCandidatesByProvider
             self.settings.customModelsByProvider = self.customModelsByProvider

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -164,6 +164,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.settings.reconcilePromptStateAfterProfileChanges()
         self.selectedProviderID = self.settings.selectedProviderID
 
+        let hasStoredCustomModels = self.settings.hasStoredCustomModelsByProvider
         self.availableModelsByProvider = self.settings.availableModelsByProvider
         self.customModelsByProvider = self.settings.customModelsByProvider
         self.selectedModelByProvider = self.settings.selectedModelByProvider
@@ -205,6 +206,15 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             if !providerKey.isEmpty, !clean.isEmpty {
                 normalizedCustom[providerKey] = clean
             }
+        }
+        if !hasStoredCustomModels {
+            normalizedCustom = Self.migratedLegacyCustomModels(
+                cachedModelsByProvider: normalized,
+                savedModelsByProvider: Dictionary(
+                    self.savedProviders.map { ($0.id, $0.models) },
+                    uniquingKeysWith: { _, newer in newer }
+                )
+            )
         }
         for (key, customModels) in normalizedCustom {
             normalized[key] = AIModelCatalog.merged(
@@ -597,6 +607,42 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             visibleModels: visibleAddition.models,
             customModels: updatedCustomModels
         )
+    }
+
+    static func migratedLegacyCustomModels(
+        cachedModelsByProvider: [String: [String]],
+        savedModelsByProvider: [String: [String]]
+    ) -> [String: [String]] {
+        var migrated: [String: [String]] = [:]
+
+        func providerKey(_ providerID: String) -> String {
+            let trimmed = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return "" }
+            let lower = trimmed.lowercased()
+            if ModelRepository.shared.isBuiltIn(lower) {
+                return lower
+            }
+            return trimmed.hasPrefix("custom:") ? trimmed : "custom:\(trimmed)"
+        }
+
+        for (providerID, models) in cachedModelsByProvider.merging(
+            savedModelsByProvider,
+            uniquingKeysWith: { cached, saved in AIModelCatalog.merged(
+                discoveredModels: cached,
+                customModels: saved
+            ) }
+        ) {
+            let key = providerKey(providerID)
+            let normalized = AIModelCatalog.normalized(models)
+            if !key.isEmpty, !normalized.isEmpty {
+                migrated[key] = AIModelCatalog.merged(
+                    discoveredModels: migrated[key] ?? [],
+                    customModels: normalized
+                )
+            }
+        }
+
+        return migrated
     }
 
     func addNewModel() {
@@ -1221,6 +1267,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.selectedModel = list.first ?? ""
         self.selectedModelByProvider[key] = self.selectedModel
         self.settings.selectedModelByProvider = self.selectedModelByProvider
+    }
+
+    func canDeleteSelectedModel() -> Bool {
+        let key = self.providerKey(for: self.selectedProviderID)
+        return !ModelRepository.shared.isBuiltIn(self.selectedProviderID) ||
+            (self.customModelsByProvider[key]?.contains(self.selectedModel) == true)
     }
 
     func fetchModelsForCurrentProvider() async {

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -628,46 +628,10 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         cachedModelsByProvider: [String: [String]],
         savedModelsByProvider: [String: [String]]
     ) -> [String: [String]] {
-        var migrated: [String: [String]] = [:]
-
-        func providerKey(_ providerID: String) -> String {
-            let trimmed = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return "" }
-            let lower = trimmed.lowercased()
-            if ModelRepository.shared.isBuiltIn(lower) {
-                return lower
-            }
-            return trimmed.hasPrefix("custom:") ? trimmed : "custom:\(trimmed)"
-        }
-
-        func appendedManualModels(_ models: [String]) -> [String] {
-            let normalizedInOrder = models
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }
-            guard normalizedInOrder.count > 1,
-                  let firstAppendedIndex = (1 ..< normalizedInOrder.count).first(where: {
-                      normalizedInOrder[$0] < normalizedInOrder[$0 - 1]
-                  })
-            else {
-                return []
-            }
-            return AIModelCatalog.normalized(Array(normalizedInOrder[firstAppendedIndex...]))
-        }
-
-        for source in [cachedModelsByProvider, savedModelsByProvider] {
-            for (providerID, models) in source {
-                let key = providerKey(providerID)
-                let appendedModels = appendedManualModels(models)
-                if !key.isEmpty, !appendedModels.isEmpty {
-                    migrated[key] = AIModelCatalog.merged(
-                        discoveredModels: migrated[key] ?? [],
-                        customModels: appendedModels
-                    )
-                }
-            }
-        }
-
-        return migrated
+        AIModelCatalog.migratedLegacyCustomModels(
+            cachedModelsByProvider: cachedModelsByProvider,
+            savedModelsByProvider: savedModelsByProvider
+        )
     }
 
     static func legacyModelCandidates(

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -18,6 +18,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
     // Model Management
     @Published var availableModelsByProvider: [String: [String]] = [:]
+    @Published var customModelsByProvider: [String: [String]] = [:]
     @Published var selectedModelByProvider: [String: String] = [:]
     @Published var availableModels: [String] = []
     @Published var selectedModel: String = "" {
@@ -158,6 +159,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.selectedProviderID = self.settings.selectedProviderID
 
         self.availableModelsByProvider = self.settings.availableModelsByProvider
+        self.customModelsByProvider = self.settings.customModelsByProvider
         self.selectedModelByProvider = self.settings.selectedModelByProvider
         self.providerAPIKeys = self.settings.providerAPIKeys
         self.savedProviders = self.settings.savedProviders
@@ -190,8 +192,24 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             let clean = Array(Set(models.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) })).sorted()
             if !clean.isEmpty { normalized[newKey] = clean }
         }
+        var normalizedCustom: [String: [String]] = [:]
+        for (key, models) in self.customModelsByProvider {
+            let providerKey = self.providerKey(for: key)
+            let clean = AIModelCatalog.normalized(models)
+            if !providerKey.isEmpty, !clean.isEmpty {
+                normalizedCustom[providerKey] = clean
+            }
+        }
+        for (key, customModels) in normalizedCustom {
+            normalized[key] = AIModelCatalog.merged(
+                discoveredModels: normalized[key] ?? [],
+                customModels: customModels
+            )
+        }
         self.availableModelsByProvider = normalized
         self.settings.availableModelsByProvider = normalized
+        self.customModelsByProvider = normalizedCustom
+        self.settings.customModelsByProvider = normalizedCustom
 
         // Normalize selected model by provider
         var normalizedSel: [String: String] = [:]
@@ -535,6 +553,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     func saveSavedProviders() {
         self.settings.savedProviders = self.savedProviders
         self.settings.availableModelsByProvider = self.availableModelsByProvider
+        self.settings.customModelsByProvider = self.customModelsByProvider
         self.settings.selectedModelByProvider = self.selectedModelByProvider
         self.settings.selectedProviderID = self.selectedProviderID
         self.refreshProviderItems()
@@ -555,32 +574,36 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     }
 
     func addNewModel() {
-        guard !self.newModelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        let modelName = self.newModelName.trimmingCharacters(in: .whitespacesAndNewlines)
         let key = self.providerKey(for: self.selectedProviderID)
+        let visibleModels = self.availableModelsByProvider[key] ?? self.availableModels
+        guard let visibleAddition = AIModelCatalog.adding(self.newModelName, to: visibleModels) else { return }
+        let modelName = visibleAddition.modelID
+        let list = visibleAddition.models
 
-        var list = self.availableModelsByProvider[key] ?? self.availableModels
-        if !list.contains(modelName) {
-            list.append(modelName)
-            self.availableModelsByProvider[key] = list
-            self.settings.availableModelsByProvider = self.availableModelsByProvider
-
-            if let providerIndex = savedProviders.firstIndex(where: { $0.id == selectedProviderID }) {
-                let updatedProvider = SettingsStore.SavedProvider(
-                    id: self.savedProviders[providerIndex].id,
-                    name: self.savedProviders[providerIndex].name,
-                    baseURL: self.savedProviders[providerIndex].baseURL,
-                    models: list
-                )
-                self.savedProviders[providerIndex] = updatedProvider
-                self.saveSavedProviders()
-            }
-
-            self.availableModels = list
-            self.selectedModel = modelName
-            self.selectedModelByProvider[key] = modelName
-            self.settings.selectedModelByProvider = self.selectedModelByProvider
+        let customModels = self.customModelsByProvider[key] ?? []
+        if let customAddition = AIModelCatalog.adding(modelName, to: customModels) {
+            self.customModelsByProvider[key] = customAddition.models
         }
+        self.settings.customModelsByProvider = self.customModelsByProvider
+
+        self.availableModelsByProvider[key] = list
+        self.settings.availableModelsByProvider = self.availableModelsByProvider
+
+        if let providerIndex = savedProviders.firstIndex(where: { $0.id == selectedProviderID }) {
+            let updatedProvider = SettingsStore.SavedProvider(
+                id: self.savedProviders[providerIndex].id,
+                name: self.savedProviders[providerIndex].name,
+                baseURL: self.savedProviders[providerIndex].baseURL,
+                models: list
+            )
+            self.savedProviders[providerIndex] = updatedProvider
+            self.saveSavedProviders()
+        }
+
+        self.availableModels = list
+        self.selectedModel = modelName
+        self.selectedModelByProvider[key] = modelName
+        self.settings.selectedModelByProvider = self.selectedModelByProvider
 
         self.showingAddModel = false
         self.newModelName = ""
@@ -1083,11 +1106,13 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.saveSavedProviders()
         let key = self.providerKey(for: self.selectedProviderID)
         self.availableModelsByProvider.removeValue(forKey: key)
+        self.customModelsByProvider.removeValue(forKey: key)
         self.selectedModelByProvider.removeValue(forKey: key)
         self.providerAPIKeys.removeValue(forKey: key)
         self.saveProviderAPIKeys()
         self.settings.verifiedProviderFingerprints.removeValue(forKey: key)
         self.settings.availableModelsByProvider = self.availableModelsByProvider
+        self.settings.customModelsByProvider = self.customModelsByProvider
         self.settings.selectedModelByProvider = self.selectedModelByProvider
         self.selectedProviderID = ""
         self.openAIBaseURL = ""
@@ -1096,6 +1121,16 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.selectedModel = ""
         self.refreshVerifiedProviders()
         self.selectSoleVerifiedProviderIfNeeded()
+    }
+
+    private func modelsAfterRefresh(
+        discoveredModels: [String],
+        providerKey: String
+    ) -> [String] {
+        return AIModelCatalog.merged(
+            discoveredModels: discoveredModels,
+            customModels: self.customModelsByProvider[providerKey] ?? []
+        )
     }
 
     func saveEditedProvider() {
@@ -1127,6 +1162,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
 
     func deleteSelectedModel() {
         let key = self.providerKey(for: self.selectedProviderID)
+        self.customModelsByProvider[key]?.removeAll { $0 == self.selectedModel }
+        if self.customModelsByProvider[key]?.isEmpty == true {
+            self.customModelsByProvider.removeValue(forKey: key)
+        }
+        self.settings.customModelsByProvider = self.customModelsByProvider
+
         var list = self.availableModelsByProvider[key] ?? self.availableModels
         list.removeAll { $0 == self.selectedModel }
         if list.isEmpty { list = ModelRepository.shared.defaultModels(for: key) }
@@ -1181,8 +1222,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
                     // Keep existing models if fetch returned empty
                     self.fetchModelsError = "No models returned from API"
                 } else {
-                    self.availableModels = models
-                    self.availableModelsByProvider[key] = models
+                    let mergedModels = self.modelsAfterRefresh(
+                        discoveredModels: models,
+                        providerKey: key
+                    )
+                    self.availableModels = mergedModels
+                    self.availableModelsByProvider[key] = mergedModels
                     self.settings.availableModelsByProvider = self.availableModelsByProvider
                     self.fetchedModelsProviders.insert(key)
 
@@ -1191,15 +1236,15 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
                             id: self.savedProviders[providerIndex].id,
                             name: self.savedProviders[providerIndex].name,
                             baseURL: self.savedProviders[providerIndex].baseURL,
-                            models: models
+                            models: mergedModels
                         )
                         self.savedProviders[providerIndex] = updatedProvider
                         self.saveSavedProviders()
                     }
 
                     // Select first model if current selection not in list
-                    if !models.contains(self.selectedModel) {
-                        self.selectedModel = models.first ?? ""
+                    if !mergedModels.contains(self.selectedModel) {
+                        self.selectedModel = mergedModels.first ?? ""
                         self.selectedModelByProvider[key] = self.selectedModel
                         self.settings.selectedModelByProvider = self.selectedModelByProvider
                     }
@@ -1285,19 +1330,23 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
                     return
                 }
 
-                self.availableModelsByProvider[key] = models
+                let selectedForProvider = self.selectedModelByProvider[key] ?? ""
+                let mergedModels = self.modelsAfterRefresh(
+                    discoveredModels: models,
+                    providerKey: key
+                )
+                self.availableModelsByProvider[key] = mergedModels
                 self.settings.availableModelsByProvider = self.availableModelsByProvider
                 self.fetchedModelsProviders.insert(key)
 
                 if providerID == self.selectedProviderID {
-                    self.availableModels = models
-                    if !models.contains(self.selectedModel) {
-                        self.selectedModel = models.first ?? ""
+                    self.availableModels = mergedModels
+                    if !mergedModels.contains(self.selectedModel) {
+                        self.selectedModel = mergedModels.first ?? ""
                     }
                 }
 
-                let selectedForProvider = self.selectedModelByProvider[key] ?? ""
-                if !models.contains(selectedForProvider), let first = models.first {
+                if !mergedModels.contains(selectedForProvider), let first = mergedModels.first {
                     self.selectedModelByProvider[key] = first
                     self.settings.selectedModelByProvider = self.selectedModelByProvider
                 }
@@ -1307,7 +1356,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
                         id: self.savedProviders[providerIndex].id,
                         name: self.savedProviders[providerIndex].name,
                         baseURL: self.savedProviders[providerIndex].baseURL,
-                        models: models
+                        models: mergedModels
                     )
                     self.savedProviders[providerIndex] = updatedProvider
                     self.saveSavedProviders()

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -102,6 +102,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         }
     }
 
+    struct ManualModelAddition: Equatable {
+        let modelID: String
+        let visibleModels: [String]
+        let customModels: [String]
+    }
+
     @Published var cachedProviderItems: [ProviderItemData] = []
     @Published var cachedVerifiedProviderItems: [ProviderItemData] = []
     @Published var cachedUnverifiedProviderItems: [ProviderItemData] = []
@@ -573,16 +579,42 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         return self.settings.isReasoningModel(self.selectedModel)
     }
 
+    static func manualModelAddition(
+        _ enteredModel: String,
+        visibleModels: [String],
+        customModels: [String]
+    ) -> ManualModelAddition? {
+        guard let visibleAddition = AIModelCatalog.adding(enteredModel, to: visibleModels) else { return nil }
+        let wasAlreadyVisible = AIModelCatalog.normalized(visibleModels).contains(visibleAddition.modelID)
+        let updatedCustomModels: [String]
+        if wasAlreadyVisible {
+            updatedCustomModels = AIModelCatalog.normalized(customModels)
+        } else {
+            updatedCustomModels = AIModelCatalog.normalized(customModels + [visibleAddition.modelID])
+        }
+        return ManualModelAddition(
+            modelID: visibleAddition.modelID,
+            visibleModels: visibleAddition.models,
+            customModels: updatedCustomModels
+        )
+    }
+
     func addNewModel() {
         let key = self.providerKey(for: self.selectedProviderID)
         let visibleModels = self.availableModelsByProvider[key] ?? self.availableModels
-        guard let visibleAddition = AIModelCatalog.adding(self.newModelName, to: visibleModels) else { return }
-        let modelName = visibleAddition.modelID
-        let list = visibleAddition.models
-
         let customModels = self.customModelsByProvider[key] ?? []
-        if let customAddition = AIModelCatalog.adding(modelName, to: customModels) {
-            self.customModelsByProvider[key] = customAddition.models
+        guard let addition = Self.manualModelAddition(
+            self.newModelName,
+            visibleModels: visibleModels,
+            customModels: customModels
+        ) else { return }
+        let modelName = addition.modelID
+        let list = addition.visibleModels
+
+        if addition.customModels.isEmpty {
+            self.customModelsByProvider.removeValue(forKey: key)
+        } else {
+            self.customModelsByProvider[key] = addition.customModels
         }
         self.settings.customModelsByProvider = self.customModelsByProvider
 

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -21,6 +21,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     @Published var customModelsByProvider: [String: [String]] = [:]
     @Published var selectedModelByProvider: [String: String] = [:]
     @Published var availableModels: [String] = []
+    private var legacyModelCandidatesByProvider: [String: [String]] = [:]
     @Published var selectedModel: String = "" {
         didSet {
             guard self.selectedModel != "__ADD_MODEL__" else { return }
@@ -167,6 +168,7 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let hasStoredCustomModels = self.settings.hasStoredCustomModelsByProvider
         self.availableModelsByProvider = self.settings.availableModelsByProvider
         self.customModelsByProvider = self.settings.customModelsByProvider
+        self.legacyModelCandidatesByProvider = self.settings.legacyModelCandidatesByProvider
         self.selectedModelByProvider = self.settings.selectedModelByProvider
         self.providerAPIKeys = self.settings.providerAPIKeys
         self.savedProviders = self.settings.savedProviders
@@ -214,6 +216,13 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             }
         }
         if !hasStoredCustomModels {
+            if self.legacyModelCandidatesByProvider.isEmpty {
+                self.legacyModelCandidatesByProvider = Self.legacyModelCandidates(
+                    cachedModelsByProvider: legacyCachedModels,
+                    savedModelsByProvider: legacySavedModels
+                )
+                self.settings.legacyModelCandidatesByProvider = self.legacyModelCandidatesByProvider
+            }
             normalizedCustom = Self.migratedLegacyCustomModels(
                 cachedModelsByProvider: legacyCachedModels,
                 savedModelsByProvider: legacySavedModels
@@ -656,6 +665,46 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         }
 
         return migrated
+    }
+
+    static func legacyModelCandidates(
+        cachedModelsByProvider: [String: [String]],
+        savedModelsByProvider: [String: [String]]
+    ) -> [String: [String]] {
+        var candidates: [String: [String]] = [:]
+
+        func providerKey(_ providerID: String) -> String {
+            let trimmed = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return "" }
+            let lower = trimmed.lowercased()
+            if ModelRepository.shared.isBuiltIn(lower) {
+                return lower
+            }
+            return trimmed.hasPrefix("custom:") ? trimmed : "custom:\(trimmed)"
+        }
+
+        for source in [cachedModelsByProvider, savedModelsByProvider] {
+            for (providerID, models) in source {
+                let key = providerKey(providerID)
+                let normalized = AIModelCatalog.normalized(models)
+                if !key.isEmpty, !normalized.isEmpty {
+                    candidates[key] = AIModelCatalog.merged(
+                        discoveredModels: candidates[key] ?? [],
+                        customModels: normalized
+                    )
+                }
+            }
+        }
+
+        return candidates
+    }
+
+    static func reconciledLegacyCustomModels(
+        legacyModels: [String],
+        discoveredModels: [String]
+    ) -> [String] {
+        let discovered = Set(AIModelCatalog.normalized(discoveredModels))
+        return AIModelCatalog.normalized(legacyModels).filter { !discovered.contains($0) }
     }
 
     func addNewModel() {
@@ -1198,12 +1247,14 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         let key = self.providerKey(for: self.selectedProviderID)
         self.availableModelsByProvider.removeValue(forKey: key)
         self.customModelsByProvider.removeValue(forKey: key)
+        self.legacyModelCandidatesByProvider.removeValue(forKey: key)
         self.selectedModelByProvider.removeValue(forKey: key)
         self.providerAPIKeys.removeValue(forKey: key)
         self.saveProviderAPIKeys()
         self.settings.verifiedProviderFingerprints.removeValue(forKey: key)
         self.settings.availableModelsByProvider = self.availableModelsByProvider
         self.settings.customModelsByProvider = self.customModelsByProvider
+        self.settings.legacyModelCandidatesByProvider = self.legacyModelCandidatesByProvider
         self.settings.selectedModelByProvider = self.selectedModelByProvider
         self.selectedProviderID = ""
         self.openAIBaseURL = ""
@@ -1218,6 +1269,20 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         discoveredModels: [String],
         providerKey: String
     ) -> [String] {
+        if let legacyModels = self.legacyModelCandidatesByProvider.removeValue(forKey: providerKey) {
+            let reconciled = Self.reconciledLegacyCustomModels(
+                legacyModels: legacyModels,
+                discoveredModels: discoveredModels
+            )
+            if !reconciled.isEmpty {
+                self.customModelsByProvider[providerKey] = AIModelCatalog.merged(
+                    discoveredModels: self.customModelsByProvider[providerKey] ?? [],
+                    customModels: reconciled
+                )
+            }
+            self.settings.legacyModelCandidatesByProvider = self.legacyModelCandidatesByProvider
+            self.settings.customModelsByProvider = self.customModelsByProvider
+        }
         return AIModelCatalog.merged(
             discoveredModels: discoveredModels,
             customModels: self.customModelsByProvider[providerKey] ?? []
@@ -1254,10 +1319,15 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
     func deleteSelectedModel() {
         let key = self.providerKey(for: self.selectedProviderID)
         self.customModelsByProvider[key]?.removeAll { $0 == self.selectedModel }
+        self.legacyModelCandidatesByProvider[key]?.removeAll { $0 == self.selectedModel }
         if self.customModelsByProvider[key]?.isEmpty == true {
             self.customModelsByProvider.removeValue(forKey: key)
         }
+        if self.legacyModelCandidatesByProvider[key]?.isEmpty == true {
+            self.legacyModelCandidatesByProvider.removeValue(forKey: key)
+        }
         self.settings.customModelsByProvider = self.customModelsByProvider
+        self.settings.legacyModelCandidatesByProvider = self.legacyModelCandidatesByProvider
 
         var list = self.availableModelsByProvider[key] ?? self.availableModels
         list.removeAll { $0 == self.selectedModel }

--- a/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
+++ b/Sources/Fluid/UI/AISettings/AIEnhancementSettingsViewModel.swift
@@ -178,6 +178,12 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         self.isDictationPromptOff = self.settings.isDictationPromptOff
         self.isEditPromptOff = self.settings.isEditPromptOff
 
+        let legacyCachedModels = self.availableModelsByProvider
+        let legacySavedModels = Dictionary(
+            self.savedProviders.map { ($0.id, $0.models) },
+            uniquingKeysWith: { _, newer in newer }
+        )
+
         if !self.selectedProviderID.isEmpty,
            !ModelRepository.shared.isBuiltIn(self.selectedProviderID),
            self.savedProviders.contains(where: { $0.id == self.selectedProviderID }) == false
@@ -209,11 +215,8 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
         }
         if !hasStoredCustomModels {
             normalizedCustom = Self.migratedLegacyCustomModels(
-                cachedModelsByProvider: normalized,
-                savedModelsByProvider: Dictionary(
-                    self.savedProviders.map { ($0.id, $0.models) },
-                    uniquingKeysWith: { _, newer in newer }
-                )
+                cachedModelsByProvider: legacyCachedModels,
+                savedModelsByProvider: legacySavedModels
             )
         }
         for (key, customModels) in normalizedCustom {
@@ -625,20 +628,30 @@ final class AIEnhancementSettingsViewModel: ObservableObject {
             return trimmed.hasPrefix("custom:") ? trimmed : "custom:\(trimmed)"
         }
 
-        for (providerID, models) in cachedModelsByProvider.merging(
-            savedModelsByProvider,
-            uniquingKeysWith: { cached, saved in AIModelCatalog.merged(
-                discoveredModels: cached,
-                customModels: saved
-            ) }
-        ) {
-            let key = providerKey(providerID)
-            let normalized = AIModelCatalog.normalized(models)
-            if !key.isEmpty, !normalized.isEmpty {
-                migrated[key] = AIModelCatalog.merged(
-                    discoveredModels: migrated[key] ?? [],
-                    customModels: normalized
-                )
+        func appendedManualModels(_ models: [String]) -> [String] {
+            let normalizedInOrder = models
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            guard normalizedInOrder.count > 1,
+                  let firstAppendedIndex = (1 ..< normalizedInOrder.count).first(where: {
+                      normalizedInOrder[$0] < normalizedInOrder[$0 - 1]
+                  })
+            else {
+                return []
+            }
+            return AIModelCatalog.normalized(Array(normalizedInOrder[firstAppendedIndex...]))
+        }
+
+        for source in [cachedModelsByProvider, savedModelsByProvider] {
+            for (providerID, models) in source {
+                let key = providerKey(providerID)
+                let appendedModels = appendedManualModels(models)
+                if !key.isEmpty, !appendedModels.isEmpty {
+                    migrated[key] = AIModelCatalog.merged(
+                        discoveredModels: migrated[key] ?? [],
+                        customModels: appendedModels
+                    )
+                }
             }
         }
 

--- a/Sources/Fluid/UI/AISettings/AIModelCatalog.swift
+++ b/Sources/Fluid/UI/AISettings/AIModelCatalog.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum AIModelCatalog {
+    struct Addition: Equatable {
+        let modelID: String
+        let models: [String]
+    }
+
+    static func merged(
+        discoveredModels: [String],
+        customModels: [String]
+    ) -> [String] {
+        self.normalized(discoveredModels + customModels)
+    }
+
+    static func adding(_ enteredModel: String, to models: [String]) -> Addition? {
+        guard let modelID = self.normalized([enteredModel]).first else { return nil }
+        return Addition(
+            modelID: modelID,
+            models: self.normalized(models + [modelID])
+        )
+    }
+
+    static func normalized(_ models: [String]) -> [String] {
+        var seen: Set<String> = []
+        return models.compactMap { model in
+            let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { return nil }
+            return trimmed
+        }
+    }
+}

--- a/Sources/Fluid/UI/AISettings/AIModelCatalog.swift
+++ b/Sources/Fluid/UI/AISettings/AIModelCatalog.swift
@@ -29,4 +29,50 @@ enum AIModelCatalog {
             return trimmed
         }
     }
+
+    static func migratedLegacyCustomModels(
+        cachedModelsByProvider: [String: [String]],
+        savedModelsByProvider: [String: [String]]
+    ) -> [String: [String]] {
+        var migrated: [String: [String]] = [:]
+
+        func providerKey(_ providerID: String) -> String {
+            let trimmed = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return "" }
+            let lower = trimmed.lowercased()
+            if ModelRepository.shared.isBuiltIn(lower) {
+                return lower
+            }
+            return trimmed.hasPrefix("custom:") ? trimmed : "custom:\(trimmed)"
+        }
+
+        func appendedManualModels(_ models: [String]) -> [String] {
+            let normalizedInOrder = models
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            guard normalizedInOrder.count > 1,
+                  let firstAppendedIndex = (1..<normalizedInOrder.count).first(where: {
+                      normalizedInOrder[$0] < normalizedInOrder[$0 - 1]
+                  })
+            else {
+                return []
+            }
+            return self.normalized(Array(normalizedInOrder[firstAppendedIndex...]))
+        }
+
+        for source in [cachedModelsByProvider, savedModelsByProvider] {
+            for (providerID, models) in source {
+                let key = providerKey(providerID)
+                let appendedModels = appendedManualModels(models)
+                if !key.isEmpty, !appendedModels.isEmpty {
+                    migrated[key] = self.merged(
+                        discoveredModels: migrated[key] ?? [],
+                        customModels: appendedModels
+                    )
+                }
+            }
+        }
+
+        return migrated
+    }
 }

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -1436,6 +1436,16 @@ extension AIEnhancementSettingsView {
                         self.activateProvider(item.id)
                         Task { await self.viewModel.fetchModelsForCurrentProvider() }
                     }
+
+                    self.companionIconButton(systemName: "plus", help: "Add custom model") {
+                        self.activateProvider(item.id)
+                        self.viewModel.newModelName = ""
+                        self.viewModel.showingAddModel = true
+                    }
+                }
+
+                if self.viewModel.showingAddModel && self.viewModel.selectedProviderID == item.id {
+                    self.addModelSection
                 }
 
                 HStack(spacing: 8) {
@@ -1715,6 +1725,13 @@ extension AIEnhancementSettingsView {
                         }
                         .frame(width: iconColumnWidth, height: AISettingsLayout.providerRowControlHeight)
 
+                        self.companionIconButton(systemName: "plus", help: "Add custom model") {
+                            self.activateProvider(item.id)
+                            self.viewModel.newModelName = ""
+                            self.viewModel.showingAddModel = true
+                        }
+                        .frame(width: iconColumnWidth, height: AISettingsLayout.providerRowControlHeight)
+
                         self.reasoningButton(for: item.id)
                             .frame(width: iconColumnWidth, height: AISettingsLayout.providerRowControlHeight)
 
@@ -1748,6 +1765,14 @@ extension AIEnhancementSettingsView {
                     showsLoadingIndicator: isFluidLoading || isFluidTesting
                 )
                 .padding(.top, 8)
+            }
+
+            if !isPrivateAIProvider,
+               self.viewModel.showingAddModel,
+               self.viewModel.selectedProviderID == item.id
+            {
+                self.addModelSection
+                    .padding(.top, 8)
             }
 
             if isPrivateAIProvider, isEditing {

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -2420,7 +2420,7 @@ extension AIEnhancementSettingsView {
                 controlHeight: AISettingsLayout.controlHeight
             )
 
-            if !ModelRepository.shared.isBuiltIn(self.viewModel.selectedProviderID) {
+            if self.viewModel.canDeleteSelectedModel() {
                 Button(action: { self.viewModel.deleteSelectedModel() }) {
                     HStack(spacing: 4) { Image(systemName: "trash"); Text("Delete") }.font(.caption)
                 }

--- a/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
+++ b/Sources/Fluid/UI/AISettingsView+AIConfiguration.swift
@@ -1442,6 +1442,8 @@ extension AIEnhancementSettingsView {
                         self.viewModel.newModelName = ""
                         self.viewModel.showingAddModel = true
                     }
+
+                    self.deleteCustomModelButton(for: item.id)
                 }
 
                 if self.viewModel.showingAddModel && self.viewModel.selectedProviderID == item.id {
@@ -1732,6 +1734,9 @@ extension AIEnhancementSettingsView {
                         }
                         .frame(width: iconColumnWidth, height: AISettingsLayout.providerRowControlHeight)
 
+                        self.deleteCustomModelButton(for: item.id)
+                            .frame(width: iconColumnWidth, height: AISettingsLayout.providerRowControlHeight)
+
                         self.reasoningButton(for: item.id)
                             .frame(width: iconColumnWidth, height: AISettingsLayout.providerRowControlHeight)
 
@@ -1969,6 +1974,16 @@ extension AIEnhancementSettingsView {
                 self.viewModel.selectModel(newValue, for: providerID)
             }
         )
+    }
+
+    @ViewBuilder
+    private func deleteCustomModelButton(for providerID: String) -> some View {
+        if self.viewModel.canDeleteSelectedModel(for: providerID) {
+            self.companionIconButton(systemName: "trash", help: "Delete custom model") {
+                self.activateProvider(providerID)
+                self.viewModel.deleteSelectedModel(for: providerID)
+            }
+        }
     }
 
     private func reasoningButton(for providerID: String) -> some View {

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -35,7 +35,7 @@ final class AIModelRefreshTests: XCTestCase {
         }
 
         SettingsStore.shared.customModelsByProvider = ["openai": ["stale-local-model"]]
-        SettingsStore.shared.restoreCustomModelsByProvider(nil)
+        SettingsStore.shared.clearStoredCustomModelsByProvider()
 
         XCTAssertFalse(SettingsStore.shared.hasStoredCustomModelsByProvider)
         XCTAssertTrue(SettingsStore.shared.customModelsByProvider.isEmpty)

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -1,0 +1,67 @@
+@testable import FluidVoice_Debug
+import XCTest
+
+@MainActor
+final class AIModelRefreshTests: XCTestCase {
+    private let customModelsByProviderKey = "CustomModelsByProvider"
+
+    func testCustomModelsPersistByProvider() {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: self.customModelsByProviderKey)
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: self.customModelsByProviderKey)
+            } else {
+                defaults.removeObject(forKey: self.customModelsByProviderKey)
+            }
+        }
+
+        let providerKey = "custom:issue-601-test"
+        SettingsStore.shared.customModelsByProvider = [providerKey: ["model/custom:nitro"]]
+
+        XCTAssertEqual(
+            SettingsStore.shared.customModelsByProvider[providerKey],
+            ["model/custom:nitro"]
+        )
+    }
+
+    func testRefreshDropsSelectedNonCustomModelMissingFromCatalog() {
+        let selectedModel = "model/retired"
+        let merged = AIModelCatalog.merged(
+            discoveredModels: ["model/a"],
+            customModels: []
+        )
+
+        XCTAssertFalse(merged.contains(selectedModel))
+    }
+
+    func testRefreshKeepsSelectedCustomModel() {
+        let selectedModel = "model/custom:nitro"
+        let merged = AIModelCatalog.merged(
+            discoveredModels: ["model/a"],
+            customModels: [selectedModel]
+        )
+
+        XCTAssertTrue(merged.contains(selectedModel))
+    }
+
+    func testAddingExistingModelReturnsNormalizedSelectionWithoutDuplicate() {
+        XCTAssertEqual(
+            AIModelCatalog.adding(" model/a ", to: ["model/a", "model/b"]),
+            AIModelCatalog.Addition(
+                modelID: "model/a",
+                models: ["model/a", "model/b"]
+            )
+        )
+    }
+
+    func testRefreshDropsBlankModelIDs() {
+        XCTAssertEqual(
+            AIModelCatalog.merged(
+                discoveredModels: ["", " \n "],
+                customModels: [" model/custom "]
+            ),
+            ["model/custom"]
+        )
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -88,6 +88,33 @@ final class AIModelRefreshTests: XCTestCase {
         )
     }
 
+    func testLegacyCandidatesExcludeSortedDiscoveryOnlyCatalogs() {
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.legacyModelCandidates(
+                cachedModelsByProvider: [
+                    "openai": ["gpt-a", "gpt-b", "gpt-retired"],
+                    "groq": ["model-a", "model-z", "manual-model"],
+                ],
+                savedModelsByProvider: [:]
+            ),
+            ["groq": ["manual-model"]]
+        )
+    }
+
+    func testCustomModelsMergeWithBuiltInDefaultsWhenCacheIsMissing() {
+        let defaultModels = ModelRepository.shared.defaultModels(for: "openai")
+        XCTAssertFalse(defaultModels.isEmpty)
+
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.modelsByMergingCustomModels(
+                nil,
+                customModels: ["gpt-custom"],
+                providerKey: "openai"
+            ),
+            AIModelCatalog.normalized(defaultModels + ["gpt-custom"])
+        )
+    }
+
     func testRefreshDropsSelectedNonCustomModelMissingFromCatalog() {
         let selectedModel = "model/retired"
         let merged = AIModelCatalog.merged(

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -54,9 +54,32 @@ final class AIModelRefreshTests: XCTestCase {
     }
 
     func testRestoringLegacyBackupRehydratesSavedProviderCatalog() {
+        let defaults = UserDefaults.standard
+        let previousCustomModels = defaults.object(
+            forKey: SettingsStore.customModelsByProviderDefaultsKey
+        )
+        let previousLegacyCandidates = defaults.object(
+            forKey: SettingsStore.legacyModelCandidatesDefaultsKey
+        )
         let previousAvailableModels = SettingsStore.shared.availableModels
         let previousAvailableModelsByProvider = SettingsStore.shared.availableModelsByProvider
         defer {
+            if let previousCustomModels {
+                defaults.set(
+                    previousCustomModels,
+                    forKey: SettingsStore.customModelsByProviderDefaultsKey
+                )
+            } else {
+                defaults.removeObject(forKey: SettingsStore.customModelsByProviderDefaultsKey)
+            }
+            if let previousLegacyCandidates {
+                defaults.set(
+                    previousLegacyCandidates,
+                    forKey: SettingsStore.legacyModelCandidatesDefaultsKey
+                )
+            } else {
+                defaults.removeObject(forKey: SettingsStore.legacyModelCandidatesDefaultsKey)
+            }
             SettingsStore.shared.availableModels = previousAvailableModels
             SettingsStore.shared.availableModelsByProvider = previousAvailableModelsByProvider
         }
@@ -323,6 +346,30 @@ final class AIModelRefreshTests: XCTestCase {
             AIModelCatalog.Addition(
                 modelID: "model/a",
                 models: ["model/a", "model/b"]
+            )
+        )
+    }
+
+    func testDeletingCustomModelRemovesOnlyManualCatalogEntries() {
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.manualModelDeletion(
+                "model/custom",
+                visibleModels: ["model/discovered", "model/custom"],
+                customModels: ["model/custom"],
+                fallbackModels: ["model/fallback"]
+            ),
+            AIEnhancementSettingsViewModel.ManualModelDeletion(
+                visibleModels: ["model/discovered"],
+                customModels: [],
+                selectedModel: "model/discovered"
+            )
+        )
+        XCTAssertNil(
+            AIEnhancementSettingsViewModel.manualModelDeletion(
+                "model/discovered",
+                visibleModels: ["model/discovered", "model/custom"],
+                customModels: ["model/custom"],
+                fallbackModels: ["model/fallback"]
             )
         )
     }

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -23,6 +23,24 @@ final class AIModelRefreshTests: XCTestCase {
         )
     }
 
+    func testRestoringLegacyBackupClearsStoredCustomModels() {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: SettingsStore.customModelsByProviderDefaultsKey)
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: SettingsStore.customModelsByProviderDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: SettingsStore.customModelsByProviderDefaultsKey)
+            }
+        }
+
+        SettingsStore.shared.customModelsByProvider = ["openai": ["stale-local-model"]]
+        SettingsStore.shared.restoreCustomModelsByProvider(nil)
+
+        XCTAssertFalse(SettingsStore.shared.hasStoredCustomModelsByProvider)
+        XCTAssertTrue(SettingsStore.shared.customModelsByProvider.isEmpty)
+    }
+
     func testEnteringDiscoveredModelSelectsWithoutPersistingAsCustom() {
         XCTAssertEqual(
             AIEnhancementSettingsViewModel.manualModelAddition(
@@ -112,6 +130,24 @@ final class AIModelRefreshTests: XCTestCase {
                 providerKey: "openai",
                 useDefaultModels: true
             ),
+            AIModelCatalog.normalized(defaultModels + ["gpt-custom"])
+        )
+    }
+
+    func testManualAdditionStartsWithBuiltInDefaultsWhenCacheIsMissing() {
+        let defaultModels = ModelRepository.shared.defaultModels(for: "openai")
+        let visibleModels = AIEnhancementSettingsViewModel.visibleModelsForManualAddition(
+            [],
+            providerKey: "openai"
+        )
+
+        XCTAssertEqual(visibleModels, AIModelCatalog.normalized(defaultModels))
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.manualModelAddition(
+                "gpt-custom",
+                visibleModels: visibleModels,
+                customModels: []
+            )?.visibleModels,
             AIModelCatalog.normalized(defaultModels + ["gpt-custom"])
         )
     }

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -107,9 +107,10 @@ final class AIModelRefreshTests: XCTestCase {
 
         XCTAssertEqual(
             AIEnhancementSettingsViewModel.modelsByMergingCustomModels(
-                nil,
+                [],
                 customModels: ["gpt-custom"],
-                providerKey: "openai"
+                providerKey: "openai",
+                useDefaultModels: true
             ),
             AIModelCatalog.normalized(defaultModels + ["gpt-custom"])
         )

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -101,7 +101,7 @@ final class AIModelRefreshTests: XCTestCase {
 
         SettingsStore.shared.clearStoredCustomModelsByProvider()
         SettingsStore.shared.availableModelsByProvider = [
-            "openai": ["gpt-a", "gpt-z", "manual-a"],
+            "openai": ["gpt-a", "gpt-z", "custom-mid"],
         ]
         SettingsStore.shared.savedProviders = [
             SettingsStore.SavedProvider(
@@ -114,7 +114,7 @@ final class AIModelRefreshTests: XCTestCase {
 
         let payload = SettingsStore.shared.makeBackupPayload()
 
-        XCTAssertEqual(payload.customModelsByProvider?["openai"], ["manual-a"])
+        XCTAssertEqual(payload.customModelsByProvider?["openai"], ["custom-mid"])
         XCTAssertEqual(
             payload.customModelsByProvider?["custom:provider-id"],
             ["manual-provider"]

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -53,20 +53,20 @@ final class AIModelRefreshTests: XCTestCase {
         )
     }
 
-    func testLegacyCachedAndSavedModelsMigrateBeforeFirstRefresh() {
+    func testLegacyAppendedModelsMigrateWithoutPromotingSortedCatalogs() {
         XCTAssertEqual(
             AIEnhancementSettingsViewModel.migratedLegacyCustomModels(
                 cachedModelsByProvider: [
-                    "OpenAI": [" gpt-cached ", "gpt-shared"],
-                    "legacy-provider": ["cached-model"],
+                    "OpenAI": ["gpt-a", "gpt-z", " custom-mid "],
+                    "sorted-provider": ["model-a", "model-b", "model-c"],
                 ],
                 savedModelsByProvider: [
-                    "legacy-provider": ["saved-model", "cached-model"],
+                    "legacy-provider": ["model-a", "model-z", "manual-a", "manual-b"],
                 ]
             ),
             [
-                "openai": ["gpt-cached", "gpt-shared"],
-                "custom:legacy-provider": ["cached-model", "saved-model"],
+                "openai": ["custom-mid"],
+                "custom:legacy-provider": ["manual-a", "manual-b"],
             ]
         )
     }

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -26,19 +26,77 @@ final class AIModelRefreshTests: XCTestCase {
     func testRestoringLegacyBackupClearsStoredCustomModels() {
         let defaults = UserDefaults.standard
         let previousValue = defaults.object(forKey: SettingsStore.customModelsByProviderDefaultsKey)
+        let previousAvailableModels = SettingsStore.shared.availableModels
+        let previousAvailableModelsByProvider = SettingsStore.shared.availableModelsByProvider
+        let previousLegacyCandidates = SettingsStore.shared.legacyModelCandidatesByProvider
         defer {
             if let previousValue {
                 defaults.set(previousValue, forKey: SettingsStore.customModelsByProviderDefaultsKey)
             } else {
                 defaults.removeObject(forKey: SettingsStore.customModelsByProviderDefaultsKey)
             }
+            SettingsStore.shared.availableModels = previousAvailableModels
+            SettingsStore.shared.availableModelsByProvider = previousAvailableModelsByProvider
+            SettingsStore.shared.legacyModelCandidatesByProvider = previousLegacyCandidates
         }
 
         SettingsStore.shared.customModelsByProvider = ["openai": ["stale-local-model"]]
-        SettingsStore.shared.clearStoredCustomModelsByProvider()
+        SettingsStore.shared.availableModels = ["stale-local-model"]
+        SettingsStore.shared.availableModelsByProvider = ["openai": ["gpt-default", "stale-local-model"]]
+        SettingsStore.shared.legacyModelCandidatesByProvider = ["openai": ["stale-local-model"]]
+        SettingsStore.shared.prepareLegacyModelCatalogRestore()
 
         XCTAssertFalse(SettingsStore.shared.hasStoredCustomModelsByProvider)
         XCTAssertTrue(SettingsStore.shared.customModelsByProvider.isEmpty)
+        XCTAssertTrue(SettingsStore.shared.availableModels.isEmpty)
+        XCTAssertTrue(SettingsStore.shared.availableModelsByProvider.isEmpty)
+        XCTAssertTrue(SettingsStore.shared.legacyModelCandidatesByProvider.isEmpty)
+    }
+
+    func testRestoringCustomModelsRehydratesAvailableCatalog() {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: SettingsStore.customModelsByProviderDefaultsKey)
+        let previousAvailableModels = SettingsStore.shared.availableModels
+        let previousAvailableModelsByProvider = SettingsStore.shared.availableModelsByProvider
+        let previousLegacyCandidates = SettingsStore.shared.legacyModelCandidatesByProvider
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: SettingsStore.customModelsByProviderDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: SettingsStore.customModelsByProviderDefaultsKey)
+            }
+            SettingsStore.shared.availableModels = previousAvailableModels
+            SettingsStore.shared.availableModelsByProvider = previousAvailableModelsByProvider
+            SettingsStore.shared.legacyModelCandidatesByProvider = previousLegacyCandidates
+        }
+
+        SettingsStore.shared.availableModelsByProvider = [:]
+        SettingsStore.shared.restoreModelCatalogState(
+            customModelsByProvider: [
+                "openai": ["gpt-custom"],
+                "custom:provider-id": ["provider-custom"],
+            ],
+            savedProviders: [
+                SettingsStore.SavedProvider(
+                    id: "provider-id",
+                    name: "Provider",
+                    baseURL: "https://example.com",
+                    models: ["provider-discovered"]
+                ),
+            ]
+        )
+
+        XCTAssertEqual(SettingsStore.shared.customModelsByProvider["openai"], ["gpt-custom"])
+        XCTAssertEqual(
+            SettingsStore.shared.availableModelsByProvider["openai"],
+            AIModelCatalog.normalized(
+                ModelRepository.shared.defaultModels(for: "openai") + ["gpt-custom"]
+            )
+        )
+        XCTAssertEqual(
+            SettingsStore.shared.availableModelsByProvider["custom:provider-id"],
+            ["provider-discovered", "provider-custom"]
+        )
     }
 
     func testEnteringDiscoveredModelSelectsWithoutPersistingAsCustom() {
@@ -101,6 +159,25 @@ final class AIModelRefreshTests: XCTestCase {
             AIEnhancementSettingsViewModel.reconciledLegacyCustomModels(
                 legacyModels: ["model-a", "model-b", "model-c"],
                 discoveredModels: ["model-a", "model-b", "model-c"]
+            ),
+            []
+        )
+    }
+
+    func testLegacyCandidateReconciliationReplacesCandidateSubset() {
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.customModelsAfterReconcilingLegacyCandidates(
+                customModels: ["official-model", "new-manual-model", "legacy-only-model"],
+                legacyCandidates: ["official-model", "legacy-only-model"],
+                discoveredModels: ["official-model"]
+            ),
+            ["new-manual-model", "legacy-only-model"]
+        )
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.customModelsAfterReconcilingLegacyCandidates(
+                customModels: ["official-model"],
+                legacyCandidates: ["official-model"],
+                discoveredModels: ["official-model"]
             ),
             []
         )

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -3,16 +3,14 @@ import XCTest
 
 @MainActor
 final class AIModelRefreshTests: XCTestCase {
-    private let customModelsByProviderKey = "CustomModelsByProvider"
-
     func testCustomModelsPersistByProvider() {
         let defaults = UserDefaults.standard
-        let previousValue = defaults.object(forKey: self.customModelsByProviderKey)
+        let previousValue = defaults.object(forKey: SettingsStore.customModelsByProviderDefaultsKey)
         defer {
             if let previousValue {
-                defaults.set(previousValue, forKey: self.customModelsByProviderKey)
+                defaults.set(previousValue, forKey: SettingsStore.customModelsByProviderDefaultsKey)
             } else {
-                defaults.removeObject(forKey: self.customModelsByProviderKey)
+                defaults.removeObject(forKey: SettingsStore.customModelsByProviderDefaultsKey)
             }
         }
 
@@ -22,6 +20,36 @@ final class AIModelRefreshTests: XCTestCase {
         XCTAssertEqual(
             SettingsStore.shared.customModelsByProvider[providerKey],
             ["model/custom:nitro"]
+        )
+    }
+
+    func testEnteringDiscoveredModelSelectsWithoutPersistingAsCustom() {
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.manualModelAddition(
+                " model/discovered ",
+                visibleModels: ["model/discovered", "model/other"],
+                customModels: []
+            ),
+            AIEnhancementSettingsViewModel.ManualModelAddition(
+                modelID: "model/discovered",
+                visibleModels: ["model/discovered", "model/other"],
+                customModels: []
+            )
+        )
+    }
+
+    func testEnteringNewManualModelPersistsAsCustom() {
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.manualModelAddition(
+                " model/custom:nitro ",
+                visibleModels: ["model/discovered"],
+                customModels: []
+            ),
+            AIEnhancementSettingsViewModel.ManualModelAddition(
+                modelID: "model/custom:nitro",
+                visibleModels: ["model/discovered", "model/custom:nitro"],
+                customModels: ["model/custom:nitro"]
+            )
         )
     }
 

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -53,6 +53,24 @@ final class AIModelRefreshTests: XCTestCase {
         )
     }
 
+    func testLegacyCachedAndSavedModelsMigrateBeforeFirstRefresh() {
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.migratedLegacyCustomModels(
+                cachedModelsByProvider: [
+                    "OpenAI": [" gpt-cached ", "gpt-shared"],
+                    "legacy-provider": ["cached-model"],
+                ],
+                savedModelsByProvider: [
+                    "legacy-provider": ["saved-model", "cached-model"],
+                ]
+            ),
+            [
+                "openai": ["gpt-cached", "gpt-shared"],
+                "custom:legacy-provider": ["cached-model", "saved-model"],
+            ]
+        )
+    }
+
     func testRefreshDropsSelectedNonCustomModelMissingFromCatalog() {
         let selectedModel = "model/retired"
         let merged = AIModelCatalog.merged(

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -71,6 +71,23 @@ final class AIModelRefreshTests: XCTestCase {
         )
     }
 
+    func testLegacyModelsReconcileAgainstFirstFreshCatalog() {
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.reconciledLegacyCustomModels(
+                legacyModels: ["gpt-4.1", "gpt-5-custom"],
+                discoveredModels: ["gpt-4.1"]
+            ),
+            ["gpt-5-custom"]
+        )
+        XCTAssertEqual(
+            AIEnhancementSettingsViewModel.reconciledLegacyCustomModels(
+                legacyModels: ["model-a", "model-b", "model-c"],
+                discoveredModels: ["model-a", "model-b", "model-c"]
+            ),
+            []
+        )
+    }
+
     func testRefreshDropsSelectedNonCustomModelMissingFromCatalog() {
         let selectedModel = "model/retired"
         let merged = AIModelCatalog.merged(

--- a/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AIModelRefreshTests.swift
@@ -44,13 +44,81 @@ final class AIModelRefreshTests: XCTestCase {
         SettingsStore.shared.availableModels = ["stale-local-model"]
         SettingsStore.shared.availableModelsByProvider = ["openai": ["gpt-default", "stale-local-model"]]
         SettingsStore.shared.legacyModelCandidatesByProvider = ["openai": ["stale-local-model"]]
-        SettingsStore.shared.prepareLegacyModelCatalogRestore()
+        SettingsStore.shared.prepareLegacyModelCatalogRestore(savedProviders: [])
 
         XCTAssertFalse(SettingsStore.shared.hasStoredCustomModelsByProvider)
         XCTAssertTrue(SettingsStore.shared.customModelsByProvider.isEmpty)
         XCTAssertTrue(SettingsStore.shared.availableModels.isEmpty)
         XCTAssertTrue(SettingsStore.shared.availableModelsByProvider.isEmpty)
         XCTAssertTrue(SettingsStore.shared.legacyModelCandidatesByProvider.isEmpty)
+    }
+
+    func testRestoringLegacyBackupRehydratesSavedProviderCatalog() {
+        let previousAvailableModels = SettingsStore.shared.availableModels
+        let previousAvailableModelsByProvider = SettingsStore.shared.availableModelsByProvider
+        defer {
+            SettingsStore.shared.availableModels = previousAvailableModels
+            SettingsStore.shared.availableModelsByProvider = previousAvailableModelsByProvider
+        }
+
+        SettingsStore.shared.availableModelsByProvider = ["custom:provider-id": ["stale-model"]]
+        SettingsStore.shared.prepareLegacyModelCatalogRestore(
+            savedProviders: [
+                SettingsStore.SavedProvider(
+                    id: "provider-id",
+                    name: "Provider",
+                    baseURL: "https://example.com",
+                    models: ["provider-model"]
+                ),
+            ]
+        )
+
+        XCTAssertEqual(
+            SettingsStore.shared.availableModelsByProvider["custom:provider-id"],
+            ["provider-model"]
+        )
+    }
+
+    func testBackupMigratesLegacyManualModelsBeforeSettingsLoad() {
+        let defaults = UserDefaults.standard
+        let previousCustomModels = defaults.object(
+            forKey: SettingsStore.customModelsByProviderDefaultsKey
+        )
+        let previousAvailableModelsByProvider = SettingsStore.shared.availableModelsByProvider
+        let previousSavedProviders = SettingsStore.shared.savedProviders
+        defer {
+            if let previousCustomModels {
+                defaults.set(
+                    previousCustomModels,
+                    forKey: SettingsStore.customModelsByProviderDefaultsKey
+                )
+            } else {
+                defaults.removeObject(forKey: SettingsStore.customModelsByProviderDefaultsKey)
+            }
+            SettingsStore.shared.availableModelsByProvider = previousAvailableModelsByProvider
+            SettingsStore.shared.savedProviders = previousSavedProviders
+        }
+
+        SettingsStore.shared.clearStoredCustomModelsByProvider()
+        SettingsStore.shared.availableModelsByProvider = [
+            "openai": ["gpt-a", "gpt-z", "manual-a"],
+        ]
+        SettingsStore.shared.savedProviders = [
+            SettingsStore.SavedProvider(
+                id: "provider-id",
+                name: "Provider",
+                baseURL: "https://example.com",
+                models: ["model-a", "model-z", "manual-provider"]
+            ),
+        ]
+
+        let payload = SettingsStore.shared.makeBackupPayload()
+
+        XCTAssertEqual(payload.customModelsByProvider?["openai"], ["manual-a"])
+        XCTAssertEqual(
+            payload.customModelsByProvider?["custom:provider-id"],
+            ["manual-provider"]
+        )
     }
 
     func testRestoringCustomModelsRehydratesAvailableCatalog() {


### PR DESCRIPTION
## Description

Makes manual AI model entry reachable from the current provider UI and keeps explicitly added IDs across discovery refreshes.

Custom IDs are stored separately per provider, normalized and deduplicated, merged into the normal model picker, selected immediately after entry, restored on launch, and removed with their provider. Refresh still drops retired discovery-only models and falls back to the first current model.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #601.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: deterministic compiled `AIModelCatalog` harness, `swiftc -parse` for all changed Swift files, and `plutil -lint` for the Xcode project

Upstream validation on the exact PR head:

- SwiftLint: passed
- macOS Xcode build and test: passed
- ad-hoc PR archive: passed (`e604fb152c331d2d9c6e555d7887649a77a2fff3`)
- deterministic coverage for persistence, refresh merge semantics, stale discovery fallback, whitespace, blanks, and duplicate IDs
- `git diff --check`

## Screenshots / Video

The OpenRouter provider card now exposes the Add custom model control and inline model-name field:

![FluidVoice custom model entry](https://raw.githubusercontent.com/floze-the-genius/FluidVoice/pr-assets/.github/pr-assets/fluidvoice-pr-649-custom-model.png)

Screenshot captured from the upstream-generated PR archive for head SHA `e604fb152c331d2d9c6e555d7887649a77a2fff3`.

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes

Only IDs explicitly added as custom survive refresh. A selected discovery-only model that disappears from the provider catalog keeps the existing fallback-to-first behavior instead of being silently promoted to custom storage.
