### PR TITLE
fix: preserve hidden Dock state on reopen

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -128,6 +128,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             return true
         }
 
+        // LaunchServices restores the bundle's default activation policy on an external reopen.
+        // Re-apply the saved preference before foregrounding the existing app (#753).
+        self.applyDockVisibilityPolicy()
+
         // Ensure dock-icon reopen always foregrounds FluidVoice.
         sender.activate(ignoringOtherApps: true)
 
@@ -179,8 +183,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     }
 
     /// Apply the user's dock-visibility preference ("Hide from dock", issue #162).
-    /// Re-applied after operations that can reset the process activation policy - notably the
-    /// LaunchServices reopen below, which restores the bundle default (.regular) even when the
+    /// Re-applied after operations that can reset the process activation policy - notably
+    /// LaunchServices reopens, which restore the bundle default (.regular) even when the
     /// app is reopened without activation, so hide-from-dock is honored on login launches (#396).
     private func applyDockVisibilityPolicy() {
         NSApp.setActivationPolicy(SettingsStore.shared.showInDock ? .regular : .accessory)


### PR DESCRIPTION
## Description
Re-applies the saved Dock visibility preference when macOS externally reopens an already-running FluidVoice. LaunchServices can restore the bundle's default activation policy during reopen, which made the Dock icon remain visible even when **Hide from Dock** was enabled.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #753

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 15.7.7
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: unsigned build and build-for-testing passed. After an external reopen, the patched app remained `UIElement` at 0.1, 0.3, 0.8, 1.5, and 3 seconds. The full suite was attempted: 154 tests passed and 11 tests aborted because of the known local Xcode 26.3/macOS 15.7.7 malloc/SIGABRT runner issue.

## Screenshots / Video
The proof clip keeps the Dock visible while Codex reopens FluidVoice programmatically, so no mouse click is expected. The app window returns without a FluidVoice Dock icon.

[Watch the 6-second Dock reopen proof](https://raw.githubusercontent.com/postoso/FluidVoice/pr-774-assets/pr753-dock-reopen-proof.mp4)

## Notes
This reuses the existing `applyDockVisibilityPolicy()` path and preserves the reopen-suppression guard.
