### PR TITLE
Prevent duplicate updater prompts and installs

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -371,12 +371,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                     repo: "Fluid-oss",
                     includePrerelease: includePrerelease
                 )
-                // If we get here, an update was found; SimpleUpdater will relaunch on success
-                // Show a quick heads-up before app restarts
-                self.showUpdateAlert(
-                    title: "Update Found!",
-                    message: "A new version is available and will be installed now."
-                )
+            } catch SimpleUpdateError.updateAlreadyInProgress {
+                DebugLogger.shared.info("Update installation already in progress", source: "AppDelegate")
             } catch {
                 if let pmkError = error as? PMKError, pmkError.isCancelled {
                     DebugLogger.shared.info("App is already up-to-date", source: "AppDelegate")
@@ -432,6 +428,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
                 if result.hasUpdate {
                     DebugLogger.shared.info("✅ Update available: \(result.latestVersion)", source: "AppDelegate")
+
+                    guard !SimpleUpdater.shared.isUpdateInProgress else {
+                        DebugLogger.shared.debug(
+                            "Update prompt skipped because installation is already in progress",
+                            source: "AppDelegate"
+                        )
+                        return
+                    }
 
                     // Check if user snoozed this version (clicked "Later")
                     if SettingsStore.shared.shouldShowUpdatePrompt(forVersion: result.latestVersion) {

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -683,12 +683,8 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
                     repo: "Fluid-oss",
                     includePrerelease: SettingsStore.shared.betaReleasesEnabled
                 )
-                let ok = NSAlert()
-                ok.messageText = "Update Found!"
-                ok.informativeText = "A new version is available and will be installed now."
-                ok.alertStyle = .informational
-                ok.addButton(withTitle: "OK")
-                ok.runModal()
+            } catch SimpleUpdateError.updateAlreadyInProgress {
+                DebugLogger.shared.info("Update installation already in progress", source: "MenuBarManager")
             } catch {
                 let msg = NSAlert()
                 if let pmkError = error as? PMKError, pmkError.isCancelled {

--- a/Sources/Fluid/Services/SimpleUpdater.swift
+++ b/Sources/Fluid/Services/SimpleUpdater.swift
@@ -8,6 +8,7 @@ enum SimpleUpdateError: Error, LocalizedError {
     case jsonDecoding
     case noSuitableRelease
     case noAsset
+    case updateAlreadyInProgress
     case downloadFailed
     case unzipFailed
     case notAnAppBundle
@@ -22,6 +23,7 @@ enum SimpleUpdateError: Error, LocalizedError {
         case .jsonDecoding: return "The data couldn’t be read because it isn’t in the correct format."
         case .noSuitableRelease: return "No suitable release found."
         case .noAsset: return "No matching asset found in the latest release."
+        case .updateAlreadyInProgress: return "An update is already being installed."
         case .downloadFailed: return "Failed to download update."
         case .unzipFailed: return "Failed to extract the update archive."
         case .notAnAppBundle: return "Extracted content does not contain an app bundle."
@@ -29,6 +31,20 @@ enum SimpleUpdateError: Error, LocalizedError {
         case .rollbackUnavailable: return "No rollback backup is available."
         case .rollbackRestoreFailed: return "Failed to restore a previous version."
         }
+    }
+}
+
+struct UpdateOperationGate {
+    private(set) var isActive = false
+
+    mutating func begin() -> Bool {
+        guard !self.isActive else { return false }
+        self.isActive = true
+        return true
+    }
+
+    mutating func finish() {
+        self.isActive = false
     }
 }
 
@@ -114,6 +130,12 @@ final class SimpleUpdater {
     private let fileManager = FileManager.default
     private let maxRollbackBackups = 3
     private let rollbackBackupDirectoryName = "RollbackBackups"
+    private var updateOperationGate = UpdateOperationGate()
+    private var updateStatusWindow: NSWindow?
+
+    var isUpdateInProgress: Bool {
+        return self.updateOperationGate.isActive
+    }
 
     private var installedAppName: String {
         return Bundle.main.bundleURL.deletingPathExtension().lastPathComponent
@@ -133,6 +155,17 @@ final class SimpleUpdater {
     }
 
     func rollbackToLatestBackup() async throws {
+        guard self.updateOperationGate.begin() else {
+            throw SimpleUpdateError.updateAlreadyInProgress
+        }
+
+        var shouldKeepOperationActive = false
+        defer {
+            if !shouldKeepOperationActive {
+                self.resetUpdateOperation()
+            }
+        }
+
         guard let rollbackBundleURL = self.latestRollbackBackup() else {
             throw SimpleUpdateError.rollbackUnavailable
         }
@@ -148,6 +181,7 @@ final class SimpleUpdater {
                 "SimpleUpdater: Rolled back to \(rollbackBundleURL.lastPathComponent)",
                 source: "SimpleUpdater"
             )
+            shouldKeepOperationActive = true
         } catch {
             throw SimpleUpdateError.rollbackRestoreFailed
         }
@@ -268,6 +302,10 @@ final class SimpleUpdater {
         repo: String,
         includePrerelease: Bool = false
     ) async throws -> (hasUpdate: Bool, latestVersion: String) {
+        guard !self.isUpdateInProgress else {
+            throw SimpleUpdateError.updateAlreadyInProgress
+        }
+
         let releases = try await self.fetchReleases(owner: owner, repo: repo)
 
         guard let latest = self.selectLatestRelease(
@@ -298,6 +336,17 @@ final class SimpleUpdater {
         repo: String,
         includePrerelease: Bool = false
     ) async throws {
+        guard self.updateOperationGate.begin() else {
+            throw SimpleUpdateError.updateAlreadyInProgress
+        }
+
+        var shouldKeepOperationActive = false
+        defer {
+            if !shouldKeepOperationActive {
+                self.resetUpdateOperation()
+            }
+        }
+
         let releases = try await self.fetchReleases(owner: owner, repo: repo)
 
         guard let latest = self.selectLatestRelease(
@@ -338,6 +387,8 @@ final class SimpleUpdater {
         }
 
         guard let asset = asset else { throw SimpleUpdateError.noAsset }
+
+        self.showUpdateInstallStatus(version: rawVersion)
 
         let tempDir = try FileManager.default.url(
             for: .itemReplacementDirectory,
@@ -412,9 +463,73 @@ final class SimpleUpdater {
 
         // Replace and relaunch
         try self.performSwapAndRelaunch(installedAppURL: currentBundle.bundleURL, downloadedAppURL: extractedBundleURL)
+        shouldKeepOperationActive = true
     }
 
     // MARK: - Helpers
+
+    private func showUpdateInstallStatus(version: String) {
+        guard self.updateStatusWindow == nil else { return }
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 132),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Installing FluidVoice \(version)"
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.isMovableByWindowBackground = true
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        let content = NSVisualEffectView(frame: panel.contentView?.bounds ?? .zero)
+        content.material = .popover
+        content.blendingMode = .behindWindow
+        content.state = .active
+        content.wantsLayer = true
+        content.layer?.cornerRadius = 16
+        content.layer?.masksToBounds = true
+        content.autoresizingMask = [.width, .height]
+
+        let icon = NSImageView(frame: NSRect(x: 22, y: 42, width: 52, height: 52))
+        icon.image = NSApp.applicationIconImage
+        icon.imageScaling = .scaleProportionallyUpOrDown
+        content.addSubview(icon)
+
+        let title = NSTextField(labelWithString: "Installing FluidVoice \(version)")
+        title.frame = NSRect(x: 92, y: 76, width: 304, height: 24)
+        title.font = .systemFont(ofSize: 16, weight: .semibold)
+        content.addSubview(title)
+
+        let detail = NSTextField(wrappingLabelWithString: "Downloading the update. FluidVoice will restart automatically.")
+        detail.frame = NSRect(x: 92, y: 42, width: 304, height: 34)
+        detail.font = .systemFont(ofSize: 13)
+        detail.textColor = .secondaryLabelColor
+        detail.maximumNumberOfLines = 2
+        content.addSubview(detail)
+
+        let progress = NSProgressIndicator(frame: NSRect(x: 92, y: 24, width: 304, height: 6))
+        progress.style = .bar
+        progress.isIndeterminate = true
+        progress.controlSize = .small
+        progress.startAnimation(nil)
+        content.addSubview(progress)
+
+        panel.contentView = content
+        panel.center()
+        panel.orderFrontRegardless()
+        self.updateStatusWindow = panel
+    }
+
+    private func resetUpdateOperation() {
+        self.updateOperationGate.finish()
+        self.updateStatusWindow?.close()
+        self.updateStatusWindow = nil
+    }
 
     private func fetchReleases(owner: String, repo: String) async throws -> [GHRelease] {
         guard let releasesURL = URL(string: "https://api.github.com/repos/\(owner)/\(repo)/releases") else {
@@ -781,6 +896,7 @@ final class SimpleUpdater {
             // Verify the app exists before trying to launch
             guard FileManager.default.fileExists(atPath: finalAppURL.path) else {
                 DebugLogger.shared.error("SimpleUpdater: ERROR - App not found at expected location: \(finalAppURL.path)", source: "SimpleUpdater")
+                self.resetUpdateOperation()
                 // Don't terminate if we can't find the new app
                 return
             }
@@ -792,6 +908,9 @@ final class SimpleUpdater {
                 if let error = error {
                     DebugLogger.shared.error("SimpleUpdater: Failed to relaunch app: \(error)", source: "SimpleUpdater")
                     DebugLogger.shared.error("SimpleUpdater: App location: \(finalAppURL.path)", source: "SimpleUpdater")
+                    Task { @MainActor in
+                        self.resetUpdateOperation()
+                    }
                     // Don't terminate if relaunch failed - let user manually restart
                     return
                 }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -466,12 +466,11 @@ struct SettingsView: View {
                                                 repo: "Fluid-oss",
                                                 includePrerelease: includePrerelease
                                             )
-                                            let ok = NSAlert()
-                                            ok.messageText = "Update Found!"
-                                            ok.informativeText = "A new version is available and will be installed now."
-                                            ok.alertStyle = .informational
-                                            ok.addButton(withTitle: "OK")
-                                            ok.runModal()
+                                        } catch SimpleUpdateError.updateAlreadyInProgress {
+                                            DebugLogger.shared.info(
+                                                "Update installation already in progress",
+                                                source: "SettingsView"
+                                            )
                                         } catch {
                                             let msg = NSAlert()
                                             if let pmkError = error as? PMKError, pmkError.isCancelled {

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -2357,3 +2357,19 @@ final class OverlayFailureStateTests: XCTestCase {
         XCTAssertTrue(state.canRetryAIProcessingFailure)
     }
 }
+
+@MainActor
+final class SimpleUpdaterTests: XCTestCase {
+    func testUpdateOperationGateAllowsOnlyOneActiveInstall() {
+        var gate = UpdateOperationGate()
+
+        XCTAssertTrue(gate.begin())
+        XCTAssertTrue(gate.isActive)
+        XCTAssertFalse(gate.begin())
+
+        gate.finish()
+
+        XCTAssertFalse(gate.isActive)
+        XCTAssertTrue(gate.begin())
+    }
+}


### PR DESCRIPTION
## Description
Prevents overlapping updater operations within a running FluidVoice instance, blocks rollback from modifying the app during an active update, suppresses redundant post-install “Update Found!” alerts, and shows a compact non-blocking download/restart progress panel.

The download, code-signature validation, extraction, app replacement, and relaunch sequence are unchanged. This intentionally does not rewrite the existing old-process shutdown timing.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Fixes #780

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: 174 tests passed; known Tiny Whisper fixture test skipped
- [x] Built, signed, installed, and launched with `build_with_FI_incremental.sh`; `/v1/health` returned version 1.6.7 with one running process

## Screenshots / Video
![Updater progress panel](https://github.com/user-attachments/assets/3194f9ce-463e-42d8-bbb7-010b0473d80c)

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes
The main-actor-isolated single-flight gate is shared by update and rollback operations. It resets on pre-relaunch errors and remains active through successful relaunch, preventing another operation from mutating the app during transition. Release notes were updated locally for 1.6.7 and remain gitignored by repository policy.
