### PR TITLE
Delay bottom overlay reveal to align with capture startup

### DIFF
--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -52,6 +52,7 @@ final class BottomOverlayWindowController {
     private var releaseTransitionActiveUntil: Date?
     private var deferredResizePending = false
     private var presentationGeneration: UInt64 = 0
+    private let recordingRevealDelay: TimeInterval = 0.09
     private let dismissalDuration: TimeInterval = 0.02
     private var isHideInProgress = false
     private var activeHideGeneration: UInt64?
@@ -135,16 +136,18 @@ final class BottomOverlayWindowController {
         NotchContentState.shared.setBottomOverlayDismissing(false)
 
         self.targetScreen = OverlayScreenResolver.screenForCurrentPointer()
-        self.positionWindow()
-
-        // Submit one complete frame to WindowServer.
-        self.window?.setAccessibilityChildren(nil)
-        self.window?.setAccessibilityElement(true)
         self.window?.alphaValue = 1
-        self.window?.orderFrontRegardless()
         self.window?.contentView?.displayIfNeeded()
         self.window?.displayIfNeeded()
         CATransaction.flush()
+
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+        Thread.sleep(forTimeInterval: max(self.recordingRevealDelay - elapsed, 0))
+
+        self.positionWindow()
+        self.window?.setAccessibilityChildren(nil)
+        self.window?.setAccessibilityElement(true)
+        self.window?.orderFrontRegardless()
         Self.overlayBench("bottom_order_front elapsedMs=\(Self.elapsedMs(since: startedAt))")
         Self.overlayBench("bottom_visible elapsedMs=\(Self.elapsedMs(since: startedAt))")
 


### PR DESCRIPTION
## Description
Delays the bottom recording overlay reveal until roughly 90 ms after presentation begins. The complete frame is prepared offscreen first, and only the remaining delay is applied so rendering time does not stack on top.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
N/A — follow-up to overlay startup timing work.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: swiftlint --strict --config .swiftlint.yml Sources
- [x] Ran formatter locally: swiftformat --config .swiftformat Sources
- [x] Ran tests locally: 34 focused tests passed
- [x] Built, installed, and launched with sh build_with_FI_incremental.sh
- [x] Verified installed-app overlay timing: 92 ms from show request to visible

## Screenshots / Video
Timing-only behavior change; no layout or visual styling changed. Verified in the installed app using overlay timing instrumentation.

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
The delay is measured from the start of bottom-overlay presentation. If preparing the first frame already takes 90 ms or longer, no additional wait is added.