### PR TITLE
fix(hotkey): make Change replace and Remove unbind

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1119,7 +1119,14 @@ struct ContentView: View {
                 shortcuts.append(shortcut)
             }
         }
-        self.primaryDictationShortcuts = shortcuts
+        self.updatePrimaryDictationShortcuts(shortcuts)
+    }
+
+    private func updatePrimaryDictationShortcuts(_ shortcuts: [HotkeyShortcut]) {
+        SettingsStore.shared.primaryDictationShortcuts = shortcuts
+        let storedShortcuts = SettingsStore.shared.primaryDictationShortcuts
+        self.primaryDictationShortcuts = storedShortcuts
+        self.hotkeyManager?.updatePrimaryShortcuts(storedShortcuts)
     }
 
     private func setShortcutTargetEnabled(_ enabled: Bool, for target: ShortcutRecordingTarget) {
@@ -1464,7 +1471,10 @@ struct ContentView: View {
             inputDevices: self.$inputDevices,
             outputDevices: self.$outputDevices,
             accessibilityEnabled: self.$accessibilityEnabled,
-            primaryDictationShortcuts: self.$primaryDictationShortcuts,
+            primaryDictationShortcuts: Binding(
+                get: { self.primaryDictationShortcuts },
+                set: { self.updatePrimaryDictationShortcuts($0) }
+            ),
             activeShortcutRecordingTarget: self.$activeShortcutRecordingTarget,
             shortcutRecordingMessage: self.$shortcutRecordingMessage,
             commandModeShortcut: self.$commandModeHotkeyShortcut,

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1669,7 +1669,7 @@ final class SettingsStore: ObservableObject {
         }
         set {
             objectWillChange.send()
-            let shortcuts = Self.normalizedPrimaryDictationShortcuts([newValue], fallback: Self.defaultPrimaryDictationShortcut)
+            let shortcuts = Self.normalizedPrimaryDictationShortcuts([newValue])
             self.storePrimaryDictationShortcuts(shortcuts)
             self.storeLegacyHotkeyShortcut(shortcuts[0])
         }
@@ -1680,7 +1680,7 @@ final class SettingsStore: ObservableObject {
             .map(\.displayString)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-        return displays.isEmpty ? Self.defaultPrimaryDictationShortcut.displayString : displays.joined(separator: " / ")
+        return displays.joined(separator: " / ")
     }
 
     var primaryDictationShortcuts: [HotkeyShortcut] {
@@ -1689,15 +1689,17 @@ final class SettingsStore: ObservableObject {
             if let data = defaults.data(forKey: Keys.primaryDictationShortcutsKey),
                let shortcuts = try? JSONDecoder().decode([HotkeyShortcut].self, from: data)
             {
-                return Self.normalizedPrimaryDictationShortcuts(shortcuts, fallback: fallback)
+                return Self.normalizedPrimaryDictationShortcuts(shortcuts)
             }
             return [fallback]
         }
         set {
             objectWillChange.send()
-            let shortcuts = Self.normalizedPrimaryDictationShortcuts(newValue, fallback: self.legacyHotkeyShortcut)
+            let shortcuts = Self.normalizedPrimaryDictationShortcuts(newValue)
             self.storePrimaryDictationShortcuts(shortcuts)
-            self.storeLegacyHotkeyShortcut(shortcuts[0])
+            if let firstShortcut = shortcuts.first {
+                self.storeLegacyHotkeyShortcut(firstShortcut)
+            }
         }
     }
 
@@ -1714,16 +1716,10 @@ final class SettingsStore: ObservableObject {
         return Self.defaultPrimaryDictationShortcut
     }
 
-    private static func normalizedPrimaryDictationShortcuts(
-        _ shortcuts: [HotkeyShortcut],
-        fallback: HotkeyShortcut
-    ) -> [HotkeyShortcut] {
+    private static func normalizedPrimaryDictationShortcuts(_ shortcuts: [HotkeyShortcut]) -> [HotkeyShortcut] {
         var unique: [HotkeyShortcut] = []
         for shortcut in shortcuts where !unique.contains(shortcut) {
             unique.append(shortcut)
-        }
-        if unique.isEmpty {
-            unique.append(fallback)
         }
         return unique
     }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -2151,14 +2151,12 @@ struct SettingsView: View {
             .disabled(!isRecording && self.isRecordingAnyShortcut)
 
             Button("Remove") {
-                guard self.primaryDictationShortcuts.count > 1,
-                      self.primaryDictationShortcuts.indices.contains(index)
-                else { return }
+                guard self.primaryDictationShortcuts.indices.contains(index) else { return }
                 self.primaryDictationShortcuts.remove(at: index)
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .disabled(self.primaryDictationShortcuts.count <= 1 || self.isRecordingAnyShortcut)
+            .disabled(self.isRecordingAnyShortcut)
 
             if isRecording,
                let recordingMessage = self.shortcutRecordingMessage,

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -159,6 +159,18 @@ final class HotkeyShortcutTests: XCTestCase {
         }
     }
 
+    func testPrimaryDictationShortcutsCanBeExplicitlyCleared() throws {
+        try self.withRestoredDefaults(keys: [self.legacyHotkeyShortcutKey, self.primaryDictationShortcutsKey]) {
+            let legacyShortcut = HotkeyShortcut(keyCode: 12, modifierFlags: [.option])
+            SettingsStore.shared.hotkeyShortcut = legacyShortcut
+
+            SettingsStore.shared.primaryDictationShortcuts = []
+
+            XCTAssertEqual(SettingsStore.shared.primaryDictationShortcuts, [])
+            XCTAssertEqual(SettingsStore.shared.primaryDictationShortcutDisplayString, "")
+        }
+    }
+
     func testPasteLastTranscriptionShortcutDefaultsToUnboundAndDisabled() throws {
         try self.withRestoredDefaults(keys: [
             self.pasteLastTranscriptionShortcutKey,


### PR DESCRIPTION
## Description

Changing or removing a Primary Dictation shortcut currently mutates SwiftUI state and relies on an `onChange` side effect to persist the list and refresh `GlobalHotkeyManager`. The shortcut-capture callback can bypass that refresh, leaving the manager's in-memory list stale: **Change** behaves like **Add**, and removed shortcuts continue firing until restart.

This PR routes **Change** and **Remove** through one persist-and-live-update method. It also permits removing the final primary shortcut, preserving an explicit unbound state instead of silently restoring the legacy shortcut. Fresh installs still receive the existing default when no primary-shortcut preference has ever been stored.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Related to #470 and #498.

#474 contains the direct live-manager refresh for **Change**, but does not address **Remove** or an explicitly unbound primary shortcut. #503 covers a narrower active modifier-only press-state edge case; this PR addresses settings-to-live-manager synchronization and removal semantics observed on 1.6.5.

## Testing
- [ ] Tested on Intel Mac
- [ ] Tested on Apple Silicon Mac
- [ ] Tested on macOS version:
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally:
- [x] Parsed all changed Swift files with `xcrun swiftc -parse`
- [x] Ran `git diff --check`
- [x] Fork CI passed SwiftLint, Xcode build, and tests: https://github.com/dschnurbusch/FluidVoice/actions/runs/30101354571

The local machine has Command Line Tools rather than full Xcode, so the full Xcode build/test suite was run on the same commit (`83568b8`) through the fork's macOS workflow.

## Screenshots / Video

Before: FluidVoice 1.6.5 shows **Remove** disabled when only one Primary Dictation shortcut remains. The submitted change enables removal of that final shortcut; once removed, the row disappears and **Add shortcut** remains available.

![FluidVoice 1.6.5 Global Hotkey settings with disabled Remove button](https://raw.githubusercontent.com/dschnurbusch/FluidVoice/pr-evidence/primary-hotkey/.github/pr-evidence/primary-hotkey-before.png)

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes

The settings mutation now updates persisted state, normalized SwiftUI state, and the live hotkey manager in one call. The existing `onChange` remains as an idempotent fallback for other state writes.

The explicit empty list is distinguishable from a fresh install: missing preference data still falls back to the legacy/default shortcut, while stored `[]` remains unbound. The legacy single-shortcut value is left intact for backward-compatible backup/export consumers but is no longer allowed to resurrect an explicitly cleared primary list.
