### PR TITLE
fix: update Whisper Large Turbo download size

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -4191,7 +4191,7 @@ final class SettingsStore: ObservableObject {
             case .whisperBase: return 84_962_880
             case .whisperSmall: return 269_751_136
             case .whisperMedium: return 831_538_144
-            case .whisperLargeTurbo: return 886_381_824
+            case .whisperLargeTurbo: return 886_381_760
             case .whisperLarge: return 1_668_741_440
             case .appleSpeech, .appleSpeechAnalyzer: return 0
             }


### PR DESCRIPTION
## Description

Fix Whisper Large Turbo model validation by updating its expected download size from `886,381,824` to the current Hugging Face file size of `886,381,760` bytes.

The stale value caused every download to be rejected and deleted as corrupted.

## Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #785

## Testing

- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — 0 violations, 0 serious
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:FluidDictationIntegrationTests`

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes

This is intentionally a focused one-line correction. The existing exact file-size validation remains unchanged for all models.

SwiftFormat 0.62.1 reports 60 of 138 existing source files requiring formatting, including pre-existing issues in `SettingsStore.swift`. No unrelated formatting changes were included in this focused fix.
