### PR TITLE
fix dictionary training guidance and audio capture default

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleVersion</key>
-		<string>15</string>
+		<string>16</string>
 	<key>CFBundleShortVersionString</key>
-		<string>1.6.4</string>
+		<string>1.6.5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -44,6 +44,7 @@ final class SettingsStore: ObservableObject {
         self.repairForcedOnboardingResetIfNeeded()
         self.migrateOverlayBottomOffsetTo50IfNeeded()
         self.migratePrivateAIContextDefaultTo4KIfNeeded()
+        self.disableExperimentalDirectAudioCaptureIfNeeded()
         self.refreshLaunchAtStartupStatus(clearError: true, logMismatch: false)
     }
 
@@ -1770,17 +1771,22 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Direct Core Audio capture is enabled by default for faster recording
-    /// startup, while preserving explicit user opt-out.
+    /// Direct Core Audio capture is opt-in while the faster recording path is experimental.
     var experimentalDirectAudioCaptureEnabled: Bool {
         get {
             let value = self.defaults.object(forKey: Keys.experimentalDirectAudioCaptureEnabled)
-            return value as? Bool ?? true
+            return value as? Bool ?? false
         }
         set {
             objectWillChange.send()
             self.defaults.set(newValue, forKey: Keys.experimentalDirectAudioCaptureEnabled)
         }
+    }
+
+    private func disableExperimentalDirectAudioCaptureIfNeeded() {
+        guard self.defaults.bool(forKey: Keys.experimentalDirectAudioCaptureForcedOff) == false else { return }
+        self.defaults.set(false, forKey: Keys.experimentalDirectAudioCaptureEnabled)
+        self.defaults.set(true, forKey: Keys.experimentalDirectAudioCaptureForcedOff)
     }
 
     var directAudioCaptureConsecutiveFailures: Int {
@@ -4906,6 +4912,7 @@ private extension SettingsStore {
         static let enableStreamingPreview = "EnableStreamingPreview"
         static let enableAIStreaming = "EnableAIStreaming"
         static let experimentalDirectAudioCaptureEnabled = "ExperimentalDirectAudioCaptureEnabled"
+        static let experimentalDirectAudioCaptureForcedOff = "ExperimentalDirectAudioCaptureForcedOff"
         static let directAudioCaptureConsecutiveFailures = "DirectAudioCaptureConsecutiveFailures"
         static let copyTranscriptionToClipboard = "CopyTranscriptionToClipboard"
         static let textInsertionMode = "TextInsertionMode"

--- a/Sources/Fluid/UI/CustomDictionaryView.swift
+++ b/Sources/Fluid/UI/CustomDictionaryView.swift
@@ -660,14 +660,18 @@ struct CustomDictionaryView: View {
                 VStack(alignment: .leading, spacing: 7) {
                     self.trainingInstruction(
                         number: 1,
-                        text: "Press Start once."
+                        text: "Type the correct word you want to teach in the box above."
                     )
                     self.trainingInstruction(
                         number: 2,
-                        text: "Say \(self.trainingTargetReference) naturally, then pause. FluidVoice records and listens again automatically."
+                        text: "Press Start once."
                     )
                     self.trainingInstruction(
                         number: 3,
+                        text: "Say \(self.trainingTargetReference) naturally, then pause. FluidVoice records and listens again automatically."
+                    )
+                    self.trainingInstruction(
+                        number: 4,
                         text: self.activePronunciationMatching
                             ? "Repeat 3 times to teach FluidVoice how your voice sounds."
                             : "Keep repeating it until the circle reaches 3/3."


### PR DESCRIPTION
## Description
Clarifies the Train by Voice flow by telling users to enter the correct word before starting. Keeps the experimental direct Core Audio path opt-in and disables it once for existing installations so recording uses the compatibility path by default. Bumps the app to 1.6.5 (16).

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Related to #648 and #592.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: swiftlint strict across Sources (0 violations)
- [x] Ran formatter locally: swiftformat across Sources (0 files changed)
- [x] Ran tests locally: private FI build, signed/notarized 1.6.5 app and DMG release gate, mounted-DMG payload verification, and installed app health check

## Screenshots / Video
Issue #648 includes the affected 1.6.4 screen before this guidance update:

![Train by Voice before guidance update](https://github.com/user-attachments/assets/660b5414-28f5-4326-b63a-23e598ae609b)

The installed 1.6.5 screen was visually verified with the new four-step guidance and enabled input-first flow.

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes
The direct audio setting remains available as an explicit opt-in. Existing users are moved to the compatibility path once and may re-enable the experiment afterward. The release artifact is universal, but real Intel runtime remains unvalidated.