### PR TITLE
fix(typing): stop raising every window of the target app when restoring focus after dictation

### DIFF
--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -255,6 +255,13 @@ final class TypingService {
         return nil
     }
 
+    /// Activation options used to restore focus to the external target app after dictation.
+    /// `.activateAllWindows` is intentionally omitted: raising every window of a multi-window
+    /// app (e.g. WebStorm) destroys the user's window layout on each dictation (issue #748).
+    static let focusRestoreActivationOptions: NSApplication.ActivationOptions = [
+        .activateIgnoringOtherApps,
+    ]
+
     /// Best-effort: activates the app with the given PID, unless it's Fluid itself.
     @discardableResult
     static func activateApp(pid: pid_t) -> Bool {
@@ -269,7 +276,7 @@ final class TypingService {
             return false
         }
 
-        return app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        return app.activate(options: Self.focusRestoreActivationOptions)
     }
 
     // MARK: - Public API

--- a/Tests/FluidDictationIntegrationTests/TypingServiceTransientPasteboardTests.swift
+++ b/Tests/FluidDictationIntegrationTests/TypingServiceTransientPasteboardTests.swift
@@ -63,4 +63,20 @@ final class TypingServiceTransientPasteboardTests: XCTestCase {
             "ConcealedType signals sensitive content and must not be applied to a transcript"
         )
     }
+
+    func testFocusRestoreDoesNotRaiseAllWindowsOfTargetApp() {
+        // Issue #748: restoring focus after dictation must NOT raise every window of the
+        // target app. `.activateAllWindows` brings forward all windows of the process and
+        // destroys a multi-window layout (e.g. WebStorm) on every dictation.
+        let options = TypingService.focusRestoreActivationOptions
+
+        XCTAssertTrue(
+            options.contains(.activateIgnoringOtherApps),
+            "focus restore must still activate the target app and bring it forward"
+        )
+        XCTAssertFalse(
+            options.contains(.activateAllWindows),
+            "Restoring focus must not raise every window of the target app (issue #748)"
+        )
+    }
 }


### PR DESCRIPTION
## Description

After dictation, FluidVoice restores focus to the target app through `TypingService.activateApp(pid:)`, which called `NSRunningApplication.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])`.

`.activateAllWindows` raises **every** window of the target process, not just the one the user was typing into. On a multi-window app (WebStorm, VS Code, multiple Finder windows) that reshuffles the whole window layout after *each* dictation — the behaviour reported in #748.

This PR removes `.activateAllWindows` and keeps `.activateIgnoringOtherApps`, so the target app still becomes frontmost and its key window comes forward, while sibling windows stay where the user left them.

The options are now built from one named constant, `TypingService.focusRestoreActivationOptions`, so the four focus-restore call sites (all of which already funnel through `activateApp(pid:)`) share a single definition and the contract is unit-testable.

Diff: `Sources/Fluid/Services/TypingService.swift` (+8/-1) and one test.

## Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #748.

## Testing

- [x] Tested on Apple Silicon Mac
- [ ] Tested on Intel Mac
- [x] Tested on macOS version: 26.0 (Darwin 25.6.0), Xcode latest-stable
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` → **0 violations, 0 serious in 139 files**
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -skip-testing:FluidDictationIntegrationTests/DictationE2ETests/testDictationEndToEnd_whisperTiny_transcribesFixture`

New regression test — `TypingServiceTransientPasteboardTests.testFocusRestoreDoesNotRaiseAllWindowsOfTargetApp`: asserts `focusRestoreActivationOptions` contains `.activateIgnoringOtherApps` and does **not** contain `.activateAllWindows`. It is red on `main` (the option set still carries `.activateAllWindows`) and green here. `TypingServiceTransientPasteboardTests` passes in full.

Two unrelated tests are red on my machine only, both for the environment reasons documented in this repo's own prerequisites, and both are red on a clean `main` here too:

- `HotkeyShortcutTests.testKeyboardPayloadIgnoresStrayMouseButtonField` — asserts the ASCII glyph at a keyCode; my host has a non-U.S. input source active.
- `DictationE2ETests.testAppPromptBinding_defaultFallbackIgnoresGlobalSelection` — reads real `com.FluidApp.app` defaults, which are customised on this machine.

Neither touches `TypingService`. CI runs on a clean U.S.-layout runner, so both should be green there.

Manual check for the actual behaviour (it cannot be captured in a screenshot): open two windows of a multi-window app, focus one, dictate into it. On `main` both windows are raised; with this change only the focused window comes forward.

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

To be explicit rather than just tick a box: this PR changes **no FluidVoice UI surface** — no view, layout, styling, settings, overlay or menu-bar change. What it changes is which windows of the *target third-party app* macOS raises when focus is restored; that is window-activation behaviour in another process, which a static screenshot cannot show. The manual repro steps above are the way to observe it.

## Notes

- Behaviour is unchanged for single-window targets: `.activateIgnoringOtherApps` alone already brings the app frontmost with its key window.
- `focusRestoreActivationOptions` is `internal static` so the test target can reach it via `@testable import`; no new public surface.

---

Authored by `@YuriNachos`. Implementation written by a `cccc` (Claude Code) worker under orchestrator acceptance; an independent adversarial review (logic + behaviour-equivalence + test-integrity) returned APPROVE with no blocking findings.
