### PR TITLE
Fix: Escape (cancel) ignored during push-to-talk dictation

### DIFF
--- a/Sources/Fluid/Models/HotkeyShortcut.swift
+++ b/Sources/Fluid/Models/HotkeyShortcut.swift
@@ -282,6 +282,17 @@ extension HotkeyShortcut {
         return keyCode == self.keyCode && modifiers.intersection(Self.relevantModifierMask) == self.relevantModifierFlags
     }
 
+    /// Matches this shortcut's key while tolerating *extra* modifiers that are held down
+    /// but are not part of the shortcut. The shortcut's own modifiers (if any) must still
+    /// all be present. This lets a modifier-less cancel key (e.g. Escape) fire while a
+    /// push-to-talk activation modifier (e.g. Right ⌘) is still being held — the exact
+    /// `matches(_:_:)` check fails there because the held modifier is reported on the event.
+    func matchesAllowingHeldModifiers(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> Bool {
+        guard !self.isMouseShortcut else { return false }
+        let activeModifiers = modifiers.intersection(Self.relevantModifierMask)
+        return keyCode == self.keyCode && activeModifiers.isSuperset(of: self.relevantModifierFlags)
+    }
+
     func matchesMouse(button: Int, modifiers: NSEvent.ModifierFlags) -> Bool {
         guard self.isMouseShortcut, let mouseButton else { return false }
         guard !self.isUnmodifiedLeftOrRightClick else { return false }

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -617,7 +617,17 @@ final class GlobalHotkeyManager: NSObject {
             }
 
             // Check the configured cancel shortcut first.
-            if SettingsStore.shared.cancelRecordingHotkeyShortcut.matches(keyCode: keyCode, modifiers: eventModifiers) {
+            //
+            // While recording via push-to-talk, the activation modifier (e.g. Right ⌘) is
+            // still held when the cancel key is pressed, so its flag rides along on the event
+            // and the exact-modifier match fails — Escape then gets silently ignored. Fall back
+            // to a modifier-tolerant match *only while recording* so the cancel key still fires
+            // mid-hold, without over-consuming cancel-key chords the rest of the time.
+            let cancelShortcut = SettingsStore.shared.cancelRecordingHotkeyShortcut
+            let cancelShortcutPressed = cancelShortcut.matches(keyCode: keyCode, modifiers: eventModifiers)
+                || (self.asrService.isRunning
+                    && cancelShortcut.matchesAllowingHeldModifiers(keyCode: keyCode, modifiers: eventModifiers))
+            if cancelShortcutPressed {
                 var handled = false
 
                 if self.asrService.isRunning {

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -64,6 +64,30 @@ final class HotkeyShortcutTests: XCTestCase {
         XCTAssertTrue(shortcut.matches(keyCode: 61, modifiers: NSEvent.ModifierFlags()))
     }
 
+    func testCancelShortcutMatchesWhilePushToTalkModifierIsHeld() {
+        // Repro: dictation activated by holding Right ⌘ (push-to-talk) in automatic mode,
+        // cancel shortcut is bare Escape. Pressing Escape mid-hold reports ⌘ on the event.
+        let cancelEscape = HotkeyShortcut(keyCode: 53, modifierFlags: [])
+
+        // Exact match fails because the held ⌘ is not part of the cancel shortcut — this is
+        // the bug: Escape gets ignored during push-to-talk.
+        XCTAssertFalse(cancelEscape.matches(keyCode: 53, modifiers: [.command]))
+
+        // Modifier-tolerant match recognises Escape even with the activation modifier held.
+        XCTAssertTrue(cancelEscape.matchesAllowingHeldModifiers(keyCode: 53, modifiers: [.command]))
+        XCTAssertTrue(cancelEscape.matchesAllowingHeldModifiers(keyCode: 53, modifiers: []))
+
+        // A different key still never matches, even with modifiers held.
+        XCTAssertFalse(cancelEscape.matchesAllowingHeldModifiers(keyCode: 61, modifiers: [.command]))
+
+        // The shortcut's own modifiers remain required: ⌘+Escape does not fire on bare Escape,
+        // but tolerates an extra held modifier (e.g. ⌘ + ⌥) on top of its own.
+        let cancelCommandEscape = HotkeyShortcut(keyCode: 53, modifierFlags: [.command])
+        XCTAssertFalse(cancelCommandEscape.matchesAllowingHeldModifiers(keyCode: 53, modifiers: []))
+        XCTAssertTrue(cancelCommandEscape.matchesAllowingHeldModifiers(keyCode: 53, modifiers: [.command]))
+        XCTAssertTrue(cancelCommandEscape.matchesAllowingHeldModifiers(keyCode: 53, modifiers: [.command, .option]))
+    }
+
     func testKeyboardPayloadIgnoresStrayMouseButtonField() throws {
         let json = #"{"kind":"keyboard","keyCode":0,"modifierFlagsRawValue":0,"mouseButton":3}"#
         let data = try XCTUnwrap(json.data(using: .utf8))


### PR DESCRIPTION
## Problem

When the primary dictation shortcut is a **modifier key** (e.g. Right ⌘, the default is Right ⌥) and the hotkey mode is **Hold** or **Automatic**, the activation modifier is still physically held while recording (push-to-talk). Pressing the **cancel shortcut (Escape by default)** mid-hold does nothing — recording keeps running and is never discarded.

### Root cause

Every cancel check goes through `HotkeyShortcut.matches`, which requires an **exact** modifier match:

```swift
return keyCode == self.keyCode
    && modifiers.intersection(relevantModifierMask) == self.relevantModifierFlags
```

While push-to-talk holds the activation modifier, the Escape `keyDown` event reports that modifier on `event.flags`. So for a bare-Escape cancel shortcut (`relevantModifierFlags == []`):

```
matches(53, [.command])  →  53 == 53 ✓  &&  [.command] == [] ✗  →  false
```

The cancel key is silently ignored. If you instead **tap** the shortcut to toggle (modifier released), Escape works — which is why it's config-dependent. Affects the global event-tap path in `GlobalHotkeyManager` (the authoritative one that consumes the event first).

## Fix

Add `HotkeyShortcut.matchesAllowingHeldModifiers`, which still requires the shortcut's **own** modifiers but tolerates *extra* modifiers held on top. Use it in the cancel path **only while recording is active**, so cancel-key chords aren't over-consumed the rest of the time:

```swift
let cancelShortcutPressed = cancelShortcut.matches(keyCode: keyCode, modifiers: eventModifiers)
    || (self.asrService.isRunning
        && cancelShortcut.matchesAllowingHeldModifiers(keyCode: keyCode, modifiers: eventModifiers))
```

Behaviour preserved:
- Bare Escape still cancels as before.
- A cancel shortcut that itself has modifiers keeps requiring them (⌘+Escape does **not** fire on bare Escape).
- Outside of active recording, matching is unchanged (no extra event consumption).

## Tests

Added `testCancelShortcutMatchesWhilePushToTalkModifierIsHeld` covering the push-to-talk repro and the no-regression cases (bare Escape, wrong key, modifier-bearing cancel shortcut).

Also verified by compiling `HotkeyShortcut.swift` standalone against a probe harness — all assertions pass, including that the pre-fix `matches` reproduces the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)