### PR TITLE
Fix first-run microphone selection

### DIFF
--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1867,6 +1867,10 @@ final class SettingsStore: ObservableObject {
         return mode
     }
 
+    var hasStoredMicSelectionModeForMigration: Bool {
+        self.defaults.object(forKey: Keys.microphoneSelectionMode) != nil
+    }
+
     var microphoneSelectionMode: MicrophoneSelectionMode {
         get {
             guard let rawValue = self.defaults.string(forKey: Keys.microphoneSelectionMode),

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -186,6 +186,11 @@ final class ASRService: ObservableObject {
     @Published var downloadingModelId: String? = nil // Tracks which model is currently being downloaded
     @Published private(set) var isCancellingModelDownload: Bool = false
     @Published private(set) var isDictionaryTrainingCaptureActive: Bool = false
+    @Published private(set) var isMicrophonePreviewActive: Bool = false
+    @Published private(set) var microphonePreviewError: String?
+    @Published private(set) var audioCaptureStateSettledTick: UInt64 = 0
+    private var microphonePreviewOperationGeneration: UInt64 = 0
+    private var isMicrophonePreviewRequested = false
     private(set) var lastDictionaryTrainingResult: ASRTranscriptionResult?
     private(set) var dictionaryTrainingAudioGeneration = 0
 
@@ -1488,6 +1493,122 @@ final class ASRService: ObservableObject {
         }
     }
 
+    func startMicrophonePreview() async {
+        guard self.micStatus == .authorized,
+              self.isRunning == false,
+              self.isStarting == false,
+              self.isTerminating == false
+        else { return }
+
+        self.microphonePreviewOperationGeneration &+= 1
+        let operationGeneration = self.microphonePreviewOperationGeneration
+        self.isMicrophonePreviewRequested = true
+
+        if self.isMicrophonePreviewActive || self.audioCapturePipeline.isLevelMonitoringEnabled {
+            self.audioCapturePipeline.setLevelMonitoringEnabled(false)
+            _ = await self.directAudioLifecycleController.stop(
+                retainPrepared: false,
+                reason: "onboarding_microphone_preview_restart"
+            )
+            guard operationGeneration == self.microphonePreviewOperationGeneration,
+                  self.isMicrophonePreviewRequested,
+                  self.isRunning == false,
+                  self.isStarting == false,
+                  self.isTerminating == false
+            else { return }
+            self.activeAudioCaptureBackend = .none
+            self.isMicrophonePreviewActive = false
+            self.audioLevelSubject.send(0)
+        }
+
+        self.audioEngineStandbyTask?.cancel()
+        self.audioEngineStandbyTask = nil
+        await self.audioEngineRetirementDrain.waitForScheduledReleases()
+        guard operationGeneration == self.microphonePreviewOperationGeneration,
+              self.isMicrophonePreviewRequested,
+              self.isRunning == false,
+              self.isStarting == false,
+              self.isTerminating == false
+        else { return }
+        self.microphonePreviewError = nil
+        self.audioCapturePipeline.setLevelMonitoringEnabled(true)
+
+        do {
+            guard let selection = self.directCoreAudioDeviceSelection() else {
+                throw NSError(
+                    domain: "ASRService",
+                    code: -4,
+                    userInfo: [NSLocalizedDescriptionKey: "No usable microphone is available."]
+                )
+            }
+            let device = try await self.directAudioLifecycleController.resolveDevice(
+                selection: selection,
+                reason: "onboarding_microphone_preview"
+            )
+            try Task.checkCancellation()
+            guard operationGeneration == self.microphonePreviewOperationGeneration,
+                  self.isRunning == false,
+                  self.isStarting == false,
+                  self.isTerminating == false
+            else { throw CancellationError() }
+            _ = try await self.directAudioLifecycleController.start(
+                deviceID: device.id,
+                deviceName: device.name,
+                reason: "onboarding_microphone_preview"
+            )
+            try Task.checkCancellation()
+            guard operationGeneration == self.microphonePreviewOperationGeneration,
+                  self.isRunning == false,
+                  self.isStarting == false,
+                  self.isTerminating == false
+            else { throw CancellationError() }
+            self.activeAudioCaptureBackend = .directCoreAudio
+            self.isMicrophonePreviewActive = true
+            DebugLogger.shared.info(
+                "Started onboarding microphone preview with '\(device.name)'",
+                source: "ASRService"
+            )
+        } catch {
+            // A newer preview, page-exit stop, or dictation start owns cleanup
+            // after invalidating this operation. Do not tear down its capture.
+            guard operationGeneration == self.microphonePreviewOperationGeneration else {
+                return
+            }
+            self.audioCapturePipeline.setLevelMonitoringEnabled(false)
+            await self.directAudioLifecycleController.invalidate(
+                reason: "onboarding_microphone_preview_failed"
+            )
+            self.activeAudioCaptureBackend = .none
+            self.isMicrophonePreviewActive = false
+            self.isMicrophonePreviewRequested = false
+            self.microphonePreviewError = error is CancellationError ? nil : error.localizedDescription
+            guard error is CancellationError == false else { return }
+            DebugLogger.shared.warning(
+                "Onboarding microphone preview failed: \(error.localizedDescription)",
+                source: "ASRService"
+            )
+        }
+    }
+
+    func stopMicrophonePreview(retainPreparedCapture: Bool = true) async {
+        self.microphonePreviewOperationGeneration &+= 1
+        let operationGeneration = self.microphonePreviewOperationGeneration
+        self.isMicrophonePreviewRequested = false
+        guard self.isMicrophonePreviewActive || self.audioCapturePipeline.isLevelMonitoringEnabled else {
+            return
+        }
+
+        self.audioCapturePipeline.setLevelMonitoringEnabled(false)
+        _ = await self.directAudioLifecycleController.stop(
+            retainPrepared: retainPreparedCapture,
+            reason: "onboarding_microphone_preview_stop"
+        )
+        guard operationGeneration == self.microphonePreviewOperationGeneration else { return }
+        self.activeAudioCaptureBackend = .none
+        self.isMicrophonePreviewActive = false
+        self.audioLevelSubject.send(0)
+    }
+
     func openSystemSettingsForMic() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
             NSWorkspace.shared.open(url)
@@ -1532,6 +1653,9 @@ final class ASRService: ObservableObject {
         guard self.isTerminating == false else {
             DebugLogger.shared.warning("START() blocked - app is terminating", source: "ASRService")
             return .failed
+        }
+        if self.isMicrophonePreviewActive || self.audioCapturePipeline.isLevelMonitoringEnabled {
+            await self.stopMicrophonePreview()
         }
         self.audioCaptureStartGeneration &+= 1
         let startGeneration = self.audioCaptureStartGeneration
@@ -1909,6 +2033,7 @@ final class ASRService: ObservableObject {
 
     private func finishAudioCaptureStart() {
         self.isStarting = false
+        self.audioCaptureStateSettledTick &+= 1
         let waiters = self.audioCaptureStartWaiters
         self.audioCaptureStartWaiters.removeAll(keepingCapacity: false)
         waiters.forEach { $0.resume() }
@@ -1998,6 +2123,7 @@ final class ASRService: ObservableObject {
 
         await self.stopActiveAudioCapture(reason: "recording_stop")
         self.audioCapturePipeline.finishRecording()
+        self.audioCaptureStateSettledTick &+= 1
 
         // A prepared direct IOProc owns only fixed memory and registration; it
         // does not run hardware, show the mic indicator, or hold Bluetooth in
@@ -2365,6 +2491,7 @@ final class ASRService: ObservableObject {
 
         // Cancel/no-transcription paths stay conservative and retire the engine.
         await self.retireAudioEngineAndWait(reason: "stop_without_transcription")
+        self.audioCaptureStateSettledTick &+= 1
 
         // CRITICAL FIX: Await completion of streaming task AND any pending transcriptions
         // This prevents use-after-free crashes (EXC_BAD_ACCESS) when clearing buffer
@@ -3028,6 +3155,8 @@ final class ASRService: ObservableObject {
     private func recoverIdleAudioRoute(_ request: AudioRouteRecoveryRequest) async {
         let shouldRebuild = self.hasPreparedAudioCapture || request.requiresIdlePrewarm
         guard shouldRebuild else { return }
+        let shouldRestoreMicrophonePreview = self.isMicrophonePreviewRequested
+        let microphonePreviewGeneration = self.microphonePreviewOperationGeneration
 
         // If another event arrives while retirement is draining, the next
         // generation still needs to restore the prepared capture backend.
@@ -3043,10 +3172,17 @@ final class ASRService: ObservableObject {
         await self.retireAudioEngineAndWait(reason: "idle_route_change:\(request.reason)")
 
         guard request.generation == self.audioRouteRecoveryGeneration, Task.isCancelled == false else { return }
-        await self.prewarmConfiguredAudioCaptureIfPossible(
-            reason: "idle_route_change",
-            allowDuringRouteRecovery: true
-        )
+        if shouldRestoreMicrophonePreview,
+           self.isMicrophonePreviewRequested,
+           microphonePreviewGeneration == self.microphonePreviewOperationGeneration
+        {
+            await self.startMicrophonePreview()
+        } else {
+            await self.prewarmConfiguredAudioCaptureIfPossible(
+                reason: "idle_route_change",
+                allowDuringRouteRecovery: true
+            )
+        }
     }
 
     private func recoverActiveAudioRoute(_ request: AudioRouteRecoveryRequest) async {
@@ -4614,6 +4750,7 @@ private final nonisolated class AudioCapturePipeline: @unchecked Sendable {
 
     private let lock = NSLock()
     private var recordingEnabled: Bool = false
+    private var levelMonitoringEnabled: Bool = false
     private var firstAudioReported: Bool = false
     private var recordingSessionID: Int = 0
     private var recordingAttemptID: UInt64 = 0
@@ -4677,6 +4814,25 @@ private final nonisolated class AudioCapturePipeline: @unchecked Sendable {
             self.smoothedLevel = 0.0
         }
         self.lock.unlock()
+    }
+
+    var isLevelMonitoringEnabled: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.levelMonitoringEnabled
+    }
+
+    func setLevelMonitoringEnabled(_ enabled: Bool) {
+        self.lock.lock()
+        self.levelMonitoringEnabled = enabled
+        if enabled == false, self.recordingEnabled == false {
+            self.levelHistory.removeAll(keepingCapacity: true)
+            self.smoothedLevel = 0
+        }
+        self.lock.unlock()
+        if enabled == false {
+            self.onLevel(0)
+        }
     }
 
     /// Sets the exact last acquisition time accepted for the current session.
@@ -4745,8 +4901,15 @@ private final nonisolated class AudioCapturePipeline: @unchecked Sendable {
         }
 
         self.lock.lock()
-        guard self.recordingEnabled else {
+        let recordingEnabled = self.recordingEnabled
+        let levelMonitoringEnabled = self.levelMonitoringEnabled
+        guard recordingEnabled || levelMonitoringEnabled else {
             self.lock.unlock()
+            return
+        }
+        if recordingEnabled == false {
+            self.lock.unlock()
+            self.onLevel(self.calculateAudioLevel(samples))
             return
         }
         let startHostTime = self.recordingStartHostTime

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1654,13 +1654,25 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.warning("START() blocked - app is terminating", source: "ASRService")
             return .failed
         }
-        if self.isMicrophonePreviewActive || self.audioCapturePipeline.isLevelMonitoringEnabled {
-            await self.stopMicrophonePreview()
-        }
         self.audioCaptureStartGeneration &+= 1
         let startGeneration = self.audioCaptureStartGeneration
         self.isStarting = true
         defer { self.finishAudioCaptureStart() }
+
+        // Reserve the start before preview teardown yields. Press-and-hold release
+        // must be able to see and cancel this handoff before capture hardware starts.
+        if self.isMicrophonePreviewActive || self.audioCapturePipeline.isLevelMonitoringEnabled {
+            await self.stopMicrophonePreview()
+            guard startGeneration == self.audioCaptureStartGeneration,
+                  self.isTerminating == false
+            else {
+                DebugLogger.shared.debug(
+                    "Audio capture start cancelled during microphone preview handoff",
+                    source: "ASRService"
+                )
+                return .failed
+            }
+        }
 
         // Reset media pause state for this session
         self.didPauseMediaForThisSession = false

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1528,8 +1528,12 @@ final class ASRService: ObservableObject {
                   self.isMicrophonePreviewRequested,
                   self.isRunning == false,
                   self.isStarting == false,
-                  self.isTerminating == false
-            else { return }
+                  self.isTerminating == false,
+                  Task.isCancelled == false
+            else {
+                self.abandonMicrophonePreviewRequestIfOwned(operationGeneration)
+                return
+            }
             self.activeAudioCaptureBackend = .none
             self.isMicrophonePreviewActive = false
             self.audioLevelSubject.send(0)
@@ -1542,8 +1546,12 @@ final class ASRService: ObservableObject {
               self.isMicrophonePreviewRequested,
               self.isRunning == false,
               self.isStarting == false,
-              self.isTerminating == false
-        else { return }
+              self.isTerminating == false,
+              Task.isCancelled == false
+        else {
+            self.abandonMicrophonePreviewRequestIfOwned(operationGeneration)
+            return
+        }
         self.microphonePreviewError = nil
         self.audioCapturePipeline.setLevelMonitoringEnabled(true)
 
@@ -1608,6 +1616,7 @@ final class ASRService: ObservableObject {
         self.microphonePreviewOperationGeneration &+= 1
         let operationGeneration = self.microphonePreviewOperationGeneration
         self.isMicrophonePreviewRequested = false
+        self.microphonePreviewError = nil
         guard self.isMicrophonePreviewActive || self.audioCapturePipeline.isLevelMonitoringEnabled else {
             return
         }
@@ -1620,6 +1629,33 @@ final class ASRService: ObservableObject {
         guard operationGeneration == self.microphonePreviewOperationGeneration else { return }
         self.activeAudioCaptureBackend = .none
         self.isMicrophonePreviewActive = false
+        self.audioLevelSubject.send(0)
+    }
+
+    private func abandonMicrophonePreviewRequestIfOwned(_ operationGeneration: UInt64) {
+        guard operationGeneration == self.microphonePreviewOperationGeneration else { return }
+        self.isMicrophonePreviewRequested = false
+        self.audioCapturePipeline.setLevelMonitoringEnabled(false)
+        self.activeAudioCaptureBackend = .none
+        self.isMicrophonePreviewActive = false
+        self.microphonePreviewError = nil
+        self.audioLevelSubject.send(0)
+    }
+
+    private func handOffMicrophonePreviewToCaptureStartIfNeeded() {
+        guard self.isMicrophonePreviewRequested ||
+            self.isMicrophonePreviewActive ||
+            self.audioCapturePipeline.isLevelMonitoringEnabled
+        else { return }
+
+        // Invalidate preview ownership without stopping Core Audio. The direct
+        // lifecycle serializes any in-flight preview start, and recording can
+        // reuse the already-running input without losing opening PCM.
+        self.microphonePreviewOperationGeneration &+= 1
+        self.isMicrophonePreviewRequested = false
+        self.audioCapturePipeline.setLevelMonitoringEnabled(false)
+        self.isMicrophonePreviewActive = false
+        self.microphonePreviewError = nil
         self.audioLevelSubject.send(0)
     }
 
@@ -1673,20 +1709,10 @@ final class ASRService: ObservableObject {
         self.isStarting = true
         defer { self.finishAudioCaptureStart() }
 
-        // Reserve the start before preview teardown yields. Press-and-hold release
-        // must be able to see and cancel this handoff before capture hardware starts.
-        if self.isMicrophonePreviewActive || self.audioCapturePipeline.isLevelMonitoringEnabled {
-            await self.stopMicrophonePreview()
-            guard startGeneration == self.audioCaptureStartGeneration,
-                  self.isTerminating == false
-            else {
-                DebugLogger.shared.debug(
-                    "Audio capture start cancelled during microphone preview handoff",
-                    source: "ASRService"
-                )
-                return .failed
-            }
-        }
+        // Reserve the start before relinquishing preview ownership so a
+        // press-and-hold release can cancel the handoff. Keep the running input
+        // alive; startConfiguredAudioCapture reuses it for zero-stop first PCM.
+        self.handOffMicrophonePreviewToCaptureStartIfNeeded()
 
         // Reset media pause state for this session
         self.didPauseMediaForThisSession = false

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1081,6 +1081,7 @@ final class ASRService: ObservableObject {
 
     private var inputFormat: AVAudioFormat?
     private var micPermissionGranted = false
+    private var isRequestingMicrophoneAccess = false
 
     // Internal access for MeetingTranscriptionService to share models
     // Note: Only available when using FluidAudioProvider (Apple Silicon)
@@ -1476,18 +1477,31 @@ final class ASRService: ObservableObject {
     }
 
     func requestMicAccess() {
-        AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
-            guard let self = self else { return }
-            Task { @MainActor in
-                self.micPermissionGranted = granted
-                self.micStatus = granted ? .authorized : .denied
-                if granted {
-                    AppServices.shared.microphonePreferenceCoordinator.scheduleStartupNoticeIfEligible(
-                        microphoneAuthorized: true,
-                        launchAllowsPresentation: (NSApp.delegate as? AppDelegate)?
-                            .shouldPresentStartupMicrophoneNotice ?? true
-                    )
-                    await self.prewarmConfiguredAudioCaptureIfPossible(reason: "permission_granted")
+        guard self.isRequestingMicrophoneAccess == false else { return }
+        self.isRequestingMicrophoneAccess = true
+        Task { @MainActor [weak self] in
+            await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+            await AudioStartupGate.shared.waitUntilOpen()
+            guard let self else { return }
+            guard self.isTerminating == false else {
+                self.isRequestingMicrophoneAccess = false
+                return
+            }
+
+            AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.isRequestingMicrophoneAccess = false
+                    self.micPermissionGranted = granted
+                    self.micStatus = granted ? .authorized : .denied
+                    if granted {
+                        AppServices.shared.microphonePreferenceCoordinator.scheduleStartupNoticeIfEligible(
+                            microphoneAuthorized: true,
+                            launchAllowsPresentation: (NSApp.delegate as? AppDelegate)?
+                                .shouldPresentStartupMicrophoneNotice ?? true
+                        )
+                        await self.prewarmConfiguredAudioCaptureIfPossible(reason: "permission_granted")
+                    }
                 }
             }
         }

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1642,11 +1642,11 @@ final class ASRService: ObservableObject {
         self.audioLevelSubject.send(0)
     }
 
-    private func handOffMicrophonePreviewToCaptureStartIfNeeded() {
+    private func handOffMicrophonePreviewToCaptureStartIfNeeded() -> Bool {
         guard self.isMicrophonePreviewRequested ||
             self.isMicrophonePreviewActive ||
             self.audioCapturePipeline.isLevelMonitoringEnabled
-        else { return }
+        else { return false }
 
         // Invalidate preview ownership without stopping Core Audio. The direct
         // lifecycle serializes any in-flight preview start, and recording can
@@ -1656,6 +1656,17 @@ final class ASRService: ObservableObject {
         self.audioCapturePipeline.setLevelMonitoringEnabled(false)
         self.isMicrophonePreviewActive = false
         self.microphonePreviewError = nil
+        self.audioLevelSubject.send(0)
+        return true
+    }
+
+    private func stopHandedOffMicrophonePreviewAfterCancelledStart() async {
+        self.audioCapturePipeline.setRecordingEnabled(false)
+        _ = await self.directAudioLifecycleController.stop(
+            retainPrepared: true,
+            reason: "cancelled_microphone_preview_handoff"
+        )
+        self.activeAudioCaptureBackend = .none
         self.audioLevelSubject.send(0)
     }
 
@@ -1712,7 +1723,7 @@ final class ASRService: ObservableObject {
         // Reserve the start before relinquishing preview ownership so a
         // press-and-hold release can cancel the handoff. Keep the running input
         // alive; startConfiguredAudioCapture reuses it for zero-stop first PCM.
-        self.handOffMicrophonePreviewToCaptureStartIfNeeded()
+        let handedOffMicrophonePreview = self.handOffMicrophonePreviewToCaptureStartIfNeeded()
 
         // Reset media pause state for this session
         self.didPauseMediaForThisSession = false
@@ -1722,6 +1733,9 @@ final class ASRService: ObservableObject {
         guard startGeneration == self.audioCaptureStartGeneration,
               self.isTerminating == false
         else {
+            if handedOffMicrophonePreview {
+                await self.stopHandedOffMicrophonePreviewAfterCancelledStart()
+            }
             DebugLogger.shared.debug(
                 "Audio capture start cancelled during route handoff generation=\(startGeneration)",
                 source: "ASRService"

--- a/Sources/Fluid/Services/DirectCoreAudioInput.swift
+++ b/Sources/Fluid/Services/DirectCoreAudioInput.swift
@@ -844,6 +844,29 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                     guard let validatedInput = self.input else {
                         throw Self.error("Direct Core Audio input disappeared before start.")
                     }
+                    if validatedInput.isRunning {
+                        let runningFingerprint = try self.fingerprintReader(deviceID)
+                        guard runningFingerprint == validatedInput.formatFingerprint,
+                              validatedInput.openPacketGateIfClean()
+                        else {
+                            throw Self.error(
+                                "Direct Core Audio format changed while reusing running input generation " +
+                                    "\(self.generation)."
+                            )
+                        }
+                        self.publishSnapshot(
+                            phase: .running,
+                            input: validatedInput,
+                            fingerprint: validatedInput.formatFingerprint
+                        )
+                        Self.log(
+                            "Direct capture start reused running input generation=\(self.generation) " +
+                                "device='\(deviceName)'",
+                            level: .debug
+                        )
+                        continuation.resume(returning: self.snapshot)
+                        return
+                    }
                     self.publishSnapshot(
                         phase: .starting,
                         input: validatedInput,

--- a/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
+++ b/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
@@ -87,10 +87,13 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         let enumeratedPreferredInput = availableInputs.first { input in
             input.uid == self.settings.preferredInputDeviceUID
         }
+        let enumeratedDefaultInput = defaultInputUID.flatMap { uid in
+            availableInputs.first { $0.uid == uid }
+        }
         let defaultInput = defaultInputUID.flatMap { uid in
             usableInputs.first { $0.uid == uid }
         }
-        let migrationInputs = defaultInput.map { input in
+        let migrationInputs = enumeratedDefaultInput.map { input in
             [input] + availableInputs.filter { $0.uid != input.uid }
         } ?? availableInputs
         let previousMode = self.settings.storedMicSelectionModeForMigration
@@ -133,9 +136,11 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
                 ?? defaultInput
                 ?? self.fallbackInput(from: usableInputs, defaultInputUID: defaultInputUID)
         } else if migrationVersion == 0 {
-            selectedInput = defaultInput
-                ?? preferredInput
-                ?? self.fallbackInput(from: usableInputs, defaultInputUID: defaultInputUID)
+            // A fresh install must mirror macOS's selected input, not permanently
+            // promote whichever fallback happened to enumerate first at launch.
+            // If HAL has not exposed the default yet, leave migration pending;
+            // capture can still use a temporary fallback without saving it.
+            selectedInput = enumeratedDefaultInput
         } else if migrationVersion == 1,
                   let preferredInput,
                   preferredInput.isBuiltIn,
@@ -151,6 +156,11 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
                 ?? self.fallbackInput(from: usableInputs, defaultInputUID: defaultInputUID)
         }
         guard let selectedInput else {
+            if migrationVersion == 0,
+               previousMode == .system
+            {
+                return
+            }
             self.settings.reconcileMicrophonePriority(with: migrationInputs)
             return
         }

--- a/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
+++ b/Sources/Fluid/Services/MicrophonePreferenceCoordinator.swift
@@ -97,6 +97,14 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
             [input] + availableInputs.filter { $0.uid != input.uid }
         } ?? availableInputs
         let previousMode = self.settings.storedMicSelectionModeForMigration
+        let hasStoredMode = self.settings.hasStoredMicSelectionModeForMigration
+        let preserveLegacyStoredSelection =
+            migrationVersion == 0 &&
+            hasStoredMode == false &&
+            self.settings.preferredInputDeviceUID?.isEmpty == false &&
+            self.settings.suppressedMicrophoneUIDs.contains(
+                self.settings.preferredInputDeviceUID ?? ""
+            ) == false
         if migrationVersion >= 2,
            let preferredUID = self.settings.preferredInputDeviceUID,
            preferredUID.isEmpty == false
@@ -115,7 +123,9 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
             enumeratedPreferredInput?.isBuiltIn != true &&
             Self.isLikelyBuiltInMicrophoneUID(self.settings.preferredInputDeviceUID) == false
         if preferredInput == nil,
-           preserveDisconnectedManualSelection || preserveDisconnectedVersionOneExternal,
+           preserveDisconnectedManualSelection ||
+           preserveDisconnectedVersionOneExternal ||
+           preserveLegacyStoredSelection,
            let preferredUID = self.settings.preferredInputDeviceUID,
            preferredUID.isEmpty == false
         {
@@ -132,6 +142,10 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         if migrationVersion == 0,
            previousMode == .manual
         {
+            selectedInput = preferredInput
+                ?? defaultInput
+                ?? self.fallbackInput(from: usableInputs, defaultInputUID: defaultInputUID)
+        } else if preserveLegacyStoredSelection {
             selectedInput = preferredInput
                 ?? defaultInput
                 ?? self.fallbackInput(from: usableInputs, defaultInputUID: defaultInputUID)
@@ -159,6 +173,13 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
             if migrationVersion == 0,
                previousMode == .system
             {
+                // Keep the visible priority list and removal bookkeeping useful
+                // while HAL has not exposed its default input yet. Migration stays
+                // pending, so a later default-input event can still promote the
+                // actual macOS selection to first place.
+                let preferredUIDBeforePendingReconciliation = self.settings.preferredInputDeviceUID
+                self.settings.reconcileMicrophonePriority(with: availableInputs)
+                self.settings.preferredInputDeviceUID = preferredUIDBeforePendingReconciliation
                 return
             }
             self.settings.reconcileMicrophonePriority(with: migrationInputs)
@@ -204,6 +225,10 @@ final class MicrophonePreferenceCoordinator: ObservableObject {
         let previousName = self.lastResolvedInputName
         self.lastResolvedInputUID = uid
         self.lastResolvedInputName = name
+
+        // Onboarding owns microphone feedback inside its setup panel. A global
+        // floating notice here would cover that flow and duplicate the picker.
+        guard self.settings.shouldShowOnboarding == false else { return }
 
         guard previousUID != nil, uid != previousUID else {
             if self.startupNoticeEligibilityEnabled {

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -993,7 +993,12 @@ struct OnboardingFlowView: View {
             self.stopOnboardingMicrophonePreview()
         }
         .onReceive(self.asr.audioLevelPublisher) { level in
-            guard self.step == .permissions, self.isMicrophoneReady else { return }
+            guard self.step == .permissions,
+                  self.isMicrophoneReady,
+                  self.asr.isMicrophonePreviewActive,
+                  self.asr.isRunning == false,
+                  self.asr.isStarting == false
+            else { return }
             let now = ProcessInfo.processInfo.systemUptime
             guard level == 0 || now - self.lastOnboardingMicrophoneLevelUpdate >= 0.05 else {
                 return

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -652,6 +652,15 @@ struct OnboardingFlowView: View {
     @State private var hoveredModelRouteID: String?
     @State private var hoveredModelActionButtonID: String?
     @State private var hoveredPermissionButtonID: String?
+    @State private var onboardingInputDevices: [AudioDevice.Device] = []
+    @State private var selectedOnboardingInputUID = ""
+    @State private var previewedOnboardingInputUID: String?
+    @State private var onboardingMicrophoneLevel: CGFloat = 0
+    @State private var lastOnboardingMicrophoneLevelUpdate: TimeInterval = 0
+    @State private var microphonePreviewTask: Task<Void, Never>?
+    @State private var microphonePreviewGeneration: UInt64 = 0
+    @State private var onboardingMicrophoneRefreshGeneration: UInt64 = 0
+    @State private var isOnboardingFlowVisible = false
     @State private var hoveredFooterButton: OnboardingFooterButton?
     @State private var isShowingAllLanguages = false
     @State private var isShowingOtherModelRoutes = false
@@ -936,10 +945,14 @@ struct OnboardingFlowView: View {
             }
         }
         .onAppear {
+            self.isOnboardingFlowVisible = true
             self.syncOnboardingSelectionFromSettings()
             self.playLandingWelcomeSoundIfNeeded()
             Task { @MainActor in
                 self.asr.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+                if self.step == .permissions, self.isMicrophoneReady {
+                    self.refreshOnboardingMicrophones(startPreview: true)
+                }
                 await self.asr.checkIfModelsExistAsync()
             }
         }
@@ -947,14 +960,70 @@ struct OnboardingFlowView: View {
             if self.step != .voiceModel {
                 self.cancelOnboardingModelPreparation()
             }
+            if self.step == .permissions, self.isMicrophoneReady {
+                self.refreshOnboardingMicrophones(startPreview: true)
+            } else {
+                self.stopOnboardingMicrophonePreview()
+            }
             self.playLandingWelcomeSoundIfNeeded()
         }
+        .onChange(of: self.isMicrophoneReady) { _, isReady in
+            guard self.step == .permissions else { return }
+            if isReady {
+                self.refreshOnboardingMicrophones(startPreview: true)
+            } else {
+                self.stopOnboardingMicrophonePreview()
+            }
+        }
+        .onChange(of: self.asr.isStarting) { _, isStarting in
+            guard self.isOnboardingFlowVisible,
+                  self.step == .permissions,
+                  self.isMicrophoneReady
+            else { return }
+            if isStarting {
+                self.suspendOnboardingMicrophonePreviewForDictation()
+            }
+        }
+        .onChange(of: self.asr.audioCaptureStateSettledTick) { _, _ in
+            guard self.isOnboardingFlowVisible,
+                  self.step == .permissions,
+                  self.isMicrophoneReady
+            else { return }
+            if self.asr.isRunning || self.asr.isStarting {
+                self.suspendOnboardingMicrophonePreviewForDictation()
+            } else {
+                self.refreshOnboardingMicrophones(startPreview: true)
+            }
+        }
         .onDisappear {
+            self.isOnboardingFlowVisible = false
+            self.onboardingMicrophoneRefreshGeneration &+= 1
             self.cancelOnboardingModelPreparation()
+            self.stopOnboardingMicrophonePreview()
+        }
+        .onReceive(self.asr.audioLevelPublisher) { level in
+            guard self.step == .permissions, self.isMicrophoneReady else { return }
+            let now = ProcessInfo.processInfo.systemUptime
+            guard level == 0 || now - self.lastOnboardingMicrophoneLevelUpdate >= 0.05 else {
+                return
+            }
+            self.lastOnboardingMicrophoneLevelUpdate = now
+            self.onboardingMicrophoneLevel = level
+        }
+        .onChange(of: self.appServices.audioObserver.changeTick) { _, _ in
+            guard self.step == .permissions, self.isMicrophoneReady else { return }
+            self.refreshOnboardingMicrophones(startPreview: true)
+        }
+        .onChange(of: self.appServices.audioObserver.inputAvailabilityTick) { _, _ in
+            guard self.step == .permissions, self.isMicrophoneReady else { return }
+            self.refreshOnboardingMicrophones(startPreview: true)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             self.syncOnboardingSelectionFromSettings()
             self.asr.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+            if self.step == .permissions, self.isMicrophoneReady {
+                self.refreshOnboardingMicrophones(startPreview: true)
+            }
         }
     }
 
@@ -1696,15 +1765,26 @@ struct OnboardingFlowView: View {
                             VStack(spacing: 14) {
                                 self.permissionRow(
                                     stepNumber: 1,
-                                    title: self.isMicrophoneReady ? "Microphone is ready" : "Allow microphone",
+                                    title: self.isMicrophoneReady ? "Microphone access allowed" : "Allow microphone",
                                     subtitle: self.isMicrophoneReady
-                                        ? "FluidVoice can hear your dictation."
+                                        ? "Choose the microphone you want FluidVoice to use."
                                         : "macOS will ask once. Click Allow to start dictating.",
                                     systemImage: "mic.fill",
                                     isReady: self.isMicrophoneReady,
                                     actionTitle: self.microphoneActionButtonTitle
                                 ) {
                                     self.handleMicrophoneAction()
+                                }
+
+                                if self.isMicrophoneReady {
+                                    OnboardingMicrophoneSetupPanel(
+                                        devices: self.orderedOnboardingInputDevices,
+                                        selectedUID: self.selectedOnboardingInputUID,
+                                        level: self.onboardingMicrophoneLevel,
+                                        errorMessage: self.asr.microphonePreviewError,
+                                        onSelect: { self.selectOnboardingMicrophone(uid: $0) }
+                                    )
+                                    .transition(.opacity.combined(with: .move(edge: .top)))
                                 }
 
                                 self.permissionRow(
@@ -2566,6 +2646,17 @@ struct OnboardingFlowView: View {
         )
     }
 
+    private var orderedOnboardingInputDevices: [AudioDevice.Device] {
+        let devicesByUID = Dictionary(
+            self.onboardingInputDevices.map { ($0.uid, $0) },
+            uniquingKeysWith: { current, _ in current }
+        )
+        var ordered = self.settings.microphonePriority.compactMap { devicesByUID[$0.uid] }
+        let knownUIDs = Set(ordered.map(\.uid))
+        ordered.append(contentsOf: self.onboardingInputDevices.filter { !knownUIDs.contains($0.uid) })
+        return ordered
+    }
+
     private func isOnboardingRouteSelected(_ route: VoiceEngineLanguageRoute) -> Bool {
         self.selectedOnboardingRoute?.id == route.id || self.isRouteSelectedInSettings(route)
     }
@@ -2717,5 +2808,227 @@ struct OnboardingFlowView: View {
             return
         }
         self.goNext()
+    }
+}
+
+private extension OnboardingFlowView {
+    func refreshOnboardingMicrophones(startPreview: Bool) {
+        guard self.isOnboardingFlowVisible else { return }
+        self.onboardingMicrophoneRefreshGeneration &+= 1
+        let generation = self.onboardingMicrophoneRefreshGeneration
+        let suppressedUIDs = self.settings.suppressedMicrophoneUIDs
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let inputs = AudioDevice.listInputDevicesRefreshingLiveness()
+            let defaultInputUID = AudioDevice.getDefaultInputDevice()?.uid
+            let usableInputs = inputs.filter { device in
+                suppressedUIDs.contains(device.uid) == false && AudioDevice.isInputDeviceUsable(device)
+            }
+
+            DispatchQueue.main.async {
+                guard generation == self.onboardingMicrophoneRefreshGeneration,
+                      self.isOnboardingFlowVisible,
+                      self.step == .permissions,
+                      self.isMicrophoneReady
+                else { return }
+
+                let selectedInput = self.appServices.microphonePreferenceCoordinator
+                    .reconcileMicrophoneSelection(
+                        availableInputs: inputs,
+                        defaultInputUID: defaultInputUID
+                    )
+                self.onboardingInputDevices = usableInputs
+                self.selectedOnboardingInputUID = selectedInput?.uid ?? usableInputs.first?.uid ?? ""
+
+                if startPreview {
+                    self.startOnboardingMicrophonePreviewIfNeeded()
+                }
+            }
+        }
+    }
+
+    func selectOnboardingMicrophone(uid: String) {
+        guard let device = self.onboardingInputDevices.first(where: { $0.uid == uid }) else {
+            return
+        }
+
+        self.settings.recordInputDeviceSelection(device.uid, name: device.name)
+        self.selectedOnboardingInputUID = device.uid
+        self.onboardingMicrophoneLevel = 0
+        self.lastOnboardingMicrophoneLevelUpdate = 0
+        self.startOnboardingMicrophonePreviewIfNeeded(forceRestart: true)
+    }
+
+    func startOnboardingMicrophonePreviewIfNeeded(forceRestart: Bool = false) {
+        guard self.step == .permissions,
+              self.isOnboardingFlowVisible,
+              self.isMicrophoneReady,
+              self.selectedOnboardingInputUID.isEmpty == false
+        else { return }
+        if forceRestart == false,
+           self.previewedOnboardingInputUID == self.selectedOnboardingInputUID,
+           self.asr.isMicrophonePreviewActive || self.microphonePreviewTask != nil
+        {
+            return
+        }
+
+        let selectedUID = self.selectedOnboardingInputUID
+        self.microphonePreviewGeneration &+= 1
+        let generation = self.microphonePreviewGeneration
+        self.microphonePreviewTask?.cancel()
+        self.previewedOnboardingInputUID = selectedUID
+        self.microphonePreviewTask = Task { @MainActor in
+            await self.asr.stopMicrophonePreview(retainPreparedCapture: false)
+            guard generation == self.microphonePreviewGeneration,
+                  Task.isCancelled == false,
+                  self.step == .permissions,
+                  self.isMicrophoneReady,
+                  self.selectedOnboardingInputUID == selectedUID
+            else {
+                if generation == self.microphonePreviewGeneration {
+                    self.microphonePreviewTask = nil
+                }
+                return
+            }
+
+            await self.asr.startMicrophonePreview()
+            guard generation == self.microphonePreviewGeneration,
+                  Task.isCancelled == false,
+                  self.step == .permissions,
+                  self.selectedOnboardingInputUID == selectedUID
+            else {
+                if generation == self.microphonePreviewGeneration {
+                    await self.asr.stopMicrophonePreview()
+                    self.microphonePreviewTask = nil
+                }
+                return
+            }
+            if self.asr.isMicrophonePreviewActive == false {
+                self.previewedOnboardingInputUID = nil
+            }
+            self.microphonePreviewTask = nil
+        }
+    }
+
+    func stopOnboardingMicrophonePreview() {
+        self.microphonePreviewGeneration &+= 1
+        let generation = self.microphonePreviewGeneration
+        self.microphonePreviewTask?.cancel()
+        self.microphonePreviewTask = Task { @MainActor in
+            await self.asr.stopMicrophonePreview()
+            guard generation == self.microphonePreviewGeneration else { return }
+            self.onboardingMicrophoneLevel = 0
+            self.lastOnboardingMicrophoneLevelUpdate = 0
+            self.previewedOnboardingInputUID = nil
+            self.microphonePreviewTask = nil
+        }
+    }
+
+    func suspendOnboardingMicrophonePreviewForDictation() {
+        self.microphonePreviewGeneration &+= 1
+        self.microphonePreviewTask?.cancel()
+        self.microphonePreviewTask = nil
+        self.onboardingMicrophoneLevel = 0
+        self.lastOnboardingMicrophoneLevelUpdate = 0
+        self.previewedOnboardingInputUID = nil
+    }
+}
+
+private struct OnboardingMicrophoneSetupPanel: View {
+    let devices: [AudioDevice.Device]
+    let selectedUID: String
+    let level: CGFloat
+    let errorMessage: String?
+    let onSelect: (String) -> Void
+
+    private var status: (text: String, color: Color) {
+        if let errorMessage, errorMessage.isEmpty == false {
+            return ("Microphone unavailable", Color.orange)
+        }
+        return ("Input level", Color.white.opacity(0.52))
+    }
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: 16, style: .continuous)
+        let activeBarCount = min(16, max(0, Int(ceil(self.level * 16))))
+
+        VStack(spacing: 0) {
+            HStack(spacing: 14) {
+                Text("Select your microphone")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.58))
+
+                Spacer(minLength: 12)
+
+                if self.devices.isEmpty {
+                    Text("No microphone available")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Color.orange.opacity(0.9))
+                } else {
+                    Picker(
+                        "Input microphone",
+                        selection: Binding(
+                            get: { self.selectedUID },
+                            set: self.onSelect
+                        )
+                    ) {
+                        ForEach(self.devices) { device in
+                            Text(device.name).tag(device.uid)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(width: 248)
+                    .tint(.white)
+                    .accessibilityHint("Moves the selected microphone to first in FluidVoice priority")
+                }
+            }
+            .padding(.horizontal, 18)
+            .frame(height: 62)
+
+            Rectangle()
+                .fill(Color.white.opacity(0.08))
+                .frame(height: 1)
+                .padding(.horizontal, 18)
+
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(self.status.color)
+                    .frame(width: 6, height: 6)
+
+                Text(self.status.text)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(self.status.color)
+
+                Spacer()
+
+                HStack(spacing: 0) {
+                    ForEach(0..<16, id: \.self) { index in
+                        Capsule()
+                            .fill(
+                                index < activeBarCount
+                                    ? FluidOnboardingLandingColors.blue.opacity(0.92)
+                                    : Color.white.opacity(0.14)
+                            )
+                            .frame(width: 5, height: 15)
+
+                        if index < 15 {
+                            Spacer(minLength: 0)
+                        }
+                    }
+                }
+                .frame(width: 248)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Microphone input level")
+                .accessibilityValue("\(Int((self.level * 100).rounded())) percent")
+            }
+            .padding(.horizontal, 18)
+            .frame(height: 50)
+        }
+        .background(
+            shape
+                .fill(Color.white.opacity(0.040))
+                .overlay(shape.stroke(Color.white.opacity(0.10), lineWidth: 1))
+        )
     }
 }

--- a/Sources/Fluid/UI/WelcomeView.swift
+++ b/Sources/Fluid/UI/WelcomeView.swift
@@ -392,13 +392,10 @@ struct WelcomeView: View {
             }
         }
         .onAppear {
-            // CRITICAL FIX: Refresh microphone and model status immediately on appear
-            // This prevents the Quick Setup from showing stale status before ASRService.initialize() runs
             Task { @MainActor in
-                // Check microphone status without triggering the full initialize() delay
+                await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+                await AudioStartupGate.shared.waitUntilOpen()
                 self.asr.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-
-                // Check if models exist on disk (async for accurate detection with AppleSpeechAnalyzerProvider)
                 await self.asr.checkIfModelsExistAsync()
             }
         }
@@ -948,13 +945,7 @@ struct OnboardingFlowView: View {
             self.isOnboardingFlowVisible = true
             self.syncOnboardingSelectionFromSettings()
             self.playLandingWelcomeSoundIfNeeded()
-            Task { @MainActor in
-                self.asr.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-                if self.step == .permissions, self.isMicrophoneReady {
-                    self.refreshOnboardingMicrophones(startPreview: true)
-                }
-                await self.asr.checkIfModelsExistAsync()
-            }
+            self.refreshOnboardingMicrophoneAuthorization(checkModels: true)
         }
         .onChange(of: self.currentStep) { _, _ in
             if self.step != .voiceModel {
@@ -1020,10 +1011,7 @@ struct OnboardingFlowView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             self.syncOnboardingSelectionFromSettings()
-            self.asr.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-            if self.step == .permissions, self.isMicrophoneReady {
-                self.refreshOnboardingMicrophones(startPreview: true)
-            }
+            self.refreshOnboardingMicrophoneAuthorization()
         }
     }
 
@@ -1146,8 +1134,16 @@ struct OnboardingFlowView: View {
 
     private func playLandingWelcomeSoundIfNeeded() {
         guard self.step == .landing, !self.hasPlayedLandingWelcomeSound else { return }
-        self.hasPlayedLandingWelcomeSound = true
-        OnboardingSoundPlayer.shared.playWelcomeSound()
+        Task { @MainActor in
+            await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+            await AudioStartupGate.shared.waitUntilOpen()
+            guard self.isOnboardingFlowVisible,
+                  self.step == .landing,
+                  self.hasPlayedLandingWelcomeSound == false
+            else { return }
+            self.hasPlayedLandingWelcomeSound = true
+            OnboardingSoundPlayer.shared.playWelcomeSound()
+        }
     }
 
     private var languageStep: some View {
@@ -2812,36 +2808,62 @@ struct OnboardingFlowView: View {
 }
 
 private extension OnboardingFlowView {
+    func refreshOnboardingMicrophoneAuthorization(checkModels: Bool = false) {
+        Task { @MainActor in
+            await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+            await AudioStartupGate.shared.waitUntilOpen()
+            guard self.isOnboardingFlowVisible else { return }
+
+            self.asr.micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+            if self.step == .permissions, self.isMicrophoneReady {
+                self.refreshOnboardingMicrophones(startPreview: true)
+            }
+            if checkModels {
+                await self.asr.checkIfModelsExistAsync()
+            }
+        }
+    }
+
     func refreshOnboardingMicrophones(startPreview: Bool) {
         guard self.isOnboardingFlowVisible else { return }
         self.onboardingMicrophoneRefreshGeneration &+= 1
         let generation = self.onboardingMicrophoneRefreshGeneration
         let suppressedUIDs = self.settings.suppressedMicrophoneUIDs
 
-        DispatchQueue.global(qos: .userInitiated).async {
-            let inputs = AudioDevice.listInputDevicesRefreshingLiveness()
-            let defaultInputUID = AudioDevice.getDefaultInputDevice()?.uid
-            let usableInputs = inputs.filter { device in
-                suppressedUIDs.contains(device.uid) == false && AudioDevice.isInputDeviceUsable(device)
-            }
+        Task { @MainActor in
+            await AudioStartupGate.shared.scheduleOpenAfterInitialUISettled()
+            await AudioStartupGate.shared.waitUntilOpen()
+            guard generation == self.onboardingMicrophoneRefreshGeneration,
+                  self.isOnboardingFlowVisible,
+                  self.step == .permissions,
+                  self.isMicrophoneReady
+            else { return }
 
-            DispatchQueue.main.async {
-                guard generation == self.onboardingMicrophoneRefreshGeneration,
-                      self.isOnboardingFlowVisible,
-                      self.step == .permissions,
-                      self.isMicrophoneReady
-                else { return }
+            DispatchQueue.global(qos: .userInitiated).async {
+                let inputs = AudioDevice.listInputDevicesRefreshingLiveness()
+                let defaultInputUID = AudioDevice.getDefaultInputDevice()?.uid
+                let usableInputs = inputs.filter { device in
+                    suppressedUIDs.contains(device.uid) == false && AudioDevice.isInputDeviceUsable(device)
+                }
 
-                let selectedInput = self.appServices.microphonePreferenceCoordinator
-                    .reconcileMicrophoneSelection(
-                        availableInputs: inputs,
-                        defaultInputUID: defaultInputUID
-                    )
-                self.onboardingInputDevices = usableInputs
-                self.selectedOnboardingInputUID = selectedInput?.uid ?? usableInputs.first?.uid ?? ""
+                DispatchQueue.main.async {
+                    guard generation == self.onboardingMicrophoneRefreshGeneration,
+                          self.isOnboardingFlowVisible,
+                          self.step == .permissions,
+                          self.isMicrophoneReady
+                    else { return }
 
-                if startPreview {
-                    self.startOnboardingMicrophonePreviewIfNeeded()
+                    let selectedInput = self.appServices.microphonePreferenceCoordinator
+                        .reconcileMicrophoneSelection(
+                            availableInputs: inputs,
+                            defaultInputUID: defaultInputUID
+                        )
+                    self.onboardingInputDevices = usableInputs
+                    self.selectedOnboardingInputUID = selectedInput?.uid ?? usableInputs.first?.uid ?? ""
+
+                    if startPreview {
+                        self.startOnboardingMicrophonePreviewIfNeeded()
+                    }
                 }
             }
         }

--- a/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
+++ b/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
@@ -253,6 +253,42 @@ final class DirectAudioReliabilityTests: XCTestCase {
         XCTAssertEqual(recorder.maximumConcurrentOperations, 1)
     }
 
+    func testStartingRunningInputReusesHardwareWithoutStopOrRestart() async throws {
+        let fingerprint = makeFingerprint(sampleRate: 48_000, bufferFrameSize: 512)
+        let recorder = DirectAudioEventRecorder()
+        let factory = FakeDirectAudioInputFactory(
+            fingerprints: [fingerprint],
+            recorder: recorder
+        )
+        let controller = DirectCoreAudioLifecycleController(
+            packetHandler: { _, _, _, _, _ in },
+            inputFactory: { deviceID, _ in
+                try factory.make(deviceID: deviceID)
+            },
+            fingerprintReader: { _ in fingerprint },
+            installsHardwareListeners: false,
+            onFormatInvalidated: { _ in }
+        )
+
+        _ = try await controller.start(
+            deviceID: fingerprint.deviceID,
+            deviceName: "Test microphone",
+            reason: "preview"
+        )
+        let reused = try await controller.start(
+            deviceID: fingerprint.deviceID,
+            deviceName: "Test microphone",
+            reason: "dictation_handoff"
+        )
+        await controller.shutdown(reason: "test_complete")
+
+        XCTAssertEqual(reused.phase, .running)
+        XCTAssertEqual(
+            recorder.events,
+            ["make:48000", "start:48000", "invalidate:48000"]
+        )
+    }
+
     func testFailedStopPoisonsLifecycleAndPreventsReplacement() async throws {
         let fingerprint = makeFingerprint(sampleRate: 48_000, bufferFrameSize: 512)
         let recorder = DirectAudioEventRecorder()

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -698,6 +698,91 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
+    func testFreshInstallWaitsForMacOSDefaultInsteadOfPersistingFallback() throws {
+        try self.withRestoredDefaults(keys: [
+            self.microphoneSelectionModeKey,
+            self.preferredInputDeviceUIDKey,
+            self.microphoneSelectionMigrationVersionKey,
+        ]) {
+            UserDefaults.standard.set(
+                SettingsStore.MicrophoneSelectionMode.system.rawValue,
+                forKey: self.microphoneSelectionModeKey
+            )
+            SettingsStore.shared.preferredInputDeviceUID = nil
+            SettingsStore.shared.microphoneSelectionMigrationVersion = 0
+            let fallback = Self.device(uid: "fallback", name: "Available Fallback")
+            let unsettledDevices = FakeAudioDeviceManager(
+                inputs: [fallback],
+                defaultInputUID: "system-default"
+            )
+            let unsettledCoordinator = MicrophonePreferenceCoordinator(
+                settings: .shared,
+                devices: unsettledDevices
+            )
+
+            let temporarySelection = unsettledCoordinator.reconcileMicrophoneSelection(
+                availableInputs: unsettledDevices.inputs,
+                defaultInputUID: unsettledDevices.defaultInputUID
+            )
+
+            XCTAssertEqual(temporarySelection, fallback)
+            XCTAssertTrue(SettingsStore.shared.microphonePriority.isEmpty)
+            XCTAssertNil(SettingsStore.shared.preferredInputDeviceUID)
+            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMigrationVersion, 0)
+
+            let systemDefault = Self.device(uid: "system-default", name: "macOS Default")
+            let settledDevices = FakeAudioDeviceManager(
+                inputs: [fallback, systemDefault],
+                defaultInputUID: systemDefault.uid
+            )
+            let settledCoordinator = MicrophonePreferenceCoordinator(
+                settings: .shared,
+                devices: settledDevices
+            )
+
+            settledCoordinator.migrateMicrophonePriorityIfNeeded()
+
+            XCTAssertEqual(SettingsStore.shared.microphonePriority.first?.uid, systemDefault.uid)
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, systemDefault.uid)
+            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMigrationVersion, 4)
+        }
+    }
+
+    @MainActor
+    func testFreshInstallPrioritizesMacOSDefaultWhileTemporarilyUnusable() throws {
+        try self.withRestoredDefaults(keys: [
+            self.microphoneSelectionModeKey,
+            self.preferredInputDeviceUIDKey,
+            self.microphoneSelectionMigrationVersionKey,
+        ]) {
+            UserDefaults.standard.set(
+                SettingsStore.MicrophoneSelectionMode.system.rawValue,
+                forKey: self.microphoneSelectionModeKey
+            )
+            SettingsStore.shared.preferredInputDeviceUID = nil
+            SettingsStore.shared.microphoneSelectionMigrationVersion = 0
+            let systemDefault = Self.device(uid: "system-default", name: "macOS Default")
+            let fallback = Self.device(uid: "fallback", name: "Available Fallback")
+            let devices = FakeAudioDeviceManager(
+                inputs: [fallback, systemDefault],
+                defaultInputUID: systemDefault.uid,
+                unusableInputUIDs: [systemDefault.uid]
+            )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            let resolved = coordinator.reconcileMicrophoneSelection(
+                availableInputs: devices.inputs,
+                defaultInputUID: devices.defaultInputUID
+            )
+
+            XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), [systemDefault.uid, fallback.uid])
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, systemDefault.uid)
+            XCTAssertEqual(resolved, fallback)
+            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMigrationVersion, 4)
+        }
+    }
+
+    @MainActor
     func testMicrophoneMigrationWaitsForAUsableDeviceList() throws {
         try self.withRestoredDefaults(keys: [
             self.microphoneSelectionModeKey,

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -698,16 +698,41 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
-    func testFreshInstallWaitsForMacOSDefaultInsteadOfPersistingFallback() throws {
+    func testLegacyStoredMicrophoneWithoutModeKeyKeepsUserSelection() throws {
         try self.withRestoredDefaults(keys: [
             self.microphoneSelectionModeKey,
             self.preferredInputDeviceUIDKey,
             self.microphoneSelectionMigrationVersionKey,
         ]) {
-            UserDefaults.standard.set(
-                SettingsStore.MicrophoneSelectionMode.system.rawValue,
-                forKey: self.microphoneSelectionModeKey
+            UserDefaults.standard.removeObject(forKey: self.microphoneSelectionModeKey)
+            SettingsStore.shared.preferredInputDeviceUID = "studio-mic"
+            SettingsStore.shared.microphoneSelectionMigrationVersion = 0
+            let devices = FakeAudioDeviceManager(
+                inputs: [
+                    Self.device(uid: "internal", name: "MacBook Pro Microphone"),
+                    Self.device(uid: "studio-mic", name: "Studio Mic"),
+                ],
+                defaultInputUID: "internal"
             )
+            let coordinator = MicrophonePreferenceCoordinator(settings: .shared, devices: devices)
+
+            coordinator.migrateMicrophonePriorityIfNeeded()
+
+            XCTAssertEqual(SettingsStore.shared.microphonePriority.first?.uid, "studio-mic")
+            XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "studio-mic")
+            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMode, .manual)
+            XCTAssertEqual(SettingsStore.shared.microphoneSelectionMigrationVersion, 4)
+        }
+    }
+
+    @MainActor
+    func testFreshInstallKeepsPriorityUsableWhileWaitingForMacOSDefault() throws {
+        try self.withRestoredDefaults(keys: [
+            self.microphoneSelectionModeKey,
+            self.preferredInputDeviceUIDKey,
+            self.microphoneSelectionMigrationVersionKey,
+        ]) {
+            UserDefaults.standard.removeObject(forKey: self.microphoneSelectionModeKey)
             SettingsStore.shared.preferredInputDeviceUID = nil
             SettingsStore.shared.microphoneSelectionMigrationVersion = 0
             let fallback = Self.device(uid: "fallback", name: "Available Fallback")
@@ -726,7 +751,7 @@ final class HotkeyShortcutTests: XCTestCase {
             )
 
             XCTAssertEqual(temporarySelection, fallback)
-            XCTAssertTrue(SettingsStore.shared.microphonePriority.isEmpty)
+            XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), [fallback.uid])
             XCTAssertNil(SettingsStore.shared.preferredInputDeviceUID)
             XCTAssertEqual(SettingsStore.shared.microphoneSelectionMigrationVersion, 0)
 


### PR DESCRIPTION
## Description
Fixes first-run microphone setup so FluidVoice seeds its priority list from the macOS default instead of a transient enumeration fallback. Adds an onboarding microphone picker backed by the same priority store, plus a live input-level preview with guarded device-change, page-exit, route-recovery, and dictation handoff lifecycles.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Follow-up to #822.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally

Built, signed, installed, and launched the FI-enabled Release app as FluidVoice 1.6.8. Added regression coverage for late-arriving and temporarily unusable macOS default inputs. No Debug/XCTest host run was used.

## Screenshots / Video
Onboarding microphone picker and input-level preview screenshot attached in the PR discussion.
<img width="751" height="532" alt="image" src="https://github.com/user-attachments/assets/9fbbef83-dfdf-4982-936d-55648bd10ee0" />


## Notes
The selected onboarding microphone becomes priority #1. Preview capture never delays or discards opening dictation PCM, and it yields to normal capture before dictation starts. Intel runtime remains unvalidated; the change uses APIs available at the macOS 15 deployment floor.