### PR TITLE
fix(typing): short-circuit verification for targets with no verifiable text

### DIFF
--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -1107,6 +1107,26 @@ final class TypingService {
         let selectedRange: CFRange?
     }
 
+    /// Returns `true` iff at least one of the four verifiable focused-text channels is present.
+    ///
+    /// A snapshot with a real `pid` but every verifiable channel `nil` — e.g. a GPU-rendered
+    /// terminal such as Ghostty that exposes neither an accessibility text value nor a text-field
+    /// selected range — cannot be verified, so `waitForFocusedTextVerification` short-circuits to
+    /// `.unavailable` instead of polling the full `timeoutMicros` while holding the pasteboard
+    /// session semaphore. The four channels are passed as primitive optionals so the private
+    /// `FocusedTextSnapshot` struct stays private.
+    static func focusedTextSnapshotSupportsVerification(
+        value: String?,
+        selectedRange: CFRange?,
+        appScriptValue: String?,
+        appScriptSelectedRange: CFRange?
+    ) -> Bool {
+        value != nil
+            || selectedRange != nil
+            || appScriptValue != nil
+            || appScriptSelectedRange != nil
+    }
+
     private func waitForFocusedTextVerification(
         from snapshot: FocusedTextSnapshot?,
         expectedText: String,
@@ -1114,6 +1134,20 @@ final class TypingService {
     ) -> PasteVerificationResult {
         guard let snapshot else {
             usleep(timeoutMicros)
+            return .unavailable
+        }
+
+        // Unverifiable target (e.g. a GPU-rendered terminal): no verifiable AX text value and no
+        // text-field selected range. The paste was already dispatched synchronously by `action()`
+        // before this restore task runs, so give it a single poll interval to be read, then release
+        // the pasteboard session without polling the full `timeoutMicros`.
+        if !Self.focusedTextSnapshotSupportsVerification(
+            value: snapshot.value,
+            selectedRange: snapshot.selectedRange,
+            appScriptValue: snapshot.appScriptValue,
+            appScriptSelectedRange: snapshot.appScriptSelectedRange
+        ) {
+            usleep(min(timeoutMicros, 50_000))
             return .unavailable
         }
 

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -32,7 +32,12 @@ final class TypingService {
         let items: [PasteboardItemSnapshot]
     }
 
-    private struct FocusedTextSnapshot {
+    /// Captured before a paste so verification can diff the focused target against it.
+    ///
+    /// Internal (not private) only so behavioral tests can construct an unverifiable snapshot — a
+    /// real `pid` with all four verifiable channels `nil`, the terminal case — to exercise the
+    /// short-circuit in `waitForFocusedTextVerification`. It is not part of any public contract.
+    struct FocusedTextSnapshot {
         let pid: pid_t
         let bundleIdentifier: String?
         let value: String?
@@ -41,7 +46,9 @@ final class TypingService {
         let appScriptSelectedRange: CFRange?
     }
 
-    private enum PasteVerificationResult: String {
+    /// Internal (not private) only so behavioral tests can assert the short-circuit result
+    /// (`.unavailable`). It is not part of any public contract.
+    enum PasteVerificationResult: String {
         case appScriptContainsText = "appscript_contains_text"
         case appScriptCaretMovedExpectedDistance = "appscript_caret_moved_expected_distance"
         case fieldContainsText = "field_contains_text"
@@ -55,6 +62,21 @@ final class TypingService {
     private static let pasteboardRestoreQueue = DispatchQueue(label: "TypingService.PasteboardRestore", qos: .utility)
     private static var focusSnapshot: FocusSnapshot?
     private static let ghosttyBundleIdentifier = "com.mitchellh.ghostty"
+
+    /// Pasteboard-consume window used when an unverifiable target short-circuits verification.
+    ///
+    /// `action()` only ENQUEUES Cmd+V (via `postToPid`); the target then reads
+    /// `NSPasteboard.general` asynchronously on its own main thread. Under load (a large paste, a
+    /// busy main thread during a build) that read can land hundreds of milliseconds after the event
+    /// was posted, so restoring the prior pasteboard contents too eagerly would clobber the
+    /// transcript before the target consumes it — a silent paste failure with no verification
+    /// backstop, in exactly the case this branch handles. 500 ms is a conservative floor: long
+    /// enough for a busy GPU-rendered terminal to service the posted Cmd+V and read the pasteboard,
+    /// yet ~10x under the 5 s `timeoutMicros`, so the process-global pasteboard session semaphore is
+    /// no longer held across multi-second windows (the #802 stall). Not scaled to paste size: the
+    /// risk window is pasteboard-read latency, not render latency, so text length is a weak
+    /// predictor.
+    private static let pasteConsumeWindowMicros: useconds_t = 500_000
 
     private var textInsertionMode: SettingsStore.TextInsertionMode {
         SettingsStore.shared.textInsertionMode
@@ -1113,8 +1135,8 @@ final class TypingService {
     /// terminal such as Ghostty that exposes neither an accessibility text value nor a text-field
     /// selected range — cannot be verified, so `waitForFocusedTextVerification` short-circuits to
     /// `.unavailable` instead of polling the full `timeoutMicros` while holding the pasteboard
-    /// session semaphore. The four channels are passed as primitive optionals so the private
-    /// `FocusedTextSnapshot` struct stays private.
+    /// session semaphore. The four channels are passed as primitive optionals so this stays a pure
+    /// function of a snapshot's verifiable fields, decoupled from `FocusedTextSnapshot`.
     static func focusedTextSnapshotSupportsVerification(
         value: String?,
         selectedRange: CFRange?,
@@ -1127,7 +1149,14 @@ final class TypingService {
             || appScriptSelectedRange != nil
     }
 
-    private func waitForFocusedTextVerification(
+    /// Waits for the focused target to reflect the pasted `expectedText`, or short-circuits when
+    /// the target exposes no verifiable channel.
+    ///
+    /// Internal (not private) so the unverifiable-target short-circuit has behavioral coverage:
+    /// that path is deterministic (it returns `.unavailable` after a bounded consume window without
+    /// ever reading live AX state), so it can be exercised headlessly. The verifiable poll loop
+    /// reads live accessibility state and is not driven from tests.
+    func waitForFocusedTextVerification(
         from snapshot: FocusedTextSnapshot?,
         expectedText: String,
         timeoutMicros: useconds_t
@@ -1137,17 +1166,23 @@ final class TypingService {
             return .unavailable
         }
 
-        // Unverifiable target (e.g. a GPU-rendered terminal): no verifiable AX text value and no
-        // text-field selected range. The paste was already dispatched synchronously by `action()`
-        // before this restore task runs, so give it a single poll interval to be read, then release
-        // the pasteboard session without polling the full `timeoutMicros`.
+        // Unverifiable target (e.g. a GPU-rendered terminal such as Ghostty): no AX text value and
+        // no text-field selected range, so the poll loop below could never confirm the paste.
+        // `action()` only ENQUEUES Cmd+V into the target's event queue; the target then reads
+        // `NSPasteboard.general` asynchronously on its own main thread. Under load (a large paste,
+        // a busy main thread during a build) that read can land hundreds of milliseconds later, so
+        // restoring the prior pasteboard contents too eagerly would clobber the transcript before
+        // the target consumes it — a silent paste failure with no verification backstop, in exactly
+        // the case this branch handles. Give the target a real pasteboard-consume window (see
+        // `pasteConsumeWindowMicros`), then release the pasteboard session without polling the full
+        // `timeoutMicros`.
         if !Self.focusedTextSnapshotSupportsVerification(
             value: snapshot.value,
             selectedRange: snapshot.selectedRange,
             appScriptValue: snapshot.appScriptValue,
             appScriptSelectedRange: snapshot.appScriptSelectedRange
         ) {
-            usleep(min(timeoutMicros, 50_000))
+            usleep(min(timeoutMicros, Self.pasteConsumeWindowMicros))
             return .unavailable
         }
 

--- a/Tests/FluidDictationIntegrationTests/TypingServiceTransientPasteboardTests.swift
+++ b/Tests/FluidDictationIntegrationTests/TypingServiceTransientPasteboardTests.swift
@@ -79,4 +79,53 @@ final class TypingServiceTransientPasteboardTests: XCTestCase {
             "Restoring focus must not raise every window of the target app (issue #748)"
         )
     }
+
+    func testFocusedTextSnapshotWithoutVerifiableChannelShortCircuitsVerification() {
+        // A GPU-rendered / terminal target (e.g. Ghostty) exposes no verifiable accessibility
+        // text value and no text-field selected range: all four channels are nil, so the
+        // snapshot cannot be verified and `waitForFocusedTextVerification` must short-circuit to
+        // `.unavailable` instead of polling the full 5 s `timeoutMicros` while the process-global
+        // pasteboard session semaphore is held.
+        XCTAssertFalse(
+            TypingService.focusedTextSnapshotSupportsVerification(
+                value: nil,
+                selectedRange: nil,
+                appScriptValue: nil,
+                appScriptSelectedRange: nil
+            ),
+            "a snapshot whose four verifiable channels are all nil must be unverifiable"
+        )
+
+        // Any single non-nil channel is enough to make the snapshot verifiable, so a verifiable
+        // target (e.g. CotEditor, Notes, Xcode) keeps its current fast-path behaviour.
+        XCTAssertTrue(
+            TypingService.focusedTextSnapshotSupportsVerification(
+                value: "hello",
+                selectedRange: nil,
+                appScriptValue: nil,
+                appScriptSelectedRange: nil
+            ),
+            "a non-nil accessibility text value makes the snapshot verifiable"
+        )
+
+        XCTAssertTrue(
+            TypingService.focusedTextSnapshotSupportsVerification(
+                value: nil,
+                selectedRange: nil,
+                appScriptValue: "hello",
+                appScriptSelectedRange: nil
+            ),
+            "a non-nil AppleScript text value makes the snapshot verifiable"
+        )
+
+        XCTAssertTrue(
+            TypingService.focusedTextSnapshotSupportsVerification(
+                value: nil,
+                selectedRange: CFRange(location: 0, length: 0),
+                appScriptValue: nil,
+                appScriptSelectedRange: nil
+            ),
+            "a non-nil selected range makes the snapshot verifiable"
+        )
+    }
 }

--- a/Tests/FluidDictationIntegrationTests/TypingServiceTransientPasteboardTests.swift
+++ b/Tests/FluidDictationIntegrationTests/TypingServiceTransientPasteboardTests.swift
@@ -128,4 +128,47 @@ final class TypingServiceTransientPasteboardTests: XCTestCase {
             "a non-nil selected range makes the snapshot verifiable"
         )
     }
+
+    func testWaitForFocusedTextVerificationShortCircuitsUnverifiableTargetInBoundedTime() {
+        // Behavioral coverage of the #802 fix: a target whose snapshot has a real pid but all four
+        // verifiable channels nil (a GPU-rendered terminal such as Ghostty) must short-circuit to
+        // `.unavailable` after a bounded pasteboard-consume window — NOT poll the full
+        // `timeoutMicros`. This is an assertion-level guard, not a compile-time one: remove the
+        // short-circuit from `waitForFocusedTextVerification` and this returns `.timeout` after
+        // ~`timeoutMicros`, failing both asserts below. The short-circuit path is deterministic
+        // (it never reads live AX state and does not touch the pasteboard session semaphore), so it
+        // is safe to drive headlessly; the verifiable poll loop is not, so it is not exercised here.
+        let typing = TypingService()
+        let snapshot = TypingService.FocusedTextSnapshot(
+            pid: 1,
+            bundleIdentifier: nil,
+            value: nil,
+            selectedRange: nil,
+            appScriptValue: nil,
+            appScriptSelectedRange: nil
+        )
+        let timeoutMicros: useconds_t = 5_000_000
+
+        let start = Date()
+        let result = typing.waitForFocusedTextVerification(
+            from: snapshot,
+            expectedText: "hello",
+            timeoutMicros: timeoutMicros
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertEqual(
+            result,
+            .unavailable,
+            "an unverifiable target must short-circuit to .unavailable, not poll to .timeout"
+        )
+        // Well under `timeoutMicros` (5 s): proves the short-circuit did NOT poll the full window.
+        // The bound is `timeoutMicros / 2`, so a loaded CI runner still clears it comfortably above
+        // the ~0.5 s consume window, while a full ~5 s poll would blow straight past it.
+        XCTAssertLessThan(
+            elapsed,
+            Double(timeoutMicros) / 1_000_000.0 / 2.0,
+            "short-circuit must return well under timeoutMicros; took \(elapsed) s"
+        )
+    }
 }


### PR DESCRIPTION
## Description

On targets that expose no verifiable accessibility text — GPU-rendered terminals such as Ghostty — `waitForFocusedTextVerification` polled for the full 5 s `timeoutMicros` while holding the process-global pasteboard session semaphore. That is the multi-second stall measured in #802 (sub-second → ~8.9 s) whenever dictation was injected into such a target.

The fix short-circuits verification when none of the four verifiable focused-text channels is present (`value`, `selectedRange`, `appScriptValue`, `appScriptSelectedRange` all `nil`): sleep a pasteboard-consume window, then release the session as `.unavailable`. Verifiable targets — any one channel present — keep their existing fast path unchanged.

The consume window is **500 ms** (`pasteConsumeWindowMicros`). `action()` only *enqueues* Cmd+V via `postToPid`; the target then reads `NSPasteboard.general` asynchronously on its own main thread, and under load (a large paste, a busy main thread during a build) that read can land hundreds of milliseconds later — so restoring the prior pasteboard too eagerly would clobber the transcript before the target consumes it. 500 ms is a conservative floor for a busy terminal to service the paste, yet ~10× under the 5 s timeout, so the #802 stall is gone.

Diff: `Sources/Fluid/Services/TypingService.swift` plus one test file.

## Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #802.

## Testing

- [x] Tested on Apple Silicon Mac
- [ ] Tested on Intel Mac
- [x] Tested on macOS version: 26.0 (Darwin 25.6.0), Xcode latest-stable
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` → **0 violations, 0 serious in 139 files**
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -skip-testing:FluidDictationIntegrationTests/DictationE2ETests/testDictationEndToEnd_whisperTiny_transcribesFixture`

Two new cases, both in `TypingServiceTransientPasteboardTests` (suite passes in full):

- `testFocusedTextSnapshotWithoutVerifiableChannelShortCircuitsVerification` — pins the predicate: all-four-nil is unverifiable; any single non-nil channel is verifiable.
- `testWaitForFocusedTextVerificationShortCircuitsUnverifiableTargetInBoundedTime` — **behavioural**: drives the real `waitForFocusedTextVerification` with an unverifiable snapshot (real pid, all four channels nil) and asserts it returns `.unavailable` in under `timeoutMicros / 2`. Remove the short-circuit and it polls to `.timeout` at ~5 s, failing both asserts.

Two unrelated tests are red on my machine only, for the environment reasons this repo's own prerequisites document, and both are red on a clean `main` here too:

- `HotkeyShortcutTests.testKeyboardPayloadIgnoresStrayMouseButtonField` — asserts the ASCII glyph at a keyCode; my host has a non-U.S. input source active.
- `DictationE2ETests.testAppPromptBinding_defaultFallbackIgnoresGlobalSelection` — reads real `com.FluidApp.app` defaults, which are customised on this machine.

Neither touches the typing-verification path. CI runs on a clean U.S.-layout runner, so both should be green there.

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

This is a backend typing-verification timing path — no view, layout, styling, settings, overlay or menu-bar surface is touched. The user-observable effect is latency: dictating into Ghostty returns in well under a second instead of ~8.9 s.

## Notes

- Verifiable targets are byte-identical to `main`; only the all-channels-nil case takes the new branch.
- The consume window is a named constant (`pasteConsumeWindowMicros`) so it is easy to tune if a slower target turns up.
- A few `private` declarations (`FocusedTextSnapshot`, `PasteVerificationResult`, `waitForFocusedTextVerification`) became `internal` so the short-circuit path can be exercised by tests; none of them are public API.
