### PR TITLE
Harden media pause and resume lifecycle

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1810,7 +1810,7 @@ final class ASRService: ObservableObject {
         await self.cancelAudioRouteRecoveryAndWait()
 
         // Capture media pause state before we reset it, for resuming at the end
-        let shouldResumeMedia = SettingsStore.shared.pauseMediaDuringTranscription && self.didPauseMediaForThisSession
+        let shouldResumeMedia = self.didPauseMediaForThisSession
         self.didPauseMediaForThisSession = false // Reset for next session
 
         DebugLogger.shared.debug("📍 Preparing final transcription", source: "ASRService")
@@ -2180,7 +2180,7 @@ final class ASRService: ObservableObject {
         await self.cancelAudioRouteRecoveryAndWait()
 
         // Capture media pause state before we reset it, for resuming at the end
-        let shouldResumeMedia = SettingsStore.shared.pauseMediaDuringTranscription && self.didPauseMediaForThisSession
+        let shouldResumeMedia = self.didPauseMediaForThisSession
         self.didPauseMediaForThisSession = false // Reset for next session
 
         DebugLogger.shared.info("🛑 Stopping recording - releasing audio devices", source: "ASRService")

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -35,7 +35,12 @@ final class MediaPlaybackService {
             let resumeLock = NSLock()
             var didResume = false
 
-            func resumeOnce(_ value: Bool) {
+            @discardableResult
+            func resumeOnce(
+                _ value: Bool,
+                logDuplicate: Bool = true,
+                beforeResume: () -> Void = {}
+            ) -> Bool {
                 var shouldResume = false
 
                 resumeLock.lock()
@@ -46,14 +51,27 @@ final class MediaPlaybackService {
                 resumeLock.unlock()
 
                 guard shouldResume else {
-                    DebugLogger.shared.warning(
-                        "MediaPlaybackService: Suppressed duplicate resume (MediaRemoteAdapter callback fired more than once)",
-                        source: "MediaPlaybackService"
-                    )
-                    return
+                    if logDuplicate {
+                        DebugLogger.shared.warning(
+                            "MediaPlaybackService: Suppressed late or duplicate media callback",
+                            source: "MediaPlaybackService"
+                        )
+                    }
+                    return false
                 }
 
+                beforeResume()
                 continuation.resume(returning: value)
+                return true
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                if resumeOnce(false, logDuplicate: false) {
+                    DebugLogger.shared.warning(
+                        "MediaPlaybackService: Now Playing query timed out; leaving playback unchanged",
+                        source: "MediaPlaybackService"
+                    )
+                }
             }
 
             self.mediaController.getTrackInfo { [weak self] trackInfo in
@@ -97,12 +115,13 @@ final class MediaPlaybackService {
                 )
 
                 if isPlaying {
-                    DebugLogger.shared.info(
-                        "MediaPlaybackService: Media is playing, sending pause command",
-                        source: "MediaPlaybackService"
-                    )
-                    self.mediaController.pause()
-                    resumeOnce(true)
+                    resumeOnce(true) {
+                        DebugLogger.shared.info(
+                            "MediaPlaybackService: Media is playing, sending pause command",
+                            source: "MediaPlaybackService"
+                        )
+                        self.mediaController.pause()
+                    }
                 } else {
                     DebugLogger.shared.debug(
                         "MediaPlaybackService: Media is not playing, no action needed",


### PR DESCRIPTION
## Description
Makes media pause asynchronous completion one-shot and timeout-safe, and resumes playback only when FluidVoice actually paused it. This prevents stuck playback state when media commands race, time out, or the preference changes during dictation.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Stacked on #777, which depends on #749.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0 beta
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: full stacked regression suite passed 172/172

The installed stacked build also completed 10/10 fresh-launch first-PCM probes. Media pausing begins after first PCM, so this PR does not add recording startup delay or discard opening audio.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Review and merge after #777. The sound-cue timing concern is intentionally excluded and will be handled separately.