### PR TITLE
Mark temporary pasteboard writes with org.nspasteboard.TransientType so clipboard managers skip dictations

### DIFF
--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -55,6 +55,10 @@ final class TypingService {
     private static let pasteboardRestoreQueue = DispatchQueue(label: "TypingService.PasteboardRestore", qos: .utility)
     private static var focusSnapshot: FocusSnapshot?
 
+    /// Community pasteboard convention (nspasteboard.org): items carrying this type are
+    /// temporary programmatic writes that clipboard managers should not record.
+    private static let transientPasteboardType = NSPasteboard.PasteboardType("org.nspasteboard.TransientType")
+
     private var textInsertionMode: SettingsStore.TextInsertionMode {
         SettingsStore.shared.textInsertionMode
     }
@@ -574,6 +578,9 @@ final class TypingService {
             for (type, data) in snap.dataByType {
                 item.setData(data, forType: type)
             }
+            // The restored payload was already on the pasteboard before we borrowed it, so
+            // clipboard managers recorded it then; the marker stops them re-recording a duplicate.
+            item.setData(Data(), forType: Self.transientPasteboardType)
             return item
         }
         _ = pasteboard.writeObjects(restoredItems)
@@ -596,7 +603,10 @@ final class TypingService {
         let snapshot = self.capturePasteboardSnapshot(pasteboard)
 
         pasteboard.clearContents()
-        guard pasteboard.setString(text, forType: .string) else {
+        let temporaryItem = NSPasteboardItem()
+        temporaryItem.setString(text, forType: .string)
+        temporaryItem.setData(Data(), forType: Self.transientPasteboardType)
+        guard pasteboard.writeObjects([temporaryItem]) else {
             self.log("[TypingService] ERROR: Failed to set temporary clipboard string")
             self.restorePasteboardSnapshot(snapshot, to: pasteboard)
             return false


### PR DESCRIPTION
## Description
Clipboard Paste mode (`reliablePaste`) borrows `NSPasteboard.general` for every dictation: the transcript is written, ⌘V is synthesized into the target app, and the previous clipboard contents are restored a moment later. Both of those writes are programmatic — the user never "copied" anything — but they carry no metadata, so clipboard history managers (Maccy, Raycast Clipboard History, Paste, Alfred, …) record every dictated phrase as a user copy, and then record the snapshot restore as a duplicate of the user's previous clip. Per-app ignore lists in those tools cannot filter this out, because pasteboard changes are attributed to the frontmost application — which during dictation is the paste target, not FluidVoice.

This PR adopts the community pasteboard convention from [nspasteboard.org](http://nspasteboard.org): the temporary transcript item and the restored snapshot items are marked with `org.nspasteboard.TransientType`, which clipboard managers skip by default (Maccy ships it in its built-in ignore list; Raycast, Paste, and Alfred honor it as well). Paste behavior in the target app is unchanged — the marker is just an extra declared type alongside the existing string payload, and the existing `changeCount` / read-back logic is unaffected.

The intentional "copy transcript to clipboard" path (`ClipboardService`) is deliberately untouched: that is a user-requested copy and should remain visible to history tools.

## Type of Change
- [x] ✨ New feature

## Related Issue or Discussion
Discussion #652. Also relevant to #479, where switching to Clipboard Paste mode is the practical workaround — this change removes the clipboard-history side effect of that advice.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5 (Tahoe)
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — 0 violations in 134 files
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources` — note: with no `.swift-version` pinned, the current Homebrew SwiftFormat also wants to reformat several untouched lines in this file; I kept the diff limited to the functional change
- [x] Ran tests locally: `xcodebuild build -project Fluid.xcodeproj -scheme Fluid` succeeds; plus a direct end-to-end validation of the pasteboard convention (below). Left the E2E dictation suite to CI since it exercises STT, not the pasteboard path.

**End-to-end validation against a real clipboard manager** (Maccy 2.6.1, default settings, poll interval 0.5 s): a small harness wrote two sentinel strings to `NSPasteboard.general` — one plain, one constructed exactly as this patch does (`NSPasteboardItem` with `.string` payload + empty-data `org.nspasteboard.TransientType`). Inspecting Maccy's history store afterwards: the plain sentinel was recorded, the marked sentinel was not, and a transient-marked snapshot restore was not re-recorded.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Marking the *restore* write as well is intentional: the restored payload was already on the pasteboard before FluidVoice borrowed it, so history tools recorded it at the time of the original user copy; marking the rewrite prevents the duplicate/reordered entry users currently see after every dictation. Tradeoff: if a clipboard manager was launched mid-session after the original copy, it would also skip the restored clip — that seems acceptable against polluting history on every dictation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
