### PR TITLE
Require direct Core Audio and reduce first-PCM latency

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1780,17 +1780,10 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Direct Core Audio capture defaults on while preserving stored user choices.
-    var experimentalDirectAudioCaptureEnabled: Bool {
-        get {
-            let value = self.defaults.object(forKey: Keys.experimentalDirectAudioCaptureEnabled)
-            return value as? Bool ?? true
-        }
-        set {
-            objectWillChange.send()
-            self.defaults.set(newValue, forKey: Keys.experimentalDirectAudioCaptureEnabled)
-        }
-    }
+    /// Direct Core Audio is the required capture backend. Legacy persisted
+    /// preferences are intentionally ignored because AVAudioEngine can block or
+    /// crash while audio devices are changing.
+    var experimentalDirectAudioCaptureEnabled: Bool { true }
 
     var copyTranscriptionToClipboard: Bool {
         get { self.defaults.bool(forKey: Keys.copyTranscriptionToClipboard) }
@@ -4915,7 +4908,6 @@ private extension SettingsStore {
         static let enableStreamingPreview = "EnableStreamingPreview"
         static let skipSilentRecordingsEnabled = "SkipSilentRecordingsEnabled"
         static let enableAIStreaming = "EnableAIStreaming"
-        static let experimentalDirectAudioCaptureEnabled = "ExperimentalDirectAudioCaptureEnabled"
         static let copyTranscriptionToClipboard = "CopyTranscriptionToClipboard"
         static let textInsertionMode = "TextInsertionMode"
         static let autoUpdateCheckEnabled = "AutoUpdateCheckEnabled"

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1119,7 +1119,7 @@ final class ASRService: ObservableObject {
             audioBuffer: self.audioBuffer,
             onFirstAudio: { sessionID, attemptID, sampleCount, frameLength, sampleRate, acquisitionMs, elapsedMs in
                 Task {
-                    await readinessGate.signalFirstPCM(
+                    readinessGate.signalFirstPCM(
                         sessionID: sessionID,
                         attemptID: attemptID
                     )
@@ -1435,7 +1435,7 @@ final class ASRService: ObservableObject {
         let captureSessionID = self.benchmarkSessionID
         self.audioCaptureAttemptID &+= 1
         var readinessAttemptID = self.audioCaptureAttemptID
-        await self.audioCaptureReadinessGate.arm(
+        self.audioCaptureReadinessGate.arm(
             sessionID: captureSessionID,
             attemptID: readinessAttemptID
         )
@@ -1709,7 +1709,7 @@ final class ASRService: ObservableObject {
 
         self.audioCaptureAttemptID &+= 1
         let attemptID = self.audioCaptureAttemptID
-        await self.audioCaptureReadinessGate.arm(
+        self.audioCaptureReadinessGate.arm(
             sessionID: sessionID,
             attemptID: attemptID
         )
@@ -2862,7 +2862,7 @@ final class ASRService: ObservableObject {
         do {
             self.audioCaptureAttemptID &+= 1
             let readinessAttemptID = self.audioCaptureAttemptID
-            await self.audioCaptureReadinessGate.arm(
+            self.audioCaptureReadinessGate.arm(
                 sessionID: self.benchmarkSessionID,
                 attemptID: readinessAttemptID
             )

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1033,24 +1033,6 @@ final class ASRService: ObservableObject {
         self.activeAudioCaptureBackend = .none
     }
 
-    /// Applies the experimental capture preference immediately when idle.
-    /// If a recording transition is already underway, start() reads the latest
-    /// persisted value and the following session will use it.
-    func refreshAudioCaptureBackendPreference() {
-        guard self.isRunning == false, self.isStarting == false else {
-            DebugLogger.shared.debug(
-                "Audio capture preference changed during a recording transition; deferring backend refresh",
-                source: "ASRService"
-            )
-            return
-        }
-
-        self.scheduleAudioRouteRecovery(
-            reason: "capture preference changed",
-            requiresIdlePrewarm: true
-        )
-    }
-
     private var inputFormat: AVAudioFormat?
     private var micPermissionGranted = false
 
@@ -4326,9 +4308,10 @@ private extension ASRService {
 
 //
 // Audio callbacks are not main-actor isolated. Direct Core Audio arrives through
-// a lock-free C ring. AVAudioEngine is used only when Faster Recording Start is
-// disabled. This pipeline owns timestamp trimming, 16 kHz conversion, levels,
-// and session-safe delivery without touching ASRService from a realtime callback.
+// a lock-free C ring. The AVAudioEngine implementation remains as legacy code but
+// is no longer user-selectable. This pipeline owns timestamp trimming, 16 kHz
+// conversion, levels, and session-safe delivery without touching ASRService from
+// a realtime callback.
 
 private final nonisolated class AudioCapturePipeline: @unchecked Sendable {
     private let audioBuffer: ThreadSafeAudioBuffer

--- a/Sources/Fluid/Services/AudioCaptureReadinessGate.swift
+++ b/Sources/Fluid/Services/AudioCaptureReadinessGate.swift
@@ -8,7 +8,7 @@ nonisolated enum AudioCaptureReadinessResult: Equatable {
     case staleSession
 }
 
-actor AudioCaptureReadinessGate {
+final class AudioCaptureReadinessGate: @unchecked Sendable {
     private struct Key: Equatable {
         let sessionID: Int
         let attemptID: UInt64
@@ -19,15 +19,24 @@ actor AudioCaptureReadinessGate {
         let continuation: CheckedContinuation<AudioCaptureReadinessResult, Never>
     }
 
+    private let lock = NSLock()
     private var key: Key?
     private var result: AudioCaptureReadinessResult?
     private var waiter: Waiter?
     private var timeoutTask: Task<Void, Never>?
 
     func arm(sessionID: Int, attemptID: UInt64) {
-        self.finishCurrent(with: .cancelled)
+        self.lock.lock()
+        let previousTimeoutTask = self.timeoutTask
+        let previousWaiter = self.waiter
+        self.timeoutTask = nil
+        self.waiter = nil
         self.key = Key(sessionID: sessionID, attemptID: attemptID)
         self.result = nil
+        self.lock.unlock()
+
+        previousTimeoutTask?.cancel()
+        previousWaiter?.continuation.resume(returning: .cancelled)
     }
 
     func wait(
@@ -37,23 +46,23 @@ actor AudioCaptureReadinessGate {
     ) async -> AudioCaptureReadinessResult {
         let key = Key(sessionID: sessionID, attemptID: attemptID)
         guard Task.isCancelled == false else { return .cancelled }
-        guard self.key == key else { return .staleSession }
-        if let result {
-            return result
-        }
 
         let waiterID = UUID()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
+                self.lock.lock()
                 guard self.key == key else {
+                    self.lock.unlock()
                     continuation.resume(returning: .staleSession)
                     return
                 }
                 if let result = self.result {
+                    self.lock.unlock()
                     continuation.resume(returning: result)
                     return
                 }
                 guard self.waiter == nil else {
+                    self.lock.unlock()
                     continuation.resume(returning: .cancelled)
                     return
                 }
@@ -66,21 +75,20 @@ actor AudioCaptureReadinessGate {
                     } catch {
                         return
                     }
-                    await self?.finish(
+                    self?.finish(
                         key: key,
                         waiterID: waiterID,
                         with: .timedOut
                     )
                 }
+                self.lock.unlock()
             }
         } onCancel: {
-            Task {
-                await self.finish(
-                    key: key,
-                    waiterID: waiterID,
-                    with: .cancelled
-                )
-            }
+            self.finish(
+                key: key,
+                waiterID: waiterID,
+                with: .cancelled
+            )
         }
     }
 
@@ -110,22 +118,23 @@ actor AudioCaptureReadinessGate {
         waiterID: UUID? = nil,
         with result: AudioCaptureReadinessResult
     ) {
-        guard self.key == key, self.result == nil else { return }
+        self.lock.lock()
+        guard self.key == key, self.result == nil else {
+            self.lock.unlock()
+            return
+        }
         if let waiterID, self.waiter?.id != waiterID {
+            self.lock.unlock()
             return
         }
         self.result = result
-        self.timeoutTask?.cancel()
+        let timeoutTask = self.timeoutTask
         self.timeoutTask = nil
         let waiter = self.waiter
         self.waiter = nil
-        waiter?.continuation.resume(returning: result)
-    }
+        self.lock.unlock()
 
-    private func finishCurrent(with result: AudioCaptureReadinessResult) {
-        guard let key else { return }
-        self.finish(key: key, with: result)
-        self.key = nil
-        self.result = nil
+        timeoutTask?.cancel()
+        waiter?.continuation.resume(returning: result)
     }
 }

--- a/Sources/Fluid/Services/AudioCaptureReadinessGate.swift
+++ b/Sources/Fluid/Services/AudioCaptureReadinessGate.swift
@@ -51,6 +51,11 @@ final class AudioCaptureReadinessGate: @unchecked Sendable {
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 self.lock.lock()
+                guard Task.isCancelled == false else {
+                    self.lock.unlock()
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
                 guard self.key == key else {
                     self.lock.unlock()
                     continuation.resume(returning: .staleSession)

--- a/Sources/Fluid/Services/AudioCaptureReadinessGate.swift
+++ b/Sources/Fluid/Services/AudioCaptureReadinessGate.swift
@@ -8,7 +8,7 @@ nonisolated enum AudioCaptureReadinessResult: Equatable {
     case staleSession
 }
 
-final class AudioCaptureReadinessGate: @unchecked Sendable {
+final nonisolated class AudioCaptureReadinessGate: @unchecked Sendable {
     private struct Key: Equatable {
         let sessionID: Int
         let attemptID: UInt64
@@ -23,6 +23,7 @@ final class AudioCaptureReadinessGate: @unchecked Sendable {
     private var key: Key?
     private var result: AudioCaptureReadinessResult?
     private var waiter: Waiter?
+    private var cancelledWaiterIDs = Set<UUID>()
     private var timeoutTask: Task<Void, Never>?
 
     func arm(sessionID: Int, attemptID: UInt64) {
@@ -31,6 +32,7 @@ final class AudioCaptureReadinessGate: @unchecked Sendable {
         let previousWaiter = self.waiter
         self.timeoutTask = nil
         self.waiter = nil
+        self.cancelledWaiterIDs.removeAll(keepingCapacity: true)
         self.key = Key(sessionID: sessionID, attemptID: attemptID)
         self.result = nil
         self.lock.unlock()
@@ -67,6 +69,11 @@ final class AudioCaptureReadinessGate: @unchecked Sendable {
                     return
                 }
                 guard self.waiter == nil else {
+                    self.lock.unlock()
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
+                guard self.cancelledWaiterIDs.remove(waiterID) == nil else {
                     self.lock.unlock()
                     continuation.resume(returning: .cancelled)
                     return
@@ -128,9 +135,18 @@ final class AudioCaptureReadinessGate: @unchecked Sendable {
             self.lock.unlock()
             return
         }
-        if let waiterID, self.waiter?.id != waiterID {
-            self.lock.unlock()
-            return
+        if let waiterID {
+            guard let waiter = self.waiter else {
+                if result == .cancelled {
+                    self.cancelledWaiterIDs.insert(waiterID)
+                }
+                self.lock.unlock()
+                return
+            }
+            guard waiter.id == waiterID else {
+                self.lock.unlock()
+                return
+            }
         }
         self.result = result
         let timeoutTask = self.timeoutTask

--- a/Sources/Fluid/Services/AudioEngineRetirementDrain.swift
+++ b/Sources/Fluid/Services/AudioEngineRetirementDrain.swift
@@ -25,20 +25,33 @@ final nonisolated class AudioEngineRetirementToken: @unchecked Sendable {
 /// construction must be able to await its completion.
 final nonisolated class AudioEngineRetirementDrain: @unchecked Sendable {
     private let queue: DispatchQueue
+    private let stateLock = NSLock()
+    private var scheduledReleaseCount = 0
 
     init(label: String = "app.fluidvoice.audio-engine-retirement") {
         self.queue = DispatchQueue(label: label, qos: .utility)
     }
 
     func schedule(_ token: AudioEngineRetirementToken) {
-        self.queue.async {
+        self.stateLock.lock()
+        self.scheduledReleaseCount += 1
+        self.queue.async { [self] in
             token.releaseEngine()
+            self.completeScheduledRelease()
         }
+        self.stateLock.unlock()
     }
 
     func releaseAndWait(_ token: AudioEngineRetirementToken) async {
-        await self.enqueueAndWait {
-            token.releaseEngine()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.stateLock.lock()
+            self.scheduledReleaseCount += 1
+            self.queue.async { [self] in
+                token.releaseEngine()
+                self.completeScheduledRelease()
+                continuation.resume()
+            }
+            self.stateLock.unlock()
         }
     }
 
@@ -46,15 +59,27 @@ final nonisolated class AudioEngineRetirementDrain: @unchecked Sendable {
     /// capture start so a fire-and-forget retirement from a non-route path cannot
     /// overlap construction of the next AVAudioEngine.
     func waitForScheduledReleases() async {
-        await self.enqueueAndWait {}
-    }
-
-    private func enqueueAndWait(_ operation: @escaping @Sendable () -> Void) async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.stateLock.lock()
+            guard self.scheduledReleaseCount > 0 else {
+                self.stateLock.unlock()
+                continuation.resume()
+                return
+            }
+
+            // Enqueue while holding the same lock used by schedule(_:). This
+            // preserves the barrier ordering without paying a utility-queue hop
+            // when no AVAudioEngine release is pending.
             self.queue.async {
-                operation()
                 continuation.resume()
             }
+            self.stateLock.unlock()
         }
+    }
+
+    private func completeScheduledRelease() {
+        self.stateLock.lock()
+        self.scheduledReleaseCount -= 1
+        self.stateLock.unlock()
     }
 }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -1498,27 +1498,6 @@ struct SettingsView: View {
                     }
                     .padding(16)
                 }
-
-                // Experimental Card
-                ThemedCard(style: .standard) {
-                    VStack(alignment: .leading, spacing: 14) {
-                        Label("Experimental Settings", systemImage: "exclamationmark.triangle")
-                            .font(.headline)
-                            .foregroundStyle(.primary)
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            self.lowLatencyAudioCaptureToggle
-
-                            if self.asr.isRunning {
-                                Text("Settings are disabled during active recording")
-                                    .font(.caption)
-                                    .foregroundStyle(self.settingsSecondaryText)
-                                    .italic()
-                            }
-                        }
-                    }
-                    .padding(16)
-                }
             }
             .padding(16)
         }
@@ -2627,28 +2606,6 @@ struct FlowLayout: Layout {
 
         cache.containerSize = CGSize(width: maxWidth, height: y + rowHeight)
         cache.lastWidth = maxWidth
-    }
-}
-
-private extension SettingsView {
-    var lowLatencyAudioCaptureToggle: some View {
-        Group {
-            self.settingsToggleRow(
-                title: "Faster Recording Start",
-                description: "FluidVoice starts listening sooner, so your first word is less likely to be missed.",
-                footnote: "If your microphone does not work correctly, turn this off.",
-                isOn: Binding(
-                    get: { self.settings.experimentalDirectAudioCaptureEnabled },
-                    set: { enabled in
-                        self.settings.experimentalDirectAudioCaptureEnabled = enabled
-                        self.asr.refreshAudioCaptureBackendPreference()
-                    }
-                )
-            )
-            .disabled(self.asr.isRunning)
-
-            Divider().padding(.vertical, 8)
-        }
     }
 }
 

--- a/Tests/FluidDictationIntegrationTests/AudioEngineRetirementDrainTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AudioEngineRetirementDrainTests.swift
@@ -39,6 +39,22 @@ final class AudioEngineRetirementDrainTests: XCTestCase {
             ]
         )
     }
+
+    func testWaitForScheduledReleasesCompletesAfterScheduledRelease() async throws {
+        let drain = AudioEngineRetirementDrain(label: "test.audio-engine-retirement.barrier")
+        let recorder = DeinitRecorder()
+        var probe: DeinitProbe? = DeinitProbe(id: 1, recorder: recorder)
+        let token = AudioEngineRetirementToken(try XCTUnwrap(probe))
+        probe = nil
+
+        drain.schedule(token)
+        await drain.waitForScheduledReleases()
+
+        XCTAssertEqual(
+            recorder.events,
+            [DeinitEvent(id: 1, occurredOnMainThread: false)]
+        )
+    }
 }
 
 private final class DeinitProbe {

--- a/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
+++ b/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
@@ -6,8 +6,8 @@ import XCTest
 final class DirectAudioReliabilityTests: XCTestCase {
     func testReadinessGatePreservesFirstPCMThatArrivesBeforeWait() async {
         let gate = AudioCaptureReadinessGate()
-        await gate.arm(sessionID: 41, attemptID: 1)
-        await gate.signalFirstPCM(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 1)
+        gate.signalFirstPCM(sessionID: 41, attemptID: 1)
 
         let result = await gate.wait(
             sessionID: 41,
@@ -20,7 +20,7 @@ final class DirectAudioReliabilityTests: XCTestCase {
 
     func testReadinessGateCancelsWaitAndIgnoresStalePCM() async {
         let gate = AudioCaptureReadinessGate()
-        await gate.arm(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 1)
         let firstWait = Task {
             await gate.wait(
                 sessionID: 41,
@@ -29,12 +29,12 @@ final class DirectAudioReliabilityTests: XCTestCase {
             )
         }
         await Task.yield()
-        await gate.cancel(sessionID: 41, attemptID: 1)
+        gate.cancel(sessionID: 41, attemptID: 1)
         let firstResult = await firstWait.value
         XCTAssertEqual(firstResult, .cancelled)
 
-        await gate.arm(sessionID: 41, attemptID: 2)
-        await gate.signalFirstPCM(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 2)
+        gate.signalFirstPCM(sessionID: 41, attemptID: 1)
         let staleResult = await gate.wait(
             sessionID: 41,
             attemptID: 1,
@@ -42,7 +42,32 @@ final class DirectAudioReliabilityTests: XCTestCase {
         )
         XCTAssertEqual(staleResult, .staleSession)
 
-        await gate.signalFirstPCM(sessionID: 41, attemptID: 2)
+        gate.signalFirstPCM(sessionID: 41, attemptID: 2)
+        let replacementResult = await gate.wait(
+            sessionID: 41,
+            attemptID: 2,
+            timeoutNanoseconds: 1_000_000
+        )
+        XCTAssertEqual(replacementResult, .ready)
+    }
+
+    func testReadinessGateRearmingCancelsExistingWaiter() async {
+        let gate = AudioCaptureReadinessGate()
+        gate.arm(sessionID: 41, attemptID: 1)
+        let firstWait = Task {
+            await gate.wait(
+                sessionID: 41,
+                attemptID: 1,
+                timeoutNanoseconds: 10_000_000_000
+            )
+        }
+        await Task.yield()
+
+        gate.arm(sessionID: 41, attemptID: 2)
+
+        let firstResult = await firstWait.value
+        XCTAssertEqual(firstResult, .cancelled)
+        gate.signalFirstPCM(sessionID: 41, attemptID: 2)
         let replacementResult = await gate.wait(
             sessionID: 41,
             attemptID: 2,
@@ -53,7 +78,7 @@ final class DirectAudioReliabilityTests: XCTestCase {
 
     func testReadinessGateTimesOutWithoutPCM() async {
         let gate = AudioCaptureReadinessGate()
-        await gate.arm(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 1)
 
         let result = await gate.wait(
             sessionID: 41,
@@ -66,7 +91,7 @@ final class DirectAudioReliabilityTests: XCTestCase {
 
     func testReadinessWaitRespondsPromptlyToTaskCancellation() async {
         let gate = AudioCaptureReadinessGate()
-        await gate.arm(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 1)
         let waitTask = Task {
             await gate.wait(
                 sessionID: 41,

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -137,7 +137,7 @@ final class HotkeyShortcutTests: XCTestCase {
         XCTAssertNil(decoded.settings.skipSilentRecordingsEnabled)
     }
 
-    func testFasterRecordingStartDefaultsToEnabledWhenUnset() {
+    func testDirectAudioCaptureIsEnabledWhenLegacyPreferenceIsUnset() {
         self.withRestoredDefaults(keys: [self.experimentalDirectAudioCaptureEnabledKey]) {
             UserDefaults.standard.removeObject(forKey: self.experimentalDirectAudioCaptureEnabledKey)
 
@@ -145,17 +145,9 @@ final class HotkeyShortcutTests: XCTestCase {
         }
     }
 
-    func testFasterRecordingStartPreservesStoredDisabledPreference() {
+    func testDirectAudioCaptureIgnoresStoredDisabledPreference() {
         self.withRestoredDefaults(keys: [self.experimentalDirectAudioCaptureEnabledKey]) {
             UserDefaults.standard.set(false, forKey: self.experimentalDirectAudioCaptureEnabledKey)
-
-            XCTAssertFalse(SettingsStore.shared.experimentalDirectAudioCaptureEnabled)
-        }
-    }
-
-    func testFasterRecordingStartPreservesStoredEnabledPreference() {
-        self.withRestoredDefaults(keys: [self.experimentalDirectAudioCaptureEnabledKey]) {
-            UserDefaults.standard.set(true, forKey: self.experimentalDirectAudioCaptureEnabledKey)
 
             XCTAssertTrue(SettingsStore.shared.experimentalDirectAudioCaptureEnabled)
         }


### PR DESCRIPTION
## Description
Makes direct Core Audio the single dictation capture path and removes avoidable startup serialization. This keeps the crash/device-lifecycle protections from #749 while reducing hotkey-to-first-real-PCM latency without delaying or dropping opening audio.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Depends on #749.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0 beta
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: 171/171 passed

Measured the final installed commit over 10 fresh-launch recording starts: 88 ms median from ASR start to first real PCM, 78–94 ms range, 10/10 ready, 10/10 below 100 ms.

Private Fluid Intelligence app build and installation succeeded. The development build uses the local unverified bridge override because the private bridge manifest targets a different FluidVoice commit.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
`B/audio-fix-1.6.7-base` mirrors the exact tip of #749 because #749 originates from a fork and cannot be selected as a GitHub base branch. After #749 merges, retarget this PR to `main` and remove the temporary base branch.

Invariant: do not introduce an artificial recording delay or discard initial PCM; first-word capture latency is the primary UX constraint.