### PR TITLE
Fix silent dictation in clamshell mode

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -908,13 +908,41 @@ final class ASRService: ObservableObject {
         AppServices.shared.microphonePreferenceCoordinator.inputDeviceForCapture()
     }
 
-    private func directCoreAudioDeviceSelection() -> DirectCoreAudioDeviceSelection {
-        if let preferredUID = SettingsStore.shared.preferredInputDeviceUID,
-           preferredUID.isEmpty == false
-        {
-            return .preferredUID(preferredUID)
+    private func directCoreAudioDeviceSelection() throws -> DirectCoreAudioDeviceSelection {
+        switch AppServices.shared.microphonePreferenceCoordinator.captureResolution() {
+        case .standard:
+            if let preferredUID = SettingsStore.shared.preferredInputDeviceUID,
+               preferredUID.isEmpty == false
+            {
+                return .preferredUID(preferredUID)
+            }
+            return .systemDefault
+        case let .clamshellSelectedExternal(device):
+            return .preferredUID(device.uid)
+        case let .clamshellFallback(device):
+            DebugLogger.shared.warning(
+                "Built-in microphone is unavailable with the lid closed; " +
+                    "using external input '\(device.name)' for this capture.",
+                source: "ASRService"
+            )
+            return .preferredUID(device.uid)
+        case .clamshellRequiresExternalMicrophone:
+            throw NSError(
+                domain: "ASRService",
+                code: -3,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "The built-in microphone is disconnected while your MacBook lid is closed. " +
+                        "Connect and select an external microphone, or open the lid.",
+                ]
+            )
+        case .unavailable:
+            throw NSError(
+                domain: "ASRService",
+                code: -4,
+                userInfo: [NSLocalizedDescriptionKey: "No audio input device is available."]
+            )
         }
-        return .systemDefault
     }
 
     /// Prepares the direct device callback without starting hardware IO. This
@@ -1496,7 +1524,11 @@ final class ASRService: ObservableObject {
                 do {
                     try await self.startConfiguredAudioCapture()
                 } catch {
-                    guard startAttempt < maximumStartAttempts,
+                    let nsError = error as NSError
+                    let isNonRetryableInputResolutionError =
+                        nsError.domain == "ASRService" && [-3, -4].contains(nsError.code)
+                    guard isNonRetryableInputResolutionError == false,
+                          startAttempt < maximumStartAttempts,
                           startGeneration == self.audioCaptureStartGeneration,
                           self.isTerminating == false
                     else {
@@ -1673,7 +1705,7 @@ final class ASRService: ObservableObject {
                         errorMessage = "Failed to start audio recording: \(underlyingError.localizedDescription)"
                     }
                 } else {
-                    errorMessage = "Failed to start audio recording after multiple attempts. Please check your audio device and try again."
+                    errorMessage = nsError.localizedDescription
                 }
             } else {
                 errorMessage = "Failed to start audio recording: \(error.localizedDescription)"

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -212,6 +212,12 @@ final class ASRService: ObservableObject {
     @Published var errorMessage: String = ""
     @Published var showError: Bool = false
 
+    func presentAudioCaptureStartFailure(_ message: String) {
+        self.errorTitle = "Recording Failed"
+        self.errorMessage = message
+        self.showError = true
+    }
+
     /// Returns a user-friendly status message for model loading state
     var modelStatusMessage: String {
         if self.isAsrReady { return "Model ready" }
@@ -1711,7 +1717,9 @@ final class ASRService: ObservableObject {
                 errorMessage = "Failed to start audio recording: \(error.localizedDescription)"
             }
 
-            // Post notification for UI to display
+            self.presentAudioCaptureStartFailure(errorMessage)
+
+            // Preserve the existing notification for external observers.
             NotificationCenter.default.post(
                 name: NSNotification.Name("ASRServiceStartFailed"),
                 object: nil,

--- a/Sources/Fluid/Services/MacLidStateProvider.swift
+++ b/Sources/Fluid/Services/MacLidStateProvider.swift
@@ -1,0 +1,22 @@
+import Foundation
+import IOKit
+
+enum MacLidState {
+    static func isClosed() -> Bool? {
+        let rootDomain = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching("IOPMrootDomain")
+        )
+        guard rootDomain != MACH_PORT_NULL else { return nil }
+        defer { IOObjectRelease(rootDomain) }
+
+        guard let value = IORegistryEntryCreateCFProperty(
+            rootDomain,
+            "AppleClamshellState" as CFString,
+            kCFAllocatorDefault,
+            0
+        )?.takeRetainedValue() else { return nil }
+
+        return (value as? NSNumber)?.boolValue
+    }
+}

--- a/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
+++ b/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
@@ -17,6 +17,14 @@ struct CoreAudioDeviceManager: AudioDeviceManaging {
     }
 }
 
+enum MicrophoneCaptureResolution: Equatable {
+    case standard
+    case clamshellSelectedExternal(AudioDevice.Device)
+    case clamshellFallback(AudioDevice.Device)
+    case clamshellRequiresExternalMicrophone
+    case unavailable
+}
+
 @MainActor
 final class MicrophonePreferenceCoordinator: ObservableObject {
     private static let appOnlyMigrationVersion = 1
@@ -121,6 +129,47 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
             )
         }
         return fallback
+    }
+
+    func captureResolution() -> MicrophoneCaptureResolution {
+        let isLidClosed = MacLidState.isClosed()
+        guard isLidClosed == true else { return .standard }
+
+        let inputs = self.devices.listInputDevices()
+        return self.captureResolution(
+            availableInputs: inputs,
+            defaultInputUID: self.devices.defaultInputDevice()?.uid,
+            isLidClosed: isLidClosed
+        )
+    }
+
+    func captureResolution(
+        availableInputs: [AudioDevice.Device],
+        defaultInputUID: String? = nil,
+        isLidClosed: Bool?
+    ) -> MicrophoneCaptureResolution {
+        guard isLidClosed == true else { return .standard }
+
+        guard let selectedInput = self.inputDeviceForCapture(
+            availableInputs: availableInputs,
+            defaultInputUID: defaultInputUID
+        ) else {
+            return .unavailable
+        }
+        guard selectedInput.isBuiltIn else {
+            return .clamshellSelectedExternal(selectedInput)
+        }
+
+        let externalInputs = availableInputs.filter { $0.isBuiltIn == false }
+        if let defaultInputUID,
+           let defaultExternalInput = externalInputs.first(where: { $0.uid == defaultInputUID })
+        {
+            return .clamshellFallback(defaultExternalInput)
+        }
+        if let externalInput = externalInputs.first {
+            return .clamshellFallback(externalInput)
+        }
+        return .clamshellRequiresExternalMicrophone
     }
 
     private func fallbackInput(

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -457,6 +457,139 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
+    func testClamshellCaptureKeepsSelectedExternalMicrophone() {
+        self.withRestoredDefaults(keys: [self.preferredInputDeviceUIDKey]) {
+            SettingsStore.shared.preferredInputDeviceUID = "usb"
+            let builtIn = Self.device(
+                uid: "internal",
+                name: "MacBook Pro Microphone",
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+            let usb = Self.device(uid: "usb", name: "USB Microphone")
+            let devices = FakeAudioDeviceManager(
+                inputs: [builtIn, usb],
+                defaultInputUID: "internal"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let resolution = coordinator.captureResolution(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID,
+                isLidClosed: true
+            )
+
+            XCTAssertEqual(resolution, .clamshellSelectedExternal(usb))
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "usb")
+        }
+    }
+
+    @MainActor
+    func testClamshellCaptureTemporarilyUsesDefaultExternalMicrophone() {
+        self.withRestoredDefaults(keys: [self.preferredInputDeviceUIDKey]) {
+            SettingsStore.shared.preferredInputDeviceUID = "internal"
+            let builtIn = Self.device(
+                uid: "internal",
+                name: "MacBook Pro Microphone",
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+            let display = Self.device(uid: "display", name: "Display Microphone")
+            let usb = Self.device(uid: "usb", name: "USB Microphone")
+            let devices = FakeAudioDeviceManager(
+                inputs: [builtIn, display, usb],
+                defaultInputUID: "usb"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let resolution = coordinator.captureResolution(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID,
+                isLidClosed: true
+            )
+
+            XCTAssertEqual(resolution, .clamshellFallback(usb))
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+        }
+    }
+
+    @MainActor
+    func testClamshellCaptureUsesAvailableExternalWhenDefaultIsBuiltIn() {
+        self.withRestoredDefaults(keys: [self.preferredInputDeviceUIDKey]) {
+            SettingsStore.shared.preferredInputDeviceUID = "internal"
+            let builtIn = Self.device(
+                uid: "internal",
+                name: "MacBook Pro Microphone",
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+            let usb = Self.device(uid: "usb", name: "USB Microphone")
+            let devices = FakeAudioDeviceManager(
+                inputs: [builtIn, usb],
+                defaultInputUID: "internal"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let resolution = coordinator.captureResolution(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID,
+                isLidClosed: true
+            )
+
+            XCTAssertEqual(resolution, .clamshellFallback(usb))
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+        }
+    }
+
+    @MainActor
+    func testClamshellCaptureRejectsBuiltInMicrophoneWithoutExternalInput() {
+        self.withRestoredDefaults(keys: [self.preferredInputDeviceUIDKey]) {
+            SettingsStore.shared.preferredInputDeviceUID = "internal"
+            let builtIn = Self.device(
+                uid: "internal",
+                name: "MacBook Pro Microphone",
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+            let devices = FakeAudioDeviceManager(
+                inputs: [builtIn],
+                defaultInputUID: "internal"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let resolution = coordinator.captureResolution(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID,
+                isLidClosed: true
+            )
+
+            XCTAssertEqual(resolution, .clamshellRequiresExternalMicrophone)
+        }
+    }
+
+    @MainActor
+    func testOpenLidCaptureKeepsStandardRouting() {
+        self.withRestoredDefaults(keys: [self.preferredInputDeviceUIDKey]) {
+            SettingsStore.shared.preferredInputDeviceUID = "internal"
+            let builtIn = Self.device(
+                uid: "internal",
+                name: "MacBook Pro Microphone",
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+            let usb = Self.device(uid: "usb", name: "USB Microphone")
+            let devices = FakeAudioDeviceManager(
+                inputs: [builtIn, usb],
+                defaultInputUID: "usb"
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let resolution = coordinator.captureResolution(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID,
+                isLidClosed: false
+            )
+
+            XCTAssertEqual(resolution, .standard)
+        }
+    }
+
+    @MainActor
     func testMicrophoneMigrationChoosesBuiltInOnce() throws {
         try self.withRestoredDefaults(keys: [
             self.microphoneSelectionModeKey,

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -590,6 +590,17 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
+    func testAudioCaptureStartFailureUsesExistingAlertState() {
+        let service = ASRService()
+
+        service.presentAudioCaptureStartFailure("Connect an external microphone.")
+
+        XCTAssertEqual(service.errorTitle, "Recording Failed")
+        XCTAssertEqual(service.errorMessage, "Connect an external microphone.")
+        XCTAssertTrue(service.showError)
+    }
+
+    @MainActor
     func testMicrophoneMigrationChoosesBuiltInOnce() throws {
         try self.withRestoredDefaults(keys: [
             self.microphoneSelectionModeKey,


### PR DESCRIPTION
## Description

Prevents silent dictation when a MacBook is used in closed-display mode and FluidVoice still has the built-in microphone selected. Apple silicon Mac laptops disconnect the built-in microphone in hardware when the lid closes, even though Core Audio can continue presenting the device and delivering buffers.

This PR:

- reads the documented clamshell state from `IOPMrootDomain` when resolving a capture device
- preserves the existing microphone route when the lid is open or its state is unavailable
- keeps a selected external microphone, or temporarily falls back to an available external input without changing the saved preference
- fails immediately with an actionable message when the built-in microphone is disconnected and no external input is available
- adds focused coverage for selected, default, fallback, unavailable, open-lid, and visible-error behavior

## Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #797.

## Testing

- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.1
- [x] Ran linter locally: exact CI SwiftLint 0.63.2 Docker command passed with 0 violations in 151 files
- [x] Ran formatter locally: targeted SwiftFormat lint passed for the new provider, coordinator, and tests; modified `ASRService.swift` hunks comply, while SwiftFormat 0.62.1 still reports unrelated pre-existing `wrapIfStatementBodies` findings elsewhere in that file
- [x] Ran tests locally: exact CI `xcodebuild test` command passed 190/190 tests with the flaky Tiny Whisper E2E excluded, matching the workflow
- [x] Public unsigned build completed, installed at `/Applications/FluidVoice.app`, and launched successfully

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes

Apple documents that closing an Apple silicon Mac laptop display disconnects the built-in microphone in hardware: https://support.apple.com/en-asia/guide/security/secbbd20b00b/web

The clamshell fallback is capture-only and does not rewrite the user's FluidVoice microphone preference. Normal open-lid routing is unchanged. No power-management settings are modified.

