### PR TITLE
fix: stop HuggingFace rate-limit failures from breaking voice engine downloads (#683)

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -3258,6 +3258,12 @@ final class ASRService: ObservableObject {
             if nsError.domain == NSURLErrorDomain {
                 return nsError.code != NSURLErrorCancelled
             }
+            // The app's own HuggingFaceModelDownloader signals HTTP failures as
+            // NSError(domain: "HF", code: <status>) — treat its rate-limit statuses
+            // the same way so Nemotron/Cohere downloads never wipe cache on a 429.
+            if nsError.domain == "HF", nsError.code == 429 || nsError.code == 503 {
+                return true
+            }
             current = nsError.userInfo[NSUnderlyingErrorKey] as? Error
             depth += 1
         }

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -3244,6 +3244,7 @@ final class ASRService: ObservableObject {
         var current: Error? = error
         var depth = 0
         while let candidate = current, depth < 5 {
+            #if arch(arm64)
             if let hfError = candidate as? DownloadUtils.HuggingFaceDownloadError {
                 switch hfError {
                 case .rateLimited, .htmlErrorResponse:
@@ -3252,6 +3253,7 @@ final class ASRService: ObservableObject {
                     return false
                 }
             }
+            #endif
             let nsError = candidate as NSError
             if nsError.domain == NSURLErrorDomain {
                 return nsError.code != NSURLErrorCancelled

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -3169,6 +3169,14 @@ final class ASRService: ObservableObject {
             if Task.isCancelled || Self.isModelPreparationCancellation(error) {
                 throw CancellationError()
             }
+            if Self.isRateLimitOrNetworkError(error) {
+                DebugLogger.shared.warning(
+                    "ASRService: Prepare failed for \(provider.name) due to rate limiting or a network error; " +
+                        "skipping cache-clear recovery so cached files stay resumable: \(error)",
+                    source: "ASRService"
+                )
+                throw error
+            }
             firstError = error
             DebugLogger.shared.error("ASRService: First prepare attempt for \(provider.name) failed after \(String(format: "%.2f", Date().timeIntervalSince(start)))s", source: "ASRService")
             DebugLogger.shared.warning(
@@ -3226,6 +3234,32 @@ final class ASRService: ObservableObject {
         if error is CancellationError { return true }
         let nsError = error as NSError
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+    }
+
+    /// Rate-limit and transport failures must not trigger the cache-clear recovery: clearing the
+    /// cache forces a full re-download, which burns more of HuggingFace's fixed per-IP API window
+    /// and turns a transient 429 into a self-reinforcing failure loop (issue #683).
+    private nonisolated static func isRateLimitOrNetworkError(_ error: Error) -> Bool {
+        // Providers may rebox the download error, so walk the underlying-error chain.
+        var current: Error? = error
+        var depth = 0
+        while let candidate = current, depth < 5 {
+            if let hfError = candidate as? DownloadUtils.HuggingFaceDownloadError {
+                switch hfError {
+                case .rateLimited, .htmlErrorResponse:
+                    return true
+                case .invalidResponse, .downloadFailed, .modelNotFound:
+                    return false
+                }
+            }
+            let nsError = candidate as NSError
+            if nsError.domain == NSURLErrorDomain {
+                return nsError.code != NSURLErrorCancelled
+            }
+            current = nsError.userInfo[NSUnderlyingErrorKey] as? Error
+            depth += 1
+        }
+        return false
     }
 
     // MARK: - Model lifecycle helpers (parity with original API)


### PR DESCRIPTION
## Description

- Skip the cache-clear + re-prepare recovery in `ASRService.prepareProviderWithRecovery` when the first prepare attempt failed due to HuggingFace rate limiting (`rateLimited`, `htmlErrorResponse`) or a network error, rethrowing instead so cached model files stay resumable.
- New classifier walks the `NSUnderlyingErrorKey` chain (depth-capped) so errors reboxed by provider layers are still recognized; cancellation is excluded and keeps its existing handling.

Why: clearing the provider cache on a transient 429 forces a full re-download, which burns more of HuggingFace's fixed 500-requests/5-minutes per-IP API window and turns one rate limit into a self-reinforcing failure loop where every engine's download fails ("Rate limited while listing files"). Root fix lands in FluidAudio (altic-dev/FluidAudio#2 — single recursive listing, header-aware retries, no cache wipe on rate limits); this PR removes the app-level amplifier. The app picks up the FluidAudio fix automatically once #2 merges into the pinned `B/cohere-coreml-asr` branch.

Repro evidence (offline stub HuggingFace server, real Parakeet v3 tree): before the fixes, one download gesture cost 41 listing API calls, any 429 failed instantly with the exact issue error, and a mid-flight failure wiped the cache and re-listed (a 45-call budget that fit one full pass still blew up at call #46). After the fixes: 1 listing call, downloaded file set byte-identical (23/23), sustained 429s produce header-paced retries then a clean error with the cache intact, and corrupt-model recovery still works. Full tables in altic-dev/FluidAudio#2.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #683

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.1
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` (0 violations on the changed file)
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources` (changed file already fails formatter lint on `main`; not reformatting ~3k unrelated lines in this PR)
- [x] Ran tests locally: FluidAudio `DownloadUtilsRateLimitTests` 15/15 pass; app built via `./build.sh unsigned`; behavior verified end-to-end with an offline stub HuggingFace server (details in altic-dev/FluidAudio#2)

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes

Companion root-cause PR: altic-dev/FluidAudio#2. This change is safe standalone (it only narrows a destructive retry), but the user-facing rate-limit failures in #683 fully disappear when both land.

**The same dependency bump also fixes #679** (progress stuck at 3%, then completes all at once). Root cause, verified empirically: the FluidAudio revision pinned by v1.6.5 (`edee7154`) attaches a progress delegate but downloads via the async `session.download(for:)` convenience, which never delivers `didWriteData` — so progress only ticks at file boundaries and freezes for the entire multi-hundred-MB encoder transfer. FluidAudio `6af7925` (merged to `B/cohere-coreml-asr` two days after the 1.6.5 pin) rewrites this with a delegate-backed download task. Measured with an offline stub (30 MB file): pinned revision = 23 progress events / 9 distinct values for a whole repo download; current branch incl. FluidAudio#2 = 1,142 events / 73 distinct values (continuous). Re-pinning FluidAudio to the branch head once FluidAudio#2 merges resolves both #683 and #679.
