### PR TITLE
Keep main window hidden during dictation

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -125,13 +125,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        self.mainWindowHiddenByAppHide = nil
-        self.shouldSuppressMainWindowLaunchReveal = false
-
         if self.shouldSuppressNextReopenActivation {
             self.shouldSuppressNextReopenActivation = false
             return true
         }
+
+        self.mainWindowHiddenByAppHide = nil
+        self.shouldSuppressMainWindowLaunchReveal = false
 
         // Ensure dock-icon reopen always foregrounds FluidVoice.
         sender.activate(ignoringOtherApps: true)
@@ -243,6 +243,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                         return
                     }
                 } else if self.bootMainWindowHiddenIfPresent() {
+                    if self.shouldSuppressMainWindowLaunchReveal,
+                       self.mainWindowHiddenByAppHide == nil
+                    {
+                        self.mainWindowHiddenByAppHide = NSApp.windows.first(where: self.isMainWindow)
+                    }
                     self.didRevealMainWindowOnLaunch = true
                     return
                 }

--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -140,6 +140,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     }
 
     func applicationWillHide(_ notification: Notification) {
+        // A system-hidden login launch is not a user request to suppress its configured reveal.
+        if self.wasLaunchedAsLoginItem,
+           !self.didRevealMainWindowOnLaunch,
+           !NSApp.isActive
+        {
+            return
+        }
+
         // A nonactivating recording panel can make AppKit unhide the process. Remember
         // the visible main window so the panel does not restore it along with itself.
         self.shouldSuppressMainWindowLaunchReveal = true

--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -18,6 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var shouldSuppressNextReopenActivation = false
     private var wasLaunchedAsLoginItem = false
     private var hasDeferredMLXUpgradeOffer = false
+    private weak var mainWindowHiddenByAppHide: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Bring up file logging + crash handlers immediately during launch.
@@ -123,6 +124,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        self.mainWindowHiddenByAppHide = nil
+
         if self.shouldSuppressNextReopenActivation {
             self.shouldSuppressNextReopenActivation = false
             return true
@@ -134,10 +137,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         return !self.bringMainWindowToFrontIfPresent()
     }
 
+    func applicationWillHide(_ notification: Notification) {
+        // A nonactivating recording panel can make AppKit unhide the process. Remember
+        // the visible main window so the panel does not restore it along with itself.
+        self.didRevealMainWindowOnLaunch = true
+        self.mainWindowHiddenByAppHide = NSApp.windows.first {
+            self.isMainWindow($0) && $0.isVisible && !$0.isMiniaturized
+        }
+    }
+
+    func applicationDidHide(_ notification: Notification) {
+        self.mainWindowHiddenByAppHide?.orderOut(nil)
+    }
+
     func applicationDidBecomeActive(_ notification: Notification) {
-        guard self.hasDeferredMLXUpgradeOffer else { return }
-        self.hasDeferredMLXUpgradeOffer = false
-        self.scheduleMLXUpgradeOffer()
+        if let mainWindow = self.mainWindowHiddenByAppHide {
+            self.mainWindowHiddenByAppHide = nil
+            mainWindow.orderFrontRegardless()
+            mainWindow.makeKeyAndOrderFront(nil)
+        }
+
+        if self.hasDeferredMLXUpgradeOffer {
+            self.hasDeferredMLXUpgradeOffer = false
+            self.scheduleMLXUpgradeOffer()
+        }
     }
 
     func userNotificationCenter(

--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -19,6 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var wasLaunchedAsLoginItem = false
     private var hasDeferredMLXUpgradeOffer = false
     private weak var mainWindowHiddenByAppHide: NSWindow?
+    private var shouldSuppressMainWindowLaunchReveal = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Bring up file logging + crash handlers immediately during launch.
@@ -125,6 +126,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         self.mainWindowHiddenByAppHide = nil
+        self.shouldSuppressMainWindowLaunchReveal = false
 
         if self.shouldSuppressNextReopenActivation {
             self.shouldSuppressNextReopenActivation = false
@@ -140,9 +142,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     func applicationWillHide(_ notification: Notification) {
         // A nonactivating recording panel can make AppKit unhide the process. Remember
         // the visible main window so the panel does not restore it along with itself.
-        self.didRevealMainWindowOnLaunch = true
+        self.shouldSuppressMainWindowLaunchReveal = true
         self.mainWindowHiddenByAppHide = NSApp.windows.first {
             self.isMainWindow($0) && $0.isVisible && !$0.isMiniaturized
+        }
+        if self.mainWindowHiddenByAppHide != nil {
+            self.didRevealMainWindowOnLaunch = true
         }
     }
 
@@ -151,8 +156,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
+        self.shouldSuppressMainWindowLaunchReveal = false
+
         if let mainWindow = self.mainWindowHiddenByAppHide {
             self.mainWindowHiddenByAppHide = nil
+            if mainWindow.alphaValue <= 0.01 {
+                mainWindow.alphaValue = 1
+            }
             mainWindow.orderFrontRegardless()
             mainWindow.makeKeyAndOrderFront(nil)
         }
@@ -223,7 +233,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                 guard let self else { return }
                 guard self.didRevealMainWindowOnLaunch == false else { return }
 
-                if revealWindow {
+                let shouldRevealWindow = revealWindow && !self.shouldSuppressMainWindowLaunchReveal
+                if shouldRevealWindow {
                     NSApp.unhide(nil)
                     NSApp.activate(ignoringOtherApps: true)
 
@@ -238,7 +249,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
                 DebugLogger.shared.debug("Main window not ready during launch reveal retry", source: "AppDelegate")
                 if delay >= 0.6 {
-                    self.requestMainWindowReopenIfNeeded(activate: revealWindow)
+                    self.requestMainWindowReopenIfNeeded(activate: shouldRevealWindow)
                 }
             }
         }


### PR DESCRIPTION
## Description
Keeps the main FluidVoice window hidden when dictation starts after Command-H, while restoring it on intentional app activation.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #631

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: FI build/install and live Command-H, minimize, close, and reopen checks

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Preserves standard minimize, close, and intentional reopen behavior.