### PR TITLE
fix(settings): clear orphaned per-prompt shortcuts on legacy retirement

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -3343,7 +3343,31 @@ final class SettingsStore: ObservableObject {
         self.defaults.set(true, forKey: Keys.secondaryDictationPromptOff)
         self.defaults.removeObject(forKey: Keys.promptModeHotkeyShortcut)
         self.defaults.removeObject(forKey: Keys.promptModeSelectedPromptID)
+        self.clearOrphanedDictationPromptShortcuts()
         self.defaults.set(true, forKey: Keys.legacySecondaryPromptShortcutRetired)
+    }
+
+    /// Before per-prompt "Custom shortcut" assignments existed, the single legacy secondary-prompt
+    /// hotkey (`PromptModeHotkeyShortcut` / `PromptModeSelectedPromptID`, cleared above) left a
+    /// residual `.shortcut` behind in `DictationPromptConfigurations` — most commonly a bare Command
+    /// keypress under the `__default__` entry. `dictationPromptShortcutAssignments()` treats any
+    /// stored `.shortcut` as an always-on global hotkey with no dependency on
+    /// `PromptModeShortcutEnabled`, so that residue kept firing dictation on every Cmd+key chord even
+    /// though the feature that created it was retired (altic-dev/FluidVoice#675). Provider/model
+    /// overrides are unaffected — only the shortcut binding is cleared, and only once, here, at the
+    /// same retirement boundary that already governs the legacy key.
+    func clearOrphanedDictationPromptShortcuts() {
+        var configurations = self.dictationPromptConfigurations
+        guard configurations.values.contains(where: { $0.shortcut != nil }) else { return }
+
+        for key in configurations.keys {
+            configurations[key]?.shortcut = nil
+        }
+        configurations = configurations.filter { _, configuration in
+            !configuration.providerID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                !configuration.modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        self.dictationPromptConfigurations = configurations
     }
 
     private func normalizePromptSelectionsIfNeeded() {

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -10,6 +10,7 @@ final class HotkeyShortcutTests: XCTestCase {
     private let pasteLastTranscriptionShortcutKey = "PasteLastTranscriptionHotkeyShortcut"
     private let pasteLastTranscriptionEnabledKey = "PasteLastTranscriptionShortcutEnabled"
     private let microphoneSelectionModeKey = "MicrophoneSelectionMode"
+    private let dictationPromptConfigurationsKey = "DictationPromptConfigurations"
     private let preferredInputDeviceUIDKey = "PreferredInputDeviceUID"
     private let systemInputDeviceUIDBeforeManualKey = "SystemInputDeviceUIDBeforeManual"
 
@@ -199,6 +200,46 @@ final class HotkeyShortcutTests: XCTestCase {
             XCTAssertEqual(stored, mouseShortcut)
             XCTAssertTrue(stored?.isMouseShortcut ?? false)
             XCTAssertTrue(stored?.matchesMouse(button: 3, modifiers: [.option]) ?? false)
+        }
+    }
+
+    /// Regression test for altic-dev/FluidVoice#675: a residual `.shortcut` left behind by the
+    /// retired legacy secondary-prompt-mode hotkey kept firing as an always-on global hotkey
+    /// (most commonly a bare Command keypress under the `__default__` entry) because
+    /// `dictationPromptShortcutAssignments()` has no dependency on `PromptModeShortcutEnabled`.
+    func testClearOrphanedDictationPromptShortcutsRemovesShortcutButKeepsProviderOverrides() throws {
+        try self.withRestoredDefaults(keys: [self.dictationPromptConfigurationsKey]) {
+            let orphanedDefault = SettingsStore.DictationPromptConfiguration(
+                shortcut: HotkeyShortcut(keyCode: 55, modifierFlags: []), // bare Command, matches field reports
+                providerID: "",
+                modelName: ""
+            )
+            let profileWithOverride = SettingsStore.DictationPromptConfiguration(
+                shortcut: HotkeyShortcut(keyCode: 62, modifierFlags: []),
+                providerID: "openrouter",
+                modelName: "some-model"
+            )
+            SettingsStore.shared.dictationPromptConfigurations = [
+                "__default__": orphanedDefault,
+                "__privateAI__": profileWithOverride,
+            ]
+            XCTAssertEqual(SettingsStore.shared.dictationPromptShortcutAssignments().count, 2)
+
+            SettingsStore.shared.clearOrphanedDictationPromptShortcuts()
+
+            let result = SettingsStore.shared.dictationPromptConfigurations
+            XCTAssertNil(result["__default__"], "Entry left with no shortcut, provider, or model should be dropped entirely")
+            XCTAssertNil(result["__privateAI__"]?.shortcut, "Shortcut binding must be cleared")
+            XCTAssertEqual(result["__privateAI__"]?.providerID, "openrouter", "Provider override must survive the cleanup")
+            XCTAssertEqual(result["__privateAI__"]?.modelName, "some-model", "Model override must survive the cleanup")
+            XCTAssertTrue(
+                SettingsStore.shared.dictationPromptShortcutAssignments().isEmpty,
+                "No stale shortcut should remain reachable as a live global hotkey"
+            )
+
+            // Calling it again once already clean is a no-op, not a crash or a re-write.
+            SettingsStore.shared.clearOrphanedDictationPromptShortcuts()
+            XCTAssertEqual(SettingsStore.shared.dictationPromptConfigurations, result)
         }
     }
 


### PR DESCRIPTION
## Description

Retiring the legacy secondary-prompt-mode hotkey (`retireLegacySecondaryPromptShortcutIfNeeded()`) clears `PromptModeHotkeyShortcut` / `PromptModeSelectedPromptID`, but never touches `DictationPromptConfigurations` — a separate, still-active data store used by the current "Custom shortcut per AI Prompt profile" feature.

`dictationPromptShortcutAssignments()` turns every stored `.shortcut` in `DictationPromptConfigurations` into a live global hotkey unconditionally, with no dependency on `PromptModeShortcutEnabled` or either retirement flag. Any residual `.shortcut` left over from before the legacy hotkey was retired — most commonly a bare Command keypress under the `__default__` entry — keeps firing forever, even though nothing in Settings shows or lets you clear it.

This matches the two independent reports on #675: both show the exact same orphaned `keyCode: 55` (Command) under `__default__`, despite having different Primary Dictation shortcuts configured (Right Option / Right Control). That consistency across unrelated users is why I'm confident this is leftover legacy state rather than an intentional per-profile shortcut.

This PR clears any stale `.shortcut` bindings once, at the same retirement boundary that already governs `PromptModeHotkeyShortcut`, while preserving any real `providerID`/`modelName` overrides a user may have set on a prompt configuration.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Fixes #675

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` (SourceKit crashes on this machine — only Command Line Tools installed, no full Xcode; see note below)
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources` — diffed `--lint` output against unmodified `main` for both touched files; this change introduces zero new formatting findings (45 pre-existing findings unrelated to this change, unchanged before/after)
- [ ] Ran tests locally (blocked — see note below)

**Note on local verification:** this machine only has Command Line Tools, not full Xcode, so `xcodebuild test` isn't available and `swiftlint` crashes on a missing `sourcekitdInProc` framework. I verified both changed files parse cleanly with `xcrun swiftc -parse`, and confirmed with `swiftformat --lint` that this diff adds no new style issues. I also manually reproduced the exact preference-file shape from #675 on my own affected install (`DictationPromptConfigurations.__default__.shortcut = {keyCode: 55, modifierKeyCodes: [55]}`, `PromptModeShortcutEnabled = false`) and applied the equivalent of this fix via `defaults delete` as a live workaround, which stopped Command from triggering dictation without disturbing the configured Primary Dictation shortcut. The new regression test reproduces that same data shape and asserts `dictationPromptShortcutAssignments()` — the source `GlobalHotkeyManager` reads for these hotkeys — ends up empty after cleanup. CI (`build.yml`, `macos-latest` with full Xcode) should be able to run the full suite including this test.

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes

`clearOrphanedDictationPromptShortcuts()` clears `.shortcut` on *every* entry in `DictationPromptConfigurations`, not just `__default__`, since the legacy single-shortcut system could plausibly have left residue under `__privateAI__` or a `profile:*` key too. The tradeoff: if anyone genuinely used the current "Custom shortcut" editor (Advanced AI Settings → prompt editor → "Custom shortcut") to bind a shortcut before updating past this migration, that binding would also be cleared. Given both #675 reports show the identical `keyCode: 55` artifact regardless of their actual configured Primary Dictation shortcut, I believe this is safe, but happy to narrow the scope (e.g. only `__default__`, or only shortcuts matching the known legacy default) if you'd prefer — you have visibility I don't into how many users use per-profile custom shortcuts today.
