### PR TITLE
update meeting transcription copy

### DIFF
--- a/Sources/Fluid/UI/MeetingTranscriptionView.swift
+++ b/Sources/Fluid/UI/MeetingTranscriptionView.swift
@@ -45,7 +45,7 @@ struct MeetingTranscriptionView: View {
                     .font(.title2)
                     .fontWeight(.semibold)
 
-                Text("Upload audio or video files to transcribe")
+                Text("Choose an audio or video file to transcribe")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
@@ -189,7 +189,7 @@ struct MeetingTranscriptionView: View {
                         Image(systemName: "arrow.up.doc.fill")
                             .font(.system(size: 32))
 
-                        Text("Choose Audio or Video File")
+                        Text("Drag and drop a file here, or click to open")
                             .font(.headline)
 
                         Text(MeetingTranscriptionService.supportedFormatsDescription)


### PR DESCRIPTION
<!--
PRs that do not follow this template will be blocked by the PR Policy check.
If the missing information is not fixed after 48 hours, the PR may be closed.
-->

## Description
Tweak the meeting transcription copy so that it doesn't allude to something being uploaded

## Type of Change
- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
#708 

## Testing
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`

## Screenshots / Video
<img width="2834" height="1890" alt="CleanShot 2026-07-27 at 18 00 44@2x" src="https://github.com/user-attachments/assets/a7bb58fc-4e99-410c-a469-c1de9fe339bf" />


## Notes
Add reviewer context, rollout notes, or known tradeoffs here.
