### PR TITLE
fix(audio): preserve saved input device across disconnects

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -908,11 +908,23 @@ final class ASRService: ObservableObject {
         AppServices.shared.microphonePreferenceCoordinator.inputDeviceForCapture()
     }
 
-    private func directCoreAudioDeviceSelection() -> DirectCoreAudioDeviceSelection {
+    private func directCoreAudioDeviceSelection() async -> DirectCoreAudioDeviceSelection {
         // Resolve through the coordinator so capture falls back to a live
         // device while the preferred one is disconnected, without rewriting
-        // the stored preference.
-        if let device = self.resolvedInputDeviceForCapture() {
+        // the stored preference. The CoreAudio snapshot is taken off-main:
+        // during a device topology change the HAL may still be settling, and
+        // synchronous queries on main can deadlock.
+        let snapshot = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let devices = AudioDevice.listInputDevices()
+                let defaultInputUID = AudioDevice.getDefaultInputDevice()?.uid
+                continuation.resume(returning: (devices, defaultInputUID))
+            }
+        }
+        if let device = AppServices.shared.microphonePreferenceCoordinator.inputDeviceForCapture(
+            availableInputs: snapshot.0,
+            defaultInputUID: snapshot.1
+        ) {
             return .preferredUID(device.uid)
         }
         return .systemDefault
@@ -932,7 +944,7 @@ final class ASRService: ObservableObject {
             )
         }
         let device = try await self.directAudioLifecycleController.resolveDevice(
-            selection: self.directCoreAudioDeviceSelection(),
+            selection: await self.directCoreAudioDeviceSelection(),
             reason: "prepare:\(reason)"
         )
         let snapshot = try await self.directAudioLifecycleController.prepare(
@@ -958,7 +970,7 @@ final class ASRService: ObservableObject {
             await self.audioEngineRetirementDrain.waitForScheduledReleases()
             do {
                 let device = try await self.directAudioLifecycleController.resolveDevice(
-                    selection: self.directCoreAudioDeviceSelection(),
+                    selection: await self.directCoreAudioDeviceSelection(),
                     reason: "recording_start"
                 )
                 let snapshot = try await self.directAudioLifecycleController.start(

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -909,10 +909,11 @@ final class ASRService: ObservableObject {
     }
 
     private func directCoreAudioDeviceSelection() -> DirectCoreAudioDeviceSelection {
-        if let preferredUID = SettingsStore.shared.preferredInputDeviceUID,
-           preferredUID.isEmpty == false
-        {
-            return .preferredUID(preferredUID)
+        // Resolve through the coordinator so capture falls back to a live
+        // device while the preferred one is disconnected, without rewriting
+        // the stored preference.
+        if let device = self.resolvedInputDeviceForCapture() {
+            return .preferredUID(device.uid)
         }
         return .systemDefault
     }

--- a/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
+++ b/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
@@ -85,8 +85,7 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         )
         return self.inputDeviceForCapture(
             availableInputs: availableInputs,
-            defaultInputUID: defaultInputUID,
-            persistFallback: true
+            defaultInputUID: defaultInputUID
         )
     }
 
@@ -97,10 +96,14 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         )
     }
 
+    /// Resolves the device to capture from without mutating the stored
+    /// preference. When the preferred device is unavailable the fallback is
+    /// transient: `preferredInputDeviceUID` only changes through an explicit
+    /// user selection or the one-time app-only migration, so the preferred
+    /// device is re-selected as soon as it reconnects.
     func inputDeviceForCapture(
         availableInputs: [AudioDevice.Device],
-        defaultInputUID: String? = nil,
-        persistFallback: Bool = false
+        defaultInputUID: String? = nil
     ) -> AudioDevice.Device? {
         if let preferredUID = self.settings.preferredInputDeviceUID,
            preferredUID.isEmpty == false,
@@ -109,18 +112,10 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
             return preferredDevice
         }
 
-        guard let fallback = self.fallbackInput(
+        return self.fallbackInput(
             from: availableInputs,
             defaultInputUID: defaultInputUID
-        ) else { return nil }
-        if persistFallback {
-            self.settings.preferredInputDeviceUID = fallback.uid
-            DebugLogger.shared.info(
-                "Selected fallback FluidVoice microphone '\(fallback.name)'",
-                source: "MicrophonePreferenceCoordinator"
-            )
-        }
-        return fallback
+        )
     }
 
     private func fallbackInput(

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -568,7 +568,7 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
-    func testCompletedMigrationReconcilesMissingSavedInputAtLaunch() throws {
+    func testCompletedMigrationKeepsMissingSavedInputAtLaunch() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,
             self.appOnlyMicMigrationVersionKey,
@@ -592,7 +592,7 @@ final class HotkeyShortcutTests: XCTestCase {
             )
 
             XCTAssertEqual(reconciled, builtIn)
-            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "disconnected-usb")
             XCTAssertEqual(devices.defaultInputUID, "usb")
         }
     }
@@ -625,16 +625,19 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
-    func testMicrophoneCoordinatorFallsBackToBuiltInWhenSelectionDisappears() throws {
+    func testMicrophoneCoordinatorRestoresSelectionAfterReconnect() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,
+            self.appOnlyMicMigrationVersionKey,
         ]) {
             SettingsStore.shared.preferredInputDeviceUID = "airpods"
+            SettingsStore.shared.appMicSelectionMigrationVersion = 1
             let builtIn = Self.device(
                 uid: "internal",
                 name: "MacBook Pro Microphone",
                 transportType: kAudioDeviceTransportTypeBuiltIn
             )
+            let airpods = Self.device(uid: "airpods", name: "AirPods")
             let devices = FakeAudioDeviceManager(
                 inputs: [builtIn, Self.device(uid: "usb", name: "USB Mic")],
                 defaultInputUID: "usb"
@@ -647,21 +650,20 @@ final class HotkeyShortcutTests: XCTestCase {
             XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
             XCTAssertEqual(devices.defaultInputUID, "usb")
 
-            let settledFallback = coordinator.inputDeviceForCapture(
+            let settledFallback = coordinator.reconcileAppOnlySelection(
                 availableInputs: devices.inputs,
-                defaultInputUID: devices.defaultInputUID,
-                persistFallback: true
+                defaultInputUID: devices.defaultInputUID
             )
             XCTAssertEqual(settledFallback, builtIn)
-            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
             XCTAssertEqual(devices.defaultInputUID, "usb")
 
-            let afterReconnect = coordinator.inputDeviceForCapture(availableInputs: [
-                builtIn,
-                Self.device(uid: "airpods", name: "AirPods"),
-            ])
-            XCTAssertEqual(afterReconnect, builtIn)
-            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "internal")
+            let afterReconnect = coordinator.reconcileAppOnlySelection(
+                availableInputs: [builtIn, airpods],
+                defaultInputUID: "usb"
+            )
+            XCTAssertEqual(afterReconnect, airpods)
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "airpods")
         }
     }
 
@@ -683,11 +685,10 @@ final class HotkeyShortcutTests: XCTestCase {
 
             let settledFallback = coordinator.inputDeviceForCapture(
                 availableInputs: devices.inputs,
-                defaultInputUID: devices.defaultInputUID,
-                persistFallback: true
+                defaultInputUID: devices.defaultInputUID
             )
             XCTAssertEqual(settledFallback, currentInput)
-            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "usb")
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "disconnected")
         }
     }
 


### PR DESCRIPTION
## Description
When the selected input device temporarily disappears (USB mic unplugged with a dock, system sleep/wake, Bluetooth drop), the app permanently reverts to the built-in microphone and never returns to the user's chosen device when it reconnects.

**Root cause:** the reconciliation that runs after every device topology change (`MicrophonePreferenceCoordinator.reconcileAppOnlySelection`) resolved the capture device with `persistFallback: true`, which **overwrote the persisted `PreferredInputDeviceUID` with the fallback (built-in) device's UID**. Once clobbered, `AudioCaptureIdlePolicy.didPreferredInputAvailabilityChange` had nothing left to compare against, so reconnecting the preferred device triggered no re-selection.

**Fix:**
- `MicrophonePreferenceCoordinator`: fallback selection is now transient — the stored preference is only written by an explicit user selection, settings import, or the one-time app-only migration. This mirrors how the output-device path already behaves (fallback affects display state only, never the persisted preference).
- `ASRService.directCoreAudioDeviceSelection()`: resolve the capture device through the coordinator instead of reading the raw stored UID. Previously the direct Core Audio path threw if the stored UID wasn't present — it only appeared to work because the preference had been clobbered to a live device. Now capture temporarily falls back to a live device while the preferred one is disconnected, and the existing availability-change listener rebinds to the preferred device on reconnect. This also matches the resolution the settings UI and menu bar already display.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #807

## Testing
- [ ] Tested on Intel Mac
- [ ] Tested on Apple Silicon Mac
- [ ] Tested on macOS version:
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — 0 violations in 139 files
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources` — run in `--lint` mode: the changed files introduce no violations. 60 files have pre-existing formatting drift unrelated to this PR (e.g. `SettingsStore.swift`), so in-place formatting was intentionally not applied to keep the diff focused.
- [x] Ran tests locally: full suite run via the repo's Build and Test workflow on my fork before opening this PR ready — 184 tests, 0 failures ([run](https://github.com/AdamBrauns/FluidVoice/actions/runs/31190174870))

Updated the `HotkeyShortcutTests` coordinator tests to assert the new invariant, including a regression test for the full cycle: preferred device disappears → fallback used without touching the stored preference → device reappears → preferred device re-selected (`testMicrophoneCoordinatorRestoresSelectionAfterReconnect`).

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
The behavior change is deliberate: a temporarily missing device no longer rewrites the saved selection. Three existing tests codified the old persist-on-fallback behavior and were updated accordingly. Reviewers may want to double-check the `reconcileAppOnlySelection` call sites (startup and route recovery) — both are automatic paths where persisting a fallback is undesirable.
