### PR TITLE
Fix Bluetooth headset mode churn while idle

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -251,7 +251,9 @@ struct ContentView: View {
     @State private var visualizerNoiseThreshold: Double = SettingsStore.shared.visualizerNoiseThreshold
     @State private var inputDevices: [AudioDevice.Device] = []
     @State private var outputDevices: [AudioDevice.Device] = []
-    @State private var selectedInputUID: String = AudioDevice.getDefaultInputDevice()?.uid ?? ""
+    // Populated by gated audio initialization; querying Core Audio while SwiftUI
+    // constructs this view can race AttributeGraph metadata processing.
+    @State private var selectedInputUID: String = ""
     @State private var selectedOutputUID: String = SettingsStore.shared.preferredOutputDeviceUID ?? ""
     @State private var microphoneSelectionMode: SettingsStore.MicrophoneSelectionMode = SettingsStore.shared.microphoneSelectionMode
 

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -601,38 +601,43 @@ struct ContentView: View {
             DebugLogger.shared.info("🚦 Startup delay complete, signaling UI ready...", source: "ContentView")
             self.appServices.signalUIReady()
 
-            DebugLogger.shared.info("🔊 Starting delayed audio initialization...", source: "ContentView")
-            self.audioObserver.startObserving()
-            self.asr.initialize()
-            self.menuBarManager.configure(asrService: self.appServices.asr)
-            self.refreshDevices()
+            Task { @MainActor in
+                await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+                await AudioStartupGate.shared.waitUntilOpen()
 
-            switch SettingsStore.shared.microphoneSelectionMode {
-            case .system:
-                if let defaultUID = AudioDevice.getDefaultInputDevice()?.uid {
-                    self.selectedInputUID = defaultUID
+                DebugLogger.shared.info("🔊 Starting gated audio initialization...", source: "ContentView")
+                self.audioObserver.startObserving()
+                await self.asr.initialize()
+                self.menuBarManager.configure(asrService: self.appServices.asr)
+                self.refreshDevices()
+
+                switch SettingsStore.shared.microphoneSelectionMode {
+                case .system:
+                    if let defaultUID = AudioDevice.getDefaultInputDevice()?.uid {
+                        self.selectedInputUID = defaultUID
+                    }
+                case .manual:
+                    if let preferredUID = SettingsStore.shared.preferredInputDeviceUID, !preferredUID.isEmpty {
+                        self.selectedInputUID = preferredUID
+                    } else if let defaultUID = AudioDevice.getDefaultInputDevice()?.uid {
+                        self.selectedInputUID = defaultUID
+                        SettingsStore.shared.preferredInputDeviceUID = defaultUID
+                    }
                 }
-            case .manual:
-                if let preferredUID = SettingsStore.shared.preferredInputDeviceUID, !preferredUID.isEmpty {
-                    self.selectedInputUID = preferredUID
-                } else if let defaultUID = AudioDevice.getDefaultInputDevice()?.uid {
-                    self.selectedInputUID = defaultUID
-                    SettingsStore.shared.preferredInputDeviceUID = defaultUID
+
+                if self.selectedOutputUID.isEmpty, let defOut = AudioDevice.getDefaultOutputDevice()?.uid {
+                    self.selectedOutputUID = defOut
                 }
-            }
 
-            if self.selectedOutputUID.isEmpty, let defOut = AudioDevice.getDefaultOutputDevice()?.uid {
-                self.selectedOutputUID = defOut
-            }
+                if let prefOut = SettingsStore.shared.preferredOutputDeviceUID,
+                   !prefOut.isEmpty,
+                   outputDevices.first(where: { $0.uid == prefOut }) != nil
+                {
+                    self.selectedOutputUID = prefOut
+                }
 
-            if let prefOut = SettingsStore.shared.preferredOutputDeviceUID,
-               !prefOut.isEmpty,
-               outputDevices.first(where: { $0.uid == prefOut }) != nil
-            {
-                self.selectedOutputUID = prefOut
+                DebugLogger.shared.info("✅ Audio subsystems initialized", source: "ContentView")
             }
-
-            DebugLogger.shared.info("✅ Audio subsystems initialized", source: "ContentView")
         }
     }
 

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -557,6 +557,10 @@ struct ContentView: View {
         self.appear = true
         self.refreshAccessibilityPermissionState()
 
+        Task {
+            await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+        }
+
         self.handleMenuBarNavigation(self.menuBarManager.requestedNavigationDestination)
         if UserDefaults.standard.bool(forKey: self.accessibilityRestartFlagKey) {
             UserDefaults.standard.set(false, forKey: self.accessibilityRestartFlagKey)

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -827,20 +827,9 @@ final class ASRService: ObservableObject {
         self.audioEngineStandbyTask = nil
 
         await self.directAudioLifecycleController.invalidate(reason: reason)
-        self.activeAudioCaptureBackend = .none
-
-        if self.isEngineTapInstalled {
-            if let engine = self.engineStorage as? AVAudioEngine {
-                engine.inputNode.removeTap(onBus: 0)
-            }
-            self.isEngineTapInstalled = false
-        }
-        if let engine = self.engineStorage as? AVAudioEngine, engine.isRunning {
-            engine.stop()
-        }
-        self.audioCapturePipeline.clearPreroll()
-        self.benchmarkLog("audio_engine_standby cooled=true reason=\(reason)")
-        DebugLogger.shared.debug("Audio engine cooled to stopped warm state (\(reason))", source: "ASRService")
+        await self.retireAudioEngineAndWait(reason: reason)
+        self.benchmarkLog("audio_engine_standby retired=true reason=\(reason)")
+        DebugLogger.shared.debug("Audio engine fully retired from standby (\(reason))", source: "ASRService")
     }
 
     private func prewarmConfiguredAudioCaptureIfPossible(
@@ -865,31 +854,35 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.debug("Audio engine prewarm skipped - route recovery active", source: "ASRService")
             return
         }
+        guard AudioCaptureIdlePolicy.shouldPrewarmCapture(
+            experimentalDirectAudioCaptureEnabled: SettingsStore.shared.experimentalDirectAudioCaptureEnabled
+        ) else {
+            // Constructing AVAudioEngine while idle instantiates its input and
+            // output audio units. Bluetooth headsets can then remain in the
+            // low-bandwidth HFP route even though no recording is active.
+            if self.hasWarmAudioEngine {
+                await self.retireAudioEngineAndWait(reason: "legacy_idle_prewarm_suppressed")
+            }
+            DebugLogger.shared.debug(
+                "Legacy AVAudioEngine idle prewarm skipped to preserve playback quality",
+                source: "ASRService"
+            )
+            return
+        }
         guard self.hasPreparedAudioCapture == false else {
             DebugLogger.shared.debug("Audio capture prewarm skipped - backend already prepared", source: "ASRService")
             return
         }
 
         let startedAt = Date().timeIntervalSince1970
-        if SettingsStore.shared.experimentalDirectAudioCaptureEnabled {
-            do {
-                _ = try await self.prepareDirectAudioInput(reason: reason)
-                self.benchmarkLog("direct_audio_prewarm reason=\(reason) elapsedMs=\(self.elapsedMilliseconds(since: startedAt))")
-            } catch {
-                DebugLogger.shared.warning(
-                    "Direct Core Audio prewarm failed: \(error.localizedDescription)",
-                    source: "ASRService"
-                )
-            }
-            return
-        }
-
         do {
-            try self.configureSession()
-            self.benchmarkLog("audio_engine_prewarm reason=\(reason) elapsedMs=\(self.elapsedMilliseconds(since: startedAt))")
+            _ = try await self.prepareDirectAudioInput(reason: reason)
+            self.benchmarkLog("direct_audio_prewarm reason=\(reason) elapsedMs=\(self.elapsedMilliseconds(since: startedAt))")
         } catch {
-            self.retireAudioEngine(reason: "prewarm_failed")
-            DebugLogger.shared.warning("Audio engine prewarm failed: \(error.localizedDescription)", source: "ASRService")
+            DebugLogger.shared.warning(
+                "Direct Core Audio prewarm failed: \(error.localizedDescription)",
+                source: "ASRService"
+            )
         }
     }
 
@@ -1262,6 +1255,13 @@ final class ASRService: ObservableObject {
         // Check microphone permission (deferred from init to avoid AVFCapture race condition)
         self.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         self.micPermissionGranted = (self.micStatus == .authorized)
+
+        let microphonePreferenceCoordinator =
+            AppServices.shared.microphonePreferenceCoordinator
+        _ = microphonePreferenceCoordinator.enforcePreferredInput(reason: "startup")
+        microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
+            reason: "startup"
+        )
 
         self.registerDefaultDeviceChangeListener()
         self.registerEngineConfigurationChangeObserver()
@@ -1832,14 +1832,14 @@ final class ASRService: ObservableObject {
 
         // A prepared direct IOProc owns only fixed memory and registration; it
         // does not run hardware, show the mic indicator, or hold Bluetooth in
-        // headset mode. Keep it prepared across idle periods. The heavier
-        // AVAudioEngine remains available when Faster Recording Start is disabled.
+        // headset mode. Keep it prepared across idle periods. AVAudioEngine,
+        // however, must be fully released so Bluetooth returns to stereo A2DP.
         if self.directAudioLifecycleController.snapshot.isPrepared {
             self.audioEngineStandbyTask?.cancel()
             self.audioEngineStandbyTask = nil
             DebugLogger.shared.debug("♻️ Direct audio capture remains prepared", source: "ASRService")
         } else {
-            self.scheduleAudioEngineStandbyRetirement()
+            await self.retireAudioEngineAndWait(reason: "recording_stop_release")
         }
 
         // Capture has fully ended — invoke the callback so callers can play a
@@ -2979,10 +2979,10 @@ final class ASRService: ObservableObject {
 
     private func handleDefaultInputChanged() {
         if SettingsStore.shared.microphoneSelectionMode == .manual {
+            AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
+                reason: "default input changed"
+            )
             if self.isRunning || self.isStarting {
-                AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
-                    reason: "default input changed"
-                )
                 self.scheduleAudioRouteRecovery(reason: "manual preferred input reasserted")
             }
             return
@@ -3004,6 +3004,16 @@ final class ASRService: ObservableObject {
         guard let currentEngine = self.engineStorage as? AVAudioEngine,
               ObjectIdentifier(currentEngine) == changedEngineIdentifier
         else { return }
+        guard AudioCaptureIdlePolicy.shouldRecoverEngineConfigurationChange(
+            isRunning: self.isRunning,
+            isStarting: self.isStarting
+        ) else {
+            DebugLogger.shared.debug(
+                "Ignoring AVAudioEngine configuration change while capture is idle",
+                source: "ASRService"
+            )
+            return
+        }
 
         self.scheduleAudioRouteRecovery(reason: "engine configuration changed")
     }
@@ -3235,8 +3245,7 @@ final class ASRService: ObservableObject {
 
                 DebugLogger.shared.debug("Current input devices: \(currentDevices.map { $0.name }.joined(separator: ", "))", source: "ASRService")
 
-                if self.isRunning,
-                   SettingsStore.shared.microphoneSelectionMode == .manual,
+                if SettingsStore.shared.microphoneSelectionMode == .manual,
                    Set(currentDevices.map(\.uid)) != cachedUIDs
                 {
                     AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -3255,11 +3255,12 @@ final class ASRService: ObservableObject {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 let cachedUIDs = self.cachedDeviceUIDs
+                let currentUIDs = Set(currentDevices.map(\.uid))
 
                 DebugLogger.shared.debug("Current input devices: \(currentDevices.map { $0.name }.joined(separator: ", "))", source: "ASRService")
 
                 if SettingsStore.shared.microphoneSelectionMode == .manual,
-                   Set(currentDevices.map(\.uid)) != cachedUIDs
+                   currentUIDs != cachedUIDs
                 {
                     if AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
                         experimentalDirectAudioCaptureEnabled: SettingsStore.shared.experimentalDirectAudioCaptureEnabled
@@ -3267,9 +3268,13 @@ final class ASRService: ObservableObject {
                         AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
                             reason: "input device list changed"
                         )
-                    } else {
+                    } else if AudioCaptureIdlePolicy.didPreferredInputAvailabilityChange(
+                        preferredInputUID: SettingsStore.shared.preferredInputDeviceUID,
+                        previousInputUIDs: cachedUIDs,
+                        currentInputUIDs: currentUIDs
+                    ) {
                         self.scheduleAudioRouteRecovery(
-                            reason: "direct input device list changed",
+                            reason: "direct preferred input availability changed",
                             requiresIdlePrewarm: true
                         )
                     }

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1256,13 +1256,6 @@ final class ASRService: ObservableObject {
         self.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         self.micPermissionGranted = (self.micStatus == .authorized)
 
-        let microphonePreferenceCoordinator =
-            AppServices.shared.microphonePreferenceCoordinator
-        _ = microphonePreferenceCoordinator.enforcePreferredInput(reason: "startup")
-        microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
-            reason: "startup"
-        )
-
         self.registerDefaultDeviceChangeListener()
         self.registerEngineConfigurationChangeObserver()
         self.registerDeviceListChangeListener()
@@ -1273,7 +1266,18 @@ final class ASRService: ObservableObject {
         // Register the input callback and allocate its fixed ring now. This
         // does not start the device or show the microphone privacy indicator.
         Task { @MainActor [weak self] in
-            await self?.prewarmConfiguredAudioCaptureIfPossible(reason: "startup")
+            await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+            await AudioStartupGate.shared.waitUntilOpen()
+            guard let self, self.isTerminating == false else { return }
+
+            let microphonePreferenceCoordinator =
+                AppServices.shared.microphonePreferenceCoordinator
+            _ = microphonePreferenceCoordinator.enforcePreferredInput(reason: "startup")
+            microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
+                reason: "startup"
+            )
+
+            await self.prewarmConfiguredAudioCaptureIfPossible(reason: "startup")
         }
 
         // Check if models exist on disk and auto-load if present
@@ -1832,14 +1836,17 @@ final class ASRService: ObservableObject {
 
         // A prepared direct IOProc owns only fixed memory and registration; it
         // does not run hardware, show the mic indicator, or hold Bluetooth in
-        // headset mode. Keep it prepared across idle periods. AVAudioEngine,
-        // however, must be fully released so Bluetooth returns to stereo A2DP.
+        // headset mode. Keep it prepared across idle periods. AVAudioEngine is
+        // detached immediately and released by the off-main serial drain so
+        // Bluetooth can return to stereo A2DP without delaying stop cues or
+        // transcription. The next capture waits on the drain before creating
+        // another engine.
         if self.directAudioLifecycleController.snapshot.isPrepared {
             self.audioEngineStandbyTask?.cancel()
             self.audioEngineStandbyTask = nil
             DebugLogger.shared.debug("♻️ Direct audio capture remains prepared", source: "ASRService")
         } else {
-            await self.retireAudioEngineAndWait(reason: "recording_stop_release")
+            self.retireAudioEngine(reason: "recording_stop_release")
         }
 
         // Capture has fully ended — invoke the callback so callers can play a

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -874,6 +874,22 @@ final class ASRService: ObservableObject {
             return
         }
 
+        // A legacy stop releases AVAudioEngine on the serial retirement drain.
+        // Do not register a direct Core Audio backend until that teardown has
+        // completed, then recheck state because this await yields the main actor.
+        await self.audioEngineRetirementDrain.waitForScheduledReleases()
+        guard self.isTerminating == false,
+              self.isRunning == false,
+              self.isStarting == false || allowDuringRouteRecovery,
+              self.hasPreparedAudioCapture == false
+        else {
+            DebugLogger.shared.debug(
+                "Audio capture prewarm skipped - state changed while waiting for engine retirement",
+                source: "ASRService"
+            )
+            return
+        }
+
         let startedAt = Date().timeIntervalSince1970
         do {
             _ = try await self.prepareDirectAudioInput(reason: reason)

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1251,10 +1251,25 @@ final class ASRService: ObservableObject {
 
     /// Call this AFTER the app has finished launching to complete ASR initialization.
     /// This must be called from onAppear or later, never during init.
-    func initialize() {
+    func initialize() async {
+        await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+        await AudioStartupGate.shared.waitUntilOpen()
+        guard self.isTerminating == false else { return }
+
         // Check microphone permission (deferred from init to avoid AVFCapture race condition)
         self.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         self.micPermissionGranted = (self.micStatus == .authorized)
+
+        if AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
+            experimentalDirectAudioCaptureEnabled: SettingsStore.shared.experimentalDirectAudioCaptureEnabled
+        ) {
+            let microphonePreferenceCoordinator =
+                AppServices.shared.microphonePreferenceCoordinator
+            _ = microphonePreferenceCoordinator.enforcePreferredInput(reason: "startup")
+            microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
+                reason: "startup"
+            )
+        }
 
         self.registerDefaultDeviceChangeListener()
         self.registerEngineConfigurationChangeObserver()
@@ -1265,20 +1280,7 @@ final class ASRService: ObservableObject {
 
         // Register the input callback and allocate its fixed ring now. This
         // does not start the device or show the microphone privacy indicator.
-        Task { @MainActor [weak self] in
-            await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
-            await AudioStartupGate.shared.waitUntilOpen()
-            guard let self, self.isTerminating == false else { return }
-
-            let microphonePreferenceCoordinator =
-                AppServices.shared.microphonePreferenceCoordinator
-            _ = microphonePreferenceCoordinator.enforcePreferredInput(reason: "startup")
-            microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
-                reason: "startup"
-            )
-
-            await self.prewarmConfiguredAudioCaptureIfPossible(reason: "startup")
-        }
+        await self.prewarmConfiguredAudioCaptureIfPossible(reason: "startup")
 
         // Check if models exist on disk and auto-load if present
         // This is done in a Task to support async model detection (e.g., AppleSpeechAnalyzerProvider)
@@ -2986,11 +2988,15 @@ final class ASRService: ObservableObject {
 
     private func handleDefaultInputChanged() {
         if SettingsStore.shared.microphoneSelectionMode == .manual {
-            AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
-                reason: "default input changed"
-            )
-            if self.isRunning || self.isStarting {
-                self.scheduleAudioRouteRecovery(reason: "manual preferred input reasserted")
+            if AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
+                experimentalDirectAudioCaptureEnabled: SettingsStore.shared.experimentalDirectAudioCaptureEnabled
+            ) {
+                AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
+                    reason: "default input changed"
+                )
+                if self.isRunning || self.isStarting {
+                    self.scheduleAudioRouteRecovery(reason: "manual preferred input reasserted")
+                }
             }
             return
         }
@@ -3255,9 +3261,18 @@ final class ASRService: ObservableObject {
                 if SettingsStore.shared.microphoneSelectionMode == .manual,
                    Set(currentDevices.map(\.uid)) != cachedUIDs
                 {
-                    AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
-                        reason: "input device list changed"
-                    )
+                    if AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
+                        experimentalDirectAudioCaptureEnabled: SettingsStore.shared.experimentalDirectAudioCaptureEnabled
+                    ) {
+                        AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
+                            reason: "input device list changed"
+                        )
+                    } else {
+                        self.scheduleAudioRouteRecovery(
+                            reason: "direct input device list changed",
+                            requiresIdlePrewarm: true
+                        )
+                    }
                 }
 
                 self.cacheCurrentDeviceList(currentDevices)

--- a/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
+++ b/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
@@ -3,6 +3,12 @@ enum AudioCaptureIdlePolicy {
         experimentalDirectAudioCaptureEnabled
     }
 
+    static func shouldEnforceSystemPreferredInput(
+        experimentalDirectAudioCaptureEnabled: Bool
+    ) -> Bool {
+        experimentalDirectAudioCaptureEnabled == false
+    }
+
     static func shouldRecoverEngineConfigurationChange(
         isRunning: Bool,
         isStarting: Bool

--- a/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
+++ b/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
@@ -9,6 +9,15 @@ enum AudioCaptureIdlePolicy {
         experimentalDirectAudioCaptureEnabled == false
     }
 
+    static func didPreferredInputAvailabilityChange(
+        preferredInputUID: String?,
+        previousInputUIDs: Set<String>,
+        currentInputUIDs: Set<String>
+    ) -> Bool {
+        guard let preferredInputUID, preferredInputUID.isEmpty == false else { return false }
+        return previousInputUIDs.contains(preferredInputUID) != currentInputUIDs.contains(preferredInputUID)
+    }
+
     static func shouldRecoverEngineConfigurationChange(
         isRunning: Bool,
         isStarting: Bool

--- a/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
+++ b/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
@@ -1,0 +1,12 @@
+enum AudioCaptureIdlePolicy {
+    static func shouldPrewarmCapture(experimentalDirectAudioCaptureEnabled: Bool) -> Bool {
+        experimentalDirectAudioCaptureEnabled
+    }
+
+    static func shouldRecoverEngineConfigurationChange(
+        isRunning: Bool,
+        isStarting: Bool
+    ) -> Bool {
+        isRunning || isStarting
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -182,6 +182,26 @@ final class HotkeyShortcutTests: XCTestCase {
         ))
     }
 
+    func testDirectRecoveryTracksOnlyPreferredInputAvailability() {
+        let previousUIDs = Set(["preferred", "built-in"])
+
+        XCTAssertFalse(AudioCaptureIdlePolicy.didPreferredInputAvailabilityChange(
+            preferredInputUID: "preferred",
+            previousInputUIDs: previousUIDs,
+            currentInputUIDs: previousUIDs.union(["unrelated"])
+        ))
+        XCTAssertTrue(AudioCaptureIdlePolicy.didPreferredInputAvailabilityChange(
+            preferredInputUID: "preferred",
+            previousInputUIDs: previousUIDs,
+            currentInputUIDs: ["built-in"]
+        ))
+        XCTAssertTrue(AudioCaptureIdlePolicy.didPreferredInputAvailabilityChange(
+            preferredInputUID: "preferred",
+            previousInputUIDs: ["built-in"],
+            currentInputUIDs: previousUIDs
+        ))
+    }
+
     func testEngineConfigurationChangesRecoverOnlyDuringCaptureTransitions() {
         XCTAssertFalse(AudioCaptureIdlePolicy.shouldRecoverEngineConfigurationChange(
             isRunning: false,

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -173,6 +173,15 @@ final class HotkeyShortcutTests: XCTestCase {
         ))
     }
 
+    func testSystemPreferredInputIsEnforcedOnlyForLegacyCapture() {
+        XCTAssertTrue(AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
+            experimentalDirectAudioCaptureEnabled: false
+        ))
+        XCTAssertFalse(AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
+            experimentalDirectAudioCaptureEnabled: true
+        ))
+    }
+
     func testEngineConfigurationChangesRecoverOnlyDuringCaptureTransitions() {
         XCTAssertFalse(AudioCaptureIdlePolicy.shouldRecoverEngineConfigurationChange(
             isRunning: false,

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -161,6 +161,33 @@ final class HotkeyShortcutTests: XCTestCase {
         }
     }
 
+    func testLegacyAVAudioEngineDoesNotPrewarmWhileIdle() {
+        XCTAssertFalse(AudioCaptureIdlePolicy.shouldPrewarmCapture(
+            experimentalDirectAudioCaptureEnabled: false
+        ))
+    }
+
+    func testPreparedDirectCaptureMayRemainWarmWhileIdle() {
+        XCTAssertTrue(AudioCaptureIdlePolicy.shouldPrewarmCapture(
+            experimentalDirectAudioCaptureEnabled: true
+        ))
+    }
+
+    func testEngineConfigurationChangesRecoverOnlyDuringCaptureTransitions() {
+        XCTAssertFalse(AudioCaptureIdlePolicy.shouldRecoverEngineConfigurationChange(
+            isRunning: false,
+            isStarting: false
+        ))
+        XCTAssertTrue(AudioCaptureIdlePolicy.shouldRecoverEngineConfigurationChange(
+            isRunning: true,
+            isStarting: false
+        ))
+        XCTAssertTrue(AudioCaptureIdlePolicy.shouldRecoverEngineConfigurationChange(
+            isRunning: false,
+            isStarting: true
+        ))
+    }
+
     func testLegacyKeyboardShortcutPayloadDefaultsToKeyboardKind() throws {
         let json = #"{"keyCode":61,"modifierFlagsRawValue":0}"#
         let data = try XCTUnwrap(json.data(using: .utf8))


### PR DESCRIPTION
## Description

Prevents FluidVoice from repeatedly forcing Bluetooth headphones into low-quality HFP/call mode while dictation is idle.

On v1.6.6, a legacy `AVAudioEngine` idle prewarm can publish `AVAudioEngineConfigurationChange` immediately after it is created. FluidVoice treats that notification as another idle route change, retires the engine, prewarms a replacement, and repeats indefinitely. In a reproduced session this reached more than 3,000 recovery generations, with each generation creating input/output audio units again. Bluetooth playback oscillated or remained at 16 kHz mono until FluidVoice quit.

This PR:

- only prewarms the idle capture backend when direct Core Audio is enabled; the legacy `AVAudioEngine` is created on demand instead
- ignores `AVAudioEngineConfigurationChange` while capture is fully idle, preventing the self-generated recovery loop
- fully retires the legacy engine after dictation rather than retaining a stopped engine that still owns AUHAL resources
- reasserts the manually selected microphone at startup and after default-input/device-list changes even when no recording is active
- keeps the safe direct Core Audio prepared path unchanged
- adds regression coverage for the idle capture policy

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #694.

Also relates to #678 and the user reports collected in #727, #663, and #695.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2 (25F84)
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — blocked because this machine has Command Line Tools but not Xcode's `sourcekitdInProc.framework`
- [x] Ran formatter locally: targeted SwiftFormat lint passed for all three changed files (the repository currently has unrelated `wrapIfStatementBodies` baseline findings in `ASRService.swift` under SwiftFormat 0.62.1)
- [x] Ran tests locally: the extracted idle-policy smoke test passed and all changed Swift files passed compiler parsing; the added XCTest cases are included for CI/Xcode

Hardware regression sequence:

1. Sony WH-CH720N connected as output; MacBook Pro Microphone selected manually as input.
2. Confirmed the release build looped through `engine configuration changed` idle recoveries and dropped output to the Bluetooth headset route.
3. Confirmed quitting FluidVoice restored `2 ch 32-bit Float 44.1 kHz` output.
4. Enabled direct Core Audio and verified a real record/stop cycle used the MacBook microphone at 48 kHz with zero dropped packets while headphone output stayed 2-channel/44.1 kHz.
5. Quit and relaunched FluidVoice; the direct input preference persisted and headphone output remained stereo.

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes

The normal Bluetooth quality drop while actively recording from a Bluetooth microphone is inherent to HFP. This fix targets the avoidable case: FluidVoice touching or retaining the input audio unit while idle, or allowing macOS to replace an explicitly preferred built-in microphone after a Bluetooth reconnect.

The direct Core Audio prewarm remains safe because it prepares registration and fixed memory without starting hardware IO.