### PR TITLE
Show warning in overaly if edit mode used with fluid-1

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2443,8 +2443,40 @@ struct ContentView: View {
         self.hideOverlayAsync(reason: "after_output")
     }
 
+    private func showPrivateAIEditModeUnavailableIfNeeded() -> Bool {
+        let settings = SettingsStore.shared
+        let providerID = settings.rewriteModeLinkedToGlobal
+            ? settings.selectedProviderID
+            : settings.rewriteModeSelectedProviderID
+        guard PrivateFeatures.privateAIProvider,
+              providerID.trimmingCharacters(in: .whitespacesAndNewlines) ==
+              PrivateAIProviderFeature.shared.providerID
+        else {
+            return false
+        }
+
+        self.menuBarManager.setOverlayMode(.edit)
+        self.advanceOverlayLifecycle()
+        let expectedOverlayLifecycleID = self.overlayLifecycleID
+        self.menuBarManager.showRecordingOverlayImmediately()
+        NotchContentState.shared.showAIProcessingFailure(
+            message: "Edit Mode cannot be used with Fluid-1",
+            canRetry: false
+        )
+        self.menuBarManager.finishProcessingKeepingOverlayVisible()
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 6_000_000_000)
+            guard self.overlayLifecycleID == expectedOverlayLifecycleID else { return }
+            NotchContentState.shared.clearAIProcessingFailure()
+            await self.menuBarManager.finishProcessingAndHideOverlay()
+        }
+        return true
+    }
+
     private func advanceOverlayLifecycle() {
         self.overlayLifecycleID &+= 1
+        NotchContentState.shared.clearAIProcessingFailure()
     }
 
     private func hideOverlayAsync(reason: String) {
@@ -3319,6 +3351,8 @@ struct ContentView: View {
                 }
             },
             rewriteModeCallback: {
+                guard !self.showPrivateAIEditModeUnavailableIfNeeded() else { return }
+
                 self.captureRecordingContext()
 
                 // Try to capture text first while still in the other app

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2455,6 +2455,12 @@ struct ContentView: View {
             return false
         }
 
+        guard !self.asr.isRunningOrStarting,
+              !NotchContentState.shared.isProcessing
+        else {
+            return true
+        }
+
         self.menuBarManager.setOverlayMode(.edit)
         self.advanceOverlayLifecycle()
         let expectedOverlayLifecycleID = self.overlayLifecycleID

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -2275,7 +2275,8 @@ struct BottomOverlayView: View {
     }
 
     private var shouldReservePreviewArea: Bool {
-        self.layout.showsPreview && self.settings.enableStreamingPreview
+        self.layout.showsPreview &&
+            (self.settings.enableStreamingPreview || self.contentState.isAIProcessingFailureVisible)
     }
 
     private var overlayFrameHeight: CGFloat? {
@@ -2777,17 +2778,23 @@ struct BottomOverlayView: View {
 
     private var aiProcessingFailureView: some View {
         HStack(spacing: 8) {
-            Text("AI Enhancement failed")
+            Text(self.contentState.aiProcessingFailureMessage)
                 .font(.system(size: self.layout.transFontSize, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.9))
+                .foregroundStyle(
+                    self.contentState.canRetryAIProcessingFailure
+                        ? Color.white.opacity(0.9)
+                        : Color.orange.opacity(0.9)
+                )
                 .lineLimit(1)
                 .truncationMode(.tail)
 
             Spacer(minLength: 4)
 
-            self.failureIconButton(systemName: "arrow.clockwise", help: "Try again") {
-                self.contentState.clearAIProcessingFailure()
-                self.contentState.onReprocessLastRequested?()
+            if self.contentState.canRetryAIProcessingFailure {
+                self.failureIconButton(systemName: "arrow.clockwise", help: "Try again") {
+                    self.contentState.clearAIProcessingFailure()
+                    self.contentState.onReprocessLastRequested?()
+                }
             }
 
             self.failureIconButton(systemName: "xmark", help: "Dismiss") {

--- a/Sources/Fluid/Views/NotchContentViews.swift
+++ b/Sources/Fluid/Views/NotchContentViews.swift
@@ -23,6 +23,8 @@ class NotchContentState: ObservableObject {
     @Published var promptPickerMode: SettingsStore.PromptMode = .dictate
     @Published var isProcessing: Bool = false // AI processing state
     @Published var isAIProcessingFailureVisible: Bool = false
+    @Published private(set) var aiProcessingFailureMessage: String = "AI Enhancement failed"
+    @Published private(set) var canRetryAIProcessingFailure: Bool = true
     @Published var activeDictationShortcutSlot: SettingsStore.DictationShortcutSlot? = nil
     @Published var promptModeOverrideProfileName: String? = nil // Name shown in overlay when prompt mode hotkey is active
     @Published var promptModeOverrideProfileID: String? = nil // ID of the active override profile (for checkmark in menu)
@@ -96,7 +98,12 @@ class NotchContentState: ObservableObject {
         self.isProcessing = processing
     }
 
-    func showAIProcessingFailure() {
+    func showAIProcessingFailure(
+        message: String = "AI Enhancement failed",
+        canRetry: Bool = true
+    ) {
+        self.aiProcessingFailureMessage = message
+        self.canRetryAIProcessingFailure = canRetry
         self.isAIProcessingFailureVisible = true
     }
 
@@ -905,24 +912,30 @@ struct NotchExpandedView: View {
 
             if self.contentState.isAIProcessingFailureVisible && !self.contentState.isProcessing {
                 HStack(spacing: 6) {
-                    Text("AI Enhancement failed")
+                    Text(self.contentState.aiProcessingFailureMessage)
                         .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.82))
+                        .foregroundStyle(
+                            self.contentState.canRetryAIProcessingFailure
+                                ? Color.white.opacity(0.82)
+                                : Color.orange.opacity(0.9)
+                        )
                         .lineLimit(1)
                         .truncationMode(.tail)
 
                     Spacer(minLength: 2)
 
-                    Button {
-                        self.contentState.clearAIProcessingFailure()
-                        self.contentState.onReprocessLastRequested?()
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 9, weight: .bold))
-                            .frame(width: 16, height: 16)
+                    if self.contentState.canRetryAIProcessingFailure {
+                        Button {
+                            self.contentState.clearAIProcessingFailure()
+                            self.contentState.onReprocessLastRequested?()
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 9, weight: .bold))
+                                .frame(width: 16, height: 16)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Try again")
                     }
-                    .buttonStyle(.plain)
-                    .help("Try again")
 
                     Button {
                         self.contentState.clearAIProcessingFailure()

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -60,6 +60,28 @@ final class DictationE2ETests: XCTestCase {
         ]
     }
 
+    func testOverlayFailureSupportsCustomNonRetryableMessage() {
+        let state = NotchContentState.shared
+        defer {
+            state.showAIProcessingFailure()
+            state.clearAIProcessingFailure()
+        }
+
+        state.showAIProcessingFailure(
+            message: "Edit Mode cannot be used with Fluid-1",
+            canRetry: false
+        )
+
+        XCTAssertTrue(state.isAIProcessingFailureVisible)
+        XCTAssertEqual(state.aiProcessingFailureMessage, "Edit Mode cannot be used with Fluid-1")
+        XCTAssertFalse(state.canRetryAIProcessingFailure)
+
+        state.showAIProcessingFailure()
+
+        XCTAssertEqual(state.aiProcessingFailureMessage, "AI Enhancement failed")
+        XCTAssertTrue(state.canRetryAIProcessingFailure)
+    }
+
     func testTranscriptionHistoryEntryClipboardTextPrefersProcessedText() {
         let entry = TranscriptionHistoryEntry(
             rawText: " raw transcript ",

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -60,28 +60,6 @@ final class DictationE2ETests: XCTestCase {
         ]
     }
 
-    func testOverlayFailureSupportsCustomNonRetryableMessage() {
-        let state = NotchContentState.shared
-        defer {
-            state.showAIProcessingFailure()
-            state.clearAIProcessingFailure()
-        }
-
-        state.showAIProcessingFailure(
-            message: "Edit Mode cannot be used with Fluid-1",
-            canRetry: false
-        )
-
-        XCTAssertTrue(state.isAIProcessingFailureVisible)
-        XCTAssertEqual(state.aiProcessingFailureMessage, "Edit Mode cannot be used with Fluid-1")
-        XCTAssertFalse(state.canRetryAIProcessingFailure)
-
-        state.showAIProcessingFailure()
-
-        XCTAssertEqual(state.aiProcessingFailureMessage, "AI Enhancement failed")
-        XCTAssertTrue(state.canRetryAIProcessingFailure)
-    }
-
     func testTranscriptionHistoryEntryClipboardTextPrefersProcessedText() {
         let entry = TranscriptionHistoryEntry(
             rawText: " raw transcript ",
@@ -2352,5 +2330,30 @@ final class DictationE2ETests: XCTestCase {
             ],
             run: run
         )
+    }
+}
+
+@MainActor
+final class OverlayFailureStateTests: XCTestCase {
+    func testCustomNonRetryableMessage() {
+        let state = NotchContentState.shared
+        defer {
+            state.showAIProcessingFailure()
+            state.clearAIProcessingFailure()
+        }
+
+        state.showAIProcessingFailure(
+            message: "Edit Mode cannot be used with Fluid-1",
+            canRetry: false
+        )
+
+        XCTAssertTrue(state.isAIProcessingFailureVisible)
+        XCTAssertEqual(state.aiProcessingFailureMessage, "Edit Mode cannot be used with Fluid-1")
+        XCTAssertFalse(state.canRetryAIProcessingFailure)
+
+        state.showAIProcessingFailure()
+
+        XCTAssertEqual(state.aiProcessingFailureMessage, "AI Enhancement failed")
+        XCTAssertTrue(state.canRetryAIProcessingFailure)
     }
 }


### PR DESCRIPTION
<!--
PRs that do not follow this template will be blocked by the PR Policy check.
If the missing information is not fixed after 48 hours, the PR may be closed.
-->

## Description
Adds a warning message in the overlay if users attempt to trigger edit mode with fluid-1 selected as their provider

## Type of Change
- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
#706 

## Testing
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version:
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`

## Screenshots / Video
<img width="1504" height="444" alt="CleanShot 2026-07-28 at 16 33 22@2x" src="https://github.com/user-attachments/assets/ecb386f2-0ec1-4da9-94ff-916715f855fe" />


## Notes
Add reviewer context, rollout notes, or known tradeoffs here.
