### PR TITLE
fix(hotkey): stop modifier-only shortcut from firing on unrelated Shift+key combos

### DIFF
--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Foundation
 
-private nonisolated enum HotkeyHoldModeType: Hashable {
+nonisolated enum HotkeyHoldModeType: Hashable {
     case transcription
     case promptMode
     case commandMode
@@ -12,6 +12,173 @@ private nonisolated enum HotkeyHoldModeType: Hashable {
 private nonisolated enum ActivePrimaryShortcutPress: Equatable {
     case keyboard(UInt16)
     case mouse(Int)
+}
+
+/// Snapshot of the modifier-only tracking state fed into `ModifierOnlyShortcutFlagsDecision`.
+struct ModifierOnlyShortcutTrackingState: Equatable {
+    /// Currently-pressed modifier key codes (output of `synchronizedPressedModifierKeyCodes`).
+    let pressedModifierKeyCodes: Set<UInt16>
+    /// The currently-active modifier-only mode, if any.
+    let activeModifierOnlyType: HotkeyHoldModeType?
+    /// Whether a non-configured key was pressed during the active modifier-only press.
+    let otherKeyPressedDuringModifier: Bool
+    /// Snapshot of the behavior's mode-key-pressed flag.
+    let isModeKeyPressed: Bool
+}
+
+/// Pure, side-effect-free decision describing how a modifier-only shortcut responds to a single
+/// `flagsChanged` event. Extracted from `GlobalHotkeyManager.handleModifierOnlyShortcutFlagsChanged`
+/// so the modifier-only start/finish state machine is unit-testable without the global event tap.
+struct ModifierOnlyShortcutFlagsDecision: Equatable {
+    enum Outcome: Equatable {
+        /// The event neither starts nor finishes the press.
+        case ignore
+        /// The configured modifier was pressed: arm the modifier-only press.
+        case start
+        /// The configured modifier was released: finish the press; a clean tap only when
+        /// `wasCleanPress` is true.
+        case finish(wasCleanPress: Bool)
+    }
+
+    let outcome: Outcome
+    /// True when an extra modifier was pressed during an active press this event; the caller logs
+    /// and marks the press interrupted.
+    let markInterrupted: Bool
+    /// Value `activeModifierOnlyType` should hold after this event.
+    let activeModifierOnlyType: HotkeyHoldModeType?
+    /// Value `otherKeyPressedDuringModifier` should hold after this event.
+    let otherKeyPressedDuringModifier: Bool
+
+    /// Mirrors the decision logic of `handleModifierOnlyShortcutFlagsChanged`. Branch 1 handles
+    /// shortcuts that carry explicit modifier key codes (e.g. a captured Left Option); branch 2
+    /// handles the flag-only form.
+    static func evaluate(
+        shortcut: HotkeyShortcut,
+        holdModeType: HotkeyHoldModeType,
+        isEnabled: Bool,
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags,
+        state: ModifierOnlyShortcutTrackingState
+    ) -> ModifierOnlyShortcutFlagsDecision {
+        let pressedModifierKeyCodes = state.pressedModifierKeyCodes
+        let activeModifierOnlyType = state.activeModifierOnlyType
+        let otherKeyPressedDuringModifier = state.otherKeyPressedDuringModifier
+        let isModeKeyPressed = state.isModeKeyPressed
+
+        guard isEnabled, shortcut.isModifierOnlyShortcut else {
+            return .init(
+                outcome: .ignore,
+                markInterrupted: false,
+                activeModifierOnlyType: activeModifierOnlyType,
+                otherKeyPressedDuringModifier: otherKeyPressedDuringModifier
+            )
+        }
+
+        let relevantModifiers = modifiers.intersection(HotkeyShortcut.relevantModifierMask)
+        let expectedModifierKeyCodes = shortcut.normalizedModifierKeyCodes
+
+        if !expectedModifierKeyCodes.isEmpty {
+            let pressedKeyCodes = HotkeyShortcut.normalizedModifierKeyCodes(from: Array(pressedModifierKeyCodes))
+            // Only arm on the FIRST press of the configured modifier itself. The `activeModifierOnlyType == nil`
+            // precondition prevents a mid-press re-arm: without it, releasing an unrelated modifier (e.g. Shift)
+            // or pressing a sibling modifier while the configured modifier is held can shrink `pressedModifierKeyCodes`
+            // back to the expected set and re-enter this block, erasing `otherKeyPressedDuringModifier` so the
+            // subsequent release reads as a clean tap and falsely starts recording (#688).
+            if activeModifierOnlyType == nil,
+               pressedKeyCodes == expectedModifierKeyCodes,
+               expectedModifierKeyCodes.contains(keyCode) {
+                return .init(
+                    outcome: .start,
+                    markInterrupted: false,
+                    activeModifierOnlyType: holdModeType,
+                    otherKeyPressedDuringModifier: false
+                )
+            }
+
+            let isActiveModifierOnlyPress = activeModifierOnlyType == holdModeType
+            var markInterrupted = false
+            if isActiveModifierOnlyPress || isModeKeyPressed {
+                let extraModifierKeyCodes = pressedKeyCodes.filter { !expectedModifierKeyCodes.contains($0) }
+                markInterrupted = !extraModifierKeyCodes.isEmpty
+            }
+
+            guard isActiveModifierOnlyPress || isModeKeyPressed,
+                  expectedModifierKeyCodes.contains(keyCode),
+                  !pressedKeyCodes.contains(keyCode)
+            else {
+                return .init(
+                    outcome: .ignore,
+                    markInterrupted: markInterrupted,
+                    activeModifierOnlyType: activeModifierOnlyType,
+                    otherKeyPressedDuringModifier: markInterrupted ? true : otherKeyPressedDuringModifier
+                )
+            }
+
+            let wasCleanPress = !(markInterrupted || otherKeyPressedDuringModifier)
+            return .init(
+                outcome: .finish(wasCleanPress: wasCleanPress),
+                markInterrupted: markInterrupted,
+                activeModifierOnlyType: nil,
+                otherKeyPressedDuringModifier: false
+            )
+        }
+
+        guard let expectedPressedModifiers = shortcut.expectedModifierFlags,
+              let triggerFlag = shortcut.modifierTriggerFlag
+        else {
+            return .init(
+                outcome: .ignore,
+                markInterrupted: false,
+                activeModifierOnlyType: activeModifierOnlyType,
+                otherKeyPressedDuringModifier: otherKeyPressedDuringModifier
+            )
+        }
+
+        // Only arm on the FIRST press of a modifier that belongs to the shortcut. The
+        // `activeModifierOnlyType == nil` precondition prevents a mid-press re-arm (same #688 class
+        // as branch 1): a sibling-side modifier whose flag is in `expectedPressedModifiers` would
+        // otherwise re-enter `.start` and erase `otherKeyPressedDuringModifier`. Matching the
+        // modifier flag (not the literal key code) preserves the original side-agnostic start, so a
+        // Left-Option-stored shortcut still arms on Right Option.
+        if activeModifierOnlyType == nil,
+           relevantModifiers == expectedPressedModifiers,
+           let changedModifierFlag = HotkeyShortcut.modifierFlag(forKeyCode: keyCode),
+           expectedPressedModifiers.contains(changedModifierFlag) {
+            return .init(
+                outcome: .start,
+                markInterrupted: false,
+                activeModifierOnlyType: holdModeType,
+                otherKeyPressedDuringModifier: false
+            )
+        }
+
+        let isActiveModifierOnlyPress = activeModifierOnlyType == holdModeType
+        var markInterrupted = false
+        if isActiveModifierOnlyPress || isModeKeyPressed {
+            let unexpectedModifiers = relevantModifiers.subtracting(expectedPressedModifiers)
+            markInterrupted = !unexpectedModifiers.isEmpty
+        }
+
+        guard isActiveModifierOnlyPress || isModeKeyPressed,
+              keyCode == shortcut.keyCode,
+              !relevantModifiers.contains(triggerFlag)
+        else {
+            return .init(
+                outcome: .ignore,
+                markInterrupted: markInterrupted,
+                activeModifierOnlyType: activeModifierOnlyType,
+                otherKeyPressedDuringModifier: markInterrupted ? true : otherKeyPressedDuringModifier
+            )
+        }
+
+        let wasCleanPress = !(markInterrupted || otherKeyPressedDuringModifier)
+        return .init(
+            outcome: .finish(wasCleanPress: wasCleanPress),
+            markInterrupted: markInterrupted,
+            activeModifierOnlyType: nil,
+            otherKeyPressedDuringModifier: false
+        )
+    }
 }
 
 private final nonisolated class HotkeyState: @unchecked Sendable {
@@ -1504,91 +1671,44 @@ final class GlobalHotkeyManager: NSObject {
         keyCode: UInt16,
         modifiers: NSEvent.ModifierFlags
     ) -> Bool {
-        let shortcut = behavior.shortcut
-        guard behavior.isEnabled, shortcut.isModifierOnlyShortcut else { return false }
+        let decision = ModifierOnlyShortcutFlagsDecision.evaluate(
+            shortcut: behavior.shortcut,
+            holdModeType: behavior.holdModeType,
+            isEnabled: behavior.isEnabled,
+            keyCode: keyCode,
+            modifiers: modifiers,
+            state: ModifierOnlyShortcutTrackingState(
+                pressedModifierKeyCodes: self.pressedModifierKeyCodes,
+                activeModifierOnlyType: self.activeModifierOnlyType,
+                otherKeyPressedDuringModifier: self.otherKeyPressedDuringModifier,
+                isModeKeyPressed: behavior.isModeKeyPressed()
+            )
+        )
 
-        let relevantModifiers = modifiers.intersection(HotkeyShortcut.relevantModifierMask)
-        let expectedModifierKeyCodes = shortcut.normalizedModifierKeyCodes
-        if !expectedModifierKeyCodes.isEmpty {
-            let pressedModifierKeyCodes = HotkeyShortcut.normalizedModifierKeyCodes(from: Array(self.pressedModifierKeyCodes))
-            if pressedModifierKeyCodes == expectedModifierKeyCodes {
-                self.modifierOnlyKeyDown = true
-                self.activeModifierOnlyType = behavior.holdModeType
-                self.otherKeyPressedDuringModifier = false
-                self.modifierPressStartTime = Date()
+        self.activeModifierOnlyType = decision.activeModifierOnlyType
+        if decision.markInterrupted {
+            self.markModifierOnlyPressInterrupted(
+                message: "\(self.label(for: behavior.holdModeType)) modifier-only press interrupted - extra modifier pressed"
+            )
+        }
+        self.otherKeyPressedDuringModifier = decision.otherKeyPressedDuringModifier
 
-                self.scheduleModifierOnlyStart(for: behavior)
-                return true
-            }
+        switch decision.outcome {
+        case .ignore:
+            return false
+        case .start:
+            self.modifierOnlyKeyDown = true
+            self.modifierPressStartTime = Date()
 
-            let isActiveModifierOnlyPress = self.activeModifierOnlyType == behavior.holdModeType
-            if isActiveModifierOnlyPress || behavior.isModeKeyPressed() {
-                let extraModifierKeyCodes = pressedModifierKeyCodes.filter { !expectedModifierKeyCodes.contains($0) }
-                if !extraModifierKeyCodes.isEmpty {
-                    self.markModifierOnlyPressInterrupted(
-                        message: "\(self.label(for: behavior.holdModeType)) modifier-only press interrupted - extra modifier pressed"
-                    )
-                }
-            }
-
-            guard isActiveModifierOnlyPress || behavior.isModeKeyPressed(),
-                  expectedModifierKeyCodes.contains(keyCode),
-                  !pressedModifierKeyCodes.contains(keyCode)
-            else {
-                return false
-            }
-
-            let wasCleanPress = !self.otherKeyPressedDuringModifier
+            self.scheduleModifierOnlyStart(for: behavior)
+            return true
+        case .finish(let wasCleanPress):
             self.modifierOnlyKeyDown = false
-            self.activeModifierOnlyType = nil
-            self.otherKeyPressedDuringModifier = false
             self.modifierPressStartTime = nil
 
             self.finishModifierOnlyPress(for: behavior, wasCleanPress: wasCleanPress)
             return true
         }
-
-        guard let expectedPressedModifiers = shortcut.expectedModifierFlags,
-              let triggerFlag = shortcut.modifierTriggerFlag
-        else {
-            return false
-        }
-
-        if relevantModifiers == expectedPressedModifiers {
-            self.modifierOnlyKeyDown = true
-            self.activeModifierOnlyType = behavior.holdModeType
-            self.otherKeyPressedDuringModifier = false
-            self.modifierPressStartTime = Date()
-
-            self.scheduleModifierOnlyStart(for: behavior)
-            return true
-        }
-
-        let isActiveModifierOnlyPress = self.activeModifierOnlyType == behavior.holdModeType
-        if isActiveModifierOnlyPress || behavior.isModeKeyPressed() {
-            let unexpectedModifiers = relevantModifiers.subtracting(expectedPressedModifiers)
-            if !unexpectedModifiers.isEmpty {
-                self.markModifierOnlyPressInterrupted(
-                    message: "\(self.label(for: behavior.holdModeType)) modifier-only press interrupted - extra modifier pressed"
-                )
-            }
-        }
-
-        guard isActiveModifierOnlyPress || behavior.isModeKeyPressed(),
-              keyCode == shortcut.keyCode,
-              !relevantModifiers.contains(triggerFlag)
-        else {
-            return false
-        }
-
-        let wasCleanPress = !self.otherKeyPressedDuringModifier
-        self.modifierOnlyKeyDown = false
-        self.activeModifierOnlyType = nil
-        self.otherKeyPressedDuringModifier = false
-        self.modifierPressStartTime = nil
-
-        self.finishModifierOnlyPress(for: behavior, wasCleanPress: wasCleanPress)
-        return true
     }
 
     private func triggerPromptMode() {

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -20,6 +20,8 @@ struct ModifierOnlyShortcutTrackingState: Equatable {
     let pressedModifierKeyCodes: Set<UInt16>
     /// The currently-active modifier-only mode, if any.
     let activeModifierOnlyType: HotkeyHoldModeType?
+    /// The exact shortcut that owns the active modifier-only press.
+    let activeModifierOnlyShortcut: HotkeyShortcut?
     /// Whether a non-configured key was pressed during the active modifier-only press.
     let otherKeyPressedDuringModifier: Bool
     /// Snapshot of the behavior's mode-key-pressed flag.
@@ -46,6 +48,8 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
     let markInterrupted: Bool
     /// Value `activeModifierOnlyType` should hold after this event.
     let activeModifierOnlyType: HotkeyHoldModeType?
+    /// Shortcut that should own the active modifier-only press after this event.
+    let activeModifierOnlyShortcut: HotkeyShortcut?
     /// Value `otherKeyPressedDuringModifier` should hold after this event.
     let otherKeyPressedDuringModifier: Bool
 
@@ -62,6 +66,7 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
     ) -> ModifierOnlyShortcutFlagsDecision {
         let pressedModifierKeyCodes = state.pressedModifierKeyCodes
         let activeModifierOnlyType = state.activeModifierOnlyType
+        let activeModifierOnlyShortcut = state.activeModifierOnlyShortcut
         let otherKeyPressedDuringModifier = state.otherKeyPressedDuringModifier
         let isModeKeyPressed = state.isModeKeyPressed
 
@@ -70,6 +75,7 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
                 outcome: .ignore,
                 markInterrupted: false,
                 activeModifierOnlyType: activeModifierOnlyType,
+                activeModifierOnlyShortcut: activeModifierOnlyShortcut,
                 otherKeyPressedDuringModifier: otherKeyPressedDuringModifier
             )
         }
@@ -86,23 +92,26 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
             // subsequent release reads as a clean tap and falsely starts recording (#688).
             if activeModifierOnlyType == nil,
                pressedKeyCodes == expectedModifierKeyCodes,
-               expectedModifierKeyCodes.contains(keyCode) {
+               expectedModifierKeyCodes.contains(keyCode)
+            {
                 return .init(
                     outcome: .start,
                     markInterrupted: false,
                     activeModifierOnlyType: holdModeType,
+                    activeModifierOnlyShortcut: shortcut,
                     otherKeyPressedDuringModifier: false
                 )
             }
 
-            let isActiveModifierOnlyPress = activeModifierOnlyType == holdModeType
+            let isActiveModifierOnlyPress = activeModifierOnlyType == holdModeType && activeModifierOnlyShortcut == shortcut
+            let isLegacyModePress = activeModifierOnlyShortcut == nil && isModeKeyPressed
             var markInterrupted = false
-            if isActiveModifierOnlyPress || isModeKeyPressed {
+            if isActiveModifierOnlyPress || isLegacyModePress {
                 let extraModifierKeyCodes = pressedKeyCodes.filter { !expectedModifierKeyCodes.contains($0) }
                 markInterrupted = !extraModifierKeyCodes.isEmpty
             }
 
-            guard isActiveModifierOnlyPress || isModeKeyPressed,
+            guard isActiveModifierOnlyPress || isLegacyModePress,
                   expectedModifierKeyCodes.contains(keyCode),
                   !pressedKeyCodes.contains(keyCode)
             else {
@@ -110,6 +119,7 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
                     outcome: .ignore,
                     markInterrupted: markInterrupted,
                     activeModifierOnlyType: activeModifierOnlyType,
+                    activeModifierOnlyShortcut: activeModifierOnlyShortcut,
                     otherKeyPressedDuringModifier: markInterrupted ? true : otherKeyPressedDuringModifier
                 )
             }
@@ -119,6 +129,7 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
                 outcome: .finish(wasCleanPress: wasCleanPress),
                 markInterrupted: markInterrupted,
                 activeModifierOnlyType: nil,
+                activeModifierOnlyShortcut: nil,
                 otherKeyPressedDuringModifier: false
             )
         }
@@ -130,6 +141,7 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
                 outcome: .ignore,
                 markInterrupted: false,
                 activeModifierOnlyType: activeModifierOnlyType,
+                activeModifierOnlyShortcut: activeModifierOnlyShortcut,
                 otherKeyPressedDuringModifier: otherKeyPressedDuringModifier
             )
         }
@@ -143,23 +155,26 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
         if activeModifierOnlyType == nil,
            relevantModifiers == expectedPressedModifiers,
            let changedModifierFlag = HotkeyShortcut.modifierFlag(forKeyCode: keyCode),
-           expectedPressedModifiers.contains(changedModifierFlag) {
+           expectedPressedModifiers.contains(changedModifierFlag)
+        {
             return .init(
                 outcome: .start,
                 markInterrupted: false,
                 activeModifierOnlyType: holdModeType,
+                activeModifierOnlyShortcut: shortcut,
                 otherKeyPressedDuringModifier: false
             )
         }
 
-        let isActiveModifierOnlyPress = activeModifierOnlyType == holdModeType
+        let isActiveModifierOnlyPress = activeModifierOnlyType == holdModeType && activeModifierOnlyShortcut == shortcut
+        let isLegacyModePress = activeModifierOnlyShortcut == nil && isModeKeyPressed
         var markInterrupted = false
-        if isActiveModifierOnlyPress || isModeKeyPressed {
+        if isActiveModifierOnlyPress || isLegacyModePress {
             let unexpectedModifiers = relevantModifiers.subtracting(expectedPressedModifiers)
             markInterrupted = !unexpectedModifiers.isEmpty
         }
 
-        guard isActiveModifierOnlyPress || isModeKeyPressed,
+        guard isActiveModifierOnlyPress || isLegacyModePress,
               keyCode == shortcut.keyCode,
               !relevantModifiers.contains(triggerFlag)
         else {
@@ -167,6 +182,7 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
                 outcome: .ignore,
                 markInterrupted: markInterrupted,
                 activeModifierOnlyType: activeModifierOnlyType,
+                activeModifierOnlyShortcut: activeModifierOnlyShortcut,
                 otherKeyPressedDuringModifier: markInterrupted ? true : otherKeyPressedDuringModifier
             )
         }
@@ -176,6 +192,7 @@ struct ModifierOnlyShortcutFlagsDecision: Equatable {
             outcome: .finish(wasCleanPress: wasCleanPress),
             markInterrupted: markInterrupted,
             activeModifierOnlyType: nil,
+            activeModifierOnlyShortcut: nil,
             otherKeyPressedDuringModifier: false
         )
     }
@@ -191,6 +208,7 @@ private final nonisolated class HotkeyState: @unchecked Sendable {
     var pressedModifierKeyCodes: Set<UInt16> = []
     var modifierOnlyKeyDown = false
     var activeModifierOnlyType: HotkeyHoldModeType?
+    var activeModifierOnlyShortcut: HotkeyShortcut?
     var otherKeyPressedDuringModifier = false
     var modifierPressStartTime: Date?
     var holdModeStartTriggeredTypes: Set<HotkeyHoldModeType> = []
@@ -303,6 +321,11 @@ final class GlobalHotkeyManager: NSObject {
     private nonisolated var activeModifierOnlyType: HotkeyHoldModeType? {
         get { self.state.withLock { self.state.activeModifierOnlyType } }
         set { self.state.withLock { self.state.activeModifierOnlyType = newValue } }
+    }
+
+    private nonisolated var activeModifierOnlyShortcut: HotkeyShortcut? {
+        get { self.state.withLock { self.state.activeModifierOnlyShortcut } }
+        set { self.state.withLock { self.state.activeModifierOnlyShortcut = newValue } }
     }
 
     private nonisolated var otherKeyPressedDuringModifier: Bool {
@@ -1680,12 +1703,14 @@ final class GlobalHotkeyManager: NSObject {
             state: ModifierOnlyShortcutTrackingState(
                 pressedModifierKeyCodes: self.pressedModifierKeyCodes,
                 activeModifierOnlyType: self.activeModifierOnlyType,
+                activeModifierOnlyShortcut: self.activeModifierOnlyShortcut,
                 otherKeyPressedDuringModifier: self.otherKeyPressedDuringModifier,
                 isModeKeyPressed: behavior.isModeKeyPressed()
             )
         )
 
         self.activeModifierOnlyType = decision.activeModifierOnlyType
+        self.activeModifierOnlyShortcut = decision.activeModifierOnlyShortcut
         if decision.markInterrupted {
             self.markModifierOnlyPressInterrupted(
                 message: "\(self.label(for: behavior.holdModeType)) modifier-only press interrupted - extra modifier pressed"
@@ -1702,7 +1727,7 @@ final class GlobalHotkeyManager: NSObject {
 
             self.scheduleModifierOnlyStart(for: behavior)
             return true
-        case .finish(let wasCleanPress):
+        case let .finish(wasCleanPress):
             self.modifierOnlyKeyDown = false
             self.modifierPressStartTime = nil
 

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -466,6 +466,30 @@ final class HotkeyShortcutTests: XCTestCase {
         )
     }
 
+    func testReleasingSecondPrimaryModifierDoesNotFinishActiveShortcut() {
+        let leftOption = HotkeyShortcut(keyCode: 58, modifierFlags: .option, modifierKeyCodes: [58])
+        let rightOption = HotkeyShortcut(keyCode: 61, modifierFlags: .option, modifierKeyCodes: [61])
+
+        let decision = ModifierOnlyShortcutFlagsDecision.evaluate(
+            shortcut: rightOption,
+            holdModeType: .transcription,
+            isEnabled: true,
+            keyCode: 61,
+            modifiers: .option,
+            state: ModifierOnlyShortcutTrackingState(
+                pressedModifierKeyCodes: [58],
+                activeModifierOnlyType: .transcription,
+                activeModifierOnlyShortcut: leftOption,
+                otherKeyPressedDuringModifier: true,
+                isModeKeyPressed: true
+            )
+        )
+
+        XCTAssertEqual(decision.outcome, .ignore)
+        XCTAssertEqual(decision.activeModifierOnlyType, .transcription)
+        XCTAssertEqual(decision.activeModifierOnlyShortcut, leftOption)
+    }
+
     func testPrimaryDictationShortcutsFallbackToLegacyShortcut() throws {
         try self.withRestoredDefaults(keys: [self.legacyHotkeyShortcutKey, self.primaryDictationShortcutsKey]) {
             let legacyShortcut = HotkeyShortcut(keyCode: 12, modifierFlags: [.option])
@@ -888,6 +912,7 @@ private final class ModifierOnlyFlagsReplay {
     let shortcut: HotkeyShortcut
     private(set) var pressedModifierKeyCodes: Set<UInt16> = []
     private(set) var activeModifierOnlyType: HotkeyHoldModeType?
+    private(set) var activeModifierOnlyShortcut: HotkeyShortcut?
     private(set) var otherKeyPressedDuringModifier = false
     /// Number of `.finish(wasCleanPress: true)` outcomes — the toggle-mode "start recording" path.
     private(set) var cleanFinishCount = 0
@@ -897,32 +922,34 @@ private final class ModifierOnlyFlagsReplay {
     }
 
     func flagsChanged(keyCode: UInt16, modifiers: NSEvent.ModifierFlags, nextPressed: Set<UInt16>) {
-        pressedModifierKeyCodes = nextPressed
+        self.pressedModifierKeyCodes = nextPressed
         let decision = ModifierOnlyShortcutFlagsDecision.evaluate(
-            shortcut: shortcut,
+            shortcut: self.shortcut,
             holdModeType: .transcription,
             isEnabled: true,
             keyCode: keyCode,
             modifiers: modifiers,
             state: ModifierOnlyShortcutTrackingState(
-                pressedModifierKeyCodes: pressedModifierKeyCodes,
-                activeModifierOnlyType: activeModifierOnlyType,
-                otherKeyPressedDuringModifier: otherKeyPressedDuringModifier,
+                pressedModifierKeyCodes: self.pressedModifierKeyCodes,
+                activeModifierOnlyType: self.activeModifierOnlyType,
+                activeModifierOnlyShortcut: self.activeModifierOnlyShortcut,
+                otherKeyPressedDuringModifier: self.otherKeyPressedDuringModifier,
                 isModeKeyPressed: false
             )
         )
-        activeModifierOnlyType = decision.activeModifierOnlyType
-        otherKeyPressedDuringModifier = decision.otherKeyPressedDuringModifier
-        if case .finish(let wasCleanPress) = decision.outcome, wasCleanPress {
-            cleanFinishCount += 1
+        self.activeModifierOnlyType = decision.activeModifierOnlyType
+        self.activeModifierOnlyShortcut = decision.activeModifierOnlyShortcut
+        self.otherKeyPressedDuringModifier = decision.otherKeyPressedDuringModifier
+        if case let .finish(wasCleanPress) = decision.outcome, wasCleanPress {
+            self.cleanFinishCount += 1
         }
     }
 
     /// Simulates a non-modifier keyDown during an active modifier-only press
     /// (GlobalHotkeyManager.markOtherInputDuringModifierOnly).
     func keyDown() {
-        if activeModifierOnlyType != nil {
-            otherKeyPressedDuringModifier = true
+        if self.activeModifierOnlyType != nil {
+            self.otherKeyPressedDuringModifier = true
         }
     }
 }

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -335,6 +335,137 @@ final class HotkeyShortcutTests: XCTestCase {
         XCTAssertFalse(unmodifiedSideButton.conflictsWith(optionOnly))
     }
 
+    /// Regression for #688: a single-modifier dictation hotkey (Left Option) must not falsely
+    /// start recording when an unrelated Shift+key combo is typed while the configured modifier
+    /// is held. The release of the extra Shift used to re-enter the modifier-only start block and
+    /// erase the "another key was pressed" flag, so the subsequent Option release read as a clean
+    /// tap and started recording.
+    func testModifierOnlyShortcutDoesNotFireOnUnrelatedShiftKeyCombo() {
+        let replay = ModifierOnlyFlagsReplay(
+            shortcut: HotkeyShortcut(keyCode: 58, modifierFlags: .option, modifierKeyCodes: [58])
+        )
+
+        // Genuine Left-Option press arms the modifier-only press (toggle: no recording yet).
+        replay.flagsChanged(keyCode: 58, modifiers: .option, nextPressed: [58])
+        XCTAssertEqual(replay.activeModifierOnlyType, .transcription)
+        XCTAssertEqual(replay.cleanFinishCount, 0)
+
+        // Shift held during the Option press records an interruption.
+        replay.flagsChanged(keyCode: 56, modifiers: [.option, .shift], nextPressed: [56, 58])
+        XCTAssertTrue(replay.otherKeyPressedDuringModifier)
+
+        // An unrelated key (Return) is typed while the Option press is active.
+        replay.keyDown()
+        XCTAssertTrue(replay.otherKeyPressedDuringModifier)
+
+        // The unrelated Shift is released while Option is still held. This must NOT re-arm the
+        // press or erase the recorded interruption.
+        replay.flagsChanged(keyCode: 56, modifiers: .option, nextPressed: [58])
+
+        // The configured Option is released; the press must be treated as interrupted (not a clean
+        // tap), so recording is NOT started.
+        replay.flagsChanged(keyCode: 58, modifiers: [], nextPressed: [])
+
+        XCTAssertEqual(
+            replay.cleanFinishCount,
+            0,
+            "An unrelated Shift+key combo must not falsely start recording for a Left-Option modifier-only hotkey"
+        )
+        XCTAssertNil(replay.activeModifierOnlyType)
+    }
+
+    /// Companion guard: a genuine clean Left-Option tap must still start recording after the fix.
+    func testModifierOnlyShortcutFiresOnGenuineModifierTap() {
+        let replay = ModifierOnlyFlagsReplay(
+            shortcut: HotkeyShortcut(keyCode: 58, modifierFlags: .option, modifierKeyCodes: [58])
+        )
+
+        replay.flagsChanged(keyCode: 58, modifiers: .option, nextPressed: [58])
+        XCTAssertEqual(replay.activeModifierOnlyType, .transcription)
+
+        replay.flagsChanged(keyCode: 58, modifiers: [], nextPressed: [])
+
+        XCTAssertEqual(replay.cleanFinishCount, 1, "A genuine clean Left-Option tap must still start recording")
+        XCTAssertNil(replay.activeModifierOnlyType)
+    }
+
+    /// From idle (no configured modifier pressed), a bare Shift+Enter must never arm the
+    /// modifier-only hotkey, so `activeModifierOnlyType` stays nil.
+    func testModifierOnlyShortcutIgnoresShiftComboFromIdle() {
+        let replay = ModifierOnlyFlagsReplay(
+            shortcut: HotkeyShortcut(keyCode: 58, modifierFlags: .option, modifierKeyCodes: [58])
+        )
+
+        replay.flagsChanged(keyCode: 56, modifiers: .shift, nextPressed: [56])
+        replay.keyDown()
+
+        XCTAssertNil(replay.activeModifierOnlyType, "Shift+Enter from idle must not arm a Left-Option modifier-only hotkey")
+        XCTAssertEqual(replay.cleanFinishCount, 0)
+    }
+
+    /// Branch-2 (flag-only) modifier-only shortcut coverage. The original start matched on modifier
+    /// flags (side-agnostic), so a Left-Option-stored shortcut must still arm on the sibling Right
+    /// Option, and the #688 re-arm on releasing an extra Shift must stay blocked.
+    func testBranch2ModifierOnlyShortcutArmsOnSiblingAndIgnoresShiftCombo() {
+        // Flag-only form: keyCode 58 with an .option flag and no modifierKeyCodes -> branch 2.
+        let shortcut = HotkeyShortcut(keyCode: 58, modifierFlags: .option)
+        XCTAssertTrue(shortcut.normalizedModifierKeyCodes.isEmpty, "precondition: flag-only shortcut takes branch 2")
+
+        // Sibling side: Right Option (keyCode 61, same .option flag) arms the press.
+        let siblingReplay = ModifierOnlyFlagsReplay(shortcut: shortcut)
+        siblingReplay.flagsChanged(keyCode: 61, modifiers: .option, nextPressed: [61])
+        XCTAssertEqual(
+            siblingReplay.activeModifierOnlyType,
+            .transcription,
+            "Branch-2 Left-Option shortcut must arm on the sibling Right Option (side-agnostic flags)"
+        )
+
+        // #688 analog for branch 2: releasing an extra Shift while Option is held must not re-arm.
+        let comboReplay = ModifierOnlyFlagsReplay(shortcut: shortcut)
+        comboReplay.flagsChanged(keyCode: 58, modifiers: .option, nextPressed: [58])
+        comboReplay.flagsChanged(keyCode: 56, modifiers: [.option, .shift], nextPressed: [56, 58])
+        comboReplay.keyDown()
+        comboReplay.flagsChanged(keyCode: 56, modifiers: .option, nextPressed: [58])
+        comboReplay.flagsChanged(keyCode: 58, modifiers: [], nextPressed: [])
+
+        XCTAssertEqual(comboReplay.cleanFinishCount, 0, "Branch-2 shortcut must not falsely start on an unrelated Shift+key combo")
+    }
+
+    /// Regression for the sibling-side re-arm: while a modifier-only press is active, pressing the
+    /// sibling modifier of the same family (Right Option while Left Option is armed) must NOT
+    /// re-enter `.start` and erase the "another key was pressed" flag. Without the active-press
+    /// guard the sibling's flag is in the expected set so `.start` fires again, the interrupt flag
+    /// is wiped, and the configured modifier's later release reads as a clean tap (#688 class).
+    func testBranch2ModifierOnlyShortcutSiblingPressDoesNotEraseInterrupt() {
+        // Branch-2 (flag-only) Left-Option shortcut.
+        let replay = ModifierOnlyFlagsReplay(shortcut: HotkeyShortcut(keyCode: 58, modifierFlags: .option))
+        XCTAssertTrue(replay.shortcut.normalizedModifierKeyCodes.isEmpty, "precondition: flag-only shortcut takes branch 2")
+
+        // Arm with Left Option, type a key, then press the sibling Right Option mid-press.
+        replay.flagsChanged(keyCode: 58, modifiers: .option, nextPressed: [58])
+        XCTAssertEqual(replay.activeModifierOnlyType, .transcription)
+        replay.keyDown()
+        XCTAssertTrue(replay.otherKeyPressedDuringModifier)
+        replay.flagsChanged(keyCode: 61, modifiers: .option, nextPressed: [58, 61])
+
+        // The sibling press must not re-arm the press or erase the recorded interrupt.
+        XCTAssertTrue(
+            replay.otherKeyPressedDuringModifier,
+            "Sibling-side modifier press must not erase the recorded interrupt flag"
+        )
+        XCTAssertEqual(replay.activeModifierOnlyType, .transcription)
+
+        // Release the sibling, then release the configured Left Option last.
+        replay.flagsChanged(keyCode: 61, modifiers: .option, nextPressed: [58])
+        replay.flagsChanged(keyCode: 58, modifiers: [], nextPressed: [])
+
+        XCTAssertEqual(
+            replay.cleanFinishCount,
+            0,
+            "Sibling press during an active press must not lead to a false clean-tap start"
+        )
+    }
+
     func testPrimaryDictationShortcutsFallbackToLegacyShortcut() throws {
         try self.withRestoredDefaults(keys: [self.legacyHotkeyShortcutKey, self.primaryDictationShortcutsKey]) {
             let legacyShortcut = HotkeyShortcut(keyCode: 12, modifierFlags: [.option])
@@ -746,5 +877,52 @@ private final class FakeAudioDeviceManager: AudioDeviceManaging {
     func defaultInputDevice() -> AudioDevice.Device? {
         guard let defaultInputUID else { return nil }
         return self.inputs.first { $0.uid == defaultInputUID }
+    }
+}
+
+/// Minimal driver that replays a `flagsChanged` / `keyDown` sequence through the pure
+/// `ModifierOnlyShortcutFlagsDecision` state machine. `nextPressed` is the
+/// `synchronizedPressedModifierKeyCodes` output for each event (the sync function is provably
+/// correct for these inputs, so it is driven directly to focus the test on the decision logic).
+private final class ModifierOnlyFlagsReplay {
+    let shortcut: HotkeyShortcut
+    private(set) var pressedModifierKeyCodes: Set<UInt16> = []
+    private(set) var activeModifierOnlyType: HotkeyHoldModeType?
+    private(set) var otherKeyPressedDuringModifier = false
+    /// Number of `.finish(wasCleanPress: true)` outcomes — the toggle-mode "start recording" path.
+    private(set) var cleanFinishCount = 0
+
+    init(shortcut: HotkeyShortcut) {
+        self.shortcut = shortcut
+    }
+
+    func flagsChanged(keyCode: UInt16, modifiers: NSEvent.ModifierFlags, nextPressed: Set<UInt16>) {
+        pressedModifierKeyCodes = nextPressed
+        let decision = ModifierOnlyShortcutFlagsDecision.evaluate(
+            shortcut: shortcut,
+            holdModeType: .transcription,
+            isEnabled: true,
+            keyCode: keyCode,
+            modifiers: modifiers,
+            state: ModifierOnlyShortcutTrackingState(
+                pressedModifierKeyCodes: pressedModifierKeyCodes,
+                activeModifierOnlyType: activeModifierOnlyType,
+                otherKeyPressedDuringModifier: otherKeyPressedDuringModifier,
+                isModeKeyPressed: false
+            )
+        )
+        activeModifierOnlyType = decision.activeModifierOnlyType
+        otherKeyPressedDuringModifier = decision.otherKeyPressedDuringModifier
+        if case .finish(let wasCleanPress) = decision.outcome, wasCleanPress {
+            cleanFinishCount += 1
+        }
+    }
+
+    /// Simulates a non-modifier keyDown during an active modifier-only press
+    /// (GlobalHotkeyManager.markOtherInputDuringModifierOnly).
+    func keyDown() {
+        if activeModifierOnlyType != nil {
+            otherKeyPressedDuringModifier = true
+        }
     }
 }


### PR DESCRIPTION
## Description
When the primary dictation hotkey is a single modifier (e.g. Left Option), an unrelated
Shift+key combo (Shift+Enter, Shift+R) could falsely start recording.

Root cause: the modifier-only start path in `GlobalHotkeyManager` was re-entrant. While the
configured modifier was held together with an extra modifier (Shift), releasing the extra
modifier shrank the pressed-modifier set back to just the configured modifier, which re-triggered
the start block and reset the "another key was pressed" flag. The subsequent release of the
configured modifier then looked like a clean tap and started recording.

The fix gates the start on the `flagsChanged` actually being for the configured modifier, so
releasing an unrelated modifier can no longer re-arm the press or erase the interrupt flag. A
genuine tap (and multi-modifier chords) still work. The start/finish decision was extracted into a
pure, unit-testable helper so a regression test could be added without instantiating the full
global event-tap manager.

## Type of Change
- [x] 🐞 Bug fix

## Related Issue or Discussion
Fixes #688

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: macOS 26.6 (Tahoe, Darwin 25.6.0)
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` → 0 violations in 139 files
- [ ] Ran formatter locally: `swiftformat` is not a CI check for this repo (swiftlint --strict is the authoritative gate)
- [x] Ran tests locally: `xcodebuild test … -only-testing:FluidDictationIntegrationTests/HotkeyShortcutTests` → 43 passed, 0 failures (under a U.S. input source)

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Pure logic fix in the modifier-only state machine — no UI, no hardware, no recording-pipeline
change. `HotkeyHoldModeType` was made internal and the start/finish decision was extracted into
`ModifierOnlyShortcutFlagsDecision.evaluate` to make the state machine unit-testable (the manager
can't be constructed in a test). Behavior-equivalence of the extraction was verified against the
original method; the only intentional behavior change is the new start guard.
