### PR TITLE
add info/warning for input device

### DIFF
--- a/Sources/Fluid/Services/AudioDeviceService.swift
+++ b/Sources/Fluid/Services/AudioDeviceService.swift
@@ -18,6 +18,32 @@ enum AudioDevice {
         let name: String
         let hasInput: Bool
         let hasOutput: Bool
+        let transportType: UInt32
+
+        init(
+            id: AudioObjectID,
+            uid: String,
+            name: String,
+            hasInput: Bool,
+            hasOutput: Bool,
+            transportType: UInt32 = kAudioDeviceTransportTypeUnknown
+        ) {
+            self.id = id
+            self.uid = uid
+            self.name = name
+            self.hasInput = hasInput
+            self.hasOutput = hasOutput
+            self.transportType = transportType
+        }
+
+        var isBluetooth: Bool {
+            self.transportType == kAudioDeviceTransportTypeBluetooth ||
+                self.transportType == kAudioDeviceTransportTypeBluetoothLE
+        }
+
+        var isBuiltIn: Bool {
+            self.transportType == kAudioDeviceTransportTypeBuiltIn
+        }
     }
 
     static func listAllDevices() -> [Device] {
@@ -64,7 +90,21 @@ enum AudioDevice {
             let uid = self.getStringProperty(devId, selector: kAudioDevicePropertyDeviceUID, scope: kAudioObjectPropertyScopeGlobal) ?? ""
             let hasIn = self.hasChannels(devId, scope: kAudioObjectPropertyScopeInput)
             let hasOut = self.hasChannels(devId, scope: kAudioObjectPropertyScopeOutput)
-            devices.append(Device(id: devId, uid: uid, name: name, hasInput: hasIn, hasOutput: hasOut))
+            let transportType = self.getUInt32Property(
+                devId,
+                selector: kAudioDevicePropertyTransportType,
+                scope: kAudioObjectPropertyScopeGlobal
+            ) ?? kAudioDeviceTransportTypeUnknown
+            devices.append(
+                Device(
+                    id: devId,
+                    uid: uid,
+                    name: name,
+                    hasInput: hasIn,
+                    hasOutput: hasOut,
+                    transportType: transportType
+                )
+            )
         }
 
         return devices.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
@@ -171,6 +211,22 @@ enum AudioDevice {
         let status = AudioObjectGetPropertyData(devId, &address, 0, nil, &dataSize, &value)
         guard status == noErr else { return nil }
         return value?.takeRetainedValue() as String?
+    }
+
+    private static func getUInt32Property(
+        _ devId: AudioObjectID,
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope
+    ) -> UInt32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: UInt32 = 0
+        var dataSize = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(devId, &address, 0, nil, &dataSize, &value)
+        return status == noErr ? value : nil
     }
 
     private static func hasChannels(_ devId: AudioObjectID, scope: AudioObjectPropertyScope) -> Bool {

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -1132,9 +1132,7 @@ struct SettingsView: View {
                                         Text("Loading...").tag("")
                                     } else {
                                         ForEach(self.inputDevices, id: \.uid) { dev in
-                                            // Add "(System Default)" tag using cached name to avoid CoreAudio calls during layout
-                                            let isSystemDefault = !self.cachedDefaultInputName.isEmpty && dev.name == self.cachedDefaultInputName
-                                            Text(isSystemDefault ? "\(dev.name) (System Default)" : dev.name).tag(dev.uid)
+                                            Text(self.inputDeviceTitle(dev)).tag(dev.uid)
                                         }
                                     }
                                 }
@@ -1231,17 +1229,7 @@ struct SettingsView: View {
                                 }
                             }
 
-                            // CRITICAL FIX: Use cached values instead of querying CoreAudio in view body.
-                            // Querying AudioDevice here triggers HALSystem::InitializeShell() race condition.
-                            if !self.cachedDefaultInputName.isEmpty && !self.cachedDefaultOutputName.isEmpty {
-                                HStack {
-                                    Spacer()
-                                    Text("Default: \(self.cachedDefaultInputName) / \(self.cachedDefaultOutputName)")
-                                        .font(.caption)
-                                        .foregroundStyle(self.settingsTertiaryText)
-                                        .lineLimit(1)
-                                }
-                            }
+                            self.microphoneQualityGuidance
                         }
                     }
                     .padding(16)
@@ -2313,6 +2301,59 @@ struct SettingsView: View {
 }
 
 private extension SettingsView {
+    var selectedInputDevice: AudioDevice.Device? {
+        self.inputDevices.first { $0.uid == self.selectedInputUID }
+    }
+
+    func inputDeviceTitle(_ device: AudioDevice.Device) -> String {
+        var annotations: [String] = []
+        if self.cachedDefaultInputName.isEmpty == false,
+           device.name == self.cachedDefaultInputName
+        {
+            annotations.append("System Default")
+        }
+        if device.isBuiltIn {
+            annotations.append("Recommended")
+        } else if device.isBluetooth {
+            annotations.append("Reduces output quality")
+        }
+
+        guard annotations.isEmpty == false else { return device.name }
+        return "\(device.name) (\(annotations.joined(separator: ", ")))"
+    }
+
+    @ViewBuilder
+    var microphoneQualityGuidance: some View {
+        if self.selectedInputDevice?.isBluetooth == true {
+            self.microphoneQualityGuidanceRow(
+                message: "AirPods and other Bluetooth microphones reduce headphone audio quality. Use your Mac’s microphone or another non-Bluetooth mic.",
+                systemImage: "exclamationmark.triangle.fill",
+                color: self.theme.palette.warning
+            )
+        } else {
+            self.microphoneQualityGuidanceRow(
+                message: "For the best audio quality, use your Mac’s microphone or another non-Bluetooth mic.",
+                systemImage: "info.circle",
+                color: self.settingsSecondaryText
+            )
+        }
+    }
+
+    func microphoneQualityGuidanceRow(
+        message: String,
+        systemImage: String,
+        color: Color
+    ) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: systemImage)
+                .foregroundStyle(color)
+            Text(message)
+                .font(self.theme.typography.bodySmall)
+                .foregroundStyle(color)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     var microphoneModeInfo: some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "info.circle")

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -440,6 +440,35 @@ final class HotkeyShortcutTests: XCTestCase {
         }
     }
 
+    func testAudioDeviceClassifiesBluetoothTransports() {
+        let bluetoothDevice = Self.device(
+            uid: "bluetooth",
+            name: "Bluetooth Microphone",
+            transportType: kAudioDeviceTransportTypeBluetooth
+        )
+        let bluetoothLEDevice = Self.device(
+            uid: "bluetooth-le",
+            name: "Bluetooth LE Microphone",
+            transportType: kAudioDeviceTransportTypeBluetoothLE
+        )
+
+        XCTAssertTrue(bluetoothDevice.isBluetooth)
+        XCTAssertTrue(bluetoothLEDevice.isBluetooth)
+        XCTAssertFalse(bluetoothDevice.isBuiltIn)
+        XCTAssertFalse(bluetoothLEDevice.isBuiltIn)
+    }
+
+    func testAudioDeviceClassifiesBuiltInTransport() {
+        let builtInDevice = Self.device(
+            uid: "built-in",
+            name: "MacBook Pro Microphone",
+            transportType: kAudioDeviceTransportTypeBuiltIn
+        )
+
+        XCTAssertTrue(builtInDevice.isBuiltIn)
+        XCTAssertFalse(builtInDevice.isBluetooth)
+    }
+
     @MainActor
     func testMicrophoneCoordinatorSkipsSystemMode() throws {
         try self.withRestoredDefaults(keys: [
@@ -554,13 +583,18 @@ final class HotkeyShortcutTests: XCTestCase {
         }
     }
 
-    private static func device(uid: String, name: String) -> AudioDevice.Device {
+    private static func device(
+        uid: String,
+        name: String,
+        transportType: UInt32 = kAudioDeviceTransportTypeUnknown
+    ) -> AudioDevice.Device {
         AudioDevice.Device(
             id: AudioObjectID(abs(uid.hashValue % 100_000) + 1),
             uid: uid,
             name: name,
             hasInput: true,
-            hasOutput: false
+            hasOutput: false,
+            transportType: transportType
         )
     }
 


### PR DESCRIPTION
<!--
PRs that do not follow this template will be blocked by the PR Policy check.
If the missing information is not fixed after 48 hours, the PR may be closed.
-->

## Description
A few folks have complained that when using FluidVoice with Airpods, the audio gets muffled. This is because Airpods goes into "call mode" as mic is activated, as a result the audio is downsampled, which makes it looks like its muffled. For now, this PR adds a info/warning message as there is not much we can do about this. We might be able to release the mic during idle periods which could offset this problem. Will look into this further and take it up in a later PR. 

## Type of Change
- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
#709 

## Testing
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`


## Screenshots / Video
<img width="2682" height="1882" alt="CleanShot 2026-07-28 at 20 15 50@2x" src="https://github.com/user-attachments/assets/8b5212e1-340b-42b7-b3bd-12ca7cb80385" />
<img width="2682" height="1882" alt="CleanShot 2026-07-28 at 20 16 04@2x" src="https://github.com/user-attachments/assets/1d4499f5-8c2e-4467-8e99-8edca5c1d694" />


## Notes
Add reviewer context, rollout notes, or known tradeoffs here.
