### PR TITLE
Complete 1.6.7 audio and microphone reliability fixes

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -255,7 +255,6 @@ struct ContentView: View {
     // constructs this view can race AttributeGraph metadata processing.
     @State private var selectedInputUID: String = ""
     @State private var selectedOutputUID: String = SettingsStore.shared.preferredOutputDeviceUID ?? ""
-    @State private var microphoneSelectionMode: SettingsStore.MicrophoneSelectionMode = SettingsStore.shared.microphoneSelectionMode
 
     // AI Prompts Tab State
     @State private var aiInputText: String = ""
@@ -384,16 +383,6 @@ struct ContentView: View {
             .onChange(of: self.audioObserver.changeTick) { _, _ in
                 // Hardware change detected → refresh device lists
                 self.refreshDevices()
-
-                switch SettingsStore.shared.microphoneSelectionMode {
-                case .system:
-                    if let sysIn = AudioDevice.getDefaultInputDevice()?.uid {
-                        self.selectedInputUID = sysIn
-                    }
-                case .manual:
-                    // The refreshed device list drives the displayed selection.
-                    break
-                }
 
                 if let sysOut = AudioDevice.getDefaultOutputDevice()?.uid {
                     self.selectedOutputUID = sysOut
@@ -613,18 +602,8 @@ struct ContentView: View {
                 self.menuBarManager.configure(asrService: self.appServices.asr)
                 self.refreshDevices()
 
-                switch SettingsStore.shared.microphoneSelectionMode {
-                case .system:
-                    if let defaultUID = AudioDevice.getDefaultInputDevice()?.uid {
-                        self.selectedInputUID = defaultUID
-                    }
-                case .manual:
-                    if let preferredUID = SettingsStore.shared.preferredInputDeviceUID, !preferredUID.isEmpty {
-                        self.selectedInputUID = preferredUID
-                    } else if let defaultUID = AudioDevice.getDefaultInputDevice()?.uid {
-                        self.selectedInputUID = defaultUID
-                        SettingsStore.shared.preferredInputDeviceUID = defaultUID
-                    }
+                if let preferredUID = SettingsStore.shared.preferredInputDeviceUID, !preferredUID.isEmpty {
+                    self.selectedInputUID = preferredUID
                 }
 
                 if self.selectedOutputUID.isEmpty, let defOut = AudioDevice.getDefaultOutputDevice()?.uid {
@@ -1471,7 +1450,6 @@ struct ContentView: View {
             visualizerNoiseThreshold: self.$visualizerNoiseThreshold,
             selectedInputUID: self.$selectedInputUID,
             selectedOutputUID: self.$selectedOutputUID,
-            microphoneSelectionMode: self.$microphoneSelectionMode,
             inputDevices: self.$inputDevices,
             outputDevices: self.$outputDevices,
             accessibilityEnabled: self.$accessibilityEnabled,
@@ -1545,6 +1523,11 @@ struct ContentView: View {
             DispatchQueue.main.async {
                 self.inputDevices = inputs
                 self.outputDevices = outputs
+                if let selectedInput = self.appServices.microphonePreferenceCoordinator
+                    .inputDeviceForCapture(availableInputs: inputs)
+                {
+                    self.selectedInputUID = selectedInput.uid
+                }
             }
         }
     }
@@ -4398,13 +4381,7 @@ private extension ContentView {
         self.isRewriteModeShortcutEnabled = SettingsStore.shared.rewriteModeShortcutEnabled
         self.playgroundUsed = SettingsStore.shared.playgroundUsed
         self.visualizerNoiseThreshold = SettingsStore.shared.visualizerNoiseThreshold
-        self.microphoneSelectionMode = SettingsStore.shared.microphoneSelectionMode
-        switch SettingsStore.shared.microphoneSelectionMode {
-        case .system:
-            self.selectedInputUID = AudioDevice.getDefaultInputDevice()?.uid ?? ""
-        case .manual:
-            self.selectedInputUID = SettingsStore.shared.preferredInputDeviceUID ?? AudioDevice.getDefaultInputDevice()?.uid ?? ""
-        }
+        self.selectedInputUID = SettingsStore.shared.preferredInputDeviceUID ?? ""
         self.selectedOutputUID = SettingsStore.shared.preferredOutputDeviceUID ?? ""
         self.enableDebugLogs = SettingsStore.shared.enableDebugLogs
         self.hotkeyMode = SettingsStore.shared.hotkeyMode

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1800,61 +1800,25 @@ final class SettingsStore: ObservableObject {
         set { self.defaults.set(newValue, forKey: Keys.preferredOutputDeviceUID) }
     }
 
-    var microphoneSelectionMode: MicrophoneSelectionMode {
-        get {
-            if let raw = self.defaults.string(forKey: Keys.microphoneSelectionMode),
-               let mode = MicrophoneSelectionMode(rawValue: raw)
-            {
-                return mode
-            }
+    var microphoneSelectionMode: MicrophoneSelectionMode { .manual }
 
-            return .system
+    func enforceAppOnlyMicrophoneSelection() {
+        guard self.defaults.string(forKey: Keys.microphoneSelectionMode) != MicrophoneSelectionMode.manual.rawValue else {
+            return
         }
-        set {
-            objectWillChange.send()
-            self.defaults.set(newValue.rawValue, forKey: Keys.microphoneSelectionMode)
-        }
+        objectWillChange.send()
+        self.defaults.set(MicrophoneSelectionMode.manual.rawValue, forKey: Keys.microphoneSelectionMode)
     }
 
     func recordInputDeviceSelection(_ uid: String) {
         guard uid.isEmpty == false else { return }
-        guard self.microphoneSelectionMode == .manual else { return }
 
         self.preferredInputDeviceUID = uid
     }
 
-    func shouldSyncInputSelectionToSystemDefault() -> Bool {
-        self.microphoneSelectionMode == .system
-    }
-
-    @discardableResult
-    func setMicrophoneSelectionMode(
-        _ mode: MicrophoneSelectionMode,
-        currentSystemInputUID: String?,
-        availableInputUIDs: Set<String>
-    ) -> String? {
-        let previousMode = self.microphoneSelectionMode
-
-        if previousMode == .system,
-           mode == .manual,
-           let currentSystemInputUID,
-           currentSystemInputUID.isEmpty == false
-        {
-            self.defaults.set(currentSystemInputUID, forKey: Keys.systemInputDeviceUIDBeforeManual)
-        }
-
-        self.microphoneSelectionMode = mode
-
-        guard mode == .system else { return nil }
-
-        if let previousSystemInputUID = self.defaults.string(forKey: Keys.systemInputDeviceUIDBeforeManual),
-           previousSystemInputUID.isEmpty == false,
-           availableInputUIDs.contains(previousSystemInputUID)
-        {
-            return previousSystemInputUID
-        }
-
-        return currentSystemInputUID
+    var appMicSelectionMigrationVersion: Int {
+        get { self.defaults.integer(forKey: Keys.appMicSelectionMigrationVersion) }
+        set { self.defaults.set(newValue, forKey: Keys.appMicSelectionMigrationVersion) }
     }
 
     var visualizerNoiseThreshold: Double {
@@ -3159,9 +3123,7 @@ final class SettingsStore: ObservableObject {
         self.textInsertionMode = payload.textInsertionMode
         self.preferredInputDeviceUID = payload.preferredInputDeviceUID
         self.preferredOutputDeviceUID = payload.preferredOutputDeviceUID
-        if let microphoneSelectionMode = payload.microphoneSelectionMode {
-            self.microphoneSelectionMode = microphoneSelectionMode
-        }
+        self.enforceAppOnlyMicrophoneSelection()
         self.visualizerNoiseThreshold = payload.visualizerNoiseThreshold
         self.overlayPosition = payload.overlayPosition
         self.overlayBottomOffset = payload.overlayBottomOffset
@@ -4893,7 +4855,7 @@ private extension SettingsStore {
         static let preferredInputDeviceUID = "PreferredInputDeviceUID"
         static let preferredOutputDeviceUID = "PreferredOutputDeviceUID"
         static let microphoneSelectionMode = "MicrophoneSelectionMode"
-        static let systemInputDeviceUIDBeforeManual = "SystemInputDeviceUIDBeforeManual"
+        static let appMicSelectionMigrationVersion = "AppOnlyMicrophoneSelectionMigrationVersion"
         static let visualizerNoiseThreshold = "VisualizerNoiseThreshold"
         static let launchAtStartup = "LaunchAtStartup"
         static let showInDock = "ShowInDock"

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -3123,6 +3123,9 @@ final class SettingsStore: ObservableObject {
         self.textInsertionMode = payload.textInsertionMode
         self.preferredInputDeviceUID = payload.preferredInputDeviceUID
         self.preferredOutputDeviceUID = payload.preferredOutputDeviceUID
+        if payload.microphoneSelectionMode == .system {
+            self.appMicSelectionMigrationVersion = 0
+        }
         self.enforceAppOnlyMicrophoneSelection()
         self.visualizerNoiseThreshold = payload.visualizerNoiseThreshold
         self.overlayPosition = payload.overlayPosition

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1780,17 +1780,10 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Direct Core Audio capture defaults on while preserving stored user choices.
-    var experimentalDirectAudioCaptureEnabled: Bool {
-        get {
-            let value = self.defaults.object(forKey: Keys.experimentalDirectAudioCaptureEnabled)
-            return value as? Bool ?? true
-        }
-        set {
-            objectWillChange.send()
-            self.defaults.set(newValue, forKey: Keys.experimentalDirectAudioCaptureEnabled)
-        }
-    }
+    /// Direct Core Audio is the required capture backend. Legacy persisted
+    /// preferences are intentionally ignored because AVAudioEngine can block or
+    /// crash while audio devices are changing.
+    var experimentalDirectAudioCaptureEnabled: Bool { true }
 
     var copyTranscriptionToClipboard: Bool {
         get { self.defaults.bool(forKey: Keys.copyTranscriptionToClipboard) }
@@ -4915,7 +4908,6 @@ private extension SettingsStore {
         static let enableStreamingPreview = "EnableStreamingPreview"
         static let skipSilentRecordingsEnabled = "SkipSilentRecordingsEnabled"
         static let enableAIStreaming = "EnableAIStreaming"
-        static let experimentalDirectAudioCaptureEnabled = "ExperimentalDirectAudioCaptureEnabled"
         static let copyTranscriptionToClipboard = "CopyTranscriptionToClipboard"
         static let textInsertionMode = "TextInsertionMode"
         static let autoUpdateCheckEnabled = "AutoUpdateCheckEnabled"

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -204,6 +204,7 @@ final class ASRService: ObservableObject {
     private var lastBoostHitTerm: String?
     private var hasPendingParakeetVocabularyReload: Bool = false
     private var vocabularyChangeObserver: NSObjectProtocol?
+    private var settingsBackupRestoreObserver: NSObjectProtocol?
 
     // MARK: - Error Handling
 
@@ -1167,6 +1168,19 @@ final class ASRService: ObservableObject {
                 self?.handleParakeetVocabularyDidChange()
             }
         }
+        self.settingsBackupRestoreObserver = NotificationCenter.default.addObserver(
+            forName: .settingsBackupDidRestore,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleAudioRouteRecovery(
+                    reason: "settings backup restored",
+                    requiresIdlePrewarm: true,
+                    reconcilesInputSelection: true
+                )
+            }
+        }
     }
 
     deinit {
@@ -1174,6 +1188,9 @@ final class ASRService: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
         }
         if let observer = self.engineConfigurationChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = self.settingsBackupRestoreObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }
@@ -1268,7 +1285,7 @@ final class ASRService: ObservableObject {
         guard self.isTerminating == false else { return }
 
         let microphonePreferenceCoordinator = AppServices.shared.microphonePreferenceCoordinator
-        microphonePreferenceCoordinator.migrateToAppOnlySelectionIfNeeded(
+        microphonePreferenceCoordinator.reconcileAppOnlySelection(
             availableInputs: initialInputSnapshot.0,
             defaultInputUID: initialInputSnapshot.1
         )
@@ -2847,15 +2864,9 @@ final class ASRService: ObservableObject {
             return false
         }
 
-        let coordinator = AppServices.shared.microphonePreferenceCoordinator
-        coordinator.migrateToAppOnlySelectionIfNeeded(
+        AppServices.shared.microphonePreferenceCoordinator.reconcileAppOnlySelection(
             availableInputs: snapshot.0,
             defaultInputUID: snapshot.1
-        )
-        _ = coordinator.inputDeviceForCapture(
-            availableInputs: snapshot.0,
-            defaultInputUID: snapshot.1,
-            persistFallback: true
         )
         return true
     }

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1832,7 +1832,7 @@ final class ASRService: ObservableObject {
         await self.cancelAudioRouteRecoveryAndWait()
 
         // Capture media pause state before we reset it, for resuming at the end
-        let shouldResumeMedia = SettingsStore.shared.pauseMediaDuringTranscription && self.didPauseMediaForThisSession
+        let shouldResumeMedia = self.didPauseMediaForThisSession
         self.didPauseMediaForThisSession = false // Reset for next session
 
         DebugLogger.shared.debug("📍 Preparing final transcription", source: "ASRService")
@@ -2202,7 +2202,7 @@ final class ASRService: ObservableObject {
         await self.cancelAudioRouteRecoveryAndWait()
 
         // Capture media pause state before we reset it, for resuming at the end
-        let shouldResumeMedia = SettingsStore.shared.pauseMediaDuringTranscription && self.didPauseMediaForThisSession
+        let shouldResumeMedia = self.didPauseMediaForThisSession
         self.didPauseMediaForThisSession = false // Reset for next session
 
         DebugLogger.shared.info("🛑 Stopping recording - releasing audio devices", source: "ASRService")

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -730,6 +730,7 @@ final class ASRService: ObservableObject {
         let generation: UInt64
         let reason: String
         let requiresIdlePrewarm: Bool
+        let reconcilesInputSelection: Bool
     }
 
     private lazy var directAudioLifecycleController: DirectCoreAudioLifecycleController = {
@@ -907,8 +908,7 @@ final class ASRService: ObservableObject {
     }
 
     private func directCoreAudioDeviceSelection() -> DirectCoreAudioDeviceSelection {
-        if SettingsStore.shared.microphoneSelectionMode == .manual,
-           let preferredUID = SettingsStore.shared.preferredInputDeviceUID,
+        if let preferredUID = SettingsStore.shared.preferredInputDeviceUID,
            preferredUID.isEmpty == false
         {
             return .preferredUID(preferredUID)
@@ -1258,23 +1258,27 @@ final class ASRService: ObservableObject {
         self.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         self.micPermissionGranted = (self.micStatus == .authorized)
 
-        if AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
-            experimentalDirectAudioCaptureEnabled: SettingsStore.shared.experimentalDirectAudioCaptureEnabled
-        ) {
-            let microphonePreferenceCoordinator =
-                AppServices.shared.microphonePreferenceCoordinator
-            _ = microphonePreferenceCoordinator.enforcePreferredInput(reason: "startup")
-            microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
-                reason: "startup"
-            )
+        let initialInputSnapshot = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let devices = AudioDevice.listInputDevices()
+                let defaultInputUID = AudioDevice.getDefaultInputDevice()?.uid
+                continuation.resume(returning: (devices, defaultInputUID))
+            }
         }
+        guard self.isTerminating == false else { return }
+
+        let microphonePreferenceCoordinator = AppServices.shared.microphonePreferenceCoordinator
+        microphonePreferenceCoordinator.migrateToAppOnlySelectionIfNeeded(
+            availableInputs: initialInputSnapshot.0,
+            defaultInputUID: initialInputSnapshot.1
+        )
 
         self.registerDefaultDeviceChangeListener()
         self.registerEngineConfigurationChangeObserver()
         self.registerDeviceListChangeListener()
 
         // Initialize device list cache
-        self.cacheCurrentDeviceList(AudioDevice.listInputDevices())
+        self.cacheCurrentDeviceList(initialInputSnapshot.0)
 
         // Register the input callback and allocate its fixed ring now. This
         // does not start the device or show the microphone privacy indicator.
@@ -1460,12 +1464,6 @@ final class ASRService: ObservableObject {
         self.isDictionaryTrainingCaptureActive = false
 
         do {
-            if SettingsStore.shared.microphoneSelectionMode == .manual,
-               SettingsStore.shared.experimentalDirectAudioCaptureEnabled == false
-            {
-                AppServices.shared.microphonePreferenceCoordinator.enforcePreferredInput(reason: "recording start")
-            }
-
             let maximumStartAttempts =
                 SettingsStore.shared.experimentalDirectAudioCaptureEnabled ? 3 : 1
             var startAttempt = 1
@@ -2264,11 +2262,6 @@ final class ASRService: ObservableObject {
     private func bindPreferredInputDeviceIfNeeded() -> Bool {
         DebugLogger.shared.debug("bindPreferredInputDeviceIfNeeded() - Starting input device binding", source: "ASRService")
 
-        guard SettingsStore.shared.microphoneSelectionMode == .manual else {
-            DebugLogger.shared.info("Using current macOS default input device", source: "ASRService")
-            return true
-        }
-
         guard let device = self.resolvedInputDeviceForCapture() else {
             DebugLogger.shared.error(
                 "No input device available for manual microphone capture.",
@@ -2688,7 +2681,8 @@ final class ASRService: ObservableObject {
 
     private func scheduleAudioRouteRecovery(
         reason: String,
-        requiresIdlePrewarm: Bool = false
+        requiresIdlePrewarm: Bool = false,
+        reconcilesInputSelection: Bool = false
     ) {
         guard self.isTerminating == false else {
             self.benchmarkLog("route_recovery_ignored reason=app_terminating event=\(reason)")
@@ -2697,10 +2691,13 @@ final class ASRService: ObservableObject {
         self.audioRouteRecoveryGeneration &+= 1
         let requiresPrewarmAfterRecovery =
             requiresIdlePrewarm || self.pendingAudioRouteRecovery?.requiresIdlePrewarm == true
+        let reconcilesInputAfterRecovery =
+            reconcilesInputSelection || self.pendingAudioRouteRecovery?.reconcilesInputSelection == true
         let request = AudioRouteRecoveryRequest(
             generation: self.audioRouteRecoveryGeneration,
             reason: reason,
-            requiresIdlePrewarm: requiresPrewarmAfterRecovery
+            requiresIdlePrewarm: requiresPrewarmAfterRecovery,
+            reconcilesInputSelection: reconcilesInputAfterRecovery
         )
         self.pendingAudioRouteRecovery = request
 
@@ -2796,6 +2793,12 @@ final class ASRService: ObservableObject {
             self.finishAudioRouteRecovery(request)
         }
 
+        if request.reconcilesInputSelection,
+           await self.reconcileInputSelectionAfterTopologySettles(request) == false
+        {
+            return
+        }
+
         if self.isRunning {
             await self.recoverActiveAudioRoute(request)
         } else {
@@ -2819,6 +2822,44 @@ final class ASRService: ObservableObject {
         self.armAudioRouteRecovery(pendingRequest)
     }
 
+    private func reconcileInputSelectionAfterTopologySettles(
+        _ request: AudioRouteRecoveryRequest
+    ) async -> Bool {
+        let snapshot = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let devices = AudioDevice.listInputDevices()
+                let defaultInputUID = AudioDevice.getDefaultInputDevice()?.uid
+                continuation.resume(returning: (devices, defaultInputUID))
+            }
+        }
+        guard request.generation == self.audioRouteRecoveryGeneration,
+              Task.isCancelled == false
+        else { return false }
+
+        let currentUIDs = Set(snapshot.0.map(\.uid))
+        guard currentUIDs == self.cachedDeviceUIDs else {
+            self.cacheCurrentDeviceList(snapshot.0)
+            self.scheduleAudioRouteRecovery(
+                reason: "input topology still settling",
+                requiresIdlePrewarm: request.requiresIdlePrewarm,
+                reconcilesInputSelection: true
+            )
+            return false
+        }
+
+        let coordinator = AppServices.shared.microphonePreferenceCoordinator
+        coordinator.migrateToAppOnlySelectionIfNeeded(
+            availableInputs: snapshot.0,
+            defaultInputUID: snapshot.1
+        )
+        _ = coordinator.inputDeviceForCapture(
+            availableInputs: snapshot.0,
+            defaultInputUID: snapshot.1,
+            persistFallback: true
+        )
+        return true
+    }
+
     private func recoverIdleAudioRoute(_ request: AudioRouteRecoveryRequest) async {
         let shouldRebuild = self.hasPreparedAudioCapture || request.requiresIdlePrewarm
         guard shouldRebuild else { return }
@@ -2828,7 +2869,8 @@ final class ASRService: ObservableObject {
         self.pendingAudioRouteRecovery = AudioRouteRecoveryRequest(
             generation: request.generation,
             reason: request.reason,
-            requiresIdlePrewarm: true
+            requiresIdlePrewarm: true,
+            reconcilesInputSelection: request.reconcilesInputSelection
         )
         await self.directAudioLifecycleController.invalidate(
             reason: "idle_route_change:\(request.reason)"
@@ -2985,21 +3027,8 @@ final class ASRService: ObservableObject {
     }
 
     private func handleDefaultInputChanged() {
-        if SettingsStore.shared.microphoneSelectionMode == .manual {
-            if AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
-                experimentalDirectAudioCaptureEnabled: SettingsStore.shared.experimentalDirectAudioCaptureEnabled
-            ) {
-                AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
-                    reason: "default input changed"
-                )
-                if self.isRunning || self.isStarting {
-                    self.scheduleAudioRouteRecovery(reason: "manual preferred input reasserted")
-                }
-            }
-            return
-        }
-
-        self.scheduleAudioRouteRecovery(reason: "default input changed")
+        // FluidVoice owns only its app-specific input selection. A macOS
+        // default-input change must not move or restart the selected mic.
     }
 
     private func handleDefaultOutputChanged() {
@@ -3257,23 +3286,20 @@ final class ASRService: ObservableObject {
 
                 DebugLogger.shared.debug("Current input devices: \(currentDevices.map { $0.name }.joined(separator: ", "))", source: "ASRService")
 
-                if SettingsStore.shared.microphoneSelectionMode == .manual,
-                   currentUIDs != cachedUIDs
-                {
-                    if AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
-                        experimentalDirectAudioCaptureEnabled: SettingsStore.shared.experimentalDirectAudioCaptureEnabled
-                    ) {
-                        AppServices.shared.microphonePreferenceCoordinator.stabilizePreferredInputAfterHardwareChange(
-                            reason: "input device list changed"
-                        )
-                    } else if AudioCaptureIdlePolicy.didPreferredInputAvailabilityChange(
-                        preferredInputUID: SettingsStore.shared.preferredInputDeviceUID,
+                if currentUIDs != cachedUIDs {
+                    let previousPreferredUID = SettingsStore.shared.preferredInputDeviceUID
+                    let preferredAvailabilityChanged = AudioCaptureIdlePolicy.didPreferredInputAvailabilityChange(
+                        preferredInputUID: previousPreferredUID,
                         previousInputUIDs: cachedUIDs,
                         currentInputUIDs: currentUIDs
-                    ) {
+                    )
+                    let needsInitialSelection =
+                        (previousPreferredUID?.isEmpty ?? true) && currentDevices.isEmpty == false
+                    if needsInitialSelection || preferredAvailabilityChanged {
                         self.scheduleAudioRouteRecovery(
-                            reason: "direct preferred input availability changed",
-                            requiresIdlePrewarm: true
+                            reason: "app microphone availability changed",
+                            requiresIdlePrewarm: true,
+                            reconcilesInputSelection: true
                         )
                     }
                 }
@@ -3310,7 +3336,10 @@ final class ASRService: ObservableObject {
                     "Device changed during recording - deferring rebuild until audio route recovery",
                     source: "ASRService"
                 )
-                self.scheduleAudioRouteRecovery(reason: "monitored input disconnected")
+                self.scheduleAudioRouteRecovery(
+                    reason: "monitored input disconnected",
+                    reconcilesInputSelection: true
+                )
             } else {
                 DebugLogger.shared.info("Not recording - device disconnect handled gracefully", source: "ASRService")
             }

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1296,6 +1296,13 @@ final class ASRService: ObservableObject {
 
         // Initialize device list cache
         self.cacheCurrentDeviceList(initialInputSnapshot.0)
+        if microphonePreferenceCoordinator.needsAppOnlySelectionMigration {
+            self.scheduleAudioRouteRecovery(
+                reason: "app microphone migration pending",
+                requiresIdlePrewarm: true,
+                reconcilesInputSelection: true
+            )
+        }
 
         // Register the input callback and allocate its fixed ring now. This
         // does not start the device or show the microphone privacy indicator.
@@ -3299,14 +3306,15 @@ final class ASRService: ObservableObject {
 
                 if currentUIDs != cachedUIDs {
                     let previousPreferredUID = SettingsStore.shared.preferredInputDeviceUID
-                    let preferredAvailabilityChanged = AudioCaptureIdlePolicy.didPreferredInputAvailabilityChange(
+                    let microphonePreferenceCoordinator =
+                        AppServices.shared.microphonePreferenceCoordinator
+                    let shouldReconcileInputSelection = AudioCaptureIdlePolicy.shouldReconcileInputSelection(
                         preferredInputUID: previousPreferredUID,
+                        migrationPending: microphonePreferenceCoordinator.needsAppOnlySelectionMigration,
                         previousInputUIDs: cachedUIDs,
                         currentInputUIDs: currentUIDs
                     )
-                    let needsInitialSelection =
-                        (previousPreferredUID?.isEmpty ?? true) && currentDevices.isEmpty == false
-                    if needsInitialSelection || preferredAvailabilityChanged {
+                    if shouldReconcileInputSelection {
                         self.scheduleAudioRouteRecovery(
                             reason: "app microphone availability changed",
                             requiresIdlePrewarm: true,

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1033,24 +1033,6 @@ final class ASRService: ObservableObject {
         self.activeAudioCaptureBackend = .none
     }
 
-    /// Applies the experimental capture preference immediately when idle.
-    /// If a recording transition is already underway, start() reads the latest
-    /// persisted value and the following session will use it.
-    func refreshAudioCaptureBackendPreference() {
-        guard self.isRunning == false, self.isStarting == false else {
-            DebugLogger.shared.debug(
-                "Audio capture preference changed during a recording transition; deferring backend refresh",
-                source: "ASRService"
-            )
-            return
-        }
-
-        self.scheduleAudioRouteRecovery(
-            reason: "capture preference changed",
-            requiresIdlePrewarm: true
-        )
-    }
-
     private var inputFormat: AVAudioFormat?
     private var micPermissionGranted = false
 
@@ -1137,7 +1119,7 @@ final class ASRService: ObservableObject {
             audioBuffer: self.audioBuffer,
             onFirstAudio: { sessionID, attemptID, sampleCount, frameLength, sampleRate, acquisitionMs, elapsedMs in
                 Task {
-                    await readinessGate.signalFirstPCM(
+                    readinessGate.signalFirstPCM(
                         sessionID: sessionID,
                         attemptID: attemptID
                     )
@@ -1453,7 +1435,7 @@ final class ASRService: ObservableObject {
         let captureSessionID = self.benchmarkSessionID
         self.audioCaptureAttemptID &+= 1
         var readinessAttemptID = self.audioCaptureAttemptID
-        await self.audioCaptureReadinessGate.arm(
+        self.audioCaptureReadinessGate.arm(
             sessionID: captureSessionID,
             attemptID: readinessAttemptID
         )
@@ -1727,7 +1709,7 @@ final class ASRService: ObservableObject {
 
         self.audioCaptureAttemptID &+= 1
         let attemptID = self.audioCaptureAttemptID
-        await self.audioCaptureReadinessGate.arm(
+        self.audioCaptureReadinessGate.arm(
             sessionID: sessionID,
             attemptID: attemptID
         )
@@ -2880,7 +2862,7 @@ final class ASRService: ObservableObject {
         do {
             self.audioCaptureAttemptID &+= 1
             let readinessAttemptID = self.audioCaptureAttemptID
-            await self.audioCaptureReadinessGate.arm(
+            self.audioCaptureReadinessGate.arm(
                 sessionID: self.benchmarkSessionID,
                 attemptID: readinessAttemptID
             )
@@ -4326,9 +4308,10 @@ private extension ASRService {
 
 //
 // Audio callbacks are not main-actor isolated. Direct Core Audio arrives through
-// a lock-free C ring. AVAudioEngine is used only when Faster Recording Start is
-// disabled. This pipeline owns timestamp trimming, 16 kHz conversion, levels,
-// and session-safe delivery without touching ASRService from a realtime callback.
+// a lock-free C ring. The AVAudioEngine implementation remains as legacy code but
+// is no longer user-selectable. This pipeline owns timestamp trimming, 16 kHz
+// conversion, levels, and session-safe delivery without touching ASRService from
+// a realtime callback.
 
 private final nonisolated class AudioCapturePipeline: @unchecked Sendable {
     private let audioBuffer: ThreadSafeAudioBuffer

--- a/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
+++ b/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
@@ -3,12 +3,6 @@ enum AudioCaptureIdlePolicy {
         experimentalDirectAudioCaptureEnabled
     }
 
-    static func shouldEnforceSystemPreferredInput(
-        experimentalDirectAudioCaptureEnabled: Bool
-    ) -> Bool {
-        experimentalDirectAudioCaptureEnabled == false
-    }
-
     static func didPreferredInputAvailabilityChange(
         preferredInputUID: String?,
         previousInputUIDs: Set<String>,

--- a/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
+++ b/Sources/Fluid/Services/AudioCaptureIdlePolicy.swift
@@ -12,6 +12,21 @@ enum AudioCaptureIdlePolicy {
         return previousInputUIDs.contains(preferredInputUID) != currentInputUIDs.contains(preferredInputUID)
     }
 
+    static func shouldReconcileInputSelection(
+        preferredInputUID: String?,
+        migrationPending: Bool,
+        previousInputUIDs: Set<String>,
+        currentInputUIDs: Set<String>
+    ) -> Bool {
+        guard currentInputUIDs.isEmpty == false else { return false }
+        let needsInitialSelection = preferredInputUID?.isEmpty ?? true
+        return migrationPending || needsInitialSelection || self.didPreferredInputAvailabilityChange(
+            preferredInputUID: preferredInputUID,
+            previousInputUIDs: previousInputUIDs,
+            currentInputUIDs: currentInputUIDs
+        )
+    }
+
     static func shouldRecoverEngineConfigurationChange(
         isRunning: Bool,
         isStarting: Bool

--- a/Sources/Fluid/Services/AudioCaptureReadinessGate.swift
+++ b/Sources/Fluid/Services/AudioCaptureReadinessGate.swift
@@ -8,7 +8,7 @@ nonisolated enum AudioCaptureReadinessResult: Equatable {
     case staleSession
 }
 
-actor AudioCaptureReadinessGate {
+final nonisolated class AudioCaptureReadinessGate: @unchecked Sendable {
     private struct Key: Equatable {
         let sessionID: Int
         let attemptID: UInt64
@@ -19,15 +19,26 @@ actor AudioCaptureReadinessGate {
         let continuation: CheckedContinuation<AudioCaptureReadinessResult, Never>
     }
 
+    private let lock = NSLock()
     private var key: Key?
     private var result: AudioCaptureReadinessResult?
     private var waiter: Waiter?
+    private var cancelledWaiterIDs = Set<UUID>()
     private var timeoutTask: Task<Void, Never>?
 
     func arm(sessionID: Int, attemptID: UInt64) {
-        self.finishCurrent(with: .cancelled)
+        self.lock.lock()
+        let previousTimeoutTask = self.timeoutTask
+        let previousWaiter = self.waiter
+        self.timeoutTask = nil
+        self.waiter = nil
+        self.cancelledWaiterIDs.removeAll(keepingCapacity: true)
         self.key = Key(sessionID: sessionID, attemptID: attemptID)
         self.result = nil
+        self.lock.unlock()
+
+        previousTimeoutTask?.cancel()
+        previousWaiter?.continuation.resume(returning: .cancelled)
     }
 
     func wait(
@@ -37,23 +48,33 @@ actor AudioCaptureReadinessGate {
     ) async -> AudioCaptureReadinessResult {
         let key = Key(sessionID: sessionID, attemptID: attemptID)
         guard Task.isCancelled == false else { return .cancelled }
-        guard self.key == key else { return .staleSession }
-        if let result {
-            return result
-        }
 
         let waiterID = UUID()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
+                self.lock.lock()
+                guard Task.isCancelled == false else {
+                    self.lock.unlock()
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
                 guard self.key == key else {
+                    self.lock.unlock()
                     continuation.resume(returning: .staleSession)
                     return
                 }
                 if let result = self.result {
+                    self.lock.unlock()
                     continuation.resume(returning: result)
                     return
                 }
                 guard self.waiter == nil else {
+                    self.lock.unlock()
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
+                guard self.cancelledWaiterIDs.remove(waiterID) == nil else {
+                    self.lock.unlock()
                     continuation.resume(returning: .cancelled)
                     return
                 }
@@ -66,21 +87,20 @@ actor AudioCaptureReadinessGate {
                     } catch {
                         return
                     }
-                    await self?.finish(
+                    self?.finish(
                         key: key,
                         waiterID: waiterID,
                         with: .timedOut
                     )
                 }
+                self.lock.unlock()
             }
         } onCancel: {
-            Task {
-                await self.finish(
-                    key: key,
-                    waiterID: waiterID,
-                    with: .cancelled
-                )
-            }
+            self.finish(
+                key: key,
+                waiterID: waiterID,
+                with: .cancelled
+            )
         }
     }
 
@@ -110,22 +130,32 @@ actor AudioCaptureReadinessGate {
         waiterID: UUID? = nil,
         with result: AudioCaptureReadinessResult
     ) {
-        guard self.key == key, self.result == nil else { return }
-        if let waiterID, self.waiter?.id != waiterID {
+        self.lock.lock()
+        guard self.key == key, self.result == nil else {
+            self.lock.unlock()
             return
         }
+        if let waiterID {
+            guard let waiter = self.waiter else {
+                if result == .cancelled {
+                    self.cancelledWaiterIDs.insert(waiterID)
+                }
+                self.lock.unlock()
+                return
+            }
+            guard waiter.id == waiterID else {
+                self.lock.unlock()
+                return
+            }
+        }
         self.result = result
-        self.timeoutTask?.cancel()
+        let timeoutTask = self.timeoutTask
         self.timeoutTask = nil
         let waiter = self.waiter
         self.waiter = nil
-        waiter?.continuation.resume(returning: result)
-    }
+        self.lock.unlock()
 
-    private func finishCurrent(with result: AudioCaptureReadinessResult) {
-        guard let key else { return }
-        self.finish(key: key, with: result)
-        self.key = nil
-        self.result = nil
+        timeoutTask?.cancel()
+        waiter?.continuation.resume(returning: result)
     }
 }

--- a/Sources/Fluid/Services/AudioEngineRetirementDrain.swift
+++ b/Sources/Fluid/Services/AudioEngineRetirementDrain.swift
@@ -25,20 +25,33 @@ final nonisolated class AudioEngineRetirementToken: @unchecked Sendable {
 /// construction must be able to await its completion.
 final nonisolated class AudioEngineRetirementDrain: @unchecked Sendable {
     private let queue: DispatchQueue
+    private let stateLock = NSLock()
+    private var scheduledReleaseCount = 0
 
     init(label: String = "app.fluidvoice.audio-engine-retirement") {
         self.queue = DispatchQueue(label: label, qos: .utility)
     }
 
     func schedule(_ token: AudioEngineRetirementToken) {
-        self.queue.async {
+        self.stateLock.lock()
+        self.scheduledReleaseCount += 1
+        self.queue.async { [self] in
             token.releaseEngine()
+            self.completeScheduledRelease()
         }
+        self.stateLock.unlock()
     }
 
     func releaseAndWait(_ token: AudioEngineRetirementToken) async {
-        await self.enqueueAndWait {
-            token.releaseEngine()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.stateLock.lock()
+            self.scheduledReleaseCount += 1
+            self.queue.async { [self] in
+                token.releaseEngine()
+                self.completeScheduledRelease()
+                continuation.resume()
+            }
+            self.stateLock.unlock()
         }
     }
 
@@ -46,15 +59,27 @@ final nonisolated class AudioEngineRetirementDrain: @unchecked Sendable {
     /// capture start so a fire-and-forget retirement from a non-route path cannot
     /// overlap construction of the next AVAudioEngine.
     func waitForScheduledReleases() async {
-        await self.enqueueAndWait {}
-    }
-
-    private func enqueueAndWait(_ operation: @escaping @Sendable () -> Void) async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.stateLock.lock()
+            guard self.scheduledReleaseCount > 0 else {
+                self.stateLock.unlock()
+                continuation.resume()
+                return
+            }
+
+            // Enqueue while holding the same lock used by schedule(_:). This
+            // preserves the barrier ordering without paying a utility-queue hop
+            // when no AVAudioEngine release is pending.
             self.queue.async {
-                operation()
                 continuation.resume()
             }
+            self.stateLock.unlock()
         }
+    }
+
+    private func completeScheduledRelease() {
+        self.stateLock.lock()
+        self.scheduledReleaseCount -= 1
+        self.stateLock.unlock()
     }
 }

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -35,7 +35,12 @@ final class MediaPlaybackService {
             let resumeLock = NSLock()
             var didResume = false
 
-            func resumeOnce(_ value: Bool) {
+            @discardableResult
+            func resumeOnce(
+                _ value: Bool,
+                logDuplicate: Bool = true,
+                beforeResume: () -> Void = {}
+            ) -> Bool {
                 var shouldResume = false
 
                 resumeLock.lock()
@@ -46,14 +51,27 @@ final class MediaPlaybackService {
                 resumeLock.unlock()
 
                 guard shouldResume else {
-                    DebugLogger.shared.warning(
-                        "MediaPlaybackService: Suppressed duplicate resume (MediaRemoteAdapter callback fired more than once)",
-                        source: "MediaPlaybackService"
-                    )
-                    return
+                    if logDuplicate {
+                        DebugLogger.shared.warning(
+                            "MediaPlaybackService: Suppressed late or duplicate media callback",
+                            source: "MediaPlaybackService"
+                        )
+                    }
+                    return false
                 }
 
+                beforeResume()
                 continuation.resume(returning: value)
+                return true
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                if resumeOnce(false, logDuplicate: false) {
+                    DebugLogger.shared.warning(
+                        "MediaPlaybackService: Now Playing query timed out; leaving playback unchanged",
+                        source: "MediaPlaybackService"
+                    )
+                }
             }
 
             self.mediaController.getTrackInfo { [weak self] trackInfo in
@@ -97,12 +115,13 @@ final class MediaPlaybackService {
                 )
 
                 if isPlaying {
-                    DebugLogger.shared.info(
-                        "MediaPlaybackService: Media is playing, sending pause command",
-                        source: "MediaPlaybackService"
-                    )
-                    self.mediaController.pause()
-                    resumeOnce(true)
+                    resumeOnce(true) {
+                        DebugLogger.shared.info(
+                            "MediaPlaybackService: Media is playing, sending pause command",
+                            source: "MediaPlaybackService"
+                        )
+                        self.mediaController.pause()
+                    }
                 } else {
                     DebugLogger.shared.debug(
                         "MediaPlaybackService: Media is not playing, no action needed",

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -616,18 +616,11 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
             return
         }
 
-        let followSystemItem = NSMenuItem(
-            title: "Use macOS Default Microphone",
-            action: #selector(toggleMicrophoneSelectionMode(_:)),
-            keyEquivalent: ""
-        )
-        followSystemItem.target = self
-        followSystemItem.state = SettingsStore.shared.microphoneSelectionMode == .system ? .on : .off
-        followSystemItem.isEnabled = !self.isRecording
-        submenu.addItem(followSystemItem)
-        submenu.addItem(.separator())
-
-        let currentUID = self.currentPreferredInputUID(defaultInputUID: defaultInputUID)
+        let currentUID = AppServices.shared.microphonePreferenceCoordinator
+            .inputDeviceForCapture(
+                availableInputs: inputDevices,
+                defaultInputUID: defaultInputUID
+            )?.uid
 
         for device in inputDevices {
             let isSystemDefault = device.uid == defaultInputUID
@@ -645,15 +638,6 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
             let recordingItem = NSMenuItem(title: "Unavailable while recording", action: nil, keyEquivalent: "")
             recordingItem.isEnabled = false
             submenu.addItem(recordingItem)
-        }
-    }
-
-    private func currentPreferredInputUID(defaultInputUID: String?) -> String? {
-        switch SettingsStore.shared.microphoneSelectionMode {
-        case .system:
-            return defaultInputUID
-        case .manual:
-            return SettingsStore.shared.preferredInputDeviceUID ?? defaultInputUID
         }
     }
 
@@ -678,37 +662,6 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
         guard let uid = sender.representedObject as? String, !uid.isEmpty else { return }
 
         SettingsStore.shared.recordInputDeviceSelection(uid)
-        if SettingsStore.shared.shouldSyncInputSelectionToSystemDefault() {
-            _ = AudioDevice.setDefaultInputDevice(uid: uid)
-        }
-
-        self.refreshMicrophoneMenu()
-    }
-
-    @objc private func toggleMicrophoneSelectionMode(_ sender: NSMenuItem) {
-        guard self.isRecording == false else { return }
-
-        let nextMode: SettingsStore.MicrophoneSelectionMode =
-            SettingsStore.shared.microphoneSelectionMode == .system ? .manual : .system
-        let currentSystemInputUID = AudioDevice.getDefaultInputDevice()?.uid
-        let availableInputUIDs = Set(AudioDevice.listInputDevices().map(\.uid))
-        let restoredSystemInputUID = SettingsStore.shared.setMicrophoneSelectionMode(
-            nextMode,
-            currentSystemInputUID: currentSystemInputUID,
-            availableInputUIDs: availableInputUIDs
-        )
-
-        let preferredInputUID = SettingsStore.shared.preferredInputDeviceUID ?? ""
-        if nextMode == .manual,
-           preferredInputUID.isEmpty,
-           let defaultUID = currentSystemInputUID
-        {
-            SettingsStore.shared.preferredInputDeviceUID = defaultUID
-        }
-
-        if nextMode == .system, let restoredSystemInputUID {
-            _ = AudioDevice.setDefaultInputDevice(uid: restoredSystemInputUID)
-        }
 
         self.refreshMicrophoneMenu()
     }

--- a/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
+++ b/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
@@ -5,7 +5,6 @@ import Foundation
 protocol AudioDeviceManaging {
     func listInputDevices() -> [AudioDevice.Device]
     func defaultInputDevice() -> AudioDevice.Device?
-    @discardableResult func setDefaultInputDevice(uid: String) -> Bool
 }
 
 struct CoreAudioDeviceManager: AudioDeviceManaging {
@@ -16,29 +15,14 @@ struct CoreAudioDeviceManager: AudioDeviceManaging {
     func defaultInputDevice() -> AudioDevice.Device? {
         AudioDevice.getDefaultInputDevice()
     }
-
-    @discardableResult
-    func setDefaultInputDevice(uid: String) -> Bool {
-        AudioDevice.setDefaultInputDevice(uid: uid)
-    }
 }
 
 @MainActor
 final class MicrophonePreferenceCoordinator: ObservableObject {
-    enum EnforcementResult: Equatable {
-        case skippedSystemMode
-        case skippedNoPreferredInput
-        case skippedPreferredUnavailable(String)
-        case alreadyUsingPreferred(String)
-        case applied(String)
-        case failed(String)
-    }
-
-    @Published private(set) var lastResult: EnforcementResult?
+    private static let appOnlyMigrationVersion = 1
 
     private let settings: SettingsStore
     private let devices: any AudioDeviceManaging
-    private var stabilizationTask: Task<Void, Never>?
 
     init(
         settings: SettingsStore? = nil,
@@ -48,83 +32,87 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         self.devices = devices ?? CoreAudioDeviceManager()
     }
 
-    @discardableResult
-    func enforcePreferredInput(reason: String) -> EnforcementResult {
-        guard self.settings.microphoneSelectionMode == .manual else {
-            self.lastResult = .skippedSystemMode
-            return .skippedSystemMode
+    func migrateToAppOnlySelectionIfNeeded() {
+        guard self.settings.appMicSelectionMigrationVersion < Self.appOnlyMigrationVersion else {
+            self.settings.enforceAppOnlyMicrophoneSelection()
+            return
         }
-
-        guard let preferredUID = self.settings.preferredInputDeviceUID,
-              preferredUID.isEmpty == false
-        else {
-            self.lastResult = .skippedNoPreferredInput
-            return .skippedNoPreferredInput
-        }
-
         let inputs = self.devices.listInputDevices()
-        guard inputs.contains(where: { $0.uid == preferredUID }) else {
-            let result = EnforcementResult.skippedPreferredUnavailable(preferredUID)
-            self.lastResult = result
-            DebugLogger.shared.warning(
-                "Preferred microphone unavailable during \(reason): \(preferredUID)",
-                source: "MicrophonePreferenceCoordinator"
-            )
-            return result
+        let defaultInputUID = self.devices.defaultInputDevice()?.uid
+        self.migrateToAppOnlySelectionIfNeeded(
+            availableInputs: inputs,
+            defaultInputUID: defaultInputUID
+        )
+    }
+
+    func migrateToAppOnlySelectionIfNeeded(
+        availableInputs: [AudioDevice.Device],
+        defaultInputUID: String?
+    ) {
+        guard self.settings.appMicSelectionMigrationVersion < Self.appOnlyMigrationVersion else {
+            self.settings.enforceAppOnlyMicrophoneSelection()
+            return
         }
+        guard let selectedInput = self.fallbackInput(
+            from: availableInputs,
+            defaultInputUID: defaultInputUID
+        ) else { return }
 
-        if self.devices.defaultInputDevice()?.uid == preferredUID {
-            let result = EnforcementResult.alreadyUsingPreferred(preferredUID)
-            self.lastResult = result
-            return result
-        }
-
-        let didApply = self.devices.setDefaultInputDevice(uid: preferredUID)
-        let result: EnforcementResult = didApply ? .applied(preferredUID) : .failed(preferredUID)
-        self.lastResult = result
-
-        if didApply {
-            DebugLogger.shared.info(
-                "Reasserted preferred microphone during \(reason): \(preferredUID)",
-                source: "MicrophonePreferenceCoordinator"
-            )
-        } else {
-            DebugLogger.shared.error(
-                "Failed to reassert preferred microphone during \(reason): \(preferredUID)",
-                source: "MicrophonePreferenceCoordinator"
-            )
-        }
-
-        return result
+        self.settings.preferredInputDeviceUID = selectedInput.uid
+        self.settings.enforceAppOnlyMicrophoneSelection()
+        self.settings.appMicSelectionMigrationVersion = Self.appOnlyMigrationVersion
+        DebugLogger.shared.info(
+            "Migrated FluidVoice microphone selection to app-only input '\(selectedInput.name)'",
+            source: "MicrophonePreferenceCoordinator"
+        )
     }
 
     func inputDeviceForCapture() -> AudioDevice.Device? {
-        if self.settings.microphoneSelectionMode == .manual,
-           let preferredUID = self.settings.preferredInputDeviceUID,
+        self.inputDeviceForCapture(
+            availableInputs: self.devices.listInputDevices(),
+            defaultInputUID: self.devices.defaultInputDevice()?.uid
+        )
+    }
+
+    func inputDeviceForCapture(
+        availableInputs: [AudioDevice.Device],
+        defaultInputUID: String? = nil,
+        persistFallback: Bool = false
+    ) -> AudioDevice.Device? {
+        if let preferredUID = self.settings.preferredInputDeviceUID,
            preferredUID.isEmpty == false,
-           let preferredDevice = self.devices.listInputDevices().first(where: { $0.uid == preferredUID })
+           let preferredDevice = availableInputs.first(where: { $0.uid == preferredUID })
         {
             return preferredDevice
         }
 
-        return self.devices.defaultInputDevice()
+        guard let fallback = self.fallbackInput(
+            from: availableInputs,
+            defaultInputUID: defaultInputUID
+        ) else { return nil }
+        if persistFallback {
+            self.settings.preferredInputDeviceUID = fallback.uid
+            DebugLogger.shared.info(
+                "Selected fallback FluidVoice microphone '\(fallback.name)'",
+                source: "MicrophonePreferenceCoordinator"
+            )
+        }
+        return fallback
     }
 
-    func stabilizePreferredInputAfterHardwareChange(reason: String) {
-        self.stabilizationTask?.cancel()
-        self.stabilizationTask = Task { [weak self] in
-            let delaysNanoseconds: [UInt64] = [
-                250_000_000,
-                750_000_000,
-                1_500_000_000,
-                2_500_000_000,
-            ]
-
-            for delay in delaysNanoseconds {
-                try? await Task.sleep(nanoseconds: delay)
-                guard Task.isCancelled == false else { return }
-                _ = self?.enforcePreferredInput(reason: reason)
-            }
+    private func fallbackInput(
+        from inputs: [AudioDevice.Device],
+        defaultInputUID: String?
+    ) -> AudioDevice.Device? {
+        guard inputs.isEmpty == false else { return nil }
+        if let builtInInput = inputs.first(where: \.isBuiltIn) {
+            return builtInInput
         }
+        if let defaultUID = defaultInputUID,
+           let defaultInput = inputs.first(where: { $0.uid == defaultUID })
+        {
+            return defaultInput
+        }
+        return inputs.first
     }
 }

--- a/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
+++ b/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
@@ -32,8 +32,12 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         self.devices = devices ?? CoreAudioDeviceManager()
     }
 
+    var needsAppOnlySelectionMigration: Bool {
+        self.settings.appMicSelectionMigrationVersion < Self.appOnlyMigrationVersion
+    }
+
     func migrateToAppOnlySelectionIfNeeded() {
-        guard self.settings.appMicSelectionMigrationVersion < Self.appOnlyMigrationVersion else {
+        guard self.needsAppOnlySelectionMigration else {
             self.settings.enforceAppOnlyMicrophoneSelection()
             return
         }
@@ -49,14 +53,17 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         availableInputs: [AudioDevice.Device],
         defaultInputUID: String?
     ) {
-        guard self.settings.appMicSelectionMigrationVersion < Self.appOnlyMigrationVersion else {
+        guard self.needsAppOnlySelectionMigration else {
             self.settings.enforceAppOnlyMicrophoneSelection()
             return
         }
-        guard let selectedInput = self.fallbackInput(
-            from: availableInputs,
-            defaultInputUID: defaultInputUID
-        ) else { return }
+        let preferredInput = availableInputs.first { input in
+            input.uid == self.settings.preferredInputDeviceUID
+        }
+        guard let selectedInput = availableInputs.first(where: \.isBuiltIn)
+            ?? preferredInput
+            ?? self.fallbackInput(from: availableInputs, defaultInputUID: defaultInputUID)
+        else { return }
 
         self.settings.preferredInputDeviceUID = selectedInput.uid
         self.settings.enforceAppOnlyMicrophoneSelection()

--- a/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
+++ b/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
@@ -67,6 +67,22 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         )
     }
 
+    @discardableResult
+    func reconcileAppOnlySelection(
+        availableInputs: [AudioDevice.Device],
+        defaultInputUID: String?
+    ) -> AudioDevice.Device? {
+        self.migrateToAppOnlySelectionIfNeeded(
+            availableInputs: availableInputs,
+            defaultInputUID: defaultInputUID
+        )
+        return self.inputDeviceForCapture(
+            availableInputs: availableInputs,
+            defaultInputUID: defaultInputUID,
+            persistFallback: true
+        )
+    }
+
     func inputDeviceForCapture() -> AudioDevice.Device? {
         self.inputDeviceForCapture(
             availableInputs: self.devices.listInputDevices(),

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -1498,27 +1498,6 @@ struct SettingsView: View {
                     }
                     .padding(16)
                 }
-
-                // Experimental Card
-                ThemedCard(style: .standard) {
-                    VStack(alignment: .leading, spacing: 14) {
-                        Label("Experimental Settings", systemImage: "exclamationmark.triangle")
-                            .font(.headline)
-                            .foregroundStyle(.primary)
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            self.lowLatencyAudioCaptureToggle
-
-                            if self.asr.isRunning {
-                                Text("Settings are disabled during active recording")
-                                    .font(.caption)
-                                    .foregroundStyle(self.settingsSecondaryText)
-                                    .italic()
-                            }
-                        }
-                    }
-                    .padding(16)
-                }
             }
             .padding(16)
         }
@@ -2627,28 +2606,6 @@ struct FlowLayout: Layout {
 
         cache.containerSize = CGSize(width: maxWidth, height: y + rowHeight)
         cache.lastWidth = maxWidth
-    }
-}
-
-private extension SettingsView {
-    var lowLatencyAudioCaptureToggle: some View {
-        Group {
-            self.settingsToggleRow(
-                title: "Faster Recording Start",
-                description: "FluidVoice starts listening sooner, so your first word is less likely to be missed.",
-                footnote: "If your microphone does not work correctly, turn this off.",
-                isOn: Binding(
-                    get: { self.settings.experimentalDirectAudioCaptureEnabled },
-                    set: { enabled in
-                        self.settings.experimentalDirectAudioCaptureEnabled = enabled
-                        self.asr.refreshAudioCaptureBackendPreference()
-                    }
-                )
-            )
-            .disabled(self.asr.isRunning)
-
-            Divider().padding(.vertical, 8)
-        }
     }
 }
 

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -31,7 +31,6 @@ struct SettingsView: View {
     @Binding var visualizerNoiseThreshold: Double
     @Binding var selectedInputUID: String
     @Binding var selectedOutputUID: String
-    @Binding var microphoneSelectionMode: SettingsStore.MicrophoneSelectionMode
     @Binding var inputDevices: [AudioDevice.Device]
     @Binding var outputDevices: [AudioDevice.Device]
     @Binding var accessibilityEnabled: Bool
@@ -90,9 +89,6 @@ struct SettingsView: View {
 
                 self.selectedInputUID = newUID
                 SettingsStore.shared.recordInputDeviceSelection(newUID)
-                if SettingsStore.shared.shouldSyncInputSelectionToSystemDefault() {
-                    _ = AudioDevice.setDefaultInputDevice(uid: newUID)
-                }
             }
         )
     }
@@ -1115,12 +1111,9 @@ struct SettingsView: View {
                             .controlSize(.small)
                         }
 
-                        // Info note about device syncing
                         self.microphoneModeInfo
 
                         VStack(alignment: .leading, spacing: 12) {
-                            self.microphoneModeToggle
-
                             HStack {
                                 Text("Input Device")
                                     .font(self.theme.typography.bodyStrong)
@@ -1146,27 +1139,10 @@ struct SettingsView: View {
 
                                     guard !newDevices.isEmpty else { return }
 
-                                    switch self.microphoneSelectionMode {
-                                    case .system:
-                                        if let defaultUID = AudioDevice.getDefaultInputDevice()?.uid,
-                                           newDevices.contains(where: { $0.uid == defaultUID })
-                                        {
-                                            self.selectedInputUID = defaultUID
-                                        } else if !newDevices.contains(where: { $0.uid == self.selectedInputUID }) {
-                                            self.selectedInputUID = newDevices.first?.uid ?? ""
-                                        }
-                                    case .manual:
-                                        if let preferredUID = SettingsStore.shared.preferredInputDeviceUID,
-                                           newDevices.contains(where: { $0.uid == preferredUID })
-                                        {
-                                            self.selectedInputUID = preferredUID
-                                        } else if let defaultUID = AudioDevice.getDefaultInputDevice()?.uid,
-                                                  newDevices.contains(where: { $0.uid == defaultUID })
-                                        {
-                                            self.selectedInputUID = defaultUID
-                                        } else {
-                                            self.selectedInputUID = newDevices.first?.uid ?? ""
-                                        }
+                                    if let selectedInput = self.appServices.microphonePreferenceCoordinator
+                                        .inputDeviceForCapture(availableInputs: newDevices)
+                                    {
+                                        self.selectedInputUID = selectedInput.uid
                                     }
                                 }
                             }
@@ -2339,55 +2315,13 @@ private extension SettingsView {
                 .foregroundStyle(self.settingsSecondaryText)
                 .font(self.theme.typography.bodyStrong)
             Text(
-                self.microphoneSelectionMode == .system
-                    ? "FluidVoice follows the macOS default microphone."
-                    : "FluidVoice keeps your preferred microphone selected while it is available."
+                "FluidVoice uses this microphone independently from the macOS default."
             )
             .font(self.theme.typography.bodySmall)
             .foregroundStyle(self.settingsSecondaryText)
             .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.vertical, 4)
-    }
-
-    var microphoneModeToggle: some View {
-        Toggle(
-            "Use macOS default microphone",
-            isOn: Binding(
-                get: { self.microphoneSelectionMode == .system },
-                set: { self.updateMicrophoneSelectionMode(useSystemDefault: $0) }
-            )
-        )
-        .toggleStyle(.switch)
-        .font(self.theme.typography.bodyStrong)
-        .foregroundStyle(self.settingsTitleText)
-        .disabled(self.asr.isRunning)
-    }
-
-    func updateMicrophoneSelectionMode(useSystemDefault: Bool) {
-        let nextMode: SettingsStore.MicrophoneSelectionMode = useSystemDefault ? .system : .manual
-        let currentSystemInputUID = AudioDevice.getDefaultInputDevice()?.uid
-        let availableInputUIDs = Set(self.inputDevices.map(\.uid))
-        let restoredSystemInputUID = SettingsStore.shared.setMicrophoneSelectionMode(
-            nextMode,
-            currentSystemInputUID: currentSystemInputUID,
-            availableInputUIDs: availableInputUIDs
-        )
-        self.microphoneSelectionMode = nextMode
-
-        if nextMode == .manual {
-            if self.selectedInputUID.isEmpty,
-               let defaultUID = currentSystemInputUID
-            {
-                self.selectedInputUID = defaultUID
-                SettingsStore.shared.recordInputDeviceSelection(defaultUID)
-            } else {
-                SettingsStore.shared.recordInputDeviceSelection(self.selectedInputUID)
-            }
-        } else if let restoredSystemInputUID {
-            self.selectedInputUID = restoredSystemInputUID
-            _ = AudioDevice.setDefaultInputDevice(uid: restoredSystemInputUID)
-        }
     }
 }
 

--- a/Tests/FluidDictationIntegrationTests/AudioEngineRetirementDrainTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AudioEngineRetirementDrainTests.swift
@@ -39,6 +39,22 @@ final class AudioEngineRetirementDrainTests: XCTestCase {
             ]
         )
     }
+
+    func testWaitForScheduledReleasesCompletesAfterScheduledRelease() async throws {
+        let drain = AudioEngineRetirementDrain(label: "test.audio-engine-retirement.barrier")
+        let recorder = DeinitRecorder()
+        var probe: DeinitProbe? = DeinitProbe(id: 1, recorder: recorder)
+        let token = AudioEngineRetirementToken(try XCTUnwrap(probe))
+        probe = nil
+
+        drain.schedule(token)
+        await drain.waitForScheduledReleases()
+
+        XCTAssertEqual(
+            recorder.events,
+            [DeinitEvent(id: 1, occurredOnMainThread: false)]
+        )
+    }
 }
 
 private final class DeinitProbe {

--- a/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
+++ b/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
@@ -6,8 +6,8 @@ import XCTest
 final class DirectAudioReliabilityTests: XCTestCase {
     func testReadinessGatePreservesFirstPCMThatArrivesBeforeWait() async {
         let gate = AudioCaptureReadinessGate()
-        await gate.arm(sessionID: 41, attemptID: 1)
-        await gate.signalFirstPCM(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 1)
+        gate.signalFirstPCM(sessionID: 41, attemptID: 1)
 
         let result = await gate.wait(
             sessionID: 41,
@@ -20,7 +20,7 @@ final class DirectAudioReliabilityTests: XCTestCase {
 
     func testReadinessGateCancelsWaitAndIgnoresStalePCM() async {
         let gate = AudioCaptureReadinessGate()
-        await gate.arm(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 1)
         let firstWait = Task {
             await gate.wait(
                 sessionID: 41,
@@ -29,12 +29,12 @@ final class DirectAudioReliabilityTests: XCTestCase {
             )
         }
         await Task.yield()
-        await gate.cancel(sessionID: 41, attemptID: 1)
+        gate.cancel(sessionID: 41, attemptID: 1)
         let firstResult = await firstWait.value
         XCTAssertEqual(firstResult, .cancelled)
 
-        await gate.arm(sessionID: 41, attemptID: 2)
-        await gate.signalFirstPCM(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 2)
+        gate.signalFirstPCM(sessionID: 41, attemptID: 1)
         let staleResult = await gate.wait(
             sessionID: 41,
             attemptID: 1,
@@ -42,7 +42,32 @@ final class DirectAudioReliabilityTests: XCTestCase {
         )
         XCTAssertEqual(staleResult, .staleSession)
 
-        await gate.signalFirstPCM(sessionID: 41, attemptID: 2)
+        gate.signalFirstPCM(sessionID: 41, attemptID: 2)
+        let replacementResult = await gate.wait(
+            sessionID: 41,
+            attemptID: 2,
+            timeoutNanoseconds: 1_000_000
+        )
+        XCTAssertEqual(replacementResult, .ready)
+    }
+
+    func testReadinessGateRearmingCancelsExistingWaiter() async {
+        let gate = AudioCaptureReadinessGate()
+        gate.arm(sessionID: 41, attemptID: 1)
+        let firstWait = Task {
+            await gate.wait(
+                sessionID: 41,
+                attemptID: 1,
+                timeoutNanoseconds: 10_000_000_000
+            )
+        }
+        await Task.yield()
+
+        gate.arm(sessionID: 41, attemptID: 2)
+
+        let firstResult = await firstWait.value
+        XCTAssertEqual(firstResult, .cancelled)
+        gate.signalFirstPCM(sessionID: 41, attemptID: 2)
         let replacementResult = await gate.wait(
             sessionID: 41,
             attemptID: 2,
@@ -53,7 +78,7 @@ final class DirectAudioReliabilityTests: XCTestCase {
 
     func testReadinessGateTimesOutWithoutPCM() async {
         let gate = AudioCaptureReadinessGate()
-        await gate.arm(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 1)
 
         let result = await gate.wait(
             sessionID: 41,
@@ -66,7 +91,7 @@ final class DirectAudioReliabilityTests: XCTestCase {
 
     func testReadinessWaitRespondsPromptlyToTaskCancellation() async {
         let gate = AudioCaptureReadinessGate()
-        await gate.arm(sessionID: 41, attemptID: 1)
+        gate.arm(sessionID: 41, attemptID: 1)
         let waitTask = Task {
             await gate.wait(
                 sessionID: 41,

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -12,7 +12,7 @@ final class HotkeyShortcutTests: XCTestCase {
     private let pasteLastTranscriptionEnabledKey = "PasteLastTranscriptionShortcutEnabled"
     private let microphoneSelectionModeKey = "MicrophoneSelectionMode"
     private let preferredInputDeviceUIDKey = "PreferredInputDeviceUID"
-    private let systemInputDeviceUIDBeforeManualKey = "SystemInputDeviceUIDBeforeManual"
+    private let appOnlyMicrophoneSelectionMigrationVersionKey = "AppOnlyMicrophoneSelectionMigrationVersion"
     private let experimentalDirectAudioCaptureEnabledKey = "ExperimentalDirectAudioCaptureEnabled"
 
     @MainActor
@@ -161,15 +161,6 @@ final class HotkeyShortcutTests: XCTestCase {
 
     func testPreparedDirectCaptureMayRemainWarmWhileIdle() {
         XCTAssertTrue(AudioCaptureIdlePolicy.shouldPrewarmCapture(
-            experimentalDirectAudioCaptureEnabled: true
-        ))
-    }
-
-    func testSystemPreferredInputIsEnforcedOnlyForLegacyCapture() {
-        XCTAssertTrue(AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
-            experimentalDirectAudioCaptureEnabled: false
-        ))
-        XCTAssertFalse(AudioCaptureIdlePolicy.shouldEnforceSystemPreferredInput(
             experimentalDirectAudioCaptureEnabled: true
         ))
     }
@@ -355,130 +346,24 @@ final class HotkeyShortcutTests: XCTestCase {
         }
     }
 
-    func testMicrophoneSelectionModeDefaultsToSystem() throws {
+    func testMicrophoneSelectionModeIsAlwaysAppOnly() throws {
         try self.withRestoredDefaults(keys: [self.microphoneSelectionModeKey]) {
-            UserDefaults.standard.removeObject(forKey: self.microphoneSelectionModeKey)
-
-            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMode, .system)
-        }
-    }
-
-    func testMicrophoneSelectionModePersistsManual() throws {
-        try self.withRestoredDefaults(keys: [self.microphoneSelectionModeKey]) {
-            SettingsStore.shared.microphoneSelectionMode = .manual
+            UserDefaults.standard.set(
+                SettingsStore.MicrophoneSelectionMode.system.rawValue,
+                forKey: self.microphoneSelectionModeKey
+            )
 
             XCTAssertEqual(SettingsStore.shared.microphoneSelectionMode, .manual)
-            XCTAssertEqual(
-                UserDefaults.standard.string(forKey: self.microphoneSelectionModeKey),
-                SettingsStore.MicrophoneSelectionMode.manual.rawValue
-            )
         }
     }
 
-    func testLegacySyncFalseDoesNotEnableManualMode() throws {
+    func testInputSelectionPersistsAppPreference() throws {
         try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
-            "SyncAudioDevicesWithSystem",
-        ]) {
-            UserDefaults.standard.removeObject(forKey: self.microphoneSelectionModeKey)
-            UserDefaults.standard.set(false, forKey: "SyncAudioDevicesWithSystem")
-
-            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMode, .system)
-        }
-    }
-
-    func testSystemModeInputSelectionDoesNotOverwriteManualPreference() throws {
-        try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
             self.preferredInputDeviceUIDKey,
         ]) {
-            SettingsStore.shared.microphoneSelectionMode = .manual
-            SettingsStore.shared.preferredInputDeviceUID = "internal"
-            SettingsStore.shared.microphoneSelectionMode = .system
-
-            SettingsStore.shared.recordInputDeviceSelection("airpods")
-
-            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
-        }
-    }
-
-    func testManualModeInputSelectionPersistsManualPreference() throws {
-        try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
-            self.preferredInputDeviceUIDKey,
-        ]) {
-            SettingsStore.shared.microphoneSelectionMode = .manual
-
             SettingsStore.shared.recordInputDeviceSelection("studio-mic")
 
             XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "studio-mic")
-        }
-    }
-
-    func testSystemModeInputSelectionSyncsToSystemDefault() throws {
-        try self.withRestoredDefaults(keys: [self.microphoneSelectionModeKey]) {
-            SettingsStore.shared.microphoneSelectionMode = .system
-
-            XCTAssertTrue(SettingsStore.shared.shouldSyncInputSelectionToSystemDefault())
-        }
-    }
-
-    func testManualModeInputSelectionDoesNotImmediatelySyncToSystemDefault() throws {
-        try self.withRestoredDefaults(keys: [self.microphoneSelectionModeKey]) {
-            SettingsStore.shared.microphoneSelectionMode = .manual
-
-            XCTAssertFalse(SettingsStore.shared.shouldSyncInputSelectionToSystemDefault())
-        }
-    }
-
-    func testSwitchingBackToSystemModeRestoresPreviousSystemInput() throws {
-        try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
-            self.preferredInputDeviceUIDKey,
-            self.systemInputDeviceUIDBeforeManualKey,
-        ]) {
-            SettingsStore.shared.microphoneSelectionMode = .system
-            _ = SettingsStore.shared.setMicrophoneSelectionMode(
-                .manual,
-                currentSystemInputUID: "internal",
-                availableInputUIDs: ["internal", "airpods"]
-            )
-            SettingsStore.shared.recordInputDeviceSelection("airpods")
-
-            let restoreUID = SettingsStore.shared.setMicrophoneSelectionMode(
-                .system,
-                currentSystemInputUID: "airpods",
-                availableInputUIDs: ["internal", "airpods"]
-            )
-
-            XCTAssertEqual(restoreUID, "internal")
-            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMode, .system)
-            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
-        }
-    }
-
-    func testSwitchingBackToSystemModeFallsBackWhenPreviousSystemInputUnavailable() throws {
-        try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
-            self.preferredInputDeviceUIDKey,
-            self.systemInputDeviceUIDBeforeManualKey,
-        ]) {
-            SettingsStore.shared.microphoneSelectionMode = .system
-            _ = SettingsStore.shared.setMicrophoneSelectionMode(
-                .manual,
-                currentSystemInputUID: "internal",
-                availableInputUIDs: ["internal", "airpods"]
-            )
-            SettingsStore.shared.recordInputDeviceSelection("airpods")
-
-            let restoreUID = SettingsStore.shared.setMicrophoneSelectionMode(
-                .system,
-                currentSystemInputUID: "airpods",
-                availableInputUIDs: ["airpods"]
-            )
-
-            XCTAssertEqual(restoreUID, "airpods")
-            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
         }
     }
 
@@ -512,106 +397,80 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
-    func testMicrophoneCoordinatorSkipsSystemMode() throws {
+    func testMicrophoneMigrationChoosesBuiltInOnce() throws {
         try self.withRestoredDefaults(keys: [
             self.microphoneSelectionModeKey,
             self.preferredInputDeviceUIDKey,
+            self.appOnlyMicrophoneSelectionMigrationVersionKey,
         ]) {
-            SettingsStore.shared.microphoneSelectionMode = .system
-            SettingsStore.shared.preferredInputDeviceUID = "internal"
-            let devices = FakeAudioDeviceManager(
-                inputs: [Self.device(uid: "internal", name: "MacBook Pro Microphone")],
-                defaultInputUID: "airpods"
+            UserDefaults.standard.set(
+                SettingsStore.MicrophoneSelectionMode.system.rawValue,
+                forKey: self.microphoneSelectionModeKey
             )
-            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
-
-            let result = coordinator.enforcePreferredInput(reason: "unit test")
-
-            XCTAssertEqual(result, .skippedSystemMode)
-            XCTAssertEqual(devices.setInputCalls, [])
-        }
-    }
-
-    @MainActor
-    func testMicrophoneCoordinatorAppliesManualPreferredInput() throws {
-        try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
-            self.preferredInputDeviceUIDKey,
-        ]) {
-            SettingsStore.shared.microphoneSelectionMode = .manual
-            SettingsStore.shared.preferredInputDeviceUID = "internal"
+            SettingsStore.shared.preferredInputDeviceUID = "airpods"
+            SettingsStore.shared.appMicSelectionMigrationVersion = 0
             let devices = FakeAudioDeviceManager(
                 inputs: [
-                    Self.device(uid: "internal", name: "MacBook Pro Microphone"),
+                    Self.device(
+                        uid: "internal",
+                        name: "MacBook Pro Microphone",
+                        transportType: kAudioDeviceTransportTypeBuiltIn
+                    ),
                     Self.device(uid: "airpods", name: "AirPods"),
                 ],
                 defaultInputUID: "airpods"
             )
             let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
 
-            let result = coordinator.enforcePreferredInput(reason: "unit test")
+            coordinator.migrateToAppOnlySelectionIfNeeded()
 
-            XCTAssertEqual(result, .applied("internal"))
-            XCTAssertEqual(devices.setInputCalls, ["internal"])
-            XCTAssertEqual(devices.defaultInputUID, "internal")
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMode, .manual)
+            XCTAssertEqual(SettingsStore.shared.appMicSelectionMigrationVersion, 1)
+            XCTAssertEqual(
+                UserDefaults.standard.string(forKey: self.microphoneSelectionModeKey),
+                SettingsStore.MicrophoneSelectionMode.manual.rawValue
+            )
+            XCTAssertEqual(devices.defaultInputUID, "airpods")
+
+            SettingsStore.shared.recordInputDeviceSelection("airpods")
+            coordinator.migrateToAppOnlySelectionIfNeeded()
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
         }
     }
 
     @MainActor
-    func testMicrophoneCoordinatorKeepsUnavailableManualPreference() throws {
+    func testMicrophoneMigrationWaitsForAUsableDeviceList() throws {
         try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
             self.preferredInputDeviceUIDKey,
+            self.appOnlyMicrophoneSelectionMigrationVersionKey,
         ]) {
-            SettingsStore.shared.microphoneSelectionMode = .manual
-            SettingsStore.shared.preferredInputDeviceUID = "external"
-            let devices = FakeAudioDeviceManager(
-                inputs: [Self.device(uid: "internal", name: "MacBook Pro Microphone")],
-                defaultInputUID: "internal"
-            )
+            SettingsStore.shared.preferredInputDeviceUID = "airpods"
+            SettingsStore.shared.appMicSelectionMigrationVersion = 0
+            let devices = FakeAudioDeviceManager(inputs: [], defaultInputUID: nil)
             let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
 
-            let result = coordinator.enforcePreferredInput(reason: "unit test")
+            coordinator.migrateToAppOnlySelectionIfNeeded()
 
-            XCTAssertEqual(result, .skippedPreferredUnavailable("external"))
-            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "external")
-            XCTAssertEqual(devices.setInputCalls, [])
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
+            XCTAssertEqual(SettingsStore.shared.appMicSelectionMigrationVersion, 0)
         }
     }
 
     @MainActor
-    func testMicrophoneCoordinatorNoOpsWhenPreferredAlreadyDefault() throws {
+    func testMicrophoneCoordinatorKeepsAvailableUserSelection() throws {
         try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
             self.preferredInputDeviceUIDKey,
         ]) {
-            SettingsStore.shared.microphoneSelectionMode = .manual
-            SettingsStore.shared.preferredInputDeviceUID = "internal"
-            let devices = FakeAudioDeviceManager(
-                inputs: [Self.device(uid: "internal", name: "MacBook Pro Microphone")],
-                defaultInputUID: "internal"
-            )
-            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
-
-            let result = coordinator.enforcePreferredInput(reason: "unit test")
-
-            XCTAssertEqual(result, .alreadyUsingPreferred("internal"))
-            XCTAssertEqual(devices.setInputCalls, [])
-        }
-    }
-
-    @MainActor
-    func testMicrophoneCoordinatorResolvesManualPreferredInputForCapture() throws {
-        try self.withRestoredDefaults(keys: [
-            self.microphoneSelectionModeKey,
-            self.preferredInputDeviceUIDKey,
-        ]) {
-            SettingsStore.shared.microphoneSelectionMode = .manual
             SettingsStore.shared.preferredInputDeviceUID = "studio-mic"
             let studioMic = Self.device(uid: "studio-mic", name: "Studio Mic")
             let devices = FakeAudioDeviceManager(
                 inputs: [
-                    Self.device(uid: "internal", name: "MacBook Pro Microphone"),
+                    Self.device(
+                        uid: "internal",
+                        name: "MacBook Pro Microphone",
+                        transportType: kAudioDeviceTransportTypeBuiltIn
+                    ),
                     studioMic,
                 ],
                 defaultInputUID: "internal"
@@ -621,7 +480,74 @@ final class HotkeyShortcutTests: XCTestCase {
             let resolved = coordinator.inputDeviceForCapture()
 
             XCTAssertEqual(resolved, studioMic)
-            XCTAssertEqual(devices.setInputCalls, [])
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "studio-mic")
+        }
+    }
+
+    @MainActor
+    func testMicrophoneCoordinatorFallsBackToBuiltInWhenSelectionDisappears() throws {
+        try self.withRestoredDefaults(keys: [
+            self.preferredInputDeviceUIDKey,
+        ]) {
+            SettingsStore.shared.preferredInputDeviceUID = "airpods"
+            let builtIn = Self.device(
+                uid: "internal",
+                name: "MacBook Pro Microphone",
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+            let devices = FakeAudioDeviceManager(
+                inputs: [builtIn, Self.device(uid: "usb", name: "USB Mic")],
+                defaultInputUID: "usb"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let previewFallback = coordinator.inputDeviceForCapture()
+
+            XCTAssertEqual(previewFallback, builtIn)
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
+            XCTAssertEqual(devices.defaultInputUID, "usb")
+
+            let settledFallback = coordinator.inputDeviceForCapture(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID,
+                persistFallback: true
+            )
+            XCTAssertEqual(settledFallback, builtIn)
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+            XCTAssertEqual(devices.defaultInputUID, "usb")
+
+            let afterReconnect = coordinator.inputDeviceForCapture(availableInputs: [
+                builtIn,
+                Self.device(uid: "airpods", name: "AirPods"),
+            ])
+            XCTAssertEqual(afterReconnect, builtIn)
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+        }
+    }
+
+    @MainActor
+    func testMicrophoneCoordinatorUsesCurrentInputWhenNoBuiltInExists() throws {
+        try self.withRestoredDefaults(keys: [self.preferredInputDeviceUIDKey]) {
+            SettingsStore.shared.preferredInputDeviceUID = "disconnected"
+            let currentInput = Self.device(uid: "usb", name: "USB Mic")
+            let devices = FakeAudioDeviceManager(
+                inputs: [Self.device(uid: "other", name: "Other Mic"), currentInput],
+                defaultInputUID: "usb"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let previewFallback = coordinator.inputDeviceForCapture()
+
+            XCTAssertEqual(previewFallback, currentInput)
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "disconnected")
+
+            let settledFallback = coordinator.inputDeviceForCapture(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID,
+                persistFallback: true
+            )
+            XCTAssertEqual(settledFallback, currentInput)
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "usb")
         }
     }
 
@@ -667,7 +593,6 @@ final class HotkeyShortcutTests: XCTestCase {
 private final class FakeAudioDeviceManager: AudioDeviceManaging {
     let inputs: [AudioDevice.Device]
     var defaultInputUID: String?
-    private(set) var setInputCalls: [String] = []
 
     init(inputs: [AudioDevice.Device], defaultInputUID: String?) {
         self.inputs = inputs
@@ -681,11 +606,5 @@ private final class FakeAudioDeviceManager: AudioDeviceManaging {
     func defaultInputDevice() -> AudioDevice.Device? {
         guard let defaultInputUID else { return nil }
         return self.inputs.first { $0.uid == defaultInputUID }
-    }
-
-    func setDefaultInputDevice(uid: String) -> Bool {
-        self.setInputCalls.append(uid)
-        self.defaultInputUID = uid
-        return true
     }
 }

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -185,6 +185,27 @@ final class HotkeyShortcutTests: XCTestCase {
         ))
     }
 
+    func testPendingMicrophoneMigrationRetriesWhenDevicesAppear() {
+        XCTAssertFalse(AudioCaptureIdlePolicy.shouldReconcileInputSelection(
+            preferredInputUID: "disconnected-usb",
+            migrationPending: true,
+            previousInputUIDs: [],
+            currentInputUIDs: []
+        ))
+        XCTAssertTrue(AudioCaptureIdlePolicy.shouldReconcileInputSelection(
+            preferredInputUID: "disconnected-usb",
+            migrationPending: true,
+            previousInputUIDs: [],
+            currentInputUIDs: ["built-in"]
+        ))
+        XCTAssertTrue(AudioCaptureIdlePolicy.shouldReconcileInputSelection(
+            preferredInputUID: nil,
+            migrationPending: false,
+            previousInputUIDs: [],
+            currentInputUIDs: ["built-in"]
+        ))
+    }
+
     func testEngineConfigurationChangesRecoverOnlyDuringCaptureTransitions() {
         XCTAssertFalse(AudioCaptureIdlePolicy.shouldRecoverEngineConfigurationChange(
             isRunning: false,
@@ -454,6 +475,56 @@ final class HotkeyShortcutTests: XCTestCase {
 
             XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
             XCTAssertEqual(SettingsStore.shared.appMicSelectionMigrationVersion, 0)
+        }
+    }
+
+    @MainActor
+    func testMicrophoneMigrationWithoutBuiltInPreservesAvailableSelection() throws {
+        try self.withRestoredDefaults(keys: [
+            self.preferredInputDeviceUIDKey,
+            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+        ]) {
+            SettingsStore.shared.preferredInputDeviceUID = "studio-mic"
+            SettingsStore.shared.appMicSelectionMigrationVersion = 0
+            let devices = FakeAudioDeviceManager(
+                inputs: [
+                    Self.device(uid: "display-mic", name: "Display Mic"),
+                    Self.device(uid: "studio-mic", name: "Studio Mic"),
+                ],
+                defaultInputUID: "display-mic"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            coordinator.migrateToAppOnlySelectionIfNeeded()
+
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "studio-mic")
+            XCTAssertEqual(SettingsStore.shared.appMicSelectionMigrationVersion, 1)
+            XCTAssertEqual(devices.defaultInputUID, "display-mic")
+        }
+    }
+
+    @MainActor
+    func testMicrophoneMigrationWithoutBuiltInReplacesMissingSelectionWithDefault() throws {
+        try self.withRestoredDefaults(keys: [
+            self.preferredInputDeviceUIDKey,
+            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+        ]) {
+            SettingsStore.shared.preferredInputDeviceUID = "disconnected-usb"
+            SettingsStore.shared.appMicSelectionMigrationVersion = 0
+            let devices = FakeAudioDeviceManager(
+                inputs: [
+                    Self.device(uid: "display-mic", name: "Display Mic"),
+                    Self.device(uid: "studio-mic", name: "Studio Mic"),
+                ],
+                defaultInputUID: "studio-mic"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            coordinator.migrateToAppOnlySelectionIfNeeded()
+
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "studio-mic")
+            XCTAssertEqual(SettingsStore.shared.appMicSelectionMigrationVersion, 1)
+            XCTAssertEqual(devices.defaultInputUID, "studio-mic")
         }
     }
 

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -137,7 +137,7 @@ final class HotkeyShortcutTests: XCTestCase {
         XCTAssertNil(decoded.settings.skipSilentRecordingsEnabled)
     }
 
-    func testFasterRecordingStartDefaultsToEnabledWhenUnset() {
+    func testDirectAudioCaptureIsEnabledWhenLegacyPreferenceIsUnset() {
         self.withRestoredDefaults(keys: [self.experimentalDirectAudioCaptureEnabledKey]) {
             UserDefaults.standard.removeObject(forKey: self.experimentalDirectAudioCaptureEnabledKey)
 
@@ -145,17 +145,9 @@ final class HotkeyShortcutTests: XCTestCase {
         }
     }
 
-    func testFasterRecordingStartPreservesStoredDisabledPreference() {
+    func testDirectAudioCaptureIgnoresStoredDisabledPreference() {
         self.withRestoredDefaults(keys: [self.experimentalDirectAudioCaptureEnabledKey]) {
             UserDefaults.standard.set(false, forKey: self.experimentalDirectAudioCaptureEnabledKey)
-
-            XCTAssertFalse(SettingsStore.shared.experimentalDirectAudioCaptureEnabled)
-        }
-    }
-
-    func testFasterRecordingStartPreservesStoredEnabledPreference() {
-        self.withRestoredDefaults(keys: [self.experimentalDirectAudioCaptureEnabledKey]) {
-            UserDefaults.standard.set(true, forKey: self.experimentalDirectAudioCaptureEnabledKey)
 
             XCTAssertTrue(SettingsStore.shared.experimentalDirectAudioCaptureEnabled)
         }

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -137,6 +137,45 @@ final class HotkeyShortcutTests: XCTestCase {
         XCTAssertNil(decoded.settings.skipSilentRecordingsEnabled)
     }
 
+    @MainActor
+    func testSystemModeBackupRestartsAppOnlyMicrophoneMigration() async throws {
+        let document = await BackupService.shared.makeBackupDocument()
+
+        try self.withRestoredDefaults(keys: [
+            self.microphoneSelectionModeKey,
+            self.preferredInputDeviceUIDKey,
+            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+        ]) {
+            SettingsStore.shared.appMicSelectionMigrationVersion = 1
+            let encoded = try BackupService.shared.encode(document)
+            var root = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+            var settings = try XCTUnwrap(root["settings"] as? [String: Any])
+            settings["microphoneSelectionMode"] = SettingsStore.MicrophoneSelectionMode.system.rawValue
+            settings["preferredInputDeviceUID"] = "legacy-system-mic"
+            root["settings"] = settings
+            let backup = try BackupService.shared.decode(JSONSerialization.data(withJSONObject: root))
+
+            SettingsStore.shared.restore(from: backup.settings)
+
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "legacy-system-mic")
+            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMode, .manual)
+            XCTAssertEqual(SettingsStore.shared.appMicSelectionMigrationVersion, 0)
+        }
+    }
+
+    @MainActor
+    func testAppOnlyBackupKeepsCompletedMicrophoneMigration() async {
+        let document = await BackupService.shared.makeBackupDocument()
+
+        self.withRestoredDefaults(keys: [self.appOnlyMicrophoneSelectionMigrationVersionKey]) {
+            SettingsStore.shared.appMicSelectionMigrationVersion = 1
+
+            SettingsStore.shared.restore(from: document.settings)
+
+            XCTAssertEqual(SettingsStore.shared.appMicSelectionMigrationVersion, 1)
+        }
+    }
+
     func testDirectAudioCaptureIsEnabledWhenLegacyPreferenceIsUnset() {
         self.withRestoredDefaults(keys: [self.experimentalDirectAudioCaptureEnabledKey]) {
             UserDefaults.standard.removeObject(forKey: self.experimentalDirectAudioCaptureEnabledKey)

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -458,6 +458,36 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
+    func testCompletedMigrationReconcilesMissingSavedInputAtLaunch() throws {
+        try self.withRestoredDefaults(keys: [
+            self.preferredInputDeviceUIDKey,
+            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+        ]) {
+            SettingsStore.shared.preferredInputDeviceUID = "disconnected-usb"
+            SettingsStore.shared.appMicSelectionMigrationVersion = 1
+            let builtIn = Self.device(
+                uid: "internal",
+                name: "MacBook Pro Microphone",
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+            let devices = FakeAudioDeviceManager(
+                inputs: [builtIn, Self.device(uid: "usb", name: "USB Mic")],
+                defaultInputUID: "usb"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let reconciled = coordinator.reconcileAppOnlySelection(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID
+            )
+
+            XCTAssertEqual(reconciled, builtIn)
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+            XCTAssertEqual(devices.defaultInputUID, "usb")
+        }
+    }
+
+    @MainActor
     func testMicrophoneCoordinatorKeepsAvailableUserSelection() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -12,7 +12,7 @@ final class HotkeyShortcutTests: XCTestCase {
     private let pasteLastTranscriptionEnabledKey = "PasteLastTranscriptionShortcutEnabled"
     private let microphoneSelectionModeKey = "MicrophoneSelectionMode"
     private let preferredInputDeviceUIDKey = "PreferredInputDeviceUID"
-    private let appOnlyMicrophoneSelectionMigrationVersionKey = "AppOnlyMicrophoneSelectionMigrationVersion"
+    private let appOnlyMicMigrationVersionKey = "AppOnlyMicrophoneSelectionMigrationVersion"
     private let experimentalDirectAudioCaptureEnabledKey = "ExperimentalDirectAudioCaptureEnabled"
 
     @MainActor
@@ -144,7 +144,7 @@ final class HotkeyShortcutTests: XCTestCase {
         try self.withRestoredDefaults(keys: [
             self.microphoneSelectionModeKey,
             self.preferredInputDeviceUIDKey,
-            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+            self.appOnlyMicMigrationVersionKey,
         ]) {
             SettingsStore.shared.appMicSelectionMigrationVersion = 1
             let encoded = try BackupService.shared.encode(document)
@@ -167,7 +167,7 @@ final class HotkeyShortcutTests: XCTestCase {
     func testAppOnlyBackupKeepsCompletedMicrophoneMigration() async {
         let document = await BackupService.shared.makeBackupDocument()
 
-        self.withRestoredDefaults(keys: [self.appOnlyMicrophoneSelectionMigrationVersionKey]) {
+        self.withRestoredDefaults(keys: [self.appOnlyMicMigrationVersionKey]) {
             SettingsStore.shared.appMicSelectionMigrationVersion = 1
 
             SettingsStore.shared.restore(from: document.settings)
@@ -461,7 +461,7 @@ final class HotkeyShortcutTests: XCTestCase {
         try self.withRestoredDefaults(keys: [
             self.microphoneSelectionModeKey,
             self.preferredInputDeviceUIDKey,
-            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+            self.appOnlyMicMigrationVersionKey,
         ]) {
             UserDefaults.standard.set(
                 SettingsStore.MicrophoneSelectionMode.system.rawValue,
@@ -503,7 +503,7 @@ final class HotkeyShortcutTests: XCTestCase {
     func testMicrophoneMigrationWaitsForAUsableDeviceList() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,
-            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+            self.appOnlyMicMigrationVersionKey,
         ]) {
             SettingsStore.shared.preferredInputDeviceUID = "airpods"
             SettingsStore.shared.appMicSelectionMigrationVersion = 0
@@ -521,7 +521,7 @@ final class HotkeyShortcutTests: XCTestCase {
     func testMicrophoneMigrationWithoutBuiltInPreservesAvailableSelection() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,
-            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+            self.appOnlyMicMigrationVersionKey,
         ]) {
             SettingsStore.shared.preferredInputDeviceUID = "studio-mic"
             SettingsStore.shared.appMicSelectionMigrationVersion = 0
@@ -546,7 +546,7 @@ final class HotkeyShortcutTests: XCTestCase {
     func testMicrophoneMigrationWithoutBuiltInReplacesMissingSelectionWithDefault() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,
-            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+            self.appOnlyMicMigrationVersionKey,
         ]) {
             SettingsStore.shared.preferredInputDeviceUID = "disconnected-usb"
             SettingsStore.shared.appMicSelectionMigrationVersion = 0
@@ -571,7 +571,7 @@ final class HotkeyShortcutTests: XCTestCase {
     func testCompletedMigrationReconcilesMissingSavedInputAtLaunch() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,
-            self.appOnlyMicrophoneSelectionMigrationVersionKey,
+            self.appOnlyMicMigrationVersionKey,
         ]) {
             SettingsStore.shared.preferredInputDeviceUID = "disconnected-usb"
             SettingsStore.shared.appMicSelectionMigrationVersion = 1


### PR DESCRIPTION
## Description
Combines the remaining FluidVoice 1.6.7 audio and microphone reliability work for main.

- Keeps Direct Core Audio capture required and reduces first-audio startup delays.
- Prevents media playback from remaining paused when Now Playing is slow or settings change during recording.
- Keeps FluidVoice microphone selection app-only, with a safe built-in fallback and external-microphone preservation.
- Builds on merged PR #749 by @AshwanthramKL for Bluetooth and audio-device lifecycle reliability.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Chore
- [ ] Documentation update

## Related Issue or Discussion
Includes the changes from PR #777 and PR #778, and builds on merged PR #749.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS 27.0
- [x] SwiftFormat completed with no changes
- [x] Strict SwiftLint passed with zero violations
- [x] Private Fluid Intelligence build installed and launched successfully
- [x] Focused microphone tests previously passed 40/40; PR #778 checks passed

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
The development build used the supported FluidVoice bridge override because the private bridge manifest is still pinned to the 1.6.6 FluidVoice commit. Rebind and verify that manifest before producing the final private 1.6.7 release.