### PR TITLE
Keep overlay visible while transcribing

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2098,16 +2098,6 @@ struct ContentView: View {
         let activeDictationSlot = self.currentDictationShortcutSlot(for: modeAtStop)
         let promptOverride = self.promptModeOverrideText
         let promptTest = DictationPromptTestCoordinator.shared
-        let shouldUseAIOnStop = activeDictationSlot.map {
-            DictationAIPostProcessingGate.isConfigured(for: $0, appBundleID: self.recordingAppInfo?.bundleId)
-        } ?? DictationAIPostProcessingGate.isConfigured(for: .primary, appBundleID: self.recordingAppInfo?.bundleId)
-        let shouldHideOverlayOnStop = route == .normal &&
-            !wasRewriteMode &&
-            !wasCommandMode &&
-            !promptTest.isActive &&
-            !shouldUseAIOnStop &&
-            !self.settings.spokenSendEnabled
-        var didRequestOverlayHideOnStop = false
         DebugLogger.shared.info(
             "Routing decision snapshot | activeMode=\(modeAtStop.rawValue) | rewrite=\(wasRewriteMode) | command=\(wasCommandMode) | overlay=\(NotchContentState.shared.mode.rawValue)",
             source: "ContentView"
@@ -2115,22 +2105,14 @@ struct ContentView: View {
 
         self.clearActiveRecordingMode()
 
-        if shouldHideOverlayOnStop {
-            didRequestOverlayHideOnStop = true
-            DebugLogger.shared.debug("Hiding dictation overlay at stop path", source: "ContentView")
-            self.hideOverlayAsync(reason: "stop_path")
-        } else {
-            // Show "Transcribing" state before calling stop() when the overlay needs
-            // to remain available for prompt, command, rewrite, or AI feedback.
-            DebugLogger.shared.debug("Showing transcription processing state", source: "ContentView")
-            self.appBench("processing_ui_request status=Transcribing")
-            self.menuBarManager.setProcessing(true)
-            NotchOverlayManager.shared.updateTranscriptionText("Transcribing")
-            self.appBench("processing_ui_requested status=Transcribing")
+        DebugLogger.shared.debug("Showing transcription processing state", source: "ContentView")
+        self.appBench("processing_ui_request status=Transcribing")
+        self.menuBarManager.setProcessing(true)
+        NotchOverlayManager.shared.updateTranscriptionText("Transcribing")
+        self.appBench("processing_ui_requested status=Transcribing")
 
-            // Give SwiftUI a chance to render the processing state before heavier work.
-            await Task.yield()
-        }
+        // Give SwiftUI a chance to render the processing state before heavier work.
+        await Task.yield()
 
         // Stop the ASR service and wait for transcription to complete
         // The processing indicator will stay visible during this phase
@@ -2155,9 +2137,7 @@ struct ContentView: View {
         guard transcribedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
             DebugLogger.shared.debug("Transcription returned empty text", source: "ContentView")
             // Finish the same short exit transition even when no text is emitted.
-            if !didRequestOverlayHideOnStop {
-                await self.menuBarManager.finishProcessingAndHideOverlay()
-            }
+            await self.menuBarManager.finishProcessingAndHideOverlay()
             return
         }
 
@@ -2484,12 +2464,12 @@ struct ContentView: View {
             }
             NotchOverlayManager.shared.updateTranscriptionText("")
             NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
-            if !shouldShowAIProcessingFailure, !didRequestOverlayHideOnStop {
+            if !shouldShowAIProcessingFailure {
                 self.hideOverlayAfterOutput()
             }
         }
 
-        if !didTypeExternally, !shouldShowAIProcessingFailure, !didRequestOverlayHideOnStop {
+        if !didTypeExternally, !shouldShowAIProcessingFailure {
             self.hideOverlayAfterOutput()
         }
     }


### PR DESCRIPTION
## Description

Keep the normal dictation overlay visible in its existing “Transcribing” state until final transcription finishes, then hide it through the shared post-output lifecycle.

The regression came from a normal-dictation-only branch that requested an asynchronous overlay hide before `asr.stop()` began. Removing that special case lets normal dictation use the same processing lifecycle already used by AI, Command, Rewrite, prompt-test, and sandbox routes.

## Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #676.

## Testing

- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` (SwiftLint is not installed locally)
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources` (SwiftFormat is not installed locally)
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64'`

Also verified with `swiftc -parse`, `git diff --check`, an unsigned app build, and a real normal-dictation stop cycle. Runtime benchmarks confirmed `processing=true` before `asr.stop()`, the overlay remained visible while final transcription ran, and hide began only after `asr.stop()` returned.

## Screenshots / Video

Before: [reporter’s screen recording showing the overlay disappearing before transcription completes](https://github.com/user-attachments/assets/3cdf4a93-cb8f-4639-a3e8-6e8be1cef3d4).

After: [normal dictation keeps the overlay active through final processing and completes in the Test Playground](https://github.com/user-attachments/assets/04d4602d-8162-4b26-b7e9-42c7a2805608). The final three seconds are a still of the completed result for readability.

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes

This removes 19 net lines and adds no new state or abstraction.

AI assistance: Codex was used for implementation and validation.
