### PR TITLE
Fix text insertion mode description wrapping

### DIFF
--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -826,9 +826,9 @@ struct SettingsView: View {
                                             Text(self.hotkeyMode.description)
                                                 .font(self.theme.typography.bodySmall)
                                                 .foregroundStyle(self.settingsSecondaryText)
+                                                .fixedSize(horizontal: false, vertical: true)
                                         }
-
-                                        Spacer()
+                                        .frame(maxWidth: .infinity, alignment: .leading)
 
                                         Picker("", selection: self.$hotkeyMode) {
                                             ForEach(HotkeyActivationMode.allCases) { mode in
@@ -942,8 +942,7 @@ struct SettingsView: View {
                                         isOn: Binding(
                                             get: { SettingsStore.shared.skipSilentRecordingsEnabled },
                                             set: { SettingsStore.shared.skipSilentRecordingsEnabled = $0 }
-                                        ),
-                                        allowsDescriptionWrapping: true
+                                        )
                                     )
                                     .settingsSearchTarget(.skipSilentRecordings)
                                     Divider().opacity(0.2)
@@ -1991,8 +1990,7 @@ struct SettingsView: View {
     private func optionToggleRow(
         title: String,
         description: String,
-        isOn: Binding<Bool>,
-        allowsDescriptionWrapping: Bool = false
+        isOn: Binding<Bool>
     ) -> some View {
         HStack(alignment: .center) {
             VStack(alignment: .leading, spacing: 2) {
@@ -2002,13 +2000,9 @@ struct SettingsView: View {
                 Text(description)
                     .font(self.theme.typography.bodySmall)
                     .foregroundStyle(self.settingsSecondaryText)
-                    .fixedSize(horizontal: false, vertical: allowsDescriptionWrapping)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .frame(maxWidth: allowsDescriptionWrapping ? .infinity : nil, alignment: .leading)
-
-            if !allowsDescriptionWrapping {
-                Spacer()
-            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             Toggle("", isOn: isOn)
                 .toggleStyle(.switch)

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -864,9 +864,9 @@ struct SettingsView: View {
                                             Text(SettingsStore.shared.textInsertionMode.description)
                                                 .font(self.theme.typography.bodySmall)
                                                 .foregroundStyle(self.settingsSecondaryText)
+                                                .fixedSize(horizontal: false, vertical: true)
                                         }
-
-                                        Spacer()
+                                        .frame(maxWidth: .infinity, alignment: .leading)
 
                                         Picker("", selection: Binding(
                                             get: { SettingsStore.shared.textInsertionMode },


### PR DESCRIPTION
## Description

Allow option descriptions in Settings to wrap instead of truncating at narrower window widths. Shared toggle rows now wrap consistently, and the Activation Mode and Text Insertion Mode descriptions take the available leading space while their pickers keep the existing fixed width.

## Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #776.

## Testing

- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` (SwiftLint is not installed locally)
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources` (SwiftFormat is not installed locally)
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64'`

Also verified with `swiftc -parse`, `git diff --check`, an unsigned app build, and narrow-width visual QA.

## Screenshots / Video

After: narrow Settings window showing Activation Mode, Text Insertion Mode, and the shared option rows wrapping beside fixed-width controls.

<img width="800" height="700" alt="Settings option descriptions wrapping at narrow window width" src="https://github.com/user-attachments/assets/83bcb21b-78aa-4cd2-a515-9333b3a7d52e" />

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes

AI assistance: Codex was used for implementation and validation.
