### PR TITLE
Update build script to do signed build

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,25 @@ open Fluid.xcodeproj
 
 Build and run in Xcode. All dependencies are managed via Swift Package Manager.
 
-Run the build using the script: `./build.sh`
+Run a signed Debug build using the script:
 
 ```bash
 ./build.sh
 ```
+
+The signed build is written to `DerivedData/Build/Products/Debug/FluidVoice Debug.app`.
+Keep launching that product after each rebuild so macOS can preserve its Accessibility
+authorization.
+
+For CI or contributors who do not have a signing identity, use the explicit unsigned
+fallback:
+
+```bash
+./build.sh unsigned
+```
+
+Unsigned builds are tied to a specific executable version and may require Accessibility
+permission to be removed and granted again after rebuilding.
 
 ---
 
@@ -210,7 +224,7 @@ Contributions are welcome! Please create an issue first to discuss major changes
 ### Development Setup
 
 1. Clone and open in Xcode as above.
-2. **Signing:** `FluidVoice → Signing & Capabilities → Automatically manage signing → pick your Team` (Personal Team is fine). Stored in `xcuserdata/` (gitignored).
+2. **Signing:** `FluidVoice → Signing & Capabilities → Automatically manage signing → pick your Team` (Personal Team is fine). Alternatively, leave the project unchanged and run `FLUIDVOICE_DEVELOPMENT_TEAM=YOUR_TEAM_ID ./build.sh`.
 3. Build and run — SPM handles dependencies.
 4. **(Optional) Pre-commit hook** to prevent accidental team ID commits:
    ```bash

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Contributions are welcome! Please create an issue first to discuss major changes
 ### Development Setup
 
 1. Clone and open in Xcode as above.
-2. **Signing:** `FluidVoice → Signing & Capabilities → Automatically manage signing → pick your Team` (Personal Team is fine). Alternatively, leave the project unchanged and run `FLUIDVOICE_DEVELOPMENT_TEAM=YOUR_TEAM_ID ./build.sh`.
+2. **Signing:** `FluidVoice → Signing & Capabilities → Automatically manage signing → pick your Team` (Personal Team is fine). If you have certificates for multiple teams, select one without changing the project by running `FLUIDVOICE_DEVELOPMENT_TEAM=YOUR_TEAM_ID ./build.sh`.
 3. Build and run — SPM handles dependencies.
 4. **(Optional) Pre-commit hook** to prevent accidental team ID commits:
    ```bash

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,9 @@
 # Defaults to the public OSS build, which skips private Fluid Intelligence.
 #
 # Usage:
-#   ./build.sh                    # public OSS build
-#   ./build.sh public             # public OSS build
+#   ./build.sh                    # signed public OSS build
+#   ./build.sh public             # signed public OSS build
+#   ./build.sh unsigned           # unsigned public OSS build (CI/fallback)
 #   ./build.sh fi                 # private FI build
 
 set -euo pipefail
@@ -13,12 +14,77 @@ set -euo pipefail
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROFILE="${1:-${BUILD_PROFILE:-public}}"
 PRIVATE_FI_BUILD_SCRIPT="${PROJECT_DIR}/build_with_FI_incremental.sh"
+DERIVED_DATA_PATH="${FLUIDVOICE_DERIVED_DATA_PATH:-${PROJECT_DIR}/DerivedData}"
+
+resolve_development_team() {
+    local identity
+    identity="$(security find-identity -v -p codesigning 2>/dev/null \
+        | sed -n 's/.*"\(Apple Development:[^"]*\)".*/\1/p' \
+        | awk 'NR == 1 { identity = $0 } END { print identity }')"
+    [ -n "${identity}" ] || return
+
+    if [ -n "${FLUIDVOICE_DEVELOPMENT_TEAM:-}" ]; then
+        printf '%s\n' "${FLUIDVOICE_DEVELOPMENT_TEAM}"
+        return
+    fi
+
+    security find-certificate -c "${identity}" -p 2>/dev/null \
+        | openssl x509 -noout -subject -nameopt RFC2253 2>/dev/null \
+        | sed -n 's/.*OU=\([^,]*\).*/\1/p'
+}
+
+run_public_build() {
+    local signing_mode="$1"
+    local development_team
+    local -a build_args=(
+        -project Fluid.xcodeproj
+        -scheme Fluid
+        -configuration Debug
+        -destination 'platform=macOS'
+        -derivedDataPath "${DERIVED_DATA_PATH}"
+        build
+    )
+
+    cd "${PROJECT_DIR}"
+
+    if [ "${signing_mode}" = "unsigned" ]; then
+        echo "Running unsigned public FluidVoice build..."
+        echo "Accessibility permission may need to be granted again after rebuilding."
+        exec xcodebuild "${build_args[@]}" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
+    fi
+
+    development_team="$(resolve_development_team)"
+    if [ -z "${development_team}" ]; then
+        cat >&2 <<'EOF'
+No Apple Development signing identity was found.
+
+For stable Accessibility permission across rebuilds, add any Apple Account in:
+  Xcode > Settings > Accounts
+
+Then open Manage Certificates and create an Apple Development certificate.
+
+A free Personal Team is sufficient for local development. If you have multiple
+teams, set FLUIDVOICE_DEVELOPMENT_TEAM to the desired 10-character Team ID.
+
+To build without signing instead, run:
+  ./build.sh unsigned
+
+Unsigned builds may require Accessibility permission again after rebuilding.
+EOF
+        exit 1
+    fi
+
+    echo "Running signed public FluidVoice build..."
+    echo "Build product: ${DERIVED_DATA_PATH}/Build/Products/Debug/FluidVoice Debug.app"
+    exec xcodebuild "${build_args[@]}" DEVELOPMENT_TEAM="${development_team}"
+}
 
 case "${PROFILE}" in
     public|oss|incremental|fast)
-        echo "Running public FluidVoice build without Fluid Intelligence..."
-        cd "${PROJECT_DIR}"
-        exec xcodebuild -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
+        run_public_build signed
+        ;;
+    unsigned|ci)
+        run_public_build unsigned
         ;;
     fi|private|dev|full)
         if [ ! -x "${PRIVATE_FI_BUILD_SCRIPT}" ]; then
@@ -31,7 +97,7 @@ case "${PROFILE}" in
         ;;
     *)
         echo "Unknown build profile: ${PROFILE}"
-        echo "Valid profiles: public/oss/incremental/fast, fi/private/dev/full"
+        echo "Valid profiles: public/oss/incremental/fast, unsigned/ci, fi/private/dev/full"
         exit 1
         ;;
 esac

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ resolve_development_team() {
     identity="$(security find-identity -v -p codesigning 2>/dev/null \
         | sed -n 's/.*"\(Apple Development:[^"]*\)".*/\1/p' \
         | awk 'NR == 1 { identity = $0 } END { print identity }')"
-    [ -n "${identity}" ] || return
+    [ -n "${identity}" ] || return 0
 
     if [ -n "${FLUIDVOICE_DEVELOPMENT_TEAM:-}" ]; then
         printf '%s\n' "${FLUIDVOICE_DEVELOPMENT_TEAM}"
@@ -55,9 +55,16 @@ run_public_build() {
 
     development_team="$(resolve_development_team)"
     if [ -z "${development_team}" ]; then
-        cat >&2 <<'EOF'
-No Apple Development signing identity was found.
+        if [ -n "${FLUIDVOICE_DEVELOPMENT_TEAM:-}" ]; then
+            printf >&2 'FLUIDVOICE_DEVELOPMENT_TEAM is set to %s, but no Apple Development signing identity was found.\n\n' \
+                "${FLUIDVOICE_DEVELOPMENT_TEAM}"
+            printf >&2 '%s\n\n' \
+                "The team override selects an installed signing identity; it does not replace a certificate."
+        else
+            printf >&2 'No Apple Development signing identity was found.\n\n'
+        fi
 
+        cat >&2 <<'EOF'
 For stable Accessibility permission across rebuilds, add any Apple Account in:
   Xcode > Settings > Accounts
 


### PR DESCRIPTION
<!--
PRs that do not follow this template will be blocked by the PR Policy check.
If the missing information is not fixed after 48 hours, the PR may be closed.
-->

## Description
Update build script to do signed build so that the build hash is same, this way you don't have to keep providing permissions everytime you run the build script

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
#658 

## Testing
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally

## Screenshots / Video
Attach screenshots or a video for UI, UX, settings, onboarding, overlay, menu bar, or visual behavior changes.

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Add reviewer context, rollout notes, or known tradeoffs here.
