### PR TITLE
Fix duplicate instances remaining after update

### DIFF
--- a/Sources/Fluid/Services/SimpleUpdater.swift
+++ b/Sources/Fluid/Services/SimpleUpdater.swift
@@ -918,14 +918,14 @@ final class SimpleUpdater {
                 DebugLogger.shared.info("SimpleUpdater: Successfully relaunched app, terminating old instance", source: "SimpleUpdater")
                 // Give the new instance time to fully start before terminating
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                    NSApp.terminate(nil)
-                    
-                    // Fallback: forcefully terminate if AppKit gets stuck during or after termination.
+                    // Arm the fallback watchdog BEFORE calling terminate, because terminate blocks.
                     // The AppDelegate cleanup can take up to 16 seconds (8s for Private AI + 8s for ASR).
                     // We wait 20 seconds on a background queue to ensure it only fires if truly hung.
                     DispatchQueue.global().asyncAfter(deadline: .now() + 20.0) {
                         exit(0)
                     }
+                    
+                    NSApp.terminate(nil)
                 }
             }
         }

--- a/Sources/Fluid/Services/SimpleUpdater.swift
+++ b/Sources/Fluid/Services/SimpleUpdater.swift
@@ -920,7 +920,10 @@ final class SimpleUpdater {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                     NSApp.terminate(nil)
                     
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                    // Fallback: forcefully terminate if AppKit gets stuck during or after termination.
+                    // The AppDelegate cleanup can take up to 16 seconds (8s for Private AI + 8s for ASR).
+                    // We wait 20 seconds on a background queue to ensure it only fires if truly hung.
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 20.0) {
                         exit(0)
                     }
                 }

--- a/Sources/Fluid/Services/SimpleUpdater.swift
+++ b/Sources/Fluid/Services/SimpleUpdater.swift
@@ -918,7 +918,11 @@ final class SimpleUpdater {
                 DebugLogger.shared.info("SimpleUpdater: Successfully relaunched app, terminating old instance", source: "SimpleUpdater")
                 // Give the new instance time to fully start before terminating
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                    exit(0)
+                    NSApp.terminate(nil)
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                        exit(0)
+                    }
                 }
             }
         }

--- a/Sources/Fluid/Services/SimpleUpdater.swift
+++ b/Sources/Fluid/Services/SimpleUpdater.swift
@@ -918,7 +918,7 @@ final class SimpleUpdater {
                 DebugLogger.shared.info("SimpleUpdater: Successfully relaunched app, terminating old instance", source: "SimpleUpdater")
                 // Give the new instance time to fully start before terminating
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                    NSApp.terminate(nil)
+                    exit(0)
                 }
             }
         }


### PR DESCRIPTION
## Description
Replaced `NSApp.terminate(nil)` with `exit(0)` in `SimpleUpdater.swift`. This ensures the old instance forcefully quits after launching the new application instance, preventing a race condition where duplicate processes run simultaneously and fight over the global hotkey and microphone.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #794

## Testing
- [x] Tested on Intel Mac
- [ ] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 15.7
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally:

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
The `exit(0)` call prevents the application from lingering in the background if the runloop is blocked during an update.
