### PR TITLE
Narrow isReasoningModel to actual reasoning models

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -2822,14 +2822,20 @@ final class SettingsStore: ObservableObject {
 
     /// Global check if a model is a reasoning model (requires special params/max_completion_tokens)
     func isReasoningModel(_ model: String) -> Bool {
-        let modelLower = model.lowercased()
+        // Drop a provider/namespace prefix (e.g. OpenRouter's "openai/") so the
+        // family checks below match prefixed reasoning IDs like "openai/o3"
+        // without also matching every non-reasoning "openai/*" model (e.g.
+        // "openai/gpt-4o"), which would strip its temperature control.
+        var modelLower = model.lowercased()
+        if let slash = modelLower.firstIndex(of: "/") {
+            modelLower = String(modelLower[modelLower.index(after: slash)...])
+        }
         return modelLower.hasPrefix("gpt-5") ||
             modelLower.contains("gpt-5.") ||
             modelLower.hasPrefix("o1") ||
             modelLower.hasPrefix("o3") ||
             modelLower.hasPrefix("o4") ||
             modelLower.contains("gpt-oss") ||
-            modelLower.hasPrefix("openai/") ||
             (modelLower.contains("deepseek") && modelLower.contains("reasoner"))
     }
 

--- a/Tests/FluidDictationIntegrationTests/TemperatureSupportTests.swift
+++ b/Tests/FluidDictationIntegrationTests/TemperatureSupportTests.swift
@@ -41,6 +41,44 @@ final class TemperatureSupportTests: XCTestCase {
         }
     }
 
+    func testIsReasoningModel_doesNotMatchEveryOpenAIModel() {
+        // Regression: isReasoningModel matched the whole "openai/" prefix, so
+        // every OpenAI model on a provider like OpenRouter was mis-classified
+        // as a reasoning model and lost temperature control. Only actual
+        // reasoning model families should match.
+        let nonReasoning = [
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "chatgpt-4o-latest",
+            // Provider-prefixed (e.g. OpenRouter) non-reasoning IDs — the bug case
+            "openai/gpt-4o",
+            "openai/gpt-4.1",
+            "openai/gpt-4o-mini",
+            "openai/chatgpt-4o-latest",
+        ]
+        for model in nonReasoning {
+            XCTAssertFalse(
+                SettingsStore.shared.isReasoningModel(model),
+                "\(model) is not a reasoning model and must keep temperature control"
+            )
+        }
+
+        // Control: known reasoning models still classify as reasoning, both
+        // bare and provider-prefixed.
+        let reasoning = [
+            "o1", "o3-mini", "o4-mini", "gpt-5", "gpt-5-mini",
+            "openai/o3", "openai/o3-mini", "openai/gpt-5", "openai/gpt-oss-120b",
+            "deepseek/deepseek-reasoner",
+        ]
+        for model in reasoning {
+            XCTAssertTrue(
+                SettingsStore.shared.isReasoningModel(model),
+                "\(model) is a reasoning model"
+            )
+        }
+    }
+
     func testTemperatureSupported_olderAndNonAnthropicModels() {
         let supported = [
             "gpt-4.1",
@@ -48,6 +86,9 @@ final class TemperatureSupportTests: XCTestCase {
             "claude-sonnet-4-20250514",
             "gemini-2.5-flash",
             "llama3",
+            // OpenRouter-prefixed non-reasoning OpenAI models keep temperature
+            "openai/gpt-4o",
+            "openai/gpt-4.1",
             // Dotted OpenRouter IDs for models that still accept temperature
             "anthropic/claude-sonnet-4.6",
             "anthropic/claude-sonnet-4.5",


### PR DESCRIPTION
## Description

`isReasoningModel` — and therefore `isTemperatureUnsupported` — matched the broad `openai/` provider prefix, so **every** OpenAI model was classified as a reasoning model and silently lost its temperature setting. Non-reasoning models such as `openai/gpt-4o` and `openai/gpt-4.1` were affected.

This narrows the predicate to actual reasoning models. It strips one namespace level (the provider prefix) before matching the model family, so `o1` / `o3` / `o4` / `gpt-5` / `gpt-oss` / `deepseek-reasoner` are still recognised — and now regardless of which provider serves them — while ordinary OpenAI models regain temperature control.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue or Discussion

Related to #55 — "Temperature issue when using OpenAI reasoning models", the report this predicate was written for. That fix was correct in intent but matched on the provider prefix rather than the model family, which is what this PR narrows. #55 stays fixed: every model named in it still returns `true`. Same family as #285 and #535.

## Testing

- [x] `Tests/FluidDictationIntegrationTests/TemperatureSupportTests.swift` — new cases proving red → green: on the old broad-prefix code `isReasoningModel("openai/gpt-4o")` returned `true` (red); with the narrowed predicate it returns `false` (green). Real reasoning models are asserted to still return `true`, so #55 cannot regress.
- [ ] Full `xcodebuild test` — not run: the test host hung launching in my headless worktree ("test runner hung before establishing connection"). The predicate is pure logic and is covered by the tests above; CI runs the host normally.

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

The only production file touched is `Sources/Fluid/Persistence/SettingsStore.swift` — a string-matching predicate with no UI surface. (It trips the policy's visual-path heuristic only because its basename begins with `Settings`.)

---

This change was developed with AI assistance (Claude Code); every changed line was reviewed and understood.
