### PR TITLE
Fix Cohere long transcription truncation

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */; };
 		A62300000000000000000002 /* AudioBufferConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62300000000000000000001 /* AudioBufferConverterTests.swift */; };
 		C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */; };
+		C0A3E0010000000000000002 /* TranscribeCppLongFormProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A3E0010000000000000001 /* TranscribeCppLongFormProcessorTests.swift */; };
 		DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */; };
 		7CDB0A2F2F3C4D5600FB7CAD /* dictation_fixture.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */; };
 		7CDB0A302F3C4D5600FB7CAD /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */; };
@@ -55,6 +56,7 @@
 		980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSupportTests.swift; sourceTree = "<group>"; };
 		A62300000000000000000001 /* AudioBufferConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioBufferConverterTests.swift; sourceTree = "<group>"; };
 		C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineRetirementDrainTests.swift; sourceTree = "<group>"; };
+		C0A3E0010000000000000001 /* TranscribeCppLongFormProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscribeCppLongFormProcessorTests.swift; sourceTree = "<group>"; };
 		DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectAudioReliabilityTests.swift; sourceTree = "<group>"; };
 		7C078D8F2E3B339200FB7CAC /* FluidVoice Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FluidVoice Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 				980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */,
 				A62300000000000000000001 /* AudioBufferConverterTests.swift */,
 				C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */,
+				C0A3E0010000000000000001 /* TranscribeCppLongFormProcessorTests.swift */,
 				DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
@@ -294,6 +297,7 @@
 				272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */,
 				A62300000000000000000002 /* AudioBufferConverterTests.swift in Sources */,
 				C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */,
+				C0A3E0010000000000000002 /* TranscribeCppLongFormProcessorTests.swift in Sources */,
 				DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -4205,7 +4205,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetTDTv2: return "~442.9 MiB"
             case .parakeetRealtime: return "~428.4 MiB"
             case .qwen3Asr: return "~2.0 GiB"
-            case .cohereTranscribeSixBit: return "~1.54 GiB"
+            case .cohereTranscribeSixBit: return "~1.45 GiB"
             case .nemotronOffline: return "~530.8 MiB"
             case .nemotronStreaming: return "~668.2 MiB"
             case .nemotronStreaming320: return "~668.2 MiB"
@@ -4226,7 +4226,7 @@ final class SettingsStore: ObservableObject {
             case .parakeetTDTv2: return 464_421_712
             case .parakeetRealtime: return 449_190_189
             case .qwen3Asr: return 2000 * 1024 * 1024
-            case .cohereTranscribeSixBit: return 1_650_748_785
+            case .cohereTranscribeSixBit: return 1_558_162_944
             case .nemotronOffline: return 556_552_620
             case .nemotronStreaming, .nemotronStreaming320: return 700_685_415
             case .whisperTiny: return 45_981_088
@@ -4263,6 +4263,16 @@ final class SettingsStore: ObservableObject {
             case .whisperLargeTurbo: return "whisper-large-v3-turbo-Q8_0.gguf"
             case .whisperLarge: return "whisper-large-v3-Q8_0.gguf"
             default: return nil
+            }
+        }
+
+        /// The GGUF filename for any model served by transcribe.cpp.
+        var transcribeCppModelFile: String? {
+            switch self {
+            case .cohereTranscribeSixBit:
+                return "cohere-transcribe-03-2026-Q4_K_M.gguf"
+            default:
+                return self.whisperModelFile
             }
         }
 
@@ -4692,13 +4702,16 @@ final class SettingsStore: ObservableObject {
                 return false
                 #endif
             case .cohereTranscribeSixBit:
-                guard
-                    let spec = self.externalCoreMLSpec,
-                    let directory = SettingsStore.shared.externalCoreMLArtifactsDirectory(for: self)
-                else {
-                    return false
-                }
-                return spec.validatesInstalledArtifacts(at: directory)
+                guard let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first,
+                      let modelFile = self.transcribeCppModelFile
+                else { return false }
+                let modelURL = cacheDirectory
+                    .appendingPathComponent("CohereTranscribeModels", isDirectory: true)
+                    .appendingPathComponent(modelFile, isDirectory: false)
+                guard let attributes = try? FileManager.default.attributesOfItem(atPath: modelURL.path),
+                      let size = attributes[.size] as? NSNumber
+                else { return false }
+                return size.int64Value == self.expectedDownloadBytes
             case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
                 let hint: String
                 switch self {

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -353,7 +353,7 @@ final class ASRService: ObservableObject {
         case .parakeetRealtime:
             return self.getParakeetRealtimeProvider()
         case .cohereTranscribeSixBit:
-            return self.getExternalCoreMLProvider()
+            return self.getWhisperProvider()
         case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
             return self.getNemotronProvider(mode: model.nemotronProviderMode)
         case .qwen3Asr:
@@ -554,7 +554,7 @@ final class ASRService: ObservableObject {
         case .parakeetRealtime:
             return ParakeetRealtimeProvider()
         case .cohereTranscribeSixBit:
-            return ExternalCoreMLTranscriptionProvider(modelOverride: model)
+            return WhisperProvider(modelOverride: model)
         case .nemotronOffline, .nemotronStreaming, .nemotronStreaming320:
             return NemotronProvider(mode: model.nemotronProviderMode)
         case .qwen3Asr:

--- a/Sources/Fluid/Services/ExternalCoreMLModelRegistry.swift
+++ b/Sources/Fluid/Services/ExternalCoreMLModelRegistry.swift
@@ -206,30 +206,8 @@ struct ExternalCoreMLASRModelSpec {
 }
 
 enum ExternalCoreMLModelRegistry {
-    static func spec(for model: SettingsStore.SpeechModel) -> ExternalCoreMLASRModelSpec? {
-        switch model {
-        case .cohereTranscribeSixBit:
-            return ExternalCoreMLASRModelSpec(
-                backend: .cohereTranscribe,
-                artifactFolderHint: "cohere-transcribe-03-2026-CoreML-6bit",
-                manifestFileName: "coreml_manifest.json",
-                frontendFileName: "cohere_frontend.mlpackage",
-                encoderFileName: "cohere_encoder.mlpackage",
-                crossKVProjectorFileName: "cohere_cross_kv_projector.mlpackage",
-                decoderFileName: "cohere_decoder_fullseq_masked.mlpackage",
-                cachedDecoderFileName: "cohere_decoder_cached.mlpackage",
-                expectedModelID: "CohereLabs/cohere-transcribe-03-2026",
-                expectedSampleRate: 16_000,
-                computeConfiguration: .aneSmall,
-                sourceURL: URL(string: "https://huggingface.co/BarathwajAnandan/cohere-transcribe-03-2026-CoreML-6bit"),
-                repositoryOwner: "BarathwajAnandan",
-                repositoryName: "cohere-transcribe-03-2026-CoreML-6bit",
-                repositoryRevision: "main",
-                artifactBundleVersion: "2026-04-02-cohere-refresh-1"
-            )
-        default:
-            return nil
-        }
+    static func spec(for _: SettingsStore.SpeechModel) -> ExternalCoreMLASRModelSpec? {
+        nil
     }
 }
 

--- a/Sources/Fluid/Services/ExternalCoreMLTranscriptionProvider.swift
+++ b/Sources/Fluid/Services/ExternalCoreMLTranscriptionProvider.swift
@@ -11,8 +11,6 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
     private(set) var isReady: Bool = false
     var prefersNativeFileTranscription: Bool { true }
     private let streamingPreviewMaxSeconds: Double = 12
-    private let safeFinalChunkMaxSeconds: Double = 8
-    private let safeFinalChunkBoundarySearchSeconds: Double = 2
 
     private var cohereManager: CohereTranscribeAsrManager?
     private let modelOverride: SettingsStore.SpeechModel?
@@ -129,13 +127,9 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
             source: "ExternalCoreML"
         )
         let promptIDs = self.coherePromptIDsForCurrentLanguage()
-        let sampleRate = self.loadedManifest?.sampleRate ?? 16_000
-        let audioConverter = AudioConverter(sampleRate: Double(sampleRate))
-        let samples = try audioConverter.resampleAudioFile(fileURL)
-        let text = try await self.transcribeFinalChunks(
-            samples,
-            manager: manager,
-            promptIDs: promptIDs
+        let text = try await manager.transcribe(
+            audioFileAt: fileURL,
+            promptIDs: promptIDs.isEmpty ? nil : promptIDs
         )
         let elapsed = Date().timeIntervalSince(startedAt)
         DebugLogger.shared.info(
@@ -161,10 +155,9 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
             source: "ExternalCoreML"
         )
         let promptIDs = self.coherePromptIDsForCurrentLanguage()
-        let text = try await self.transcribeFinalChunks(
-            samples,
-            manager: manager,
-            promptIDs: promptIDs
+        let text = try await manager.transcribe(
+            audioSamples: samples,
+            promptIDs: promptIDs.isEmpty ? nil : promptIDs
         )
         let elapsed = Date().timeIntervalSince(startedAt)
         let rtf = audioSeconds > 0 ? elapsed / audioSeconds : 0
@@ -435,120 +428,6 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         let maxPreviewSamples = Int(Double(sampleRate) * self.streamingPreviewMaxSeconds)
         guard samples.count > maxPreviewSamples else { return samples }
         return Array(samples.suffix(maxPreviewSamples))
-    }
-
-    private func transcribeFinalChunks(
-        _ samples: [Float],
-        manager: CohereTranscribeAsrManager,
-        promptIDs: [Int]
-    ) async throws -> String {
-        let chunks = self.safeFinalChunkRanges(for: samples)
-        let runtimePromptIDs = promptIDs.isEmpty ? nil : promptIDs
-        var texts: [String] = []
-        texts.reserveCapacity(chunks.count)
-
-        for chunk in chunks {
-            try Task.checkCancellation()
-            let text = try await manager.transcribe(
-                audioSamples: Array(samples[chunk]),
-                promptIDs: runtimePromptIDs
-            ).trimmingCharacters(in: .whitespacesAndNewlines)
-            if !text.isEmpty {
-                texts.append(text)
-            }
-        }
-
-        DebugLogger.shared.info(
-            "ExternalCoreML: Cohere final transcription used \(chunks.count) token-safe chunk(s)",
-            source: "ExternalCoreML"
-        )
-        return self.joinFinalChunkTexts(texts)
-    }
-
-    private func joinFinalChunkTexts(_ texts: [String]) -> String {
-        texts.dropFirst().reduce(texts.first ?? "") { result, next in
-            guard
-                let previous = result.unicodeScalars.last,
-                let current = next.unicodeScalars.first
-            else { return result + next }
-
-            let needsSpace = !CharacterSet.whitespacesAndNewlines.contains(previous)
-                && !CharacterSet.punctuationCharacters.contains(current)
-                && !self.isCJK(previous)
-                && !self.isCJK(current)
-            return result + (needsSpace ? " " : "") + next
-        }
-    }
-
-    private func isCJK(_ scalar: UnicodeScalar) -> Bool {
-        switch scalar.value {
-        case 0x3040...0x30ff, 0x3400...0x4dbf, 0x4e00...0x9fff, 0xf900...0xfaff:
-            return true
-        default:
-            return false
-        }
-    }
-
-    private func safeFinalChunkRanges(for samples: [Float]) -> [Range<Int>] {
-        guard !samples.isEmpty else { return [] }
-
-        let sampleRate = self.loadedManifest?.sampleRate ?? 16_000
-        let maxChunkSamples = max(1, Int(Double(sampleRate) * self.safeFinalChunkMaxSeconds))
-        guard samples.count > maxChunkSamples else { return [samples.indices] }
-
-        let searchSamples = min(
-            maxChunkSamples - 1,
-            max(1, Int(Double(sampleRate) * self.safeFinalChunkBoundarySearchSeconds))
-        )
-        let energyWindowSamples = max(1, sampleRate / 10)
-        var chunks: [Range<Int>] = []
-        var start = 0
-
-        while start < samples.count {
-            let maximumEnd = min(start + maxChunkSamples, samples.count)
-            guard maximumEnd < samples.count else {
-                chunks.append(start..<samples.count)
-                break
-            }
-
-            let searchStart = max(start + 1, maximumEnd - searchSamples)
-            let split = self.quietestBoundary(
-                in: samples,
-                searchRange: searchStart..<maximumEnd,
-                windowSamples: energyWindowSamples
-            )
-            chunks.append(start..<split)
-            start = split
-        }
-
-        return chunks
-    }
-
-    private func quietestBoundary(
-        in samples: [Float],
-        searchRange: Range<Int>,
-        windowSamples: Int
-    ) -> Int {
-        let window = min(windowSamples, searchRange.count)
-        guard window > 0 else { return searchRange.upperBound }
-
-        var quietestStart = searchRange.lowerBound
-        var quietestEnergy = Float.greatestFiniteMagnitude
-        var windowStart = searchRange.lowerBound
-
-        while windowStart + window <= searchRange.upperBound {
-            var energy: Float = 0
-            for sample in samples[windowStart..<(windowStart + window)] {
-                energy += sample * sample
-            }
-            if energy < quietestEnergy {
-                quietestEnergy = energy
-                quietestStart = windowStart
-            }
-            windowStart += window
-        }
-
-        return max(searchRange.lowerBound, quietestStart + window / 2)
     }
 
     private func paddedSamplesToModelLimit(_ samples: [Float]) -> [Float] {

--- a/Sources/Fluid/Services/ExternalCoreMLTranscriptionProvider.swift
+++ b/Sources/Fluid/Services/ExternalCoreMLTranscriptionProvider.swift
@@ -11,6 +11,8 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
     private(set) var isReady: Bool = false
     var prefersNativeFileTranscription: Bool { true }
     private let streamingPreviewMaxSeconds: Double = 12
+    private let safeFinalChunkMaxSeconds: Double = 8
+    private let safeFinalChunkBoundarySearchSeconds: Double = 2
 
     private var cohereManager: CohereTranscribeAsrManager?
     private let modelOverride: SettingsStore.SpeechModel?
@@ -127,9 +129,13 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
             source: "ExternalCoreML"
         )
         let promptIDs = self.coherePromptIDsForCurrentLanguage()
-        let text = try await manager.transcribe(
-            audioFileAt: fileURL,
-            promptIDs: promptIDs.isEmpty ? nil : promptIDs
+        let sampleRate = self.loadedManifest?.sampleRate ?? 16_000
+        let audioConverter = AudioConverter(sampleRate: Double(sampleRate))
+        let samples = try audioConverter.resampleAudioFile(fileURL)
+        let text = try await self.transcribeFinalChunks(
+            samples,
+            manager: manager,
+            promptIDs: promptIDs
         )
         let elapsed = Date().timeIntervalSince(startedAt)
         DebugLogger.shared.info(
@@ -155,9 +161,10 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
             source: "ExternalCoreML"
         )
         let promptIDs = self.coherePromptIDsForCurrentLanguage()
-        let text = try await manager.transcribe(
-            audioSamples: samples,
-            promptIDs: promptIDs.isEmpty ? nil : promptIDs
+        let text = try await self.transcribeFinalChunks(
+            samples,
+            manager: manager,
+            promptIDs: promptIDs
         )
         let elapsed = Date().timeIntervalSince(startedAt)
         let rtf = audioSeconds > 0 ? elapsed / audioSeconds : 0
@@ -428,6 +435,120 @@ final class ExternalCoreMLTranscriptionProvider: TranscriptionProvider {
         let maxPreviewSamples = Int(Double(sampleRate) * self.streamingPreviewMaxSeconds)
         guard samples.count > maxPreviewSamples else { return samples }
         return Array(samples.suffix(maxPreviewSamples))
+    }
+
+    private func transcribeFinalChunks(
+        _ samples: [Float],
+        manager: CohereTranscribeAsrManager,
+        promptIDs: [Int]
+    ) async throws -> String {
+        let chunks = self.safeFinalChunkRanges(for: samples)
+        let runtimePromptIDs = promptIDs.isEmpty ? nil : promptIDs
+        var texts: [String] = []
+        texts.reserveCapacity(chunks.count)
+
+        for chunk in chunks {
+            try Task.checkCancellation()
+            let text = try await manager.transcribe(
+                audioSamples: Array(samples[chunk]),
+                promptIDs: runtimePromptIDs
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                texts.append(text)
+            }
+        }
+
+        DebugLogger.shared.info(
+            "ExternalCoreML: Cohere final transcription used \(chunks.count) token-safe chunk(s)",
+            source: "ExternalCoreML"
+        )
+        return self.joinFinalChunkTexts(texts)
+    }
+
+    private func joinFinalChunkTexts(_ texts: [String]) -> String {
+        texts.dropFirst().reduce(texts.first ?? "") { result, next in
+            guard
+                let previous = result.unicodeScalars.last,
+                let current = next.unicodeScalars.first
+            else { return result + next }
+
+            let needsSpace = !CharacterSet.whitespacesAndNewlines.contains(previous)
+                && !CharacterSet.punctuationCharacters.contains(current)
+                && !self.isCJK(previous)
+                && !self.isCJK(current)
+            return result + (needsSpace ? " " : "") + next
+        }
+    }
+
+    private func isCJK(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x3040...0x30ff, 0x3400...0x4dbf, 0x4e00...0x9fff, 0xf900...0xfaff:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func safeFinalChunkRanges(for samples: [Float]) -> [Range<Int>] {
+        guard !samples.isEmpty else { return [] }
+
+        let sampleRate = self.loadedManifest?.sampleRate ?? 16_000
+        let maxChunkSamples = max(1, Int(Double(sampleRate) * self.safeFinalChunkMaxSeconds))
+        guard samples.count > maxChunkSamples else { return [samples.indices] }
+
+        let searchSamples = min(
+            maxChunkSamples - 1,
+            max(1, Int(Double(sampleRate) * self.safeFinalChunkBoundarySearchSeconds))
+        )
+        let energyWindowSamples = max(1, sampleRate / 10)
+        var chunks: [Range<Int>] = []
+        var start = 0
+
+        while start < samples.count {
+            let maximumEnd = min(start + maxChunkSamples, samples.count)
+            guard maximumEnd < samples.count else {
+                chunks.append(start..<samples.count)
+                break
+            }
+
+            let searchStart = max(start + 1, maximumEnd - searchSamples)
+            let split = self.quietestBoundary(
+                in: samples,
+                searchRange: searchStart..<maximumEnd,
+                windowSamples: energyWindowSamples
+            )
+            chunks.append(start..<split)
+            start = split
+        }
+
+        return chunks
+    }
+
+    private func quietestBoundary(
+        in samples: [Float],
+        searchRange: Range<Int>,
+        windowSamples: Int
+    ) -> Int {
+        let window = min(windowSamples, searchRange.count)
+        guard window > 0 else { return searchRange.upperBound }
+
+        var quietestStart = searchRange.lowerBound
+        var quietestEnergy = Float.greatestFiniteMagnitude
+        var windowStart = searchRange.lowerBound
+
+        while windowStart + window <= searchRange.upperBound {
+            var energy: Float = 0
+            for sample in samples[windowStart..<(windowStart + window)] {
+                energy += sample * sample
+            }
+            if energy < quietestEnergy {
+                quietestEnergy = energy
+                quietestStart = windowStart
+            }
+            windowStart += window
+        }
+
+        return max(searchRange.lowerBound, quietestStart + window / 2)
     }
 
     private func paddedSamplesToModelLimit(_ samples: [Float]) -> [Float] {

--- a/Sources/Fluid/Services/WhisperProvider.swift
+++ b/Sources/Fluid/Services/WhisperProvider.swift
@@ -1,9 +1,181 @@
 import Foundation
 import TranscribeCpp
 
-/// TranscriptionProvider implementation using transcribe.cpp for Whisper GGUF models.
+enum TranscribeCppLongFormProcessor {
+    static func ranges(
+        sampleCount: Int,
+        sampleRate: Int,
+        maximumChunkSeconds: Double = 30,
+        overlapSeconds: Double = 2
+    ) -> [Range<Int>] {
+        guard sampleCount > 0, sampleRate > 0, maximumChunkSeconds > 0 else { return [] }
+
+        let maximumChunkSamples = max(1, Int(Double(sampleRate) * maximumChunkSeconds))
+        guard sampleCount > maximumChunkSamples else { return [0..<sampleCount] }
+
+        let requestedOverlap = max(0, Int(Double(sampleRate) * overlapSeconds))
+        let overlapSamples = min(requestedOverlap, maximumChunkSamples - 1)
+        var ranges: [Range<Int>] = []
+        var start = 0
+
+        while start < sampleCount {
+            let end = min(start + maximumChunkSamples, sampleCount)
+            ranges.append(start..<end)
+            guard end < sampleCount else { break }
+            start = end - overlapSamples
+        }
+
+        return ranges
+    }
+
+    static func merge(_ texts: [String]) -> String {
+        texts.reduce(into: "") { result, text in
+            let next = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !next.isEmpty else { return }
+            guard !result.isEmpty else {
+                result = next
+                return
+            }
+
+            if let merged = self.mergeCJK(left: result, right: next) {
+                result = merged
+                return
+            }
+
+            let leftTokens = result.split(whereSeparator: \.isWhitespace).map(String.init)
+            let rightTokens = next.split(whereSeparator: \.isWhitespace).map(String.init)
+            let overlap = self.wordOverlap(left: leftTokens, right: rightTokens)
+            let remaining = rightTokens.dropFirst(overlap)
+            guard !remaining.isEmpty else { return }
+            result += " " + remaining.joined(separator: " ")
+        }
+    }
+
+    private static func wordOverlap(left: [String], right: [String]) -> Int {
+        let maximum = min(24, left.count, right.count)
+        guard maximum > 0 else { return 0 }
+        let normalizedLeft = left.map(self.normalize)
+        let normalizedRight = right.map(self.normalize)
+
+        for count in stride(from: maximum, through: 1, by: -1) {
+            let leftStart = normalizedLeft.count - count
+            let matches = (0..<count).allSatisfy {
+                !normalizedLeft[leftStart + $0].isEmpty
+                    && normalizedLeft[leftStart + $0] == normalizedRight[$0]
+            }
+            guard matches else { continue }
+            if count > 1 || normalizedRight[0].count >= 4 || Int(normalizedRight[0]) != nil {
+                return count
+            }
+        }
+
+        for count in stride(from: maximum, through: 2, by: -1) {
+            let leftStart = normalizedLeft.count - count
+            let similarCount = (0..<count).reduce(into: 0) { total, index in
+                if self.tokensAreSimilar(normalizedLeft[leftStart + index], normalizedRight[index]) {
+                    total += 1
+                }
+            }
+            if similarCount >= max(2, count - 1) {
+                return count
+            }
+        }
+
+        var bestRightCount = 0
+        var bestMatchLength = 0
+        for leftCount in 2...maximum {
+            let leftPhrase = self.normalize(left.suffix(leftCount).joined())
+            for rightCount in 2...maximum {
+                let rightPhrase = self.normalize(right.prefix(rightCount).joined())
+                let matchLength = min(leftPhrase.count, rightPhrase.count)
+                guard matchLength >= 12 else { continue }
+                let distanceLimit = max(2, matchLength / 6)
+                guard abs(leftPhrase.count - rightPhrase.count) <= distanceLimit,
+                      self.editDistance(leftPhrase, rightPhrase, limit: distanceLimit) <= distanceLimit
+                else { continue }
+                if matchLength > bestMatchLength {
+                    bestMatchLength = matchLength
+                    bestRightCount = rightCount
+                }
+            }
+        }
+
+        return bestRightCount
+    }
+
+    private static func normalize(_ token: String) -> String {
+        token.lowercased().unicodeScalars
+            .filter { CharacterSet.alphanumerics.contains($0) }
+            .map(String.init)
+            .joined()
+    }
+
+    private static func tokensAreSimilar(_ left: String, _ right: String) -> Bool {
+        guard !left.isEmpty, !right.isEmpty else { return false }
+        if left == right { return true }
+        if min(left.count, right.count) >= 5, left.hasPrefix(right) || right.hasPrefix(left) {
+            return true
+        }
+        let maximumDistance = max(left.count, right.count) >= 8 ? 2 : 1
+        return self.editDistance(left, right, limit: maximumDistance) <= maximumDistance
+    }
+
+    private static func editDistance(_ left: String, _ right: String, limit: Int) -> Int {
+        let lhs = Array(left)
+        let rhs = Array(right)
+        guard abs(lhs.count - rhs.count) <= limit else { return limit + 1 }
+        var previous = Array(0...rhs.count)
+
+        for (leftIndex, leftCharacter) in lhs.enumerated() {
+            var current = [leftIndex + 1] + Array(repeating: 0, count: rhs.count)
+            var rowMinimum = current[0]
+            for (rightIndex, rightCharacter) in rhs.enumerated() {
+                current[rightIndex + 1] = min(
+                    current[rightIndex] + 1,
+                    previous[rightIndex + 1] + 1,
+                    previous[rightIndex] + (leftCharacter == rightCharacter ? 0 : 1)
+                )
+                rowMinimum = min(rowMinimum, current[rightIndex + 1])
+            }
+            if rowMinimum > limit { return limit + 1 }
+            previous = current
+        }
+
+        return previous[rhs.count]
+    }
+
+    private static func mergeCJK(left: String, right: String) -> String? {
+        guard self.containsCJK(String(left.suffix(32))),
+              self.containsCJK(String(right.prefix(32)))
+        else { return nil }
+        let leftScalars = Array(left.unicodeScalars)
+        let rightScalars = Array(right.unicodeScalars)
+        let maximum = min(48, leftScalars.count, rightScalars.count)
+        for count in stride(from: maximum, through: 1, by: -1)
+            where leftScalars.suffix(count).elementsEqual(rightScalars.prefix(count))
+        {
+            return left + String(String.UnicodeScalarView(rightScalars.dropFirst(count)))
+        }
+        return left + right
+    }
+
+    private static func containsCJK(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x3040...0x30ff, 0x3400...0x4dbf, 0x4e00...0x9fff, 0xac00...0xd7af:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}
+
+/// TranscriptionProvider implementation using transcribe.cpp GGUF models.
 final class WhisperProvider: TranscriptionProvider {
-    let name = "Whisper (Universal)"
+    var name: String {
+        self.selectedModel == .cohereTranscribeSixBit ? "Cohere Transcribe" : "Whisper (Universal)"
+    }
 
     var isAvailable: Bool {
         guard case .success = Self.backendInitialization else { return false }
@@ -49,7 +221,7 @@ final class WhisperProvider: TranscriptionProvider {
     }
 
     private var modelName: String {
-        self.selectedModel.whisperModelFile ?? "whisper-base-Q8_0.gguf"
+        self.selectedModel.transcribeCppModelFile ?? "whisper-base-Q8_0.gguf"
     }
 
     private var legacyModelName: String? {
@@ -71,10 +243,19 @@ final class WhisperProvider: TranscriptionProvider {
         guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             preconditionFailure("Could not find caches directory")
         }
-        return cacheDir.appendingPathComponent("WhisperModels")
+        let directoryName = self.selectedModel == .cohereTranscribeSixBit
+            ? "CohereTranscribeModels"
+            : "WhisperModels"
+        return cacheDir.appendingPathComponent(directoryName)
     }
 
     private var modelDownloadURL: URL? {
+        if self.selectedModel == .cohereTranscribeSixBit {
+            return URL(
+                string: "https://huggingface.co/handy-computer/cohere-transcribe-03-2026-gguf/resolve/main/\(self.modelName)"
+            )
+        }
+
         let modelName = self.modelName
         let suffix = "-Q8_0.gguf"
         guard modelName.hasSuffix(suffix) else { return nil }
@@ -132,8 +313,33 @@ final class WhisperProvider: TranscriptionProvider {
         }
     }
 
+    private func removeLegacyCohereCachesIfNeeded(for model: SettingsStore.SpeechModel) {
+        guard model == .cohereTranscribeSixBit, self.overriddenModelDirectory == nil,
+              let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        else { return }
+
+        let legacyDirectories = [
+            cacheDirectory.appendingPathComponent("cohere-transcribe-03-2026-CoreML-6bit", isDirectory: true),
+            cacheDirectory.appendingPathComponent("FluidAudio/CompiledCohereModels", isDirectory: true),
+        ]
+        for directory in legacyDirectories where FileManager.default.fileExists(atPath: directory.path) {
+            do {
+                try FileManager.default.removeItem(at: directory)
+                DebugLogger.shared.info(
+                    "WhisperProvider: Removed legacy Cohere cache at \(directory.path)",
+                    source: "WhisperProvider"
+                )
+            } catch {
+                DebugLogger.shared.warning(
+                    "WhisperProvider: Failed to remove legacy Cohere cache at \(directory.path): \(error.localizedDescription)",
+                    source: "WhisperProvider"
+                )
+            }
+        }
+    }
+
     private func isModelFileValid(at url: URL, for targetModel: SettingsStore.SpeechModel) -> Bool {
-        guard let expectedModelFile = targetModel.whisperModelFile,
+        guard let expectedModelFile = targetModel.transcribeCppModelFile,
               url.lastPathComponent == expectedModelFile
         else {
             return false
@@ -151,7 +357,7 @@ final class WhisperProvider: TranscriptionProvider {
         try Task.checkCancellation()
 
         let targetModel = self.selectedModel
-        let currentModelName = targetModel.whisperModelFile ?? "whisper-base-Q8_0.gguf"
+        let currentModelName = targetModel.transcribeCppModelFile ?? "whisper-base-Q8_0.gguf"
 
         let loadedModelName = self.currentLoadedModelName()
         if self.isReady, loadedModelName != currentModelName {
@@ -195,7 +401,9 @@ final class WhisperProvider: TranscriptionProvider {
                 userInfo: [NSLocalizedDescriptionKey: "Whisper model file is missing or corrupted. Please re-download the model."]
             )
         }
-        self.removeLegacyModelIfNeeded()
+        if targetModel.isWhisperModel {
+            self.removeLegacyModelIfNeeded()
+        }
 
         let requiredMemoryGB = targetModel.requiredMemoryGB
         let availableMemoryGB = Self.availableMemoryGB()
@@ -242,6 +450,7 @@ final class WhisperProvider: TranscriptionProvider {
 
         try Task.checkCancellation()
         self.installModel(loadedModel, session: loadedSession, modelName: currentModelName)
+        self.removeLegacyCohereCachesIfNeeded(for: targetModel)
         DebugLogger.shared.info(
             "WhisperProvider: Model ready (\(currentModelName), backend=\(loadedModel.backend), arch=\(loadedModel.arch))",
             source: "WhisperProvider"
@@ -297,7 +506,7 @@ final class WhisperProvider: TranscriptionProvider {
             throw NSError(
                 domain: "WhisperProvider",
                 code: -2,
-                userInfo: [NSLocalizedDescriptionKey: "Audio too short for Whisper transcription"]
+                userInfo: [NSLocalizedDescriptionKey: "Audio too short for transcription"]
             )
         }
 
@@ -305,15 +514,33 @@ final class WhisperProvider: TranscriptionProvider {
             throw NSError(
                 domain: "WhisperProvider",
                 code: -1,
-                userInfo: [NSLocalizedDescriptionKey: "Whisper model not loaded"]
+                userInfo: [NSLocalizedDescriptionKey: "Speech model not loaded"]
             )
         }
 
-        let transcript = try await session.run(
-            samples,
-            options: RunOptions(timestamps: .segment)
+        let isCohere = self.selectedModel == .cohereTranscribeSixBit
+        let options = RunOptions(
+            timestamps: isCohere ? .none : .segment,
+            language: isCohere ? SettingsStore.shared.selectedCohereLanguage.rawValue : nil
         )
-        let fullText = transcript.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let texts: [String]
+        if isCohere {
+            let ranges = TranscribeCppLongFormProcessor.ranges(
+                sampleCount: samples.count,
+                sampleRate: 16_000
+            )
+            var chunkTexts: [String] = []
+            chunkTexts.reserveCapacity(ranges.count)
+            for range in ranges {
+                try Task.checkCancellation()
+                let transcript = try await session.run(Array(samples[range]), options: options)
+                chunkTexts.append(transcript.text)
+            }
+            texts = chunkTexts
+        } else {
+            texts = try [await session.run(samples, options: options).text]
+        }
+        let fullText = TranscribeCppLongFormProcessor.merge(texts)
         return ASRTranscriptionResult(text: fullText, confidence: 1.0)
     }
 
@@ -322,6 +549,7 @@ final class WhisperProvider: TranscriptionProvider {
     }
 
     func clearCache() async throws {
+        let targetModel = self.selectedModel
         self.unloadModel()
 
         if FileManager.default.fileExists(atPath: self.modelURL.path) {
@@ -338,6 +566,7 @@ final class WhisperProvider: TranscriptionProvider {
                 try FileManager.default.removeItem(at: self.modelDirectory)
             }
         }
+        self.removeLegacyCohereCachesIfNeeded(for: targetModel)
     }
 
     private func downloadModel(progressHandler: ((Double) -> Void)?) async throws {

--- a/Tests/FluidDictationIntegrationTests/TranscribeCppLongFormProcessorTests.swift
+++ b/Tests/FluidDictationIntegrationTests/TranscribeCppLongFormProcessorTests.swift
@@ -1,0 +1,82 @@
+@testable import FluidVoice_Debug
+import XCTest
+
+final class TranscribeCppLongFormProcessorTests: XCTestCase {
+    func testRangesStayBoundedAndOverlap() {
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.ranges(
+                sampleCount: 70,
+                sampleRate: 10,
+                maximumChunkSeconds: 3,
+                overlapSeconds: 1
+            ),
+            [0..<30, 20..<50, 40..<70]
+        )
+    }
+
+    func testRangesKeepShortAudioWhole() {
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.ranges(sampleCount: 20, sampleRate: 10),
+            [0..<20]
+        )
+        XCTAssertTrue(TranscribeCppLongFormProcessor.ranges(sampleCount: 0, sampleRate: 10).isEmpty)
+    }
+
+    func testMergeRemovesRepeatedWordsAcrossPunctuation() {
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.merge([
+                "GPU, CPU, memory, networking.",
+                "memory networking storage and power.",
+            ]),
+            "GPU, CPU, memory, networking. storage and power."
+        )
+    }
+
+    func testMergeToleratesMinorRecognitionDrift() {
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.merge([
+                "solving the networking",
+                "the network storage problem",
+            ]),
+            "solving the networking storage problem"
+        )
+    }
+
+    func testMergeAlignsContractionsAndHyphenatedWords() {
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.merge([
+                "I'm sure there are trade-offs there.",
+                "I'm sure there's tradeoffs there. Plus, specialists collaborate.",
+            ]),
+            "I'm sure there are trade-offs there. Plus, specialists collaborate."
+        )
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.merge([
+                "networking chips and scale-up switches and scale-out switches.",
+                "Scale up switches and scale out switches. Cooling matters.",
+            ]),
+            "networking chips and scale-up switches and scale-out switches. Cooling matters."
+        )
+    }
+
+    func testMergeHandlesCJKWithoutAddingSpaces() {
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.merge(["这是一个测试结果", "测试结果非常准确"]),
+            "这是一个测试结果非常准确"
+        )
+    }
+
+    func testEarlierCJKDoesNotBreakEnglishBoundarySpacing() {
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.merge(["中文结束. English starts", "starts here"]),
+            "中文结束. English starts here"
+        )
+    }
+
+    func testMergeIgnoresEmptyChunks() {
+        XCTAssertEqual(
+            TranscribeCppLongFormProcessor.merge(["", "  ", "complete transcript"]),
+            "complete transcript"
+        )
+    }
+}


### PR DESCRIPTION
## Description
Routes Cohere through the bundled transcribe.cpp runtime and its Q4_K_M GGUF instead of the token-limited Core ML decoder. Long audio is decoded in 30-second windows with 2-second overlap and multilingual-aware deduplication, preventing silent truncation and boundary word loss.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #736

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran focused overlap, punctuation, fuzzy-boundary, and CJK tests
- [x] Ran the real 5-minute Jensen fixture through the app provider

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
- A single 5-minute GGUF decode was rejected empirically: it returned only 176 repetitive words despite the runtime advertising a 400-second input limit.
- The production 30-second/2-second-overlap path returned 828 words, retained the final sentence, and completed in 4.08s; the reference transcript is about 830 words.
- The GGUF download is 1.45 GiB, replacing the 1.54 GiB Core ML bundle. After successful load, app-managed legacy Core ML artifacts and compiled caches are removed.
- Eight focused regression tests pass. Private FI build/install/launch and strict code-sign verification pass.