### PR TITLE
Add hands-free Spoken Send

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */; };
 		DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */; };
 		7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */; };
+		B51800000000000000000002 /* SpokenSendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51800000000000000000001 /* SpokenSendTests.swift */; };
 		7CDB0A2F2F3C4D5600FB7CAD /* dictation_fixture.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */; };
 		7CDB0A302F3C4D5600FB7CAD /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */; };
 		7CE006BD2E80EBE600DDCCD6 /* AppUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = 7CE006BC2E80EBE600DDCCD6 /* AppUpdater */; };
@@ -59,6 +60,7 @@
 		D1A600000000000000000201 /* SpeakerTurnMergingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerTurnMergingTests.swift; sourceTree = "<group>"; };
 		C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineRetirementDrainTests.swift; sourceTree = "<group>"; };
 		DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectAudioReliabilityTests.swift; sourceTree = "<group>"; };
+		B51800000000000000000001 /* SpokenSendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpokenSendTests.swift; sourceTree = "<group>"; };
 		7C078D8F2E3B339200FB7CAC /* FluidVoice Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FluidVoice Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
 		7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidDictationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -141,6 +143,7 @@
 				C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */,
 				DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */,
 				7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */,
+				B51800000000000000000001 /* SpokenSendTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
 			sourceTree = "<group>";
@@ -303,6 +306,7 @@
 				C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */,
 				DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */,
 				7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */,
+				B51800000000000000000002 /* SpokenSendTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -244,6 +244,7 @@ struct ContentView: View {
     @State private var recordingAppInfo: (name: String, bundleId: String, windowTitle: String)? = nil
     @State private var recordingPrecedingText: String = ""
     @State private var recordingFocusTarget: TypingService.CapturedFocusTarget? = nil
+    @State private var recordingSessionID = UUID()
 
     // Command Mode State
     // @State private var showCommandMode: Bool = false
@@ -290,6 +291,7 @@ struct ContentView: View {
     @State private var spokenSendVoiceActivityGeneration: UInt64 = 0
     @State private var activeSpokenSendVoiceActivityID: UInt64?
     @State private var isStoppingAndProcessingTranscription = false
+    @State private var stopProcessingOperationID: UUID?
 
     private var isRecordingAnyShortcutCapture: Bool {
         self.activeShortcutRecordingTarget != nil
@@ -1623,6 +1625,20 @@ struct ContentView: View {
         return (name: "Unknown", bundleId: "unknown", windowTitle: "")
     }
 
+    nonisolated static func canDeliverCompletedRecording(
+        stoppedSessionID: UUID,
+        currentSessionID: UUID
+    ) -> Bool {
+        stoppedSessionID == currentSessionID
+    }
+
+    nonisolated static func canFinishStopProcessingOperation(
+        completingOperationID: UUID,
+        currentOperationID: UUID?
+    ) -> Bool {
+        completingOperationID == currentOperationID
+    }
+
     private func isSpokenSendBlockedTarget(_ target: TypingService.CapturedFocusTarget?) -> Bool {
         guard let target,
               let app = NSRunningApplication(processIdentifier: target.pid)
@@ -1638,7 +1654,8 @@ struct ContentView: View {
     private func deliverSpokenSend(
         _ outputPlan: DictationLiteralOutputPlan,
         targetPID: pid_t?,
-        textReadyAt: TimeInterval
+        textReadyAt: TimeInterval,
+        requiredFocusTarget: TypingService.CapturedFocusTarget?
     ) async -> TypingService.DeliveryOutcome {
         let sendsExistingDraft = outputPlan.plainText.isEmpty
         let outcome = await self.asr.typeOutputPlanToActiveFieldAndWait(
@@ -1646,7 +1663,7 @@ struct ContentView: View {
             preferredTargetPID: targetPID,
             textReadyAt: textReadyAt,
             postInsertionKey: self.settings.spokenSendKey,
-            requiredFocusTarget: self.recordingFocusTarget
+            requiredFocusTarget: requiredFocusTarget
         )
         if outcome.didDispatchAction {
             NotchContentState.shared.setSpokenSendIndicatorState(.sent)
@@ -1685,6 +1702,7 @@ struct ContentView: View {
     private func captureRecordingTargetContext() {
         // Capture the focused target PID BEFORE any overlay/UI changes.
         // Used to restore focus when the user interacts with overlay dropdowns.
+        self.recordingSessionID = UUID()
         let focusTarget = TypingService.captureSystemFocusTarget()
         self.recordingFocusTarget = focusTarget
         let focusedPID = focusTarget?.pid
@@ -1719,7 +1737,12 @@ struct ContentView: View {
     }
 
     private func resolveTypingTargetPID() -> (pid: pid_t?, shouldRestoreOriginalFocus: Bool) {
-        let originalPID = NotchContentState.shared.recordingTargetPID
+        self.resolveTypingTargetPID(originalPID: NotchContentState.shared.recordingTargetPID)
+    }
+
+    private func resolveTypingTargetPID(
+        originalPID: pid_t?
+    ) -> (pid: pid_t?, shouldRestoreOriginalFocus: Bool) {
         let currentFocusedPID = TypingService.captureSystemFocusedPID()
             ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
 
@@ -2095,15 +2118,27 @@ struct ContentView: View {
             DebugLogger.shared.debug("Ignoring duplicate stop-and-process request", source: "ContentView")
             return
         }
+        let operationID = UUID()
+        self.stopProcessingOperationID = operationID
         self.isStoppingAndProcessingTranscription = true
-        defer { self.isStoppingAndProcessingTranscription = false }
-        await self.performStopAndProcessTranscription(route: route)
+        defer { self.finishStopProcessingOperationIfCurrent(operationID) }
+        await self.performStopAndProcessTranscription(route: route, operationID: operationID)
     }
 
-    private func performStopAndProcessTranscription(route: DictationOutputRoute) async {
+    // swiftlint:disable:next function_body_length
+    private func performStopAndProcessTranscription(
+        route: DictationOutputRoute,
+        operationID: UUID
+    ) async {
         DebugLogger.shared.debug("stopAndProcessTranscription called", source: "ContentView")
         DebugLogger.shared.info("Output route selected: \(route.rawValue)", source: "ContentView")
         self.appBench("stop_path_enter route=\(route.rawValue)")
+
+        let stoppedSessionID = self.recordingSessionID
+        let stoppedFocusTarget = self.recordingFocusTarget
+        let stoppedTargetPID = NotchContentState.shared.recordingTargetPID
+        let stoppedAppInfo = self.recordingAppInfo
+        let stoppedPrecedingText = self.recordingPrecedingText
 
         // Check if we're in rewrite or command mode
         let modeAtStop = self.activeRecordingMode
@@ -2159,7 +2194,7 @@ struct ContentView: View {
         self.appBench("asr_stop_return elapsedMs=\(Int(((ProcessInfo.processInfo.systemUptime - asrStopStartedAt) * 1000).rounded()))")
         // The duplicate-stop race ends when ASR reports that it is no longer running.
         // Do not hold this guard across delivery or a new recording's stop can be swallowed.
-        self.isStoppingAndProcessingTranscription = false
+        self.finishStopProcessingOperationIfCurrent(operationID)
         let audioSnapshot = self.asr.consumeLastCompletedAudioSnapshot()
         DebugLogger.shared.info(
             "Stop transcription result | chars=\(transcribedText.count) | empty=\(transcribedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)",
@@ -2252,7 +2287,7 @@ struct ContentView: View {
         var finalText: String
         var aiFallbackReason: String?
         var postProcessingModel: String?
-        let appInfo = self.recordingAppInfo ?? self.getCurrentAppInfo()
+        let appInfo = stoppedAppInfo ?? self.getCurrentAppInfo()
         let punctuationFormattedText = ASRService.applySpokenPunctuationFormatting(
             transcribedText,
             appName: appInfo.name,
@@ -2369,13 +2404,23 @@ struct ContentView: View {
         finalText = ASRService.applyGAAVFormatting(finalText)
         // Apply Continuous Dictation Mode after GAAV so smart caps use the field
         // context captured at recording start, and the trailing space enables chaining.
-        finalText = ASRService.applyContinuousDictationFormatting(finalText, precedingText: self.recordingPrecedingText)
+        finalText = ASRService.applyContinuousDictationFormatting(finalText, precedingText: stoppedPrecedingText)
         finalText = ASRService.applyTerminalLiteralAutocompleteSpacing(
             finalText,
             appName: appInfo.name,
             bundleID: appInfo.bundleId,
             windowTitle: appInfo.windowTitle
         )
+        guard Self.canDeliverCompletedRecording(
+            stoppedSessionID: stoppedSessionID,
+            currentSessionID: self.recordingSessionID
+        ) else {
+            DebugLogger.shared.warning(
+                "Completed dictation output suppressed because a newer recording session started",
+                source: "ContentView"
+            )
+            return
+        }
         self.recordingPrecedingText = ""
         self.asr.finalText = finalText
         if route == .onboardingSandbox,
@@ -2480,19 +2525,33 @@ struct ContentView: View {
         )
 
         if shouldTypeExternally {
-            let typingTarget = self.resolveTypingTargetPID()
             let spokenSendRequested = spokenSendParse.shouldSend
+            let typingTarget = self.resolveTypingTargetPID(originalPID: stoppedTargetPID)
             let targetMatchesRecordingFocus = typingTarget.pid != nil
-                && typingTarget.pid == self.recordingFocusTarget?.pid
+                && typingTarget.pid == stoppedFocusTarget?.pid
             let spokenSendAllowed = spokenSendRequested
                 && aiFallbackReason == nil
                 && (sendsExistingDraft || !finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 && targetMatchesRecordingFocus
-                && !self.isSpokenSendBlockedTarget(self.recordingFocusTarget)
+                && !self.isSpokenSendBlockedTarget(stoppedFocusTarget)
             // Dispatch insertion as soon as the destination app is ready; the
             // overlay hides asynchronously after output so it cannot delay paste.
             if typingTarget.shouldRestoreOriginalFocus {
-                await self.restoreFocusToRecordingTarget(requireExactTarget: spokenSendAllowed)
+                await self.restoreFocusToRecordingTarget(
+                    requireExactTarget: spokenSendAllowed,
+                    targetPID: stoppedTargetPID,
+                    focusTarget: stoppedFocusTarget
+                )
+            }
+            guard Self.canDeliverCompletedRecording(
+                stoppedSessionID: stoppedSessionID,
+                currentSessionID: self.recordingSessionID
+            ) else {
+                DebugLogger.shared.warning(
+                    "Dictation delivery suppressed because a newer recording session started",
+                    source: "ContentView"
+                )
+                return
             }
             if spokenSendAllowed {
                 NotchContentState.shared.setSpokenSendIndicatorState(.sending)
@@ -2505,7 +2564,8 @@ struct ContentView: View {
                 let deliveryOutcome = await self.deliverSpokenSend(
                     finalOutputPlan,
                     targetPID: typingTarget.pid,
-                    textReadyAt: finalTextReadyAt
+                    textReadyAt: finalTextReadyAt,
+                    requiredFocusTarget: stoppedFocusTarget
                 )
                 didTypeExternally = deliveryOutcome.didInsert || deliveryOutcome.didDispatchAction
             } else {
@@ -2573,6 +2633,15 @@ struct ContentView: View {
         if !didTypeExternally, !shouldShowAIProcessingFailure, !didRequestOverlayHideOnStop {
             self.hideOverlayAfterOutput()
         }
+    }
+
+    private func finishStopProcessingOperationIfCurrent(_ operationID: UUID) {
+        guard Self.canFinishStopProcessingOperation(
+            completingOperationID: operationID,
+            currentOperationID: self.stopProcessingOperationID
+        ) else { return }
+        self.stopProcessingOperationID = nil
+        self.isStoppingAndProcessingTranscription = false
     }
 
     private func hideOverlayAfterOutput() {
@@ -3459,10 +3528,22 @@ struct ContentView: View {
     /// Best-effort: re-activate the app that was focused when recording started.
     /// Skips the AX restore work when the captured text element is already focused.
     private func restoreFocusToRecordingTarget(requireExactTarget: Bool = false) async {
-        guard let pid = NotchContentState.shared.recordingTargetPID else { return }
+        await self.restoreFocusToRecordingTarget(
+            requireExactTarget: requireExactTarget,
+            targetPID: NotchContentState.shared.recordingTargetPID,
+            focusTarget: self.recordingFocusTarget
+        )
+    }
+
+    private func restoreFocusToRecordingTarget(
+        requireExactTarget: Bool,
+        targetPID: pid_t?,
+        focusTarget: TypingService.CapturedFocusTarget?
+    ) async {
+        guard let pid = targetPID else { return }
         let startedAt = ProcessInfo.processInfo.systemUptime
         self.appBench("focus_restore_start targetPID=\(pid)")
-        if let focusTarget = self.recordingFocusTarget, focusTarget.pid == pid {
+        if let focusTarget, focusTarget.pid == pid {
             // Ordinary dictation keeps the legacy PID/editable-focus check because some apps
             // vend a fresh AX element for the same field. Spoken Send remains exact-target only.
             let targetIsStillActive = requireExactTarget

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -243,6 +243,7 @@ struct ContentView: View {
     @State private var playgroundUsed: Bool = SettingsStore.shared.playgroundUsed
     @State private var recordingAppInfo: (name: String, bundleId: String, windowTitle: String)? = nil
     @State private var recordingPrecedingText: String = ""
+    @State private var recordingFocusTarget: TypingService.CapturedFocusTarget? = nil
 
     // Command Mode State
     // @State private var showCommandMode: Bool = false
@@ -280,6 +281,11 @@ struct ContentView: View {
     @State private var accessibilityGuideRequestID: UUID?
     @State private var prewarmDictationTask: Task<Void, Never>?
     @State private var overlayLifecycleID: UInt64 = 0
+    @State private var spokenSendAutoStopTask: Task<Void, Never>?
+    @State private var spokenSendAutoStopTriggered = false
+    @State private var spokenSendPartialRevision: UInt64 = 0
+    @State private var spokenSendCountdownStartedAt: TimeInterval?
+    @State private var spokenSendLastVoiceActivityAt: TimeInterval = 0
 
     private var isRecordingAnyShortcutCapture: Bool {
         self.activeShortcutRecordingTarget != nil
@@ -352,6 +358,12 @@ struct ContentView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: .settingsBackupDidRestore)) { _ in
                 self.reloadSettingsStateAfterBackupRestore()
+            }
+            .onReceive(self.asr.$partialTranscription) { text in
+                self.handleSpokenSendPartialTranscription(text)
+            }
+            .onReceive(self.asr.audioLevelPublisher) { level in
+                self.handleSpokenSendAudioLevel(level)
             }
             .toolbar {
                 if !self.settings.shouldShowOnboarding {
@@ -1610,6 +1622,48 @@ struct ContentView: View {
         return (name: "Unknown", bundleId: "unknown", windowTitle: "")
     }
 
+    private func isSpokenSendBlockedApp(
+        _ appInfo: (name: String, bundleId: String, windowTitle: String)
+    ) -> Bool {
+        let identity = "\(appInfo.name) \(appInfo.bundleId)".lowercased()
+        return identity.contains("terminal")
+            || identity.contains("iterm")
+            || identity.contains("warp")
+            || identity.contains("ghostty")
+    }
+
+    private func deliverSpokenSend(
+        _ outputPlan: DictationLiteralOutputPlan,
+        targetPID: pid_t?,
+        textReadyAt: TimeInterval
+    ) async -> TypingService.DeliveryOutcome {
+        let sendsExistingDraft = outputPlan.plainText.isEmpty
+        let outcome = await self.asr.typeOutputPlanToActiveFieldAndWait(
+            outputPlan,
+            preferredTargetPID: targetPID,
+            textReadyAt: textReadyAt,
+            postInsertionKey: self.settings.spokenSendKey,
+            requiredFocusTarget: self.recordingFocusTarget
+        )
+        if outcome.didDispatchAction {
+            NotchContentState.shared.setSpokenSendIndicatorState(.sent)
+            try? await Task.sleep(nanoseconds: 350_000_000)
+            return outcome
+        }
+
+        NotchContentState.shared.setSpokenSendIndicatorState(.failed)
+        DebugLogger.shared.warning(
+            "Spoken Send skipped because delivery safety checks did not pass",
+            source: "ContentView"
+        )
+        let message = outcome.didInsert
+            ? "Text inserted — send skipped"
+            : sendsExistingDraft ? "Couldn't send" : "Couldn't insert or send"
+        NotchOverlayManager.shared.updateTranscriptionText(message)
+        try? await Task.sleep(nanoseconds: 650_000_000)
+        return outcome
+    }
+
     /// Best-effort frontmost window title lookup for the current app
     private func getFrontmostWindowTitle(ownerPid: pid_t) -> String? {
         let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
@@ -1628,7 +1682,9 @@ struct ContentView: View {
     private func captureRecordingTargetContext() {
         // Capture the focused target PID BEFORE any overlay/UI changes.
         // Used to restore focus when the user interacts with overlay dropdowns.
-        let focusedPID = TypingService.captureSystemFocusedPID()
+        let focusTarget = TypingService.captureSystemFocusTarget()
+        self.recordingFocusTarget = focusTarget
+        let focusedPID = focusTarget?.pid
             ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
         NotchContentState.shared.recordingTargetPID = focusedPID
 
@@ -2050,7 +2106,8 @@ struct ContentView: View {
             !wasRewriteMode &&
             !wasCommandMode &&
             !promptTest.isActive &&
-            !shouldUseAIOnStop
+            !shouldUseAIOnStop &&
+            !self.settings.spokenSendEnabled
         var didRequestOverlayHideOnStop = false
         DebugLogger.shared.info(
             "Routing decision snapshot | activeMode=\(modeAtStop.rawValue) | rewrite=\(wasRewriteMode) | command=\(wasCommandMode) | overlay=\(NotchContentState.shared.mode.rawValue)",
@@ -2180,16 +2237,25 @@ struct ContentView: View {
         var aiFallbackReason: String?
         var postProcessingModel: String?
         let appInfo = self.recordingAppInfo ?? self.getCurrentAppInfo()
-        let normalizedTranscribedText = ASRService.applySpokenPunctuationFormatting(
+        let punctuationFormattedText = ASRService.applySpokenPunctuationFormatting(
             transcribedText,
             appName: appInfo.name,
             bundleID: appInfo.bundleId,
             windowTitle: appInfo.windowTitle
         )
+        let spokenSendParse = SpokenSendParser.parse(
+            punctuationFormattedText,
+            phrase: self.settings.spokenSendPhrase,
+            enabled: route == .normal && self.settings.spokenSendEnabled
+        )
+        self.updateSpokenSendIndicatorForFinalParse(shouldSend: spokenSendParse.shouldSend)
+        let normalizedTranscribedText = spokenSendParse.text
+        let sendsExistingDraft = spokenSendParse.shouldSend &&
+            normalizedTranscribedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-        let shouldUseAI = activeDictationSlot.map {
+        let shouldUseAI = !sendsExistingDraft && (activeDictationSlot.map {
             DictationAIPostProcessingGate.isConfigured(for: $0, appBundleID: appInfo.bundleId)
-        } ?? DictationAIPostProcessingGate.isConfigured(for: .primary, appBundleID: appInfo.bundleId)
+        } ?? DictationAIPostProcessingGate.isConfigured(for: .primary, appBundleID: appInfo.bundleId))
         let transcriptionModelInfo = self.currentTranscriptionModelInfo()
 
         if shouldUseAI {
@@ -2322,7 +2388,7 @@ struct ContentView: View {
                 "mode": AnalyticsMode.dictation.rawValue,
                 "words_bucket": AnalyticsBuckets.bucketWords(AnalyticsBuckets.wordCount(in: finalText)),
                 "ai_used": shouldUseAI,
-                "ai_changed_text": transcribedText != finalText,
+                "ai_changed_text": normalizedTranscribedText != finalText,
                 "transcription_provider": transcriptionModelInfo.provider,
                 "transcription_model": transcriptionModelInfo.model,
             ]
@@ -2350,13 +2416,13 @@ struct ContentView: View {
         let isFluidFrontmost = frontmostApp?.bundleIdentifier == Bundle.main.bundleIdentifier
 
         // Save to transcription history (transcription mode only, if enabled)
-        if shouldPersistOutputs, SettingsStore.shared.saveTranscriptionHistory {
+        if shouldPersistOutputs, !sendsExistingDraft, SettingsStore.shared.saveTranscriptionHistory {
             let historyEntryID = UUID()
             let historyTimestamp = Date()
             TranscriptionHistoryStore.shared.addEntry(
                 id: historyEntryID,
                 timestamp: historyTimestamp,
-                rawText: transcribedText,
+                rawText: spokenSendParse.shouldSend ? normalizedTranscribedText : transcribedText,
                 processedText: finalText,
                 appName: appInfo.name,
                 windowTitle: appInfo.windowTitle,
@@ -2374,6 +2440,7 @@ struct ContentView: View {
         // When FluidVoice itself is frontmost, the bound editor already receives `finalText`.
         // Avoid re-inserting or overwriting the clipboard in that self-target case.
         let shouldCopyToClipboard = shouldPersistOutputs &&
+            !sendsExistingDraft &&
             SettingsStore.shared.copyTranscriptionToClipboard &&
             !isFluidFrontmost
 
@@ -2398,21 +2465,55 @@ struct ContentView: View {
 
         if shouldTypeExternally {
             let typingTarget = self.resolveTypingTargetPID()
+            let spokenSendRequested = spokenSendParse.shouldSend
+            let targetMatchesRecordingFocus = typingTarget.pid != nil
+                && typingTarget.pid == self.recordingFocusTarget?.pid
+            let spokenSendAllowed = spokenSendRequested
+                && aiFallbackReason == nil
+                && (sendsExistingDraft || !finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                && targetMatchesRecordingFocus
+                && !self.isSpokenSendBlockedApp(appInfo)
             // Dispatch insertion as soon as the destination app is ready; the
             // overlay hides asynchronously after output so it cannot delay paste.
             if typingTarget.shouldRestoreOriginalFocus {
                 await self.restoreFocusToRecordingTarget()
             }
+            if spokenSendAllowed {
+                NotchContentState.shared.setSpokenSendIndicatorState(.sending)
+                NotchOverlayManager.shared.updateTranscriptionText("Sending")
+            }
             self.appBench(
                 "text_ready_to_type_request elapsedMs=\(Int(((ProcessInfo.processInfo.systemUptime - finalTextReadyAt) * 1000).rounded()))"
             )
-            self.asr.typeOutputPlanToActiveField(
-                finalOutputPlan,
-                preferredTargetPID: typingTarget.pid,
-                textReadyAt: finalTextReadyAt,
-                tracksDictionaryCorrections: true
-            )
-            didTypeExternally = true
+            if spokenSendAllowed {
+                let deliveryOutcome = await self.deliverSpokenSend(
+                    finalOutputPlan,
+                    targetPID: typingTarget.pid,
+                    textReadyAt: finalTextReadyAt
+                )
+                didTypeExternally = deliveryOutcome.didInsert
+            } else {
+                self.asr.typeOutputPlanToActiveField(
+                    finalOutputPlan,
+                    preferredTargetPID: typingTarget.pid,
+                    textReadyAt: finalTextReadyAt,
+                    tracksDictionaryCorrections: true
+                )
+                didTypeExternally = true
+            }
+            if spokenSendRequested, !spokenSendAllowed {
+                NotchContentState.shared.setSpokenSendIndicatorState(.failed)
+                DebugLogger.shared.warning(
+                    "Spoken Send skipped because delivery safety checks did not pass",
+                    source: "ContentView"
+                )
+                if aiFallbackReason == nil {
+                    NotchOverlayManager.shared.updateTranscriptionText("Text inserted — send skipped")
+                    try? await Task.sleep(nanoseconds: 650_000_000)
+                }
+            }
+            NotchOverlayManager.shared.updateTranscriptionText("")
+            NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
             if !shouldShowAIProcessingFailure, !didRequestOverlayHideOnStop {
                 self.hideOverlayAfterOutput()
             }
@@ -2500,9 +2601,121 @@ struct ContentView: View {
         return true
     }
 
+    private func updateSpokenSendIndicatorForFinalParse(shouldSend: Bool) {
+        if shouldSend, NotchContentState.shared.spokenSendIndicatorState == .sending {
+            return
+        }
+        NotchContentState.shared.setSpokenSendIndicatorState(shouldSend ? .detected : .hidden)
+    }
+
     private func advanceOverlayLifecycle() {
+        self.spokenSendAutoStopTask?.cancel()
+        self.spokenSendAutoStopTask = nil
+        self.spokenSendAutoStopTriggered = false
+        self.spokenSendPartialRevision = 0
+        self.spokenSendCountdownStartedAt = nil
+        self.spokenSendLastVoiceActivityAt = ProcessInfo.processInfo.systemUptime
         self.overlayLifecycleID &+= 1
         NotchContentState.shared.clearAIProcessingFailure()
+    }
+
+    private func handleSpokenSendPartialTranscription(_ text: String) {
+        self.spokenSendPartialRevision &+= 1
+        let isDictationMode = self.activeRecordingMode == .dictate || self.activeRecordingMode == .promptMode
+        let shouldStop = isDictationMode &&
+            self.currentDictationOutputRouteForHotkeyStop() == .normal &&
+            self.asr.isRunning &&
+            !self.spokenSendAutoStopTriggered &&
+            SpokenSendParser.shouldStopImmediately(
+                text,
+                phrase: self.settings.spokenSendPhrase,
+                spokenSendEnabled: self.settings.spokenSendEnabled,
+                sendImmediatelyEnabled: self.settings.spokenSendImmediatelyEnabled
+            )
+
+        guard shouldStop else {
+            self.spokenSendAutoStopTask?.cancel()
+            self.spokenSendAutoStopTask = nil
+            self.spokenSendCountdownStartedAt = nil
+            if !self.spokenSendAutoStopTriggered,
+               NotchContentState.shared.spokenSendIndicatorState == .countingDown
+            {
+                NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
+            }
+            return
+        }
+
+        guard self.spokenSendAutoStopTask == nil else {
+            return
+        }
+
+        let expectedOverlayLifecycleID = self.overlayLifecycleID
+        let expectedPartialRevision = self.spokenSendPartialRevision
+        let countdownStartedAt = ProcessInfo.processInfo.systemUptime
+        self.spokenSendCountdownStartedAt = countdownStartedAt
+        let expectedCountdownID = NotchContentState.shared.beginSpokenSendCountdown()
+        self.spokenSendAutoStopTask = Task { @MainActor in
+            // Keep one countdown across harmless streaming refinements such as punctuation or casing.
+            try? await Task.sleep(nanoseconds: SpokenSendParser.immediateStopSettleNanoseconds)
+            let quietDuration = ProcessInfo.processInfo.systemUptime - self.spokenSendLastVoiceActivityAt
+            guard !Task.isCancelled,
+                  self.overlayLifecycleID == expectedOverlayLifecycleID,
+                  NotchContentState.shared.spokenSendCountdownID == expectedCountdownID,
+                  self.asr.isRunning,
+                  self.activeRecordingMode == .dictate || self.activeRecordingMode == .promptMode,
+                  self.currentDictationOutputRouteForHotkeyStop() == .normal,
+                  !self.spokenSendAutoStopTriggered,
+                  SpokenSendParser.canCompleteImmediateStop(
+                      self.asr.partialTranscription,
+                      phrase: self.settings.spokenSendPhrase,
+                      spokenSendEnabled: self.settings.spokenSendEnabled,
+                      sendImmediatelyEnabled: self.settings.spokenSendImmediatelyEnabled,
+                      receivedFreshTranscript: self.spokenSendPartialRevision > expectedPartialRevision,
+                      quietDuration: quietDuration
+                  )
+            else {
+                if self.overlayLifecycleID == expectedOverlayLifecycleID,
+                   NotchContentState.shared.spokenSendCountdownID == expectedCountdownID
+                {
+                    self.spokenSendAutoStopTask = nil
+                    self.spokenSendCountdownStartedAt = nil
+                    if NotchContentState.shared.spokenSendIndicatorState == .countingDown {
+                        NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
+                    }
+                }
+                return
+            }
+
+            self.spokenSendAutoStopTask = nil
+            self.spokenSendCountdownStartedAt = nil
+            self.spokenSendAutoStopTriggered = true
+            NotchContentState.shared.setSpokenSendIndicatorState(.sending)
+            DebugLogger.shared.info("Spoken Send countdown completed; stopping dictation", source: "ContentView")
+            await self.stopAndProcessTranscription(route: .normal)
+        }
+    }
+
+    private func handleSpokenSendAudioLevel(_ level: CGFloat) {
+        guard level > 0 else { return }
+
+        let activityAt = ProcessInfo.processInfo.systemUptime
+        self.spokenSendLastVoiceActivityAt = activityAt
+        guard let countdownStartedAt = self.spokenSendCountdownStartedAt,
+              SpokenSendParser.shouldCancelCountdownForVoiceActivity(
+                  countdownStartedAt: countdownStartedAt,
+                  voiceActivityAt: activityAt
+              ),
+              self.spokenSendAutoStopTask != nil
+        else {
+            return
+        }
+
+        self.spokenSendAutoStopTask?.cancel()
+        self.spokenSendAutoStopTask = nil
+        self.spokenSendCountdownStartedAt = nil
+        if NotchContentState.shared.spokenSendIndicatorState == .countingDown {
+            NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
+        }
     }
 
     private func hideOverlayAsync(reason: String) {
@@ -3185,6 +3398,18 @@ struct ContentView: View {
         guard let pid = NotchContentState.shared.recordingTargetPID else { return }
         let startedAt = ProcessInfo.processInfo.systemUptime
         self.appBench("focus_restore_start targetPID=\(pid)")
+        if let focusTarget = self.recordingFocusTarget, focusTarget.pid == pid {
+            if TypingService.isExactFocusTargetActive(focusTarget) {
+                self.appBench("focus_restore_result activated=false element=true elapsedMs=0 reason=already_focused")
+                return
+            }
+            let activated = TypingService.activateApp(pid: pid)
+            let focusedElementRestored = TypingService.restoreFocusTarget(focusTarget)
+            self.appBench(
+                "focus_restore_result activated=\(activated) element=\(focusedElementRestored) elapsedMs=\(Int(((ProcessInfo.processInfo.systemUptime - startedAt) * 1000).rounded()))"
+            )
+            return
+        }
         if TypingService.isCapturedFocusStillActive(for: pid) {
             self.appBench("focus_restore_result activated=false element=true elapsedMs=0 reason=already_focused")
             DebugLogger.shared.debug(

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1620,12 +1620,15 @@ struct ContentView: View {
         return (name: "Unknown", bundleId: "unknown", windowTitle: "")
     }
 
-    private func isSpokenSendBlockedApp(
-        _ appInfo: (name: String, bundleId: String, windowTitle: String)
-    ) -> Bool {
-        TerminalAppClassifier.isTerminal(
-            appName: appInfo.name,
-            bundleID: appInfo.bundleId
+    private func isSpokenSendBlockedTarget(_ target: TypingService.CapturedFocusTarget?) -> Bool {
+        guard let target,
+              let app = NSRunningApplication(processIdentifier: target.pid)
+        else {
+            return true
+        }
+        return TerminalAppClassifier.isTerminal(
+            appName: app.localizedName ?? "",
+            bundleID: app.bundleIdentifier ?? ""
         )
     }
 
@@ -2469,7 +2472,7 @@ struct ContentView: View {
                 && aiFallbackReason == nil
                 && (sendsExistingDraft || !finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 && targetMatchesRecordingFocus
-                && !self.isSpokenSendBlockedApp(appInfo)
+                && !self.isSpokenSendBlockedTarget(self.recordingFocusTarget)
             // Dispatch insertion as soon as the destination app is ready; the
             // overlay hides asynchronously after output so it cannot delay paste.
             if typingTarget.shouldRestoreOriginalFocus {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -287,6 +287,9 @@ struct ContentView: View {
     @State private var spokenSendCountdownStartedAt: TimeInterval?
     @State private var spokenSendLastVoiceActivityAt: TimeInterval = 0
     @State private var spokenSendVoiceActivityCancellable: AnyCancellable?
+    @State private var spokenSendVoiceActivityGeneration: UInt64 = 0
+    @State private var activeSpokenSendVoiceActivityID: UInt64?
+    @State private var isStoppingAndProcessingTranscription = false
 
     private var isRecordingAnyShortcutCapture: Bool {
         self.activeShortcutRecordingTarget != nil
@@ -2088,6 +2091,16 @@ struct ContentView: View {
     // MARK: - Stop and Process Transcription
 
     private func stopAndProcessTranscription(route: DictationOutputRoute = .normal) async {
+        guard !self.isStoppingAndProcessingTranscription else {
+            DebugLogger.shared.debug("Ignoring duplicate stop-and-process request", source: "ContentView")
+            return
+        }
+        self.isStoppingAndProcessingTranscription = true
+        defer { self.isStoppingAndProcessingTranscription = false }
+        await self.performStopAndProcessTranscription(route: route)
+    }
+
+    private func performStopAndProcessTranscription(route: DictationOutputRoute) async {
         DebugLogger.shared.debug("stopAndProcessTranscription called", source: "ContentView")
         DebugLogger.shared.info("Output route selected: \(route.rawValue)", source: "ContentView")
         self.appBench("stop_path_enter route=\(route.rawValue)")
@@ -2107,7 +2120,7 @@ struct ContentView: View {
             !wasCommandMode &&
             !promptTest.isActive &&
             !shouldUseAIOnStop &&
-            !self.settings.spokenSendEnabled
+            !self.spokenSendIsPendingForCurrentUtterance
         var didRequestOverlayHideOnStop = false
         DebugLogger.shared.info(
             "Routing decision snapshot | activeMode=\(modeAtStop.rawValue) | rewrite=\(wasRewriteMode) | command=\(wasCommandMode) | overlay=\(NotchContentState.shared.mode.rawValue)",
@@ -2491,7 +2504,7 @@ struct ContentView: View {
                     targetPID: typingTarget.pid,
                     textReadyAt: finalTextReadyAt
                 )
-                didTypeExternally = deliveryOutcome.didInsert
+                didTypeExternally = deliveryOutcome.didInsert || deliveryOutcome.didDispatchAction
             } else {
                 self.asr.typeOutputPlanToActiveField(
                     finalOutputPlan,
@@ -2512,8 +2525,7 @@ struct ContentView: View {
                     try? await Task.sleep(nanoseconds: 650_000_000)
                 }
             }
-            NotchOverlayManager.shared.updateTranscriptionText("")
-            NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
+            self.clearSpokenSendStatusIfNeeded(requested: spokenSendRequested)
             if !shouldShowAIProcessingFailure, !didRequestOverlayHideOnStop {
                 self.hideOverlayAfterOutput()
             }
@@ -2608,6 +2620,22 @@ struct ContentView: View {
         NotchContentState.shared.setSpokenSendIndicatorState(shouldSend ? .detected : .hidden)
     }
 
+    private var spokenSendIsPendingForCurrentUtterance: Bool {
+        guard self.settings.spokenSendEnabled else { return false }
+        if self.spokenSendAutoStopTriggered { return true }
+        return SpokenSendParser.parse(
+            self.asr.partialTranscription,
+            phrase: self.settings.spokenSendPhrase,
+            enabled: true
+        ).shouldSend
+    }
+
+    private func clearSpokenSendStatusIfNeeded(requested: Bool) {
+        guard requested else { return }
+        NotchOverlayManager.shared.updateTranscriptionText("")
+        NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
+    }
+
     private func advanceOverlayLifecycle() {
         self.spokenSendAutoStopTask?.cancel()
         self.spokenSendAutoStopTask = nil
@@ -2656,7 +2684,7 @@ struct ContentView: View {
         let countdownStartedAt = ProcessInfo.processInfo.systemUptime
         self.spokenSendCountdownStartedAt = countdownStartedAt
         self.spokenSendLastVoiceActivityAt = countdownStartedAt
-        self.startSpokenSendVoiceActivityMonitoring()
+        let expectedVoiceActivityMonitoringID = self.startSpokenSendVoiceActivityMonitoring()
         let expectedCountdownID = NotchContentState.shared.beginSpokenSendCountdown()
         self.spokenSendAutoStopTask = Task { @MainActor in
             // Keep one countdown across harmless streaming refinements such as punctuation or casing.
@@ -2678,11 +2706,11 @@ struct ContentView: View {
                       quietDuration: quietDuration
                   )
             else {
+                self.stopSpokenSendVoiceActivityMonitoring(matching: expectedVoiceActivityMonitoringID)
                 if self.overlayLifecycleID == expectedOverlayLifecycleID,
                    NotchContentState.shared.spokenSendCountdownID == expectedCountdownID
                 {
                     self.spokenSendAutoStopTask = nil
-                    self.stopSpokenSendVoiceActivityMonitoring()
                     self.spokenSendCountdownStartedAt = nil
                     if NotchContentState.shared.spokenSendIndicatorState == .countingDown {
                         NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
@@ -2692,7 +2720,7 @@ struct ContentView: View {
             }
 
             self.spokenSendAutoStopTask = nil
-            self.stopSpokenSendVoiceActivityMonitoring()
+            self.stopSpokenSendVoiceActivityMonitoring(matching: expectedVoiceActivityMonitoringID)
             self.spokenSendCountdownStartedAt = nil
             self.spokenSendAutoStopTriggered = true
             NotchContentState.shared.setSpokenSendIndicatorState(.sending)
@@ -2725,19 +2753,30 @@ struct ContentView: View {
         }
     }
 
-    private func startSpokenSendVoiceActivityMonitoring() {
-        guard self.spokenSendVoiceActivityCancellable == nil else { return }
+    private func startSpokenSendVoiceActivityMonitoring() -> UInt64 {
+        if let activeSpokenSendVoiceActivityID {
+            return activeSpokenSendVoiceActivityID
+        }
+        self.spokenSendVoiceActivityGeneration &+= 1
+        let monitoringID = self.spokenSendVoiceActivityGeneration
+        self.activeSpokenSendVoiceActivityID = monitoringID
         self.spokenSendVoiceActivityCancellable = self.asr.audioLevelPublisher
             .filter(SpokenSendParser.isMeaningfulVoiceActivity)
-            .receive(on: RunLoop.main)
-            .sink { level in
+            .receive(on: DispatchQueue.main)
+            .sink { [monitoringID] level in
+                guard self.activeSpokenSendVoiceActivityID == monitoringID else { return }
                 self.handleSpokenSendAudioLevel(level)
             }
+        return monitoringID
     }
 
-    private func stopSpokenSendVoiceActivityMonitoring() {
+    private func stopSpokenSendVoiceActivityMonitoring(matching monitoringID: UInt64? = nil) {
+        if let monitoringID, self.activeSpokenSendVoiceActivityID != monitoringID {
+            return
+        }
         self.spokenSendVoiceActivityCancellable?.cancel()
         self.spokenSendVoiceActivityCancellable = nil
+        self.activeSpokenSendVoiceActivityID = nil
     }
 
     private func hideOverlayAsync(reason: String) {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -1623,11 +1623,10 @@ struct ContentView: View {
     private func isSpokenSendBlockedApp(
         _ appInfo: (name: String, bundleId: String, windowTitle: String)
     ) -> Bool {
-        let identity = "\(appInfo.name) \(appInfo.bundleId)".lowercased()
-        return identity.contains("terminal")
-            || identity.contains("iterm")
-            || identity.contains("warp")
-            || identity.contains("ghostty")
+        TerminalAppClassifier.isTerminal(
+            appName: appInfo.name,
+            bundleID: appInfo.bundleId
+        )
     }
 
     private func deliverSpokenSend(

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2157,6 +2157,9 @@ struct ContentView: View {
             TranscriptionSoundPlayer.shared.playStopSound()
         })
         self.appBench("asr_stop_return elapsedMs=\(Int(((ProcessInfo.processInfo.systemUptime - asrStopStartedAt) * 1000).rounded()))")
+        // The duplicate-stop race ends when ASR reports that it is no longer running.
+        // Do not hold this guard across delivery or a new recording's stop can be swallowed.
+        self.isStoppingAndProcessingTranscription = false
         let audioSnapshot = self.asr.consumeLastCompletedAudioSnapshot()
         DebugLogger.shared.info(
             "Stop transcription result | chars=\(transcribedText.count) | empty=\(transcribedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)",
@@ -2489,7 +2492,7 @@ struct ContentView: View {
             // Dispatch insertion as soon as the destination app is ready; the
             // overlay hides asynchronously after output so it cannot delay paste.
             if typingTarget.shouldRestoreOriginalFocus {
-                await self.restoreFocusToRecordingTarget()
+                await self.restoreFocusToRecordingTarget(requireExactTarget: spokenSendAllowed)
             }
             if spokenSendAllowed {
                 NotchContentState.shared.setSpokenSendIndicatorState(.sending)
@@ -3455,12 +3458,17 @@ struct ContentView: View {
 
     /// Best-effort: re-activate the app that was focused when recording started.
     /// Skips the AX restore work when the captured text element is already focused.
-    private func restoreFocusToRecordingTarget() async {
+    private func restoreFocusToRecordingTarget(requireExactTarget: Bool = false) async {
         guard let pid = NotchContentState.shared.recordingTargetPID else { return }
         let startedAt = ProcessInfo.processInfo.systemUptime
         self.appBench("focus_restore_start targetPID=\(pid)")
         if let focusTarget = self.recordingFocusTarget, focusTarget.pid == pid {
-            if TypingService.isExactFocusTargetActive(focusTarget) {
+            // Ordinary dictation keeps the legacy PID/editable-focus check because some apps
+            // vend a fresh AX element for the same field. Spoken Send remains exact-target only.
+            let targetIsStillActive = requireExactTarget
+                ? TypingService.isExactFocusTargetActive(focusTarget)
+                : TypingService.isCapturedFocusStillActive(for: pid)
+            if targetIsStillActive {
                 self.appBench("focus_restore_result activated=false element=true elapsedMs=0 reason=already_focused")
                 return
             }
@@ -4051,13 +4059,6 @@ extension ContentView {
             return
         }
         self.advanceOverlayLifecycle()
-        if self.asr.micStatus == .authorized {
-            self.appBench("overlay_mode_request mode=Dictation")
-            self.menuBarManager.setOverlayMode(.dictation)
-            self.menuBarManager.showRecordingOverlayImmediately()
-            self.appBench("overlay_mode_requested mode=Dictation")
-            self.appBench("overlay_phase phase=connecting")
-        }
         Task {
             let asrStartStartedAt = ProcessInfo.processInfo.systemUptime
             DebugLogger.shared.benchmark("APP_BENCH", message: "asr_start_call", source: "AppBenchmark")
@@ -4067,6 +4068,12 @@ extension ContentView {
                 }
                 self.captureRecordingContext()
                 self.prewarmPrivateAIDictationIfNeeded(for: slot)
+                // Capture owns the critical path. Showing the overlay before asr.start()
+                // previously blocked the main actor for 58-87 ms before first PCM.
+                self.appBench("overlay_mode_request mode=Dictation")
+                self.menuBarManager.setOverlayMode(.dictation)
+                self.menuBarManager.showRecordingOverlayImmediately()
+                self.appBench("overlay_mode_requested mode=Dictation")
                 self.appBench("overlay_phase phase=recording trigger=first_pcm")
             })
             if startOutcome == .failed {

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2696,7 +2696,7 @@ struct ContentView: View {
     }
 
     private func handleSpokenSendAudioLevel(_ level: CGFloat) {
-        guard level > 0 else { return }
+        guard SpokenSendParser.isMeaningfulVoiceActivity(level) else { return }
 
         let activityAt = ProcessInfo.processInfo.systemUptime
         self.spokenSendLastVoiceActivityAt = activityAt

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -286,6 +286,7 @@ struct ContentView: View {
     @State private var spokenSendPartialRevision: UInt64 = 0
     @State private var spokenSendCountdownStartedAt: TimeInterval?
     @State private var spokenSendLastVoiceActivityAt: TimeInterval = 0
+    @State private var spokenSendVoiceActivityCancellable: AnyCancellable?
 
     private var isRecordingAnyShortcutCapture: Bool {
         self.activeShortcutRecordingTarget != nil
@@ -361,9 +362,6 @@ struct ContentView: View {
             }
             .onReceive(self.asr.$partialTranscription) { text in
                 self.handleSpokenSendPartialTranscription(text)
-            }
-            .onReceive(self.asr.audioLevelPublisher) { level in
-                self.handleSpokenSendAudioLevel(level)
             }
             .toolbar {
                 if !self.settings.shouldShowOnboarding {
@@ -2611,6 +2609,7 @@ struct ContentView: View {
     private func advanceOverlayLifecycle() {
         self.spokenSendAutoStopTask?.cancel()
         self.spokenSendAutoStopTask = nil
+        self.stopSpokenSendVoiceActivityMonitoring()
         self.spokenSendAutoStopTriggered = false
         self.spokenSendPartialRevision = 0
         self.spokenSendCountdownStartedAt = nil
@@ -2636,6 +2635,7 @@ struct ContentView: View {
         guard shouldStop else {
             self.spokenSendAutoStopTask?.cancel()
             self.spokenSendAutoStopTask = nil
+            self.stopSpokenSendVoiceActivityMonitoring()
             self.spokenSendCountdownStartedAt = nil
             if !self.spokenSendAutoStopTriggered,
                NotchContentState.shared.spokenSendIndicatorState == .countingDown
@@ -2653,6 +2653,8 @@ struct ContentView: View {
         let expectedPartialRevision = self.spokenSendPartialRevision
         let countdownStartedAt = ProcessInfo.processInfo.systemUptime
         self.spokenSendCountdownStartedAt = countdownStartedAt
+        self.spokenSendLastVoiceActivityAt = countdownStartedAt
+        self.startSpokenSendVoiceActivityMonitoring()
         let expectedCountdownID = NotchContentState.shared.beginSpokenSendCountdown()
         self.spokenSendAutoStopTask = Task { @MainActor in
             // Keep one countdown across harmless streaming refinements such as punctuation or casing.
@@ -2678,6 +2680,7 @@ struct ContentView: View {
                    NotchContentState.shared.spokenSendCountdownID == expectedCountdownID
                 {
                     self.spokenSendAutoStopTask = nil
+                    self.stopSpokenSendVoiceActivityMonitoring()
                     self.spokenSendCountdownStartedAt = nil
                     if NotchContentState.shared.spokenSendIndicatorState == .countingDown {
                         NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
@@ -2687,6 +2690,7 @@ struct ContentView: View {
             }
 
             self.spokenSendAutoStopTask = nil
+            self.stopSpokenSendVoiceActivityMonitoring()
             self.spokenSendCountdownStartedAt = nil
             self.spokenSendAutoStopTriggered = true
             NotchContentState.shared.setSpokenSendIndicatorState(.sending)
@@ -2712,10 +2716,26 @@ struct ContentView: View {
 
         self.spokenSendAutoStopTask?.cancel()
         self.spokenSendAutoStopTask = nil
+        self.stopSpokenSendVoiceActivityMonitoring()
         self.spokenSendCountdownStartedAt = nil
         if NotchContentState.shared.spokenSendIndicatorState == .countingDown {
             NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
         }
+    }
+
+    private func startSpokenSendVoiceActivityMonitoring() {
+        guard self.spokenSendVoiceActivityCancellable == nil else { return }
+        self.spokenSendVoiceActivityCancellable = self.asr.audioLevelPublisher
+            .filter(SpokenSendParser.isMeaningfulVoiceActivity)
+            .receive(on: RunLoop.main)
+            .sink { level in
+                self.handleSpokenSendAudioLevel(level)
+            }
+    }
+
+    private func stopSpokenSendVoiceActivityMonitoring() {
+        self.spokenSendVoiceActivityCancellable?.cancel()
+        self.spokenSendVoiceActivityCancellable = nil
     }
 
     private func hideOverlayAsync(reason: String) {

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -62,6 +62,10 @@ struct SettingsBackupPayload: Codable, Equatable {
     let enableAIStreaming: Bool
     let copyTranscriptionToClipboard: Bool
     let textInsertionMode: SettingsStore.TextInsertionMode
+    let spokenSendEnabled: Bool?
+    let spokenSendImmediatelyEnabled: Bool?
+    let spokenSendPhrase: String?
+    let spokenSendKey: SettingsStore.SpokenSendKey?
     let preferredInputDeviceUID: String?
     // Optional so backups created before microphone priority ordering still decode.
     // swiftlint:disable:next discouraged_optional_collection

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -3195,6 +3195,10 @@ final class SettingsStore: ObservableObject {
             enableAIStreaming: self.enableAIStreaming,
             copyTranscriptionToClipboard: self.copyTranscriptionToClipboard,
             textInsertionMode: self.textInsertionMode,
+            spokenSendEnabled: self.spokenSendEnabled,
+            spokenSendImmediatelyEnabled: self.spokenSendImmediatelyEnabled,
+            spokenSendPhrase: self.spokenSendPhrase,
+            spokenSendKey: self.spokenSendKey,
             preferredInputDeviceUID: self.preferredInputDeviceUID,
             microphonePriority: self.microphonePriority,
             suppressedMicrophoneUIDs: self.suppressedMicrophoneUIDs.sorted(),
@@ -3318,6 +3322,18 @@ final class SettingsStore: ObservableObject {
         self.enableAIStreaming = payload.enableAIStreaming
         self.copyTranscriptionToClipboard = payload.copyTranscriptionToClipboard
         self.textInsertionMode = payload.textInsertionMode
+        if let spokenSendEnabled = payload.spokenSendEnabled {
+            self.spokenSendEnabled = spokenSendEnabled
+        }
+        if let spokenSendImmediatelyEnabled = payload.spokenSendImmediatelyEnabled {
+            self.spokenSendImmediatelyEnabled = spokenSendImmediatelyEnabled
+        }
+        if let spokenSendPhrase = payload.spokenSendPhrase {
+            self.spokenSendPhrase = spokenSendPhrase
+        }
+        if let spokenSendKey = payload.spokenSendKey {
+            self.spokenSendKey = spokenSendKey
+        }
         self.preferredInputDeviceUID = payload.preferredInputDeviceUID
         self.suppressedMicrophoneUIDs = Set(payload.suppressedMicrophoneUIDs ?? [])
         if let microphonePriority = payload.microphonePriority {
@@ -5094,6 +5110,10 @@ private extension SettingsStore {
         static let enableAIStreaming = "EnableAIStreaming"
         static let copyTranscriptionToClipboard = "CopyTranscriptionToClipboard"
         static let textInsertionMode = "TextInsertionMode"
+        static let spokenSendEnabled = "SpokenSendEnabled"
+        static let spokenSendImmediatelyEnabled = "SpokenSendImmediatelyEnabled"
+        static let spokenSendPhrase = "SpokenSendPhrase"
+        static let spokenSendKey = "SpokenSendKey"
         static let autoUpdateCheckEnabled = "AutoUpdateCheckEnabled"
         static let betaReleasesEnabled = "BetaReleasesEnabled"
         static let lastUpdateCheckDate = "LastUpdateCheckDate"
@@ -5222,6 +5242,77 @@ private extension SettingsStore {
 }
 
 extension SettingsStore {
+    enum SpokenSendKey: String, CaseIterable, Identifiable, Codable {
+        case enter
+        case shiftEnter
+        case commandEnter
+
+        var id: String {
+            self.rawValue
+        }
+
+        var displayName: String {
+            switch self {
+            case .enter:
+                return "Enter"
+            case .shiftEnter:
+                return "Shift + Enter"
+            case .commandEnter:
+                return "Command + Enter"
+            }
+        }
+
+        var eventFlags: CGEventFlags {
+            switch self {
+            case .enter:
+                return []
+            case .shiftEnter:
+                return .maskShift
+            case .commandEnter:
+                return .maskCommand
+            }
+        }
+    }
+
+    var spokenSendEnabled: Bool {
+        get { self.defaults.object(forKey: Keys.spokenSendEnabled) as? Bool ?? false }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.spokenSendEnabled)
+        }
+    }
+
+    var spokenSendImmediatelyEnabled: Bool {
+        get { self.defaults.object(forKey: Keys.spokenSendImmediatelyEnabled) as? Bool ?? true }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.spokenSendImmediatelyEnabled)
+        }
+    }
+
+    var spokenSendPhrase: String {
+        get { self.defaults.string(forKey: Keys.spokenSendPhrase) ?? "send it" }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.spokenSendPhrase)
+        }
+    }
+
+    var spokenSendKey: SpokenSendKey {
+        get {
+            guard let raw = self.defaults.string(forKey: Keys.spokenSendKey),
+                  let key = SpokenSendKey(rawValue: raw)
+            else {
+                return .enter
+            }
+            return key
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue.rawValue, forKey: Keys.spokenSendKey)
+        }
+    }
+
     enum TextInsertionMode: String, CaseIterable, Identifiable, Codable {
         case standard
         case reliablePaste

--- a/Sources/Fluid/Services/ASRService+SpokenPunctuationFormatting.swift
+++ b/Sources/Fluid/Services/ASRService+SpokenPunctuationFormatting.swift
@@ -12,12 +12,25 @@ enum TerminalAppClassifier {
         "hyper",
         "termius",
     ]
+    private static let contextMarkers = [
+        "terminal",
+        "shell",
+        "ssh",
+        "console",
+        "xterm",
+        "hterm",
+    ]
 
     static func isTerminal(appName: String?, bundleID: String?) -> Bool {
         let identity = [appName, bundleID]
             .compactMap { $0?.lowercased() }
             .joined(separator: " ")
         return self.identityMarkers.contains { identity.contains($0) }
+    }
+
+    static func isTerminalContext(labels: [String]) -> Bool {
+        let context = labels.joined(separator: " ").lowercased()
+        return self.contextMarkers.contains { context.contains($0) }
     }
 }
 

--- a/Sources/Fluid/Services/ASRService+SpokenPunctuationFormatting.swift
+++ b/Sources/Fluid/Services/ASRService+SpokenPunctuationFormatting.swift
@@ -1,5 +1,24 @@
 import Foundation
 
+enum TerminalAppClassifier {
+    private static let identityMarkers = [
+        "terminal",
+        "iterm",
+        "warp",
+        "ghostty",
+        "kitty",
+        "alacritty",
+        "wezterm",
+    ]
+
+    static func isTerminal(appName: String?, bundleID: String?) -> Bool {
+        let identity = [appName, bundleID]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+        return self.identityMarkers.contains { identity.contains($0) }
+    }
+}
+
 extension ASRService {
     static func applySpokenPunctuationFormatting(
         _ text: String,
@@ -30,7 +49,8 @@ private enum SpokenPunctuationFormatter {
             let haystack = [self.appName, self.bundleID, self.windowTitle]
                 .compactMap { $0?.lowercased() }
                 .joined(separator: " ")
-            return haystack.contains("codex") ||
+            return TerminalAppClassifier.isTerminal(appName: self.appName, bundleID: self.bundleID) ||
+                haystack.contains("codex") ||
                 haystack.contains("chatgpt") ||
                 haystack.contains("claude") ||
                 haystack.contains("cursor") ||
@@ -38,12 +58,6 @@ private enum SpokenPunctuationFormatter {
                 haystack.contains("xcode") ||
                 haystack.contains("visual studio code") ||
                 haystack.contains("vscode") ||
-                haystack.contains("terminal") ||
-                haystack.contains("iterm") ||
-                haystack.contains("warp") ||
-                haystack.contains("ghostty") ||
-                haystack.contains("kitty") ||
-                haystack.contains("alacritty") ||
                 haystack.contains("slack") ||
                 haystack.contains("discord") ||
                 haystack.contains("teams")

--- a/Sources/Fluid/Services/ASRService+SpokenPunctuationFormatting.swift
+++ b/Sources/Fluid/Services/ASRService+SpokenPunctuationFormatting.swift
@@ -9,6 +9,8 @@ enum TerminalAppClassifier {
         "kitty",
         "alacritty",
         "wezterm",
+        "hyper",
+        "termius",
     ]
 
     static func isTerminal(appName: String?, bundleID: String?) -> Bool {

--- a/Sources/Fluid/Services/ASRService+SpokenPunctuationFormatting.swift
+++ b/Sources/Fluid/Services/ASRService+SpokenPunctuationFormatting.swift
@@ -65,6 +65,7 @@ private enum SpokenPunctuationFormatter {
                 .compactMap { $0?.lowercased() }
                 .joined(separator: " ")
             return TerminalAppClassifier.isTerminal(appName: self.appName, bundleID: self.bundleID) ||
+                TerminalAppClassifier.isTerminalContext(labels: [self.windowTitle ?? ""]) ||
                 haystack.contains("codex") ||
                 haystack.contains("chatgpt") ||
                 haystack.contains("claude") ||

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -4554,6 +4554,46 @@ final class ASRService: ObservableObject {
         )
     }
 
+    func typeOutputPlanToActiveFieldAndWait(
+        _ plan: DictationLiteralOutputPlan,
+        preferredTargetPID: pid_t?,
+        textReadyAt: TimeInterval? = nil,
+        tracksDictionaryCorrections: Bool = false,
+        postInsertionKey: SettingsStore.SpokenSendKey? = nil,
+        requiredFocusTarget: TypingService.CapturedFocusTarget? = nil
+    ) async -> TypingService.DeliveryOutcome {
+        let requestedAt = ProcessInfo.processInfo.systemUptime
+        let textReadyAge = textReadyAt.map { Int(((requestedAt - $0) * 1000).rounded()) }
+        let text = plan.plainText
+        DebugLogger.shared.benchmark(
+            "TYPING_BENCH",
+            message: "asr_type_request chars=\(text.count) preferredPID=\(preferredTargetPID.map { String($0) } ?? "nil") textReadyAgeMs=\(textReadyAge.map { String($0) } ?? "nil")",
+            source: "TypingBenchmark"
+        )
+        let outcome = await withCheckedContinuation { continuation in
+            self.typingService.typeOutputPlanInstantly(
+                plan,
+                preferredTargetPID: preferredTargetPID,
+                textReadyAt: textReadyAt,
+                tracksDictionaryCorrections: tracksDictionaryCorrections,
+                postInsertionKey: postInsertionKey,
+                requiredFocusTarget: requiredFocusTarget
+            ) { outcome in
+                continuation.resume(returning: outcome)
+            }
+        }
+        let dispatchedAt = ProcessInfo.processInfo.systemUptime
+        let textReadyToDispatchMs = textReadyAt.map {
+            String(Int(((dispatchedAt - $0) * 1000).rounded()))
+        } ?? "nil"
+        DebugLogger.shared.benchmark(
+            "TYPING_BENCH",
+            message: "asr_type_dispatched chars=\(text.count) preferredPID=\(preferredTargetPID.map { String($0) } ?? "nil") textReadyToDispatchMs=\(textReadyToDispatchMs)",
+            source: "TypingBenchmark"
+        )
+        return outcome
+    }
+
     /// Removes filler sounds from transcribed text
     static func removeFillerWords(_ text: String) -> String {
         guard SettingsStore.shared.removeFillerWordsEnabled else { return text }

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -782,6 +782,10 @@ final class GlobalHotkeyManager: NSObject {
             return tapRecoveryResult
         }
 
+        if Self.isSynthesizedTypingEvent(event) {
+            return Unmanaged.passUnretained(event)
+        }
+
         if self.isShortcutCaptureActiveProvider?() ?? false {
             self.resetModifierOnlyShortcutTracking()
             return Unmanaged.passUnretained(event)
@@ -1280,6 +1284,10 @@ final class GlobalHotkeyManager: NSObject {
         } else {
             DebugLogger.shared.debug("\(label) hold (\(duration)s) ignored - no automatic start", source: "GlobalHotkeyManager")
         }
+    }
+
+    nonisolated static func isSynthesizedTypingEvent(_ event: CGEvent) -> Bool {
+        event.getIntegerValueField(.eventSourceUserData) == TypingService.synthesizedEventUserData
     }
 
     private func handlePrimaryDictationTriggerDown() {

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -119,6 +119,18 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newText in
                 guard self != nil else { return }
+                if asrService.isRunning,
+                   NotchContentState.shared.mode == .dictation,
+                   SettingsStore.shared.spokenSendEnabled,
+                   !SettingsStore.shared.spokenSendImmediatelyEnabled
+                {
+                    let detected = SpokenSendParser.parse(
+                        newText,
+                        phrase: SettingsStore.shared.spokenSendPhrase,
+                        enabled: true
+                    ).shouldSend
+                    NotchContentState.shared.setSpokenSendIndicatorState(detected ? .detected : .hidden)
+                }
                 if NotchOverlayManager.shared.shouldShowOrTrackLivePreviewText {
                     NotchOverlayManager.shared.updateTranscriptionText(newText)
                 }

--- a/Sources/Fluid/Services/NotchOverlayManager.swift
+++ b/Sources/Fluid/Services/NotchOverlayManager.swift
@@ -368,6 +368,7 @@ final class NotchOverlayManager {
 
         // Safety: reset processing state when hiding
         NotchContentState.shared.setProcessing(false)
+        NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
 
         // Handle visible or showing states (can hide while still expanding)
         guard self.state == .visible || self.state == .showing, self.notch != nil else {

--- a/Sources/Fluid/Services/SpokenSendParser.swift
+++ b/Sources/Fluid/Services/SpokenSendParser.swift
@@ -83,38 +83,51 @@ enum SpokenSendParser {
         }
 
         guard let commandRegex = try? NSRegularExpression(
-            pattern: #"(?i)(?<![\p{L}\p{N}_])"# + phrasePattern + trailingPunctuation
+            pattern: #"(?i)(?<![\p{L}\p{N}_])("# +
+                phrasePattern +
+                #")(?:[\s\p{P}]+"# +
+                phrasePattern +
+                #")*"# +
+                trailingPunctuation
         ), let match = commandRegex.firstMatch(
             in: text,
             range: NSRange(text.startIndex..., in: text)
         ), match.range.location != NSNotFound,
-        let commandRange = Range(match.range, in: text)
+        let commandRange = Range(match.range, in: text),
+        let firstPhraseRange = Range(match.range(at: 1), in: text)
         else {
             return SpokenSendParseResult(text: text, shouldSend: false)
         }
 
-        let commandPrefix = String(text[..<commandRange.lowerBound])
-        let trimmedPrefix = commandPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmedPrefix.isEmpty || Self.endsWithCommandSeparator(trimmedPrefix) else {
-            return SpokenSendParseResult(text: text, shouldSend: false)
+        var commandPrefix = String(text[..<commandRange.lowerBound])
+        if let literalPrefixRegex = try? NSRegularExpression(
+            pattern: #"(?i)(?<![\p{L}\p{N}_])literal\s*$"#
+        ), let literalMatch = literalPrefixRegex.firstMatch(
+            in: commandPrefix,
+            range: NSRange(commandPrefix.startIndex..., in: commandPrefix)
+        ), let literalRange = Range(literalMatch.range, in: commandPrefix) {
+            commandPrefix.replaceSubrange(literalRange, with: text[firstPhraseRange])
         }
 
         let cleaned = Self.polishCommandPrefix(commandPrefix)
         return SpokenSendParseResult(text: cleaned, shouldSend: true)
     }
 
-    private static func endsWithCommandSeparator(_ text: String) -> Bool {
-        guard let last = text.last else { return false }
-        return [".", ",", ";", ":", "?", "!", "…", "-", "–", "—"].contains(last)
-    }
-
     private static func polishCommandPrefix(_ text: String) -> String {
         var polished = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let last = polished.last, [",", ";", ":", "-", "–", "—"].contains(last) else {
-            return polished
+        while let last = polished.last, [",", ";", ":", "-", "–", "—"].contains(last) {
+            polished.removeLast()
+            while polished.last?.isWhitespace == true {
+                polished.removeLast()
+            }
         }
 
-        polished.removeLast()
-        return polished.trimmingCharacters(in: .whitespacesAndNewlines) + "."
+        guard let last = polished.last else {
+            return polished
+        }
+        if [".", "?", "!", "…"].contains(last) {
+            return polished
+        }
+        return polished + "."
     }
 }

--- a/Sources/Fluid/Services/SpokenSendParser.swift
+++ b/Sources/Fluid/Services/SpokenSendParser.swift
@@ -9,7 +9,8 @@ enum SpokenSendParser {
     static let immediateStopSettleDuration: TimeInterval = 1.5
     static let immediateStopSettleNanoseconds: UInt64 = 1_500_000_000
     static let immediateStopRequiredSilenceDuration: TimeInterval = 0.35
-    static let immediateStopVoiceActivityGraceDuration: TimeInterval = 0.15
+    static let immediateStopVoiceActivityGraceDuration: TimeInterval = 0.35
+    static let immediateStopVoiceActivityLevelThreshold: CGFloat = 0.12
 
     static func shouldStopImmediately(
         _ text: String,
@@ -44,6 +45,10 @@ enum SpokenSendParser {
         voiceActivityAt: TimeInterval
     ) -> Bool {
         voiceActivityAt - countdownStartedAt >= self.immediateStopVoiceActivityGraceDuration
+    }
+
+    static func isMeaningfulVoiceActivity(_ level: CGFloat) -> Bool {
+        level >= self.immediateStopVoiceActivityLevelThreshold
     }
 
     static func parse(_ text: String, phrase: String, enabled: Bool) -> SpokenSendParseResult {
@@ -88,8 +93,28 @@ enum SpokenSendParser {
             return SpokenSendParseResult(text: text, shouldSend: false)
         }
 
-        let cleaned = String(text[..<commandRange.lowerBound])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let commandPrefix = String(text[..<commandRange.lowerBound])
+        let trimmedPrefix = commandPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedPrefix.isEmpty || Self.endsWithCommandSeparator(trimmedPrefix) else {
+            return SpokenSendParseResult(text: text, shouldSend: false)
+        }
+
+        let cleaned = Self.polishCommandPrefix(commandPrefix)
         return SpokenSendParseResult(text: cleaned, shouldSend: true)
+    }
+
+    private static func endsWithCommandSeparator(_ text: String) -> Bool {
+        guard let last = text.last else { return false }
+        return [".", ",", ";", ":", "?", "!", "…", "-", "–", "—"].contains(last)
+    }
+
+    private static func polishCommandPrefix(_ text: String) -> String {
+        var polished = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let last = polished.last, [",", ";", ":", "-", "–", "—"].contains(last) else {
+            return polished
+        }
+
+        polished.removeLast()
+        return polished.trimmingCharacters(in: .whitespacesAndNewlines) + "."
     }
 }

--- a/Sources/Fluid/Services/SpokenSendParser.swift
+++ b/Sources/Fluid/Services/SpokenSendParser.swift
@@ -11,6 +11,11 @@ enum SpokenSendParser {
     static let immediateStopRequiredSilenceDuration: TimeInterval = 0.35
     static let immediateStopVoiceActivityGraceDuration: TimeInterval = 0.35
     static let immediateStopVoiceActivityLevelThreshold: CGFloat = 0.12
+    private static let regexCache: NSCache<NSString, NSRegularExpression> = {
+        let cache = NSCache<NSString, NSRegularExpression>()
+        cache.countLimit = 12
+        return cache
+    }()
 
     static func shouldStopImmediately(
         _ text: String,
@@ -69,8 +74,8 @@ enum SpokenSendParser {
             .joined(separator: #"\s+"#)
         let trailingPunctuation = #"[\s\p{P}]*$"#
 
-        if let literalRegex = try? NSRegularExpression(
-            pattern: #"(?i)(?<![\p{L}\p{N}_])literal\s+("# + phrasePattern + #")"# + trailingPunctuation
+        if let literalRegex = Self.regex(
+            #"(?i)(?<![\p{L}\p{N}_])literal\s+("# + phrasePattern + #")"# + trailingPunctuation
         ), let match = literalRegex.firstMatch(
             in: text,
             range: NSRange(text.startIndex..., in: text)
@@ -82,8 +87,8 @@ enum SpokenSendParser {
             return SpokenSendParseResult(text: output, shouldSend: false)
         }
 
-        guard let commandRegex = try? NSRegularExpression(
-            pattern: #"(?i)(?<![\p{L}\p{N}_])("# +
+        guard let commandRegex = Self.regex(
+            #"(?i)(?<![\p{L}\p{N}_])("# +
                 phrasePattern +
                 #")(?:[\s\p{P}]+"# +
                 phrasePattern +
@@ -96,7 +101,10 @@ enum SpokenSendParser {
         let commandRange = Range(match.range, in: text),
         let firstPhraseRange = Range(match.range(at: 1), in: text)
         else {
-            return SpokenSendParseResult(text: text, shouldSend: false)
+            return SpokenSendParseResult(
+                text: Self.strippingLiteralMarkers(in: text, phrasePattern: phrasePattern),
+                shouldSend: false
+            )
         }
 
         var commandPrefix = String(text[..<commandRange.lowerBound])
@@ -105,17 +113,46 @@ enum SpokenSendParser {
             from: &commandPrefix,
             closedBy: commandSuffix
         )
-        if let literalPrefixRegex = try? NSRegularExpression(
-            pattern: #"(?i)(?<![\p{L}\p{N}_])literal\s*$"#
+        if let literalPrefixRegex = Self.regex(
+            #"(?i)(?<![\p{L}\p{N}_])literal\s*$"#
         ), let literalMatch = literalPrefixRegex.firstMatch(
             in: commandPrefix,
             range: NSRange(commandPrefix.startIndex..., in: commandPrefix)
         ), let literalRange = Range(literalMatch.range, in: commandPrefix) {
             commandPrefix.replaceSubrange(literalRange, with: text[firstPhraseRange])
         }
+        commandPrefix = Self.strippingLiteralMarkers(
+            in: commandPrefix,
+            phrasePattern: phrasePattern
+        )
 
         let cleaned = Self.polishCommandPrefix(commandPrefix)
         return SpokenSendParseResult(text: cleaned, shouldSend: true)
+    }
+
+    private static func strippingLiteralMarkers(in text: String, phrasePattern: String) -> String {
+        guard let regex = Self.regex(
+            #"(?i)(?<![\p{L}\p{N}_])literal\s+("# + phrasePattern + #")"#
+        ) else {
+            return text
+        }
+        return regex.stringByReplacingMatches(
+            in: text,
+            range: NSRange(text.startIndex..., in: text),
+            withTemplate: "$1"
+        )
+    }
+
+    private static func regex(_ pattern: String) -> NSRegularExpression? {
+        let key = pattern as NSString
+        if let cached = self.regexCache.object(forKey: key) {
+            return cached
+        }
+        guard let compiled = try? NSRegularExpression(pattern: pattern) else {
+            return nil
+        }
+        self.regexCache.setObject(compiled, forKey: key)
+        return compiled
     }
 
     private static func removePairedOpeningDelimiters(

--- a/Sources/Fluid/Services/SpokenSendParser.swift
+++ b/Sources/Fluid/Services/SpokenSendParser.swift
@@ -100,6 +100,11 @@ enum SpokenSendParser {
         }
 
         var commandPrefix = String(text[..<commandRange.lowerBound])
+        let commandSuffix = String(text[firstPhraseRange.upperBound..<commandRange.upperBound])
+        Self.removePairedOpeningDelimiters(
+            from: &commandPrefix,
+            closedBy: commandSuffix
+        )
         if let literalPrefixRegex = try? NSRegularExpression(
             pattern: #"(?i)(?<![\p{L}\p{N}_])literal\s*$"#
         ), let literalMatch = literalPrefixRegex.firstMatch(
@@ -111,6 +116,33 @@ enum SpokenSendParser {
 
         let cleaned = Self.polishCommandPrefix(commandPrefix)
         return SpokenSendParseResult(text: cleaned, shouldSend: true)
+    }
+
+    private static func removePairedOpeningDelimiters(
+        from text: inout String,
+        closedBy commandSuffix: String
+    ) {
+        let delimiterPairs: [Character: Character] = [
+            "(": ")", "[": "]", "{": "}",
+            "\"": "\"", "'": "'", "“": "”", "‘": "’", "«": "»",
+        ]
+        while true {
+            var candidate = text
+            while candidate.last?.isWhitespace == true {
+                candidate.removeLast()
+            }
+            guard let opener = candidate.last,
+                  let closer = delimiterPairs[opener],
+                  commandSuffix.contains(closer)
+            else {
+                return
+            }
+            candidate.removeLast()
+            text = candidate
+            while text.last?.isWhitespace == true {
+                text.removeLast()
+            }
+        }
     }
 
     private static func polishCommandPrefix(_ text: String) -> String {

--- a/Sources/Fluid/Services/SpokenSendParser.swift
+++ b/Sources/Fluid/Services/SpokenSendParser.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+struct SpokenSendParseResult: Equatable {
+    let text: String
+    let shouldSend: Bool
+}
+
+enum SpokenSendParser {
+    static let immediateStopSettleDuration: TimeInterval = 1.5
+    static let immediateStopSettleNanoseconds: UInt64 = 1_500_000_000
+    static let immediateStopRequiredSilenceDuration: TimeInterval = 0.35
+    static let immediateStopVoiceActivityGraceDuration: TimeInterval = 0.15
+
+    static func shouldStopImmediately(
+        _ text: String,
+        phrase: String,
+        spokenSendEnabled: Bool,
+        sendImmediatelyEnabled: Bool
+    ) -> Bool {
+        sendImmediatelyEnabled &&
+            self.parse(text, phrase: phrase, enabled: spokenSendEnabled).shouldSend
+    }
+
+    static func canCompleteImmediateStop(
+        _ text: String,
+        phrase: String,
+        spokenSendEnabled: Bool,
+        sendImmediatelyEnabled: Bool,
+        receivedFreshTranscript: Bool,
+        quietDuration: TimeInterval
+    ) -> Bool {
+        receivedFreshTranscript &&
+            quietDuration >= self.immediateStopRequiredSilenceDuration &&
+            self.shouldStopImmediately(
+                text,
+                phrase: phrase,
+                spokenSendEnabled: spokenSendEnabled,
+                sendImmediatelyEnabled: sendImmediatelyEnabled
+            )
+    }
+
+    static func shouldCancelCountdownForVoiceActivity(
+        countdownStartedAt: TimeInterval,
+        voiceActivityAt: TimeInterval
+    ) -> Bool {
+        voiceActivityAt - countdownStartedAt >= self.immediateStopVoiceActivityGraceDuration
+    }
+
+    static func parse(_ text: String, phrase: String, enabled: Bool) -> SpokenSendParseResult {
+        guard enabled else {
+            return SpokenSendParseResult(text: text, shouldSend: false)
+        }
+
+        let phraseWords = phrase
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isWhitespace)
+            .map(String.init)
+        guard !phraseWords.isEmpty else {
+            return SpokenSendParseResult(text: text, shouldSend: false)
+        }
+
+        let phrasePattern = phraseWords
+            .map(NSRegularExpression.escapedPattern(for:))
+            .joined(separator: #"\s+"#)
+        let trailingPunctuation = #"[\s\p{P}]*$"#
+
+        if let literalRegex = try? NSRegularExpression(
+            pattern: #"(?i)(?<![\p{L}\p{N}_])literal\s+("# + phrasePattern + #")"# + trailingPunctuation
+        ), let match = literalRegex.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ), match.range.location != NSNotFound,
+        let wholeRange = Range(match.range, in: text),
+        let phraseRange = Range(match.range(at: 1), in: text) {
+            var output = text
+            output.replaceSubrange(wholeRange, with: text[phraseRange])
+            return SpokenSendParseResult(text: output, shouldSend: false)
+        }
+
+        guard let commandRegex = try? NSRegularExpression(
+            pattern: #"(?i)(?<![\p{L}\p{N}_])"# + phrasePattern + trailingPunctuation
+        ), let match = commandRegex.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ), match.range.location != NSNotFound,
+        let commandRange = Range(match.range, in: text)
+        else {
+            return SpokenSendParseResult(text: text, shouldSend: false)
+        }
+
+        let cleaned = String(text[..<commandRange.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return SpokenSendParseResult(text: cleaned, shouldSend: true)
+    }
+}

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -743,7 +743,10 @@ final class TypingService {
             self.log("[TypingService] Exact target changed before Accessibility fallback")
             return false
         }
-        return self.tryAllTextInsertionMethods(requiredFocusTarget.element, text)
+        return self.performVerifiedExactTargetAccessibilityInsertion(
+            text,
+            target: requiredFocusTarget
+        )
     }
 
     private enum ExactTargetEventAttempt {
@@ -773,6 +776,29 @@ final class TypingService {
         )
         self.log("[TypingService] Exact-target event verification: \(verification.rawValue)")
         return verification.isConfirmed ? .confirmed : .dispatchedUnverified
+    }
+
+    private func performVerifiedExactTargetAccessibilityInsertion(
+        _ text: String,
+        target: CapturedFocusTarget
+    ) -> Bool {
+        guard Self.isExactFocusTargetActive(target),
+              let snapshot = self.captureFocusedTextSnapshot(),
+              snapshot.pid == target.pid,
+              CFEqual(snapshot.element, target.element),
+              self.tryAllTextInsertionMethods(target.element, text),
+              Self.isExactFocusTargetActive(target)
+        else {
+            return false
+        }
+
+        let verification = self.waitForFocusedTextVerification(
+            from: snapshot,
+            expectedText: text,
+            timeoutMicros: 500_000
+        )
+        self.log("[TypingService] Exact-target Accessibility verification: \(verification.rawValue)")
+        return verification.isConfirmed
     }
 
     private func waitForPhysicalModifiersToRelease(timeout: TimeInterval) -> Bool {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -49,6 +49,7 @@ final class TypingService {
         preferredTargetPID: pid_t?,
         requiredTargetPID: pid_t?,
         isSecureTextField: Bool,
+        isTerminalLikeContext: Bool = false,
         modifiersReleased: Bool,
         exactFocusIsActive: Bool,
         insertionConfirmed: Bool = true
@@ -58,7 +59,11 @@ final class TypingService {
         else {
             return false
         }
-        return !isSecureTextField && modifiersReleased && exactFocusIsActive && insertionConfirmed
+        return !isSecureTextField &&
+            !isTerminalLikeContext &&
+            modifiersReleased &&
+            exactFocusIsActive &&
+            insertionConfirmed
     }
 
     // Logging toggle (off by default). Enable by setting env FLUID_TYPING_LOGS=1
@@ -530,11 +535,14 @@ final class TypingService {
                 preferredTargetPID: preferredTargetPID,
                 requiredTargetPID: requiredFocusTarget.pid,
                 isSecureTextField: requiredFocusTarget.isSecureTextField,
+                isTerminalLikeContext: Self.hasTerminalLikeContext(requiredFocusTarget),
                 modifiersReleased: self.waitForPhysicalModifiersToRelease(
                     timeout: Self.postInsertionModifierReleaseTimeout
                 ),
                 exactFocusIsActive: Self.isExactFocusTargetActive(requiredFocusTarget),
-                insertionConfirmed: !hasTextToInsert || outcome.didInsert
+                insertionConfirmed: hasTextToInsert
+                    ? outcome.didInsert
+                    : Self.hasNonemptyEditableDraft(requiredFocusTarget)
             ),
                 self.postReturnKey(postInsertionKey, target: requiredFocusTarget)
             else {
@@ -755,12 +763,8 @@ final class TypingService {
         guard Self.isExactFocusTargetActive(target) else { return false }
         keyDown.postToPid(target.pid)
         usleep(10_000)
-        guard Self.isExactFocusTargetActive(target) else {
-            keyUp.postToPid(target.pid)
-            return false
-        }
         keyUp.postToPid(target.pid)
-        return Self.isExactFocusTargetActive(target)
+        return true
     }
 
     private func tryReliablePasteInsertion(_ text: String, preferredTargetPID: pid_t?) -> Bool {
@@ -812,6 +816,65 @@ final class TypingService {
         let result = AXUIElementCopyAttributeValue(element, attribute, &value)
         guard result == .success else { return nil }
         return value as? String
+    }
+
+    private static func accessibilityContextLabels(
+        for element: AXUIElement,
+        window: AXUIElement?
+    ) -> [String] {
+        let attributes = [
+            kAXRoleDescriptionAttribute as CFString,
+            kAXDescriptionAttribute as CFString,
+            kAXTitleAttribute as CFString,
+            kAXIdentifierAttribute as CFString,
+            kAXHelpAttribute as CFString,
+        ]
+        var labels: [String] = []
+        var current: AXUIElement? = element
+        for _ in 0..<6 {
+            guard let currentElement = current else { break }
+            labels.append(contentsOf: attributes.compactMap {
+                Self.stringAXAttribute(from: currentElement, attribute: $0)
+            })
+            if let window, CFEqual(currentElement, window) {
+                break
+            }
+            current = Self.copyAXElementAttribute(
+                from: currentElement,
+                attribute: kAXParentAttribute as CFString
+            )
+        }
+        if let window {
+            labels.append(contentsOf: attributes.compactMap {
+                Self.stringAXAttribute(from: window, attribute: $0)
+            })
+        }
+        return labels
+    }
+
+    private static func hasNonemptyEditableDraft(_ target: CapturedFocusTarget) -> Bool {
+        let editableRoles = ["AXTextField", "AXTextArea", "AXSearchField", "AXComboBox"]
+        guard self.isExactFocusTargetActive(target),
+              !target.isSecureTextField,
+              let role = self.stringAXAttribute(
+                  from: target.element,
+                  attribute: kAXRoleAttribute as CFString
+              ),
+              editableRoles.contains(role),
+              let value = self.stringAXAttribute(
+                  from: target.element,
+                  attribute: kAXValueAttribute as CFString
+              )
+        else {
+            return false
+        }
+        return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private static func hasTerminalLikeContext(_ target: CapturedFocusTarget) -> Bool {
+        TerminalAppClassifier.isTerminalContext(
+            labels: self.accessibilityContextLabels(for: target.element, window: target.window)
+        )
     }
 
     private static func currentFocusDebugDescription() -> String {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -4,6 +4,61 @@ import Carbon.HIToolbox
 import Foundation
 
 final class TypingService {
+    nonisolated static let synthesizedEventUserData: Int64 = 0x46565353
+
+    struct CapturedFocusTarget {
+        let pid: pid_t
+        let window: AXUIElement?
+        let element: AXUIElement
+
+        var isSecureTextField: Bool {
+            let subrole = TypingService.stringAXAttribute(
+                from: self.element,
+                attribute: kAXSubroleAttribute as CFString
+            ) ?? ""
+            return subrole == (kAXSecureTextFieldSubrole as String)
+                || subrole.localizedCaseInsensitiveContains("secure")
+        }
+    }
+
+    enum DeliveryOutcome: Equatable {
+        case rejected
+        case insertionFailed
+        case inserted
+        case actionSuppressed
+        case actionDispatched
+        case insertedActionSuppressed
+        case insertedAndActionDispatched
+
+        var didInsert: Bool {
+            switch self {
+            case .inserted, .insertedActionSuppressed, .insertedAndActionDispatched:
+                return true
+            case .rejected, .insertionFailed, .actionSuppressed, .actionDispatched:
+                return false
+            }
+        }
+
+        var didDispatchAction: Bool {
+            self == .actionDispatched || self == .insertedAndActionDispatched
+        }
+    }
+
+    nonisolated static func canDispatchPostInsertionAction(
+        preferredTargetPID: pid_t?,
+        requiredTargetPID: pid_t?,
+        isSecureTextField: Bool,
+        modifiersReleased: Bool,
+        exactFocusIsActive: Bool
+    ) -> Bool {
+        guard let preferredTargetPID, preferredTargetPID > 0,
+              requiredTargetPID == preferredTargetPID
+        else {
+            return false
+        }
+        return !isSecureTextField && modifiersReleased && exactFocusIsActive
+    }
+
     // Logging toggle (off by default). Enable by setting env FLUID_TYPING_LOGS=1
     // or UserDefaults bool for key "enableTypingLogs".
     private static var isLoggingEnabled: Bool {
@@ -131,7 +186,7 @@ final class TypingService {
 
     /// Best-effort: returns the PID owning the currently focused accessibility element.
     /// This is more reliable than NSWorkspace.frontmostApplication for floating overlays/launchers.
-    static func captureSystemFocusedPID() -> pid_t? {
+    static func captureSystemFocusTarget() -> CapturedFocusTarget? {
         // Accessibility is required to query system-focused AX element.
         guard AXIsProcessTrusted() else {
             self.storeFocusSnapshot(nil)
@@ -167,7 +222,57 @@ final class TypingService {
             ?? Self.copyAXElementAttribute(from: appElement, attribute: kAXMainWindowAttribute as CFString)
         Self.storeFocusSnapshot(FocusSnapshot(pid: pid, window: window, element: element))
         Self.logFocusState("[TypingService] Captured focus snapshot")
-        return pid
+        return CapturedFocusTarget(pid: pid, window: window, element: element)
+    }
+
+    static func captureSystemFocusedPID() -> pid_t? {
+        self.captureSystemFocusTarget()?.pid
+    }
+
+    static func isExactFocusTargetActive(_ target: CapturedFocusTarget) -> Bool {
+        guard AXIsProcessTrusted() else { return false }
+
+        let systemWideElement = AXUIElementCreateSystemWide()
+        var focusedElementRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            systemWideElement,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedElementRef
+        )
+        guard result == .success, let focusedElementRef,
+              CFGetTypeID(focusedElementRef) == AXUIElementGetTypeID()
+        else {
+            return false
+        }
+
+        let currentElement = unsafeBitCast(focusedElementRef, to: AXUIElement.self)
+        return CFEqual(currentElement, target.element)
+    }
+
+    @discardableResult
+    static func restoreFocusTarget(_ target: CapturedFocusTarget) -> Bool {
+        guard AXIsProcessTrusted() else { return false }
+        let appElement = AXUIElementCreateApplication(target.pid)
+
+        if let window = target.window {
+            _ = AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+            _ = AXUIElementSetAttributeValue(appElement, kAXMainWindowAttribute as CFString, window)
+            _ = AXUIElementSetAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, window)
+            usleep(40_000)
+        }
+
+        for _ in 0..<3 {
+            let result = AXUIElementSetAttributeValue(
+                target.element,
+                kAXFocusedAttribute as CFString,
+                kCFBooleanTrue
+            )
+            if result == .success, self.isExactFocusTargetActive(target) {
+                return true
+            }
+            usleep(50_000)
+        }
+        return self.isExactFocusTargetActive(target)
     }
 
     /// Best-effort: returns the text immediately before the caret in the currently focused
@@ -301,7 +406,10 @@ final class TypingService {
         _ plan: DictationLiteralOutputPlan,
         preferredTargetPID: pid_t?,
         textReadyAt: TimeInterval?,
-        tracksDictionaryCorrections: Bool = false
+        tracksDictionaryCorrections: Bool = false,
+        postInsertionKey: SettingsStore.SpokenSendKey? = nil,
+        requiredFocusTarget: CapturedFocusTarget? = nil,
+        completion: ((DeliveryOutcome) -> Void)? = nil
     ) {
         let requestedAt = ProcessInfo.processInfo.systemUptime
         let text = plan.plainText
@@ -319,9 +427,10 @@ final class TypingService {
         self.log("[TypingService] ENTRY: typeTextInstantly called with text length: \(text.count)")
         self.log("[TypingService] Text preview: \"\(String(text.prefix(100)))\"")
 
-        guard text.isEmpty == false else {
+        guard text.isEmpty == false || postInsertionKey != nil else {
             self.bench("request_return reason=empty_text")
             self.log("[TypingService] ERROR: Empty text provided, aborting")
+            completion?(.rejected)
             return
         }
 
@@ -329,6 +438,7 @@ final class TypingService {
         guard !self.isCurrentlyTyping else {
             self.bench("request_return reason=already_typing")
             self.log("[TypingService] WARNING: Skipping text injection - already in progress")
+            completion?(.rejected)
             return
         }
 
@@ -337,6 +447,7 @@ final class TypingService {
             self.bench("request_return reason=accessibility_not_trusted")
             self.log("[TypingService] ERROR: Accessibility permissions required for text injection")
             self.log("[TypingService] Current accessibility status: \(AXIsProcessTrusted())")
+            completion?(.rejected)
             return
         }
 
@@ -344,6 +455,7 @@ final class TypingService {
         self.isCurrentlyTyping = true
 
         DispatchQueue.global(qos: .userInitiated).async {
+            var outcome: DeliveryOutcome = .insertionFailed
             let workerStartedAt = ProcessInfo.processInfo.systemUptime
             self.bench("worker_start queueDelayMs=\(Self.elapsedMs(from: requestedAt, to: workerStartedAt))")
 
@@ -354,6 +466,7 @@ final class TypingService {
                     "complete totalMs=\(Self.elapsedMs(from: requestedAt, to: completedAt)) textReadyToCompleteMs=\(textReadyAt.map { String(Self.elapsedMs(from: $0, to: completedAt)) } ?? "nil")"
                 )
                 self.log("[TypingService] Typing operation completed, isCurrentlyTyping set to false")
+                completion?(outcome)
             }
 
             self.log("[TypingService] Starting async text insertion process")
@@ -361,21 +474,57 @@ final class TypingService {
                 usleep(useconds_t(settleDelayMs * 1000))
             }
             self.bench("settle_delay_done delayMs=\(settleDelayMs) elapsedMs=\(Self.elapsedMs(since: requestedAt))")
-            self.log("[TypingService] Delay completed, calling insertTextInstantly")
-            let insertStartedAt = ProcessInfo.processInfo.systemUptime
-            self.bench("insert_call")
-            self.insertTextInstantly(text, preferredTargetPID: preferredTargetPID)
-            self.bench(
-                "insert_return elapsedMs=\(Self.elapsedMs(since: insertStartedAt)) totalMs=\(Self.elapsedMs(since: requestedAt))"
-            )
-            if tracksDictionaryCorrections {
-                Task { @MainActor in
-                    AutomaticDictionaryCorrectionTracker.shared.beginObservingInsertion(
-                        text,
-                        targetPID: preferredTargetPID
-                    )
+            let hasTextToInsert = !text.isEmpty
+            if hasTextToInsert {
+                self.log("[TypingService] Delay completed, calling insertTextInstantly")
+                let insertStartedAt = ProcessInfo.processInfo.systemUptime
+                self.bench("insert_call")
+                let inserted = self.insertTextInstantly(text, preferredTargetPID: preferredTargetPID)
+                self.bench(
+                    "insert_return elapsedMs=\(Self.elapsedMs(since: insertStartedAt)) totalMs=\(Self.elapsedMs(since: requestedAt))"
+                )
+                guard inserted else {
+                    outcome = .insertionFailed
+                    return
+                }
+
+                outcome = .inserted
+                if tracksDictionaryCorrections, postInsertionKey == nil {
+                    Task { @MainActor in
+                        AutomaticDictionaryCorrectionTracker.shared.beginObservingInsertion(
+                            text,
+                            targetPID: preferredTargetPID
+                        )
+                    }
                 }
             }
+
+            guard let postInsertionKey else { return }
+            guard let preferredTargetPID, let requiredFocusTarget else {
+                outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
+                return
+            }
+            let modifiersReleased = self.waitForPhysicalModifiersToRelease(timeout: 2)
+            let exactFocusIsActive = Self.isExactFocusTargetActive(requiredFocusTarget)
+            guard Self.canDispatchPostInsertionAction(
+                preferredTargetPID: preferredTargetPID,
+                requiredTargetPID: requiredFocusTarget.pid,
+                isSecureTextField: requiredFocusTarget.isSecureTextField,
+                modifiersReleased: modifiersReleased,
+                exactFocusIsActive: exactFocusIsActive
+            ) else {
+                outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
+                return
+            }
+
+            usleep(50_000)
+            guard Self.isExactFocusTargetActive(requiredFocusTarget),
+                  self.postReturnKey(postInsertionKey, targetPID: preferredTargetPID)
+            else {
+                outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
+                return
+            }
+            outcome = hasTextToInsert ? .insertedAndActionDispatched : .actionDispatched
         }
     }
 
@@ -393,7 +542,7 @@ final class TypingService {
 
     // MARK: - Internal insertion pipeline
 
-    private func insertTextInstantly(_ text: String, preferredTargetPID: pid_t?) {
+    private func insertTextInstantly(_ text: String, preferredTargetPID: pid_t?) -> Bool {
         self.log("[TypingService] insertTextInstantly called with \(text.count) characters")
         self.log("[TypingService] Attempting to type text: \"\(text.prefix(50))\(text.count > 50 ? "..." : "")\"")
 
@@ -403,7 +552,7 @@ final class TypingService {
             self.log("[TypingService] Ghostty target detected in standard mode (PID \(ghosttyTargetPID)); forcing Reliable Paste path")
             if self.tryReliablePasteInsertion(text, preferredTargetPID: ghosttyTargetPID) {
                 self.log("[TypingService] SUCCESS: Ghostty Reliable Paste path completed")
-                return
+                return true
             }
             self.log("[TypingService] Ghostty Reliable Paste path fell through to direct-typing fallbacks")
         }
@@ -412,14 +561,14 @@ final class TypingService {
             self.log("[TypingService] Reliable Paste mode enabled")
             if self.tryReliablePasteInsertion(text, preferredTargetPID: preferredTargetPID) {
                 self.log("[TypingService] SUCCESS: Reliable Paste mode completed")
-                return
+                return true
             }
             self.log("[TypingService] Reliable Paste mode fell through to direct-typing fallbacks")
         } else if let preferredTargetPID, preferredTargetPID > 0 {
             self.log("[TypingService] Experimental Direct Typing mode: trying preferred PID unicode insertion first")
             if self.insertTextBulkInstant(text, targetPID: preferredTargetPID) {
                 self.log("[TypingService] SUCCESS: Preferred PID CGEvent insertion completed")
-                return
+                return true
             }
             self.log("[TypingService] Preferred PID CGEvent insertion failed, continuing fallback pipeline")
         }
@@ -453,7 +602,7 @@ final class TypingService {
             self.log("[TypingService] Trying CGEvent insertion targeting focused PID \(focusedPID)")
             if self.insertTextBulkInstant(text, targetPID: focusedPID) {
                 self.log("[TypingService] SUCCESS: CGEvent focused-PID insertion completed")
-                return
+                return true
             }
         }
 
@@ -461,7 +610,7 @@ final class TypingService {
         self.log("[TypingService] Trying Accessibility focused-element insertion")
         if self.insertTextViaAccessibility(text) {
             self.log("[TypingService] SUCCESS: Accessibility insertion completed")
-            return
+            return true
         }
 
         // HID Fallback if PID targeting failed
@@ -469,7 +618,7 @@ final class TypingService {
             self.log("[TypingService] No focused PID available, trying HID CGEvent insertion")
             if self.insertTextBulkHIDInstant(text) {
                 self.log("[TypingService] SUCCESS: CGEvent HID insertion completed")
-                return
+                return true
             }
         }
 
@@ -477,7 +626,7 @@ final class TypingService {
         self.log("[TypingService] CGEvent failed, trying clipboard fallback")
         if self.insertTextViaClipboard(text) {
             self.log("[TypingService] SUCCESS: Clipboard insertion completed")
-            return
+            return true
         }
 
         // Last resort: Character-by-character
@@ -490,6 +639,37 @@ final class TypingService {
             usleep(1000)
         }
         self.log("[TypingService] Character-by-character typing completed")
+        return true
+    }
+
+    private func waitForPhysicalModifiersToRelease(timeout: TimeInterval) -> Bool {
+        let relevant: CGEventFlags = [.maskCommand, .maskControl, .maskAlternate, .maskShift, .maskSecondaryFn]
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        while ProcessInfo.processInfo.systemUptime - startedAt < timeout {
+            if CGEventSource.flagsState(.combinedSessionState).isDisjoint(with: relevant) {
+                return true
+            }
+            usleep(15_000)
+        }
+        return false
+    }
+
+    private func postReturnKey(_ key: SettingsStore.SpokenSendKey, targetPID: pid_t) -> Bool {
+        let returnKeyCode = CGKeyCode(kVK_Return)
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
+        else {
+            return false
+        }
+
+        keyDown.flags = key.eventFlags
+        keyUp.flags = key.eventFlags
+        keyDown.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
+        keyUp.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
+        keyDown.postToPid(targetPID)
+        usleep(10_000)
+        keyUp.postToPid(targetPID)
+        return true
     }
 
     private func tryReliablePasteInsertion(_ text: String, preferredTargetPID: pid_t?) -> Bool {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -475,6 +475,25 @@ final class TypingService {
             }
             self.bench("settle_delay_done delayMs=\(settleDelayMs) elapsedMs=\(Self.elapsedMs(since: requestedAt))")
             let hasTextToInsert = !text.isEmpty
+            if postInsertionKey != nil {
+                guard let preferredTargetPID, let requiredFocusTarget else {
+                    outcome = .actionSuppressed
+                    return
+                }
+                let modifiersReleased = self.waitForPhysicalModifiersToRelease(timeout: 2)
+                let exactFocusIsActive = Self.isExactFocusTargetActive(requiredFocusTarget)
+                guard Self.canDispatchPostInsertionAction(
+                    preferredTargetPID: preferredTargetPID,
+                    requiredTargetPID: requiredFocusTarget.pid,
+                    isSecureTextField: requiredFocusTarget.isSecureTextField,
+                    modifiersReleased: modifiersReleased,
+                    exactFocusIsActive: exactFocusIsActive
+                ) else {
+                    outcome = .actionSuppressed
+                    return
+                }
+            }
+
             if hasTextToInsert {
                 self.log("[TypingService] Delay completed, calling insertTextInstantly")
                 let insertStartedAt = ProcessInfo.processInfo.systemUptime
@@ -500,22 +519,7 @@ final class TypingService {
             }
 
             guard let postInsertionKey else { return }
-            guard let preferredTargetPID, let requiredFocusTarget else {
-                outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
-                return
-            }
-            let modifiersReleased = self.waitForPhysicalModifiersToRelease(timeout: 2)
-            let exactFocusIsActive = Self.isExactFocusTargetActive(requiredFocusTarget)
-            guard Self.canDispatchPostInsertionAction(
-                preferredTargetPID: preferredTargetPID,
-                requiredTargetPID: requiredFocusTarget.pid,
-                isSecureTextField: requiredFocusTarget.isSecureTextField,
-                modifiersReleased: modifiersReleased,
-                exactFocusIsActive: exactFocusIsActive
-            ) else {
-                outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
-                return
-            }
+            guard let preferredTargetPID, let requiredFocusTarget else { return }
 
             usleep(50_000)
             guard Self.isExactFocusTargetActive(requiredFocusTarget),

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -5,6 +5,7 @@ import Foundation
 
 final class TypingService {
     nonisolated static let synthesizedEventUserData: Int64 = 0x46565353
+    nonisolated static let postInsertionModifierReleaseTimeout: TimeInterval = 2
 
     struct CapturedFocusTarget {
         let pid: pid_t
@@ -489,24 +490,6 @@ final class TypingService {
             }
             self.bench("settle_delay_done delayMs=\(settleDelayMs) elapsedMs=\(Self.elapsedMs(since: requestedAt))")
             let hasTextToInsert = !text.isEmpty
-            if postInsertionKey != nil {
-                guard let preferredTargetPID, let requiredFocusTarget else {
-                    outcome = .actionSuppressed
-                    return
-                }
-                let modifiersReleased = self.waitForPhysicalModifiersToRelease(timeout: 2)
-                let exactFocusIsActive = Self.isExactFocusTargetActive(requiredFocusTarget)
-                guard Self.canDispatchPostInsertionAction(
-                    preferredTargetPID: preferredTargetPID,
-                    requiredTargetPID: requiredFocusTarget.pid,
-                    isSecureTextField: requiredFocusTarget.isSecureTextField,
-                    modifiersReleased: modifiersReleased,
-                    exactFocusIsActive: exactFocusIsActive
-                ) else {
-                    outcome = .actionSuppressed
-                    return
-                }
-            }
 
             if hasTextToInsert {
                 self.log("[TypingService] Delay completed, calling insertTextInstantly")
@@ -537,14 +520,19 @@ final class TypingService {
             }
 
             guard let postInsertionKey else { return }
-            guard let preferredTargetPID, let requiredFocusTarget else { return }
+            guard let preferredTargetPID, let requiredFocusTarget else {
+                outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
+                return
+            }
 
             usleep(50_000)
             guard Self.canDispatchPostInsertionAction(
                 preferredTargetPID: preferredTargetPID,
                 requiredTargetPID: requiredFocusTarget.pid,
                 isSecureTextField: requiredFocusTarget.isSecureTextField,
-                modifiersReleased: self.waitForPhysicalModifiersToRelease(timeout: 0.2),
+                modifiersReleased: self.waitForPhysicalModifiersToRelease(
+                    timeout: Self.postInsertionModifierReleaseTimeout
+                ),
                 exactFocusIsActive: Self.isExactFocusTargetActive(requiredFocusTarget),
                 insertionConfirmed: !hasTextToInsert || outcome.didInsert
             ),

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -49,14 +49,15 @@ final class TypingService {
         requiredTargetPID: pid_t?,
         isSecureTextField: Bool,
         modifiersReleased: Bool,
-        exactFocusIsActive: Bool
+        exactFocusIsActive: Bool,
+        insertionConfirmed: Bool = true
     ) -> Bool {
         guard let preferredTargetPID, preferredTargetPID > 0,
               requiredTargetPID == preferredTargetPID
         else {
             return false
         }
-        return !isSecureTextField && modifiersReleased && exactFocusIsActive
+        return !isSecureTextField && modifiersReleased && exactFocusIsActive && insertionConfirmed
     }
 
     // Logging toggle (off by default). Enable by setting env FLUID_TYPING_LOGS=1
@@ -89,6 +90,7 @@ final class TypingService {
 
     private struct FocusedTextSnapshot {
         let pid: pid_t
+        let element: AXUIElement
         let bundleIdentifier: String?
         let value: String?
         let selectedRange: CFRange?
@@ -103,6 +105,18 @@ final class TypingService {
         case caretMovedExpectedDistance = "caret_moved_expected_distance"
         case timeout
         case unavailable
+
+        var isConfirmed: Bool {
+            switch self {
+            case .appScriptContainsText,
+                 .appScriptCaretMovedExpectedDistance,
+                 .fieldContainsText,
+                 .caretMovedExpectedDistance:
+                return true
+            case .timeout, .unavailable:
+                return false
+            }
+        }
     }
 
     private static let focusSnapshotQueue = DispatchQueue(label: "TypingService.FocusSnapshot")
@@ -498,7 +512,11 @@ final class TypingService {
                 self.log("[TypingService] Delay completed, calling insertTextInstantly")
                 let insertStartedAt = ProcessInfo.processInfo.systemUptime
                 self.bench("insert_call")
-                let inserted = self.insertTextInstantly(text, preferredTargetPID: preferredTargetPID)
+                let inserted = self.insertTextInstantly(
+                    text,
+                    preferredTargetPID: preferredTargetPID,
+                    requiredFocusTarget: postInsertionKey == nil ? nil : requiredFocusTarget
+                )
                 self.bench(
                     "insert_return elapsedMs=\(Self.elapsedMs(since: insertStartedAt)) totalMs=\(Self.elapsedMs(since: requestedAt))"
                 )
@@ -522,8 +540,15 @@ final class TypingService {
             guard let preferredTargetPID, let requiredFocusTarget else { return }
 
             usleep(50_000)
-            guard Self.isExactFocusTargetActive(requiredFocusTarget),
-                  self.postReturnKey(postInsertionKey, targetPID: preferredTargetPID)
+            guard Self.canDispatchPostInsertionAction(
+                preferredTargetPID: preferredTargetPID,
+                requiredTargetPID: requiredFocusTarget.pid,
+                isSecureTextField: requiredFocusTarget.isSecureTextField,
+                modifiersReleased: self.waitForPhysicalModifiersToRelease(timeout: 0.2),
+                exactFocusIsActive: Self.isExactFocusTargetActive(requiredFocusTarget),
+                insertionConfirmed: !hasTextToInsert || outcome.didInsert
+            ),
+                self.postReturnKey(postInsertionKey, targetPID: preferredTargetPID)
             else {
                 outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
                 return
@@ -546,9 +571,21 @@ final class TypingService {
 
     // MARK: - Internal insertion pipeline
 
-    private func insertTextInstantly(_ text: String, preferredTargetPID: pid_t?) -> Bool {
+    private func insertTextInstantly(
+        _ text: String,
+        preferredTargetPID: pid_t?,
+        requiredFocusTarget: CapturedFocusTarget?
+    ) -> Bool {
         self.log("[TypingService] insertTextInstantly called with \(text.count) characters")
         self.log("[TypingService] Attempting to type text: \"\(text.prefix(50))\(text.count > 50 ? "..." : "")\"")
+
+        if let requiredFocusTarget {
+            return self.insertTextIntoExactFocusTarget(
+                text,
+                preferredTargetPID: preferredTargetPID,
+                requiredFocusTarget: requiredFocusTarget
+            )
+        }
 
         if self.textInsertionMode == .standard,
            let ghosttyTargetPID = self.ghosttyTargetPID(preferredTargetPID: preferredTargetPID)
@@ -634,16 +671,108 @@ final class TypingService {
         }
 
         // Last resort: Character-by-character
-        self.log("[TypingService] WARNING: All methods failed, trying character-by-character")
+        self.log("[TypingService] WARNING: All methods failed, trying verified character-by-character")
+        let focusedTextSnapshot = self.captureFocusedTextSnapshot()
+        var postedEveryCharacter = true
         for (index, char) in text.enumerated() {
             if index % 10 == 0 {
                 self.log("[TypingService] Typing character \(index + 1)/\(text.count)")
             }
-            self.typeCharacter(char)
+            postedEveryCharacter = self.typeCharacter(char) && postedEveryCharacter
             usleep(1000)
         }
-        self.log("[TypingService] Character-by-character typing completed")
-        return true
+        guard postedEveryCharacter else {
+            self.log("[TypingService] Character-by-character event creation failed")
+            return false
+        }
+        let verification = self.waitForFocusedTextVerification(
+            from: focusedTextSnapshot,
+            expectedText: text,
+            timeoutMicros: 500_000
+        )
+        self.log("[TypingService] Character-by-character verification: \(verification.rawValue)")
+        return verification.isConfirmed
+    }
+
+    private func insertTextIntoExactFocusTarget(
+        _ text: String,
+        preferredTargetPID: pid_t?,
+        requiredFocusTarget: CapturedFocusTarget
+    ) -> Bool {
+        guard preferredTargetPID == requiredFocusTarget.pid,
+              !requiredFocusTarget.isSecureTextField,
+              Self.isExactFocusTargetActive(requiredFocusTarget)
+        else {
+            self.log("[TypingService] Exact-target insertion rejected before dispatch")
+            return false
+        }
+
+        let eventAttempt: ExactTargetEventAttempt
+        switch self.textInsertionMode {
+        case .standard:
+            eventAttempt = self.performVerifiedExactTargetEventInsertion(
+                text,
+                target: requiredFocusTarget
+            ) {
+                self.insertTextBulkInstant(text, targetPID: requiredFocusTarget.pid)
+            }
+        case .reliablePaste:
+            eventAttempt = self.performVerifiedExactTargetEventInsertion(
+                text,
+                target: requiredFocusTarget
+            ) {
+                self.insertTextViaClipboardToPid(
+                    text,
+                    targetPID: requiredFocusTarget.pid,
+                    activateTargetFirst: false
+                )
+            }
+        }
+
+        switch eventAttempt {
+        case .confirmed:
+            return true
+        case .dispatchedUnverified:
+            self.log("[TypingService] Exact-target event insertion could not be confirmed; suppressing action")
+            return false
+        case .notDispatched:
+            break
+        }
+
+        guard Self.isExactFocusTargetActive(requiredFocusTarget) else {
+            self.log("[TypingService] Exact target changed before Accessibility fallback")
+            return false
+        }
+        return self.tryAllTextInsertionMethods(requiredFocusTarget.element, text)
+    }
+
+    private enum ExactTargetEventAttempt {
+        case notDispatched
+        case dispatchedUnverified
+        case confirmed
+    }
+
+    private func performVerifiedExactTargetEventInsertion(
+        _ text: String,
+        target: CapturedFocusTarget,
+        action: () -> Bool
+    ) -> ExactTargetEventAttempt {
+        guard Self.isExactFocusTargetActive(target) else { return .notDispatched }
+        guard let snapshot = self.captureFocusedTextSnapshot(),
+              snapshot.pid == target.pid,
+              action()
+        else {
+            return .notDispatched
+        }
+        guard Self.isExactFocusTargetActive(target) else { return .dispatchedUnverified }
+
+        let verification = self.waitForFocusedTextVerification(
+            from: snapshot,
+            expectedText: text,
+            timeoutMicros: 500_000
+        )
+        self.log("[TypingService] Exact-target event verification: \(verification.rawValue)")
+        return verification.isConfirmed ? .confirmed : .dispatchedUnverified
     }
 
     private func waitForPhysicalModifiersToRelease(timeout: TimeInterval) -> Bool {
@@ -1253,6 +1382,7 @@ final class TypingService {
         let appScriptSnapshot = self.captureAppScriptTextSnapshot(forBundleIdentifier: bundleIdentifier)
         return FocusedTextSnapshot(
             pid: focusInfo.pid,
+            element: focusInfo.element,
             bundleIdentifier: bundleIdentifier,
             value: self.getElementStringValue(focusInfo.element),
             selectedRange: self.getSelectedTextRange(focusInfo.element),
@@ -1311,7 +1441,8 @@ final class TypingService {
             waited += pollMicros
 
             guard let current = self.captureFocusedTextSnapshot(),
-                  current.pid == snapshot.pid
+                  current.pid == snapshot.pid,
+                  CFEqual(current.element, snapshot.element)
             else {
                 continue
             }
@@ -1512,7 +1643,7 @@ final class TypingService {
         }
     }
 
-    private func typeCharacter(_ char: Character) {
+    private func typeCharacter(_ char: Character) -> Bool {
         let charString = String(char)
         let utf16Array = Array(charString.utf16)
 
@@ -1521,7 +1652,7 @@ final class TypingService {
               let keyUpEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false)
         else {
             self.log("[TypingService] ERROR: Failed to create CGEvents for character: \(char)")
-            return
+            return false
         }
 
         // Set the unicode string for both events
@@ -1532,5 +1663,6 @@ final class TypingService {
         keyDownEvent.post(tap: .cghidEventTap)
         usleep(2000) // Short delay between key down and up (2ms)
         keyUpEvent.post(tap: .cghidEventTap)
+        return true
     }
 }

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -548,7 +548,7 @@ final class TypingService {
                 exactFocusIsActive: Self.isExactFocusTargetActive(requiredFocusTarget),
                 insertionConfirmed: !hasTextToInsert || outcome.didInsert
             ),
-                self.postReturnKey(postInsertionKey, targetPID: preferredTargetPID)
+                self.postReturnKey(postInsertionKey, target: requiredFocusTarget)
             else {
                 outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
                 return
@@ -707,75 +707,10 @@ final class TypingService {
             return false
         }
 
-        let eventAttempt: ExactTargetEventAttempt
-        switch self.textInsertionMode {
-        case .standard:
-            eventAttempt = self.performVerifiedExactTargetEventInsertion(
-                text,
-                target: requiredFocusTarget
-            ) {
-                self.insertTextBulkInstant(text, targetPID: requiredFocusTarget.pid)
-            }
-        case .reliablePaste:
-            eventAttempt = self.performVerifiedExactTargetEventInsertion(
-                text,
-                target: requiredFocusTarget
-            ) {
-                self.insertTextViaClipboardToPid(
-                    text,
-                    targetPID: requiredFocusTarget.pid,
-                    activateTargetFirst: false
-                )
-            }
-        }
-
-        switch eventAttempt {
-        case .confirmed:
-            return true
-        case .dispatchedUnverified:
-            self.log("[TypingService] Exact-target event insertion could not be confirmed; suppressing action")
-            return false
-        case .notDispatched:
-            break
-        }
-
-        guard Self.isExactFocusTargetActive(requiredFocusTarget) else {
-            self.log("[TypingService] Exact target changed before Accessibility fallback")
-            return false
-        }
         return self.performVerifiedExactTargetAccessibilityInsertion(
             text,
             target: requiredFocusTarget
         )
-    }
-
-    private enum ExactTargetEventAttempt {
-        case notDispatched
-        case dispatchedUnverified
-        case confirmed
-    }
-
-    private func performVerifiedExactTargetEventInsertion(
-        _ text: String,
-        target: CapturedFocusTarget,
-        action: () -> Bool
-    ) -> ExactTargetEventAttempt {
-        guard Self.isExactFocusTargetActive(target) else { return .notDispatched }
-        guard let snapshot = self.captureFocusedTextSnapshot(),
-              snapshot.pid == target.pid,
-              action()
-        else {
-            return .notDispatched
-        }
-        guard Self.isExactFocusTargetActive(target) else { return .dispatchedUnverified }
-
-        let verification = self.waitForFocusedTextVerification(
-            from: snapshot,
-            expectedText: text,
-            timeoutMicros: 500_000
-        )
-        self.log("[TypingService] Exact-target event verification: \(verification.rawValue)")
-        return verification.isConfirmed ? .confirmed : .dispatchedUnverified
     }
 
     private func performVerifiedExactTargetAccessibilityInsertion(
@@ -813,7 +748,11 @@ final class TypingService {
         return false
     }
 
-    private func postReturnKey(_ key: SettingsStore.SpokenSendKey, targetPID: pid_t) -> Bool {
+    private func postReturnKey(
+        _ key: SettingsStore.SpokenSendKey,
+        target: CapturedFocusTarget
+    ) -> Bool {
+        guard Self.isExactFocusTargetActive(target) else { return false }
         let returnKeyCode = CGKeyCode(kVK_Return)
         guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true),
               let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
@@ -825,10 +764,15 @@ final class TypingService {
         keyUp.flags = key.eventFlags
         keyDown.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
         keyUp.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
-        keyDown.postToPid(targetPID)
+        guard Self.isExactFocusTargetActive(target) else { return false }
+        keyDown.postToPid(target.pid)
         usleep(10_000)
-        keyUp.postToPid(targetPID)
-        return true
+        guard Self.isExactFocusTargetActive(target) else {
+            keyUp.postToPid(target.pid)
+            return false
+        }
+        keyUp.postToPid(target.pid)
+        return Self.isExactFocusTargetActive(target)
     }
 
     private func tryReliablePasteInsertion(_ text: String, preferredTargetPID: pid_t?) -> Bool {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -553,6 +553,9 @@ final class TypingService {
                 return
             }
 
+            let capturedActionOnlyDraftValue = hasTextToInsert
+                ? nil
+                : Self.nonemptyEditableDraftValue(requiredFocusTarget)
             usleep(50_000)
             let modifiersReleased = self.waitForPhysicalModifiersToRelease(
                 timeout: Self.postInsertionModifierReleaseTimeout
@@ -560,7 +563,7 @@ final class TypingService {
             let expectedActionValue: String? = if hasTextToInsert {
                 expectedInsertedValue
             } else {
-                Self.nonemptyEditableDraftValue(requiredFocusTarget)
+                capturedActionOnlyDraftValue
             }
             let insertionConfirmed = expectedActionValue != nil &&
                 self.getElementStringValue(requiredFocusTarget.element) == expectedActionValue

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -66,6 +66,27 @@ final class TypingService {
             insertionConfirmed
     }
 
+    nonisolated static func valueByInserting(
+        _ insertion: String,
+        into original: String,
+        selectedRange: CFRange
+    ) -> String? {
+        let originalValue = original as NSString
+        guard selectedRange.location >= 0,
+              selectedRange.length >= 0,
+              selectedRange.location <= originalValue.length,
+              selectedRange.length <= originalValue.length - selectedRange.location
+        else {
+            return nil
+        }
+        let value = NSMutableString(string: original)
+        value.replaceCharacters(
+            in: NSRange(location: selectedRange.location, length: selectedRange.length),
+            with: insertion
+        )
+        return value as String
+    }
+
     // Logging toggle (off by default). Enable by setting env FLUID_TYPING_LOGS=1
     // or UserDefaults bool for key "enableTypingLogs".
     private static var isLoggingEnabled: Bool {
@@ -717,19 +738,44 @@ final class TypingService {
               let snapshot = self.captureFocusedTextSnapshot(),
               snapshot.pid == target.pid,
               CFEqual(snapshot.element, target.element),
-              self.tryAllTextInsertionMethods(target.element, text),
+              let originalValue = snapshot.value,
+              let selectedRange = snapshot.selectedRange,
+              let expectedValue = Self.valueByInserting(
+                  text,
+                  into: originalValue,
+                  selectedRange: selectedRange
+              ),
+              self.insertTextAtCursorUsingSelectedRange(target.element, text),
               Self.isExactFocusTargetActive(target)
         else {
             return false
         }
 
-        let verification = self.waitForFocusedTextVerification(
-            from: snapshot,
-            expectedText: text,
+        let verified = self.waitForExactTargetValue(
+            expectedValue,
+            target: target,
             timeoutMicros: 500_000
         )
-        self.log("[TypingService] Exact-target Accessibility verification: \(verification.rawValue)")
-        return verification.isConfirmed
+        self.log("[TypingService] Exact-target preserving insertion verified: \(verified)")
+        return verified
+    }
+
+    private func waitForExactTargetValue(
+        _ expectedValue: String,
+        target: CapturedFocusTarget,
+        timeoutMicros: useconds_t
+    ) -> Bool {
+        let pollMicros: useconds_t = 50_000
+        var waited: useconds_t = 0
+        while waited < timeoutMicros {
+            usleep(pollMicros)
+            waited += pollMicros
+            guard Self.isExactFocusTargetActive(target) else { continue }
+            if self.getElementStringValue(target.element) == expectedValue {
+                return true
+            }
+        }
+        return false
     }
 
     private func waitForPhysicalModifiersToRelease(timeout: TimeInterval) -> Bool {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -516,6 +516,7 @@ final class TypingService {
             }
             self.bench("settle_delay_done delayMs=\(settleDelayMs) elapsedMs=\(Self.elapsedMs(since: requestedAt))")
             let hasTextToInsert = !text.isEmpty
+            var expectedInsertedValue: String?
 
             if hasTextToInsert {
                 self.log("[TypingService] Delay completed, calling insertTextInstantly")
@@ -524,7 +525,8 @@ final class TypingService {
                 let inserted = self.insertTextInstantly(
                     text,
                     preferredTargetPID: preferredTargetPID,
-                    requiredFocusTarget: postInsertionKey == nil ? nil : requiredFocusTarget
+                    requiredFocusTarget: postInsertionKey == nil ? nil : requiredFocusTarget,
+                    expectedExactTargetValue: &expectedInsertedValue
                 )
                 self.bench(
                     "insert_return elapsedMs=\(Self.elapsedMs(since: insertStartedAt)) totalMs=\(Self.elapsedMs(since: requestedAt))"
@@ -552,20 +554,30 @@ final class TypingService {
             }
 
             usleep(50_000)
+            let modifiersReleased = self.waitForPhysicalModifiersToRelease(
+                timeout: Self.postInsertionModifierReleaseTimeout
+            )
+            let expectedActionValue: String? = if hasTextToInsert {
+                expectedInsertedValue
+            } else {
+                Self.nonemptyEditableDraftValue(requiredFocusTarget)
+            }
+            let insertionConfirmed = expectedActionValue != nil &&
+                self.getElementStringValue(requiredFocusTarget.element) == expectedActionValue
             guard Self.canDispatchPostInsertionAction(
                 preferredTargetPID: preferredTargetPID,
                 requiredTargetPID: requiredFocusTarget.pid,
                 isSecureTextField: requiredFocusTarget.isSecureTextField,
                 isTerminalLikeContext: Self.hasTerminalLikeContext(requiredFocusTarget),
-                modifiersReleased: self.waitForPhysicalModifiersToRelease(
-                    timeout: Self.postInsertionModifierReleaseTimeout
-                ),
+                modifiersReleased: modifiersReleased,
                 exactFocusIsActive: Self.isExactFocusTargetActive(requiredFocusTarget),
-                insertionConfirmed: hasTextToInsert
-                    ? outcome.didInsert
-                    : Self.hasNonemptyEditableDraft(requiredFocusTarget)
+                insertionConfirmed: insertionConfirmed
             ),
-                self.postReturnKey(postInsertionKey, target: requiredFocusTarget)
+                self.postReturnKey(
+                    postInsertionKey,
+                    target: requiredFocusTarget,
+                    expectedValue: expectedActionValue
+                )
             else {
                 outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
                 return
@@ -591,7 +603,8 @@ final class TypingService {
     private func insertTextInstantly(
         _ text: String,
         preferredTargetPID: pid_t?,
-        requiredFocusTarget: CapturedFocusTarget?
+        requiredFocusTarget: CapturedFocusTarget?,
+        expectedExactTargetValue: inout String?
     ) -> Bool {
         self.log("[TypingService] insertTextInstantly called with \(text.count) characters")
         self.log("[TypingService] Attempting to type text: \"\(text.prefix(50))\(text.count > 50 ? "..." : "")\"")
@@ -600,7 +613,8 @@ final class TypingService {
             return self.insertTextIntoExactFocusTarget(
                 text,
                 preferredTargetPID: preferredTargetPID,
-                requiredFocusTarget: requiredFocusTarget
+                requiredFocusTarget: requiredFocusTarget,
+                expectedValue: &expectedExactTargetValue
             )
         }
 
@@ -714,7 +728,8 @@ final class TypingService {
     private func insertTextIntoExactFocusTarget(
         _ text: String,
         preferredTargetPID: pid_t?,
-        requiredFocusTarget: CapturedFocusTarget
+        requiredFocusTarget: CapturedFocusTarget,
+        expectedValue: inout String?
     ) -> Bool {
         guard preferredTargetPID == requiredFocusTarget.pid,
               !requiredFocusTarget.isSecureTextField,
@@ -726,13 +741,15 @@ final class TypingService {
 
         return self.performVerifiedExactTargetAccessibilityInsertion(
             text,
-            target: requiredFocusTarget
+            target: requiredFocusTarget,
+            expectedValue: &expectedValue
         )
     }
 
     private func performVerifiedExactTargetAccessibilityInsertion(
         _ text: String,
-        target: CapturedFocusTarget
+        target: CapturedFocusTarget,
+        expectedValue: inout String?
     ) -> Bool {
         guard Self.isExactFocusTargetActive(target),
               let snapshot = self.captureFocusedTextSnapshot(),
@@ -740,7 +757,7 @@ final class TypingService {
               CFEqual(snapshot.element, target.element),
               let originalValue = snapshot.value,
               let selectedRange = snapshot.selectedRange,
-              let expectedValue = Self.valueByInserting(
+              let expectedValueAfterInsertion = Self.valueByInserting(
                   text,
                   into: originalValue,
                   selectedRange: selectedRange
@@ -752,11 +769,14 @@ final class TypingService {
         }
 
         let verified = self.waitForExactTargetValue(
-            expectedValue,
+            expectedValueAfterInsertion,
             target: target,
             timeoutMicros: 500_000
         )
         self.log("[TypingService] Exact-target preserving insertion verified: \(verified)")
+        if verified {
+            expectedValue = expectedValueAfterInsertion
+        }
         return verified
     }
 
@@ -792,9 +812,15 @@ final class TypingService {
 
     private func postReturnKey(
         _ key: SettingsStore.SpokenSendKey,
-        target: CapturedFocusTarget
+        target: CapturedFocusTarget,
+        expectedValue: String?
     ) -> Bool {
-        guard Self.isExactFocusTargetActive(target) else { return false }
+        guard let expectedValue,
+              Self.isExactFocusTargetActive(target),
+              self.getElementStringValue(target.element) == expectedValue
+        else {
+            return false
+        }
         let returnKeyCode = CGKeyCode(kVK_Return)
         guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true),
               let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
@@ -806,7 +832,11 @@ final class TypingService {
         keyUp.flags = key.eventFlags
         keyDown.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
         keyUp.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
-        guard Self.isExactFocusTargetActive(target) else { return false }
+        guard Self.isExactFocusTargetActive(target),
+              self.getElementStringValue(target.element) == expectedValue
+        else {
+            return false
+        }
         keyDown.postToPid(target.pid)
         usleep(10_000)
         keyUp.postToPid(target.pid)
@@ -898,7 +928,7 @@ final class TypingService {
         return labels
     }
 
-    private static func hasNonemptyEditableDraft(_ target: CapturedFocusTarget) -> Bool {
+    private static func nonemptyEditableDraftValue(_ target: CapturedFocusTarget) -> String? {
         let editableRoles = ["AXTextField", "AXTextArea", "AXSearchField", "AXComboBox"]
         guard self.isExactFocusTargetActive(target),
               !target.isSecureTextField,
@@ -912,9 +942,9 @@ final class TypingService {
                   attribute: kAXValueAttribute as CFString
               )
         else {
-            return false
+            return nil
         }
-        return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : value
     }
 
     private static func hasTerminalLikeContext(_ target: CapturedFocusTarget) -> Bool {

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -2842,7 +2842,7 @@ private extension SettingsView {
                             Text("Send Phrase")
                                 .font(self.theme.typography.bodyStrong)
                                 .foregroundStyle(self.settingsTitleText)
-                            Text("Matched only at the end. Say “literal \(self.settings.spokenSendPhrase)” to dictate it normally.")
+                            Text("Say it alone, or after punctuation, at the end. Say “literal \(self.settings.spokenSendPhrase)” to dictate it normally.")
                                 .font(self.theme.typography.bodySmall)
                                 .foregroundStyle(self.settingsSecondaryText)
                         }

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -871,6 +871,9 @@ struct SettingsView: View {
                                     }
                                     Divider().opacity(0.2)
 
+                                    self.spokenSendSettings
+                                    Divider().opacity(0.2)
+
                                     self.optionToggleRow(
                                         title: "Save Transcription History",
                                         description: "Save transcriptions for stats tracking. Disable for privacy.",
@@ -2808,6 +2811,82 @@ struct FlowLayout: Layout {
 
         cache.containerSize = CGSize(width: maxWidth, height: y + rowHeight)
         cache.lastWidth = maxWidth
+    }
+}
+
+private extension SettingsView {
+    var spokenSendSettings: some View {
+        Group {
+            self.optionToggleRow(
+                title: "Spoken Send",
+                description: "Say a phrase at the end of dictation to send with your chosen Enter command.",
+                isOn: Binding(
+                    get: { self.settings.spokenSendEnabled },
+                    set: { self.settings.spokenSendEnabled = $0 }
+                )
+            )
+
+            if self.settings.spokenSendEnabled {
+                VStack(spacing: 10) {
+                    self.optionToggleRow(
+                        title: "Send Immediately",
+                        description: "Stop listening and send as soon as the phrase is recognized. May not work with all voice models; Parakeet is recommended.",
+                        isOn: Binding(
+                            get: { self.settings.spokenSendImmediatelyEnabled },
+                            set: { self.settings.spokenSendImmediatelyEnabled = $0 }
+                        )
+                    )
+
+                    HStack(alignment: .center) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Send Phrase")
+                                .font(self.theme.typography.bodyStrong)
+                                .foregroundStyle(self.settingsTitleText)
+                            Text("Matched only at the end. Say “literal \(self.settings.spokenSendPhrase)” to dictate it normally.")
+                                .font(self.theme.typography.bodySmall)
+                                .foregroundStyle(self.settingsSecondaryText)
+                        }
+
+                        Spacer()
+
+                        TextField(
+                            "send it",
+                            text: Binding(
+                                get: { self.settings.spokenSendPhrase },
+                                set: { self.settings.spokenSendPhrase = $0 }
+                            )
+                        )
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 170)
+                    }
+
+                    HStack(alignment: .center) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Send Command")
+                                .font(self.theme.typography.bodyStrong)
+                                .foregroundStyle(self.settingsTitleText)
+                            Text("Choose the Enter behavior expected by the destination app.")
+                                .font(self.theme.typography.bodySmall)
+                                .foregroundStyle(self.settingsSecondaryText)
+                        }
+
+                        Spacer()
+
+                        Picker("", selection: Binding(
+                            get: { self.settings.spokenSendKey },
+                            set: { self.settings.spokenSendKey = $0 }
+                        )) {
+                            ForEach(SettingsStore.SpokenSendKey.allCases) { key in
+                                Text(key.displayName).tag(key)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 170, alignment: .trailing)
+                    }
+                }
+                .padding(.leading, 12)
+            }
+        }
     }
 }
 

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -2842,7 +2842,7 @@ private extension SettingsView {
                             Text("Send Phrase")
                                 .font(self.theme.typography.bodyStrong)
                                 .foregroundStyle(self.settingsTitleText)
-                            Text("Say it alone, or after punctuation, at the end. Say “literal \(self.settings.spokenSendPhrase)” to dictate it normally.")
+                            Text("Say it at the end. Say “literal \(self.settings.spokenSendPhrase)” to dictate it normally.")
                                 .font(self.theme.typography.bodySmall)
                                 .foregroundStyle(self.settingsSecondaryText)
                         }

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -3026,13 +3026,17 @@ struct BottomOverlayView: View {
                     .opacity((appIcon != nil || showModelLoading || !self.layout.showsModeLabel) ? 1 : 0)
 
                     // Waveform visualization
-                    BottomWaveformView(color: self.modeColor, layout: self.layout)
-                        .frame(
-                            width: self.isPillSize && self.showsSpokenSendIndicator
-                                ? 34
-                                : self.layout.waveformWidth,
-                            height: self.layout.waveformHeight
-                        )
+                    BottomWaveformView(
+                        color: self.modeColor,
+                        layout: self.layout,
+                        visibleBarCount: self.isPillSize && self.showsSpokenSendIndicator ? 6 : nil
+                    )
+                    .frame(
+                        width: self.isPillSize && self.showsSpokenSendIndicator
+                            ? 32
+                            : self.layout.waveformWidth,
+                        height: self.layout.waveformHeight
+                    )
 
                     if self.isPillSize, self.showsSpokenSendIndicator {
                         SpokenSendIndicatorView(
@@ -3291,6 +3295,7 @@ struct BottomOverlayView: View {
 struct BottomWaveformView: View {
     let color: Color
     let layout: BottomOverlayView.LayoutConstants
+    let visibleBarCount: Int?
 
     @ObservedObject private var contentState = NotchContentState.shared
     // Initialize with max possible bar count (11 for large) to prevent index-out-of-range before onAppear
@@ -3298,7 +3303,7 @@ struct BottomWaveformView: View {
     @State private var noiseThreshold: CGFloat = .init(SettingsStore.shared.visualizerNoiseThreshold)
 
     private var barCount: Int {
-        self.layout.barCount
+        self.visibleBarCount ?? self.layout.barCount
     }
 
     private var barWidth: CGFloat {

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -123,6 +123,7 @@ final class BottomOverlayWindowController {
         // offscreen. Revealing the neutral shell first causes a visible flash
         // that reads as the overlay appearing twice.
         NotchContentState.shared.setBottomOverlayPresented(true)
+        NotchContentState.shared.setSpokenSendIndicatorState(.hidden)
         NotchContentState.shared.mode = mode
         switch mode {
         case .dictation: NotchContentState.shared.promptPickerMode = .dictate
@@ -2137,6 +2138,16 @@ struct BottomOverlayView: View {
         }
     }
 
+    private var showsSpokenSendIndicator: Bool {
+        self.contentState.mode == .dictation &&
+            self.settings.spokenSendEnabled &&
+            self.contentState.spokenSendIndicatorState.isVisible
+    }
+
+    private var spokenSendIndicatorSize: CGFloat {
+        max(self.layout.modeFontSize + 3, 13)
+    }
+
     private static let transientOverlayStatusTexts: Set<String> = [
         "Transcribing",
         "Refining",
@@ -2989,7 +3000,7 @@ struct BottomOverlayView: View {
                 }
 
                 // Waveform + Mode label row
-                HStack(spacing: self.layout.hPadding / 1.5) {
+                HStack(spacing: self.isPillSize ? 4 : self.layout.hPadding / 1.5) {
                     // Target app icon (the app where text will be typed)
                     let appIcon = self.displayedAppIcon
                     let showModelLoading = self.layout.showsModeLabel && !self.appServices.asr.isAsrReady &&
@@ -3016,16 +3027,43 @@ struct BottomOverlayView: View {
 
                     // Waveform visualization
                     BottomWaveformView(color: self.modeColor, layout: self.layout)
-                        .frame(width: self.layout.waveformWidth, height: self.layout.waveformHeight)
+                        .frame(
+                            width: self.isPillSize && self.showsSpokenSendIndicator
+                                ? 34
+                                : self.layout.waveformWidth,
+                            height: self.layout.waveformHeight
+                        )
+
+                    if self.isPillSize, self.showsSpokenSendIndicator {
+                        SpokenSendIndicatorView(
+                            state: self.contentState.spokenSendIndicatorState,
+                            color: self.modeColor,
+                            size: 14
+                        )
+                        .id(self.contentState.spokenSendCountdownID)
+                        .transition(.scale(scale: 0.8).combined(with: .opacity))
+                    }
 
                     // Mode label + model load hint
                     if self.layout.showsModeLabel {
                         VStack(alignment: .leading, spacing: 2) {
-                            Text(self.modeLabel)
-                                .font(.system(size: self.layout.modeFontSize, weight: .semibold))
-                                .foregroundStyle(self.modeColor)
-                                .lineLimit(1)
-                                .fixedSize(horizontal: true, vertical: false)
+                            HStack(spacing: 5) {
+                                Text(self.modeLabel)
+                                    .font(.system(size: self.layout.modeFontSize, weight: .semibold))
+                                    .foregroundStyle(self.modeColor)
+                                    .lineLimit(1)
+                                    .fixedSize(horizontal: true, vertical: false)
+
+                                if self.showsSpokenSendIndicator {
+                                    SpokenSendIndicatorView(
+                                        state: self.contentState.spokenSendIndicatorState,
+                                        color: self.modeColor,
+                                        size: self.spokenSendIndicatorSize
+                                    )
+                                    .id(self.contentState.spokenSendCountdownID)
+                                    .transition(.scale(scale: 0.8).combined(with: .opacity))
+                                }
+                            }
 
                             if !self.appServices.asr.isAsrReady &&
                                 (self.appServices.asr.isLoadingModel || self.appServices.asr.isDownloadingModel)
@@ -3037,6 +3075,10 @@ struct BottomOverlayView: View {
                                     .lineLimit(1)
                             }
                         }
+                        .animation(
+                            self.reduceMotion ? nil : .easeOut(duration: 0.14),
+                            value: self.contentState.spokenSendIndicatorState
+                        )
                     }
                 }
             }

--- a/Sources/Fluid/Views/NotchContentViews.swift
+++ b/Sources/Fluid/Views/NotchContentViews.swift
@@ -10,6 +10,85 @@ import Combine
 import QuartzCore
 import SwiftUI
 
+enum SpokenSendIndicatorState: Equatable {
+    case hidden
+    case detected
+    case countingDown
+    case sending
+    case sent
+    case failed
+
+    var isVisible: Bool {
+        self != .hidden
+    }
+}
+
+struct SpokenSendIndicatorView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var progress: CGFloat = 0
+
+    let state: SpokenSendIndicatorState
+    let color: Color
+    let size: CGFloat
+
+    var body: some View {
+        Group {
+            switch self.state {
+            case .hidden:
+                EmptyView()
+            case .detected:
+                self.symbol("paperplane.fill", color: self.color, accessibilityLabel: "Send detected")
+            case .countingDown:
+                ZStack {
+                    Circle()
+                        .stroke(self.color.opacity(0.22), lineWidth: self.lineWidth)
+
+                    Circle()
+                        .trim(from: 0, to: self.progress)
+                        .stroke(
+                            self.color,
+                            style: StrokeStyle(lineWidth: self.lineWidth, lineCap: .round)
+                        )
+                        .rotationEffect(.degrees(-90))
+
+                    self.symbol("paperplane.fill", color: self.color, accessibilityLabel: "Waiting to send")
+                }
+                .onAppear {
+                    guard !self.reduceMotion else {
+                        self.progress = 1
+                        return
+                    }
+                    withAnimation(.linear(duration: SpokenSendParser.immediateStopSettleDuration)) {
+                        self.progress = 1
+                    }
+                }
+            case .sending:
+                ZStack {
+                    Circle()
+                        .stroke(self.color, lineWidth: self.lineWidth)
+                    self.symbol("paperplane.fill", color: self.color, accessibilityLabel: "Sending")
+                }
+            case .sent:
+                self.symbol("checkmark.circle.fill", color: self.color, accessibilityLabel: "Sent")
+            case .failed:
+                self.symbol("exclamationmark.circle.fill", color: .orange, accessibilityLabel: "Send skipped")
+            }
+        }
+        .frame(width: self.size, height: self.size)
+    }
+
+    private var lineWidth: CGFloat {
+        max(1, self.size * 0.085)
+    }
+
+    private func symbol(_ name: String, color: Color, accessibilityLabel: String) -> some View {
+        Image(systemName: name)
+            .font(.system(size: max(6, self.size * 0.46), weight: .semibold))
+            .foregroundStyle(color)
+            .accessibilityLabel(accessibilityLabel)
+    }
+}
+
 // MARK: - Observable state for notch content (Singleton)
 
 @MainActor
@@ -25,6 +104,8 @@ class NotchContentState: ObservableObject {
     @Published var isAIProcessingFailureVisible: Bool = false
     @Published private(set) var aiProcessingFailureMessage: String = "AI Enhancement failed"
     @Published private(set) var canRetryAIProcessingFailure: Bool = true
+    @Published private(set) var spokenSendIndicatorState: SpokenSendIndicatorState = .hidden
+    @Published private(set) var spokenSendCountdownID: UInt64 = 0
     @Published var activeDictationShortcutSlot: SettingsStore.DictationShortcutSlot? = nil
     @Published var promptModeOverrideProfileName: String? = nil // Name shown in overlay when prompt mode hotkey is active
     @Published var promptModeOverrideProfileID: String? = nil // ID of the active override profile (for checkmark in menu)
@@ -109,6 +190,18 @@ class NotchContentState: ObservableObject {
 
     func clearAIProcessingFailure() {
         self.isAIProcessingFailureVisible = false
+    }
+
+    func setSpokenSendIndicatorState(_ state: SpokenSendIndicatorState) {
+        guard self.spokenSendIndicatorState != state else { return }
+        self.spokenSendIndicatorState = state
+    }
+
+    @discardableResult
+    func beginSpokenSendCountdown() -> UInt64 {
+        self.spokenSendCountdownID &+= 1
+        self.spokenSendIndicatorState = .countingDown
+        return self.spokenSendCountdownID
     }
 
     /// Update transcription and recompute cached lines
@@ -416,6 +509,12 @@ struct NotchExpandedView: View {
 
     private var modeColor: Color {
         self.contentState.mode.notchColor
+    }
+
+    private var showsSpokenSendIndicator: Bool {
+        self.contentState.mode == .dictation &&
+            self.settings.spokenSendEnabled &&
+            self.contentState.spokenSendIndicatorState.isVisible
     }
 
     private var presentationPolicy: NotchOverlayManager.NotchPresentationPolicy {
@@ -904,9 +1003,20 @@ struct NotchExpandedView: View {
                 .frame(width: 48, height: 18)
 
                 self.promptSelectorControl
+
+                if self.showsSpokenSendIndicator {
+                    SpokenSendIndicatorView(
+                        state: self.contentState.spokenSendIndicatorState,
+                        color: self.modeColor,
+                        size: 14
+                    )
+                    .id(self.contentState.spokenSendCountdownID)
+                    .transition(.scale(scale: 0.8).combined(with: .opacity))
+                }
             }
             .frame(maxWidth: .infinity, alignment: .center)
             .offset(x: 4, y: 0)
+            .animation(.easeOut(duration: 0.14), value: self.contentState.spokenSendIndicatorState)
 
             self.promptHoverMenuRow
 
@@ -1160,13 +1270,33 @@ struct NotchCompactLeadingView: View {
 struct NotchCompactTrailingView: View {
     let audioPublisher: AnyPublisher<CGFloat, Never>
     @ObservedObject private var contentState = NotchContentState.shared
+    @ObservedObject private var settings = SettingsStore.shared
+
+    private var showsSpokenSendIndicator: Bool {
+        self.contentState.mode == .dictation &&
+            self.settings.spokenSendEnabled &&
+            self.contentState.spokenSendIndicatorState.isVisible
+    }
 
     var body: some View {
-        CompactNotchWaveformView(
-            audioPublisher: self.audioPublisher,
-            color: self.contentState.mode.notchColor
-        )
+        HStack(spacing: 3) {
+            CompactNotchWaveformView(
+                audioPublisher: self.audioPublisher,
+                color: self.contentState.mode.notchColor
+            )
+            .frame(width: self.showsSpokenSendIndicator ? 18 : 34, height: 16)
+
+            if self.showsSpokenSendIndicator {
+                SpokenSendIndicatorView(
+                    state: self.contentState.spokenSendIndicatorState,
+                    color: self.contentState.mode.notchColor,
+                    size: 13
+                )
+                .id(self.contentState.spokenSendCountdownID)
+            }
+        }
         .frame(width: 34, height: 16)
+        .animation(.easeOut(duration: 0.14), value: self.contentState.spokenSendIndicatorState)
     }
 }
 

--- a/Sources/Fluid/Views/NotchContentViews.swift
+++ b/Sources/Fluid/Views/NotchContentViews.swift
@@ -1279,12 +1279,13 @@ struct NotchCompactTrailingView: View {
     }
 
     var body: some View {
-        HStack(spacing: 3) {
+        HStack(spacing: self.showsSpokenSendIndicator ? 4 : 0) {
             CompactNotchWaveformView(
                 audioPublisher: self.audioPublisher,
-                color: self.contentState.mode.notchColor
+                color: self.contentState.mode.notchColor,
+                barCount: self.showsSpokenSendIndicator ? 4 : 8
             )
-            .frame(width: self.showsSpokenSendIndicator ? 18 : 34, height: 16)
+            .frame(width: self.showsSpokenSendIndicator ? 16 : 34, height: 16)
 
             if self.showsSpokenSendIndicator {
                 SpokenSendIndicatorView(
@@ -1851,14 +1852,19 @@ struct ExpandedModeWaveformView: View {
 }
 
 struct CompactNotchWaveformView: View {
+    private static let storedBarCount = 8
+
     let audioPublisher: AnyPublisher<CGFloat, Never>
     let color: Color
+    var barCount: Int = 8
 
     @StateObject private var data: AudioVisualizationData
     @ObservedObject private var contentState = NotchContentState.shared
-    @State private var barHeights: [CGFloat] = Array(repeating: 3, count: 8)
+    @State private var barHeights: [CGFloat] = Array(
+        repeating: 3,
+        count: CompactNotchWaveformView.storedBarCount
+    )
 
-    private let barCount = 8
     private let barWidth: CGFloat = 2.5
     private let barSpacing: CGFloat = 2
     private let minHeight: CGFloat = 3
@@ -1866,9 +1872,10 @@ struct CompactNotchWaveformView: View {
     private let noiseThreshold: CGFloat = 0.05
     private let processingFlatHeight: CGFloat = 3
 
-    init(audioPublisher: AnyPublisher<CGFloat, Never>, color: Color) {
+    init(audioPublisher: AnyPublisher<CGFloat, Never>, color: Color, barCount: Int = 8) {
         self.audioPublisher = audioPublisher
         self.color = color
+        self.barCount = min(max(barCount, 1), Self.storedBarCount)
         _data = StateObject(wrappedValue: AudioVisualizationData(audioLevelPublisher: audioPublisher))
     }
 
@@ -1950,7 +1957,7 @@ struct CompactNotchWaveformView: View {
 
     private func resetBarsToBaseline(animated: Bool) {
         let apply = {
-            self.barHeights = Array(repeating: self.minHeight, count: self.barCount)
+            self.barHeights = Array(repeating: self.minHeight, count: Self.storedBarCount)
         }
 
         if animated {

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -13,21 +13,21 @@ final class SpokenSendTests: XCTestCase {
     func testTerminalPhraseIsRemovedAndArmsSend() {
         XCTAssertEqual(
             SpokenSendParser.parse("Hello there, send it.", phrase: "send it", enabled: true),
-            SpokenSendParseResult(text: "Hello there,", shouldSend: true)
+            SpokenSendParseResult(text: "Hello there.", shouldSend: true)
         )
     }
 
     func testCapitalizationAndFullStopDoNotAffectSend() {
         XCTAssertEqual(
             SpokenSendParser.parse("Ready to go, SEND IT.", phrase: "send it", enabled: true),
-            SpokenSendParseResult(text: "Ready to go,", shouldSend: true)
+            SpokenSendParseResult(text: "Ready to go.", shouldSend: true)
         )
     }
 
     func testNearbyTrailingPunctuationDoesNotAffectSend() {
         XCTAssertEqual(
             SpokenSendParser.parse(#"Ready to go — send it…")]"#, phrase: "send it", enabled: true),
-            SpokenSendParseResult(text: "Ready to go —", shouldSend: true)
+            SpokenSendParseResult(text: "Ready to go.", shouldSend: true)
         )
     }
 
@@ -35,6 +35,40 @@ final class SpokenSendTests: XCTestCase {
         XCTAssertEqual(
             SpokenSendParser.parse("Send it when you are ready", phrase: "send it", enabled: true),
             SpokenSendParseResult(text: "Send it when you are ready", shouldSend: false)
+        )
+    }
+
+    func testNaturalSentenceEndingWithPhraseDoesNotArmSend() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("I wanna send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "I wanna send it.", shouldSend: false)
+        )
+    }
+
+    func testPunctuationBreakDisambiguatesTerminalCommand() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("I wanna send it, send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "I wanna send it.", shouldSend: true)
+        )
+    }
+
+    func testOpeningPunctuationDoesNotDisambiguateTerminalCommand() {
+        for text in ["I wanna (send it.", #"I wanna "send it.""#, "I_wanna_send it."] {
+            XCTAssertEqual(
+                SpokenSendParser.parse(text, phrase: "send it", enabled: true),
+                SpokenSendParseResult(text: text, shouldSend: false)
+            )
+        }
+    }
+
+    func testFinalQuestionOrExclamationMarkIsPreserved() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Are we ready? send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Are we ready?", shouldSend: true)
+        )
+        XCTAssertEqual(
+            SpokenSendParser.parse("Ship it! send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ship it!", shouldSend: true)
         )
     }
 
@@ -159,7 +193,17 @@ final class SpokenSendTests: XCTestCase {
         XCTAssertTrue(
             SpokenSendParser.shouldCancelCountdownForVoiceActivity(
                 countdownStartedAt: startedAt,
-                voiceActivityAt: startedAt + SpokenSendParser.immediateStopVoiceActivityGraceDuration
+                voiceActivityAt: startedAt + SpokenSendParser.immediateStopVoiceActivityGraceDuration + 0.001
+            )
+        )
+        XCTAssertFalse(
+            SpokenSendParser.isMeaningfulVoiceActivity(
+                SpokenSendParser.immediateStopVoiceActivityLevelThreshold.nextDown
+            )
+        )
+        XCTAssertTrue(
+            SpokenSendParser.isMeaningfulVoiceActivity(
+                SpokenSendParser.immediateStopVoiceActivityLevelThreshold
             )
         )
     }
@@ -180,8 +224,8 @@ final class SpokenSendTests: XCTestCase {
 
     func testCustomPhraseAllowsFlexibleWhitespaceAndCase() {
         XCTAssertEqual(
-            SpokenSendParser.parse("Looks good PLEASE   SUBMIT", phrase: "please submit", enabled: true),
-            SpokenSendParseResult(text: "Looks good", shouldSend: true)
+            SpokenSendParser.parse("Looks good. PLEASE   SUBMIT", phrase: "please submit", enabled: true),
+            SpokenSendParseResult(text: "Looks good.", shouldSend: true)
         )
     }
 

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -1,0 +1,316 @@
+import CoreGraphics
+@testable import FluidVoice_Debug
+import XCTest
+
+final class SpokenSendTests: XCTestCase {
+    func testDisabledFeatureLeavesTextUntouched() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Hello send it", phrase: "send it", enabled: false),
+            SpokenSendParseResult(text: "Hello send it", shouldSend: false)
+        )
+    }
+
+    func testTerminalPhraseIsRemovedAndArmsSend() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Hello there, send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Hello there,", shouldSend: true)
+        )
+    }
+
+    func testCapitalizationAndFullStopDoNotAffectSend() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Ready to go, SEND IT.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready to go,", shouldSend: true)
+        )
+    }
+
+    func testNearbyTrailingPunctuationDoesNotAffectSend() {
+        XCTAssertEqual(
+            SpokenSendParser.parse(#"Ready to go — send it…")]"#, phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready to go —", shouldSend: true)
+        )
+    }
+
+    func testPhraseInMiddleDoesNotArmSend() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Send it when you are ready", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Send it when you are ready", shouldSend: false)
+        )
+    }
+
+    func testImmediateStopRequiresChildOption() {
+        XCTAssertTrue(
+            SpokenSendParser.shouldStopImmediately(
+                "Ready, send it.",
+                phrase: "send it",
+                spokenSendEnabled: true,
+                sendImmediatelyEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            SpokenSendParser.shouldStopImmediately(
+                "Ready, send it.",
+                phrase: "send it",
+                spokenSendEnabled: true,
+                sendImmediatelyEnabled: false
+            )
+        )
+    }
+
+    func testImmediateStopDoesNotTriggerForPhraseInMiddle() {
+        XCTAssertFalse(
+            SpokenSendParser.shouldStopImmediately(
+                "Send it when you are ready",
+                phrase: "send it",
+                spokenSendEnabled: true,
+                sendImmediatelyEnabled: true
+            )
+        )
+    }
+
+    func testTerminalASRRefinementStaysArmed() {
+        XCTAssertTrue(
+            SpokenSendParser.shouldStopImmediately(
+                "Ready, send it",
+                phrase: "send it",
+                spokenSendEnabled: true,
+                sendImmediatelyEnabled: true
+            )
+        )
+        XCTAssertTrue(
+            SpokenSendParser.shouldStopImmediately(
+                "Ready, SEND IT.",
+                phrase: "send it",
+                spokenSendEnabled: true,
+                sendImmediatelyEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            SpokenSendParser.shouldStopImmediately(
+                "Ready, send it after I finish this sentence.",
+                phrase: "send it",
+                spokenSendEnabled: true,
+                sendImmediatelyEnabled: true
+            )
+        )
+    }
+
+    func testImmediateStopCompletionRequiresFreshTranscriptAndSilence() {
+        let arguments = (
+            text: "Ready, send it.",
+            phrase: "send it",
+            spokenSendEnabled: true,
+            sendImmediatelyEnabled: true
+        )
+
+        XCTAssertFalse(
+            SpokenSendParser.canCompleteImmediateStop(
+                arguments.text,
+                phrase: arguments.phrase,
+                spokenSendEnabled: arguments.spokenSendEnabled,
+                sendImmediatelyEnabled: arguments.sendImmediatelyEnabled,
+                receivedFreshTranscript: false,
+                quietDuration: 2
+            )
+        )
+        XCTAssertFalse(
+            SpokenSendParser.canCompleteImmediateStop(
+                arguments.text,
+                phrase: arguments.phrase,
+                spokenSendEnabled: arguments.spokenSendEnabled,
+                sendImmediatelyEnabled: arguments.sendImmediatelyEnabled,
+                receivedFreshTranscript: true,
+                quietDuration: 0
+            )
+        )
+        XCTAssertTrue(
+            SpokenSendParser.canCompleteImmediateStop(
+                arguments.text,
+                phrase: arguments.phrase,
+                spokenSendEnabled: arguments.spokenSendEnabled,
+                sendImmediatelyEnabled: arguments.sendImmediatelyEnabled,
+                receivedFreshTranscript: true,
+                quietDuration: SpokenSendParser.immediateStopRequiredSilenceDuration
+            )
+        )
+    }
+
+    func testImmediateStopCompletionCancelsForContinuedSpeech() {
+        XCTAssertFalse(
+            SpokenSendParser.canCompleteImmediateStop(
+                "Ready, send it after I finish this sentence.",
+                phrase: "send it",
+                spokenSendEnabled: true,
+                sendImmediatelyEnabled: true,
+                receivedFreshTranscript: true,
+                quietDuration: 2
+            )
+        )
+    }
+
+    func testVoiceActivityGraceIgnoresOnlyTheRecognitionTail() {
+        let startedAt: TimeInterval = 100
+        XCTAssertFalse(
+            SpokenSendParser.shouldCancelCountdownForVoiceActivity(
+                countdownStartedAt: startedAt,
+                voiceActivityAt: startedAt + 0.05
+            )
+        )
+        XCTAssertTrue(
+            SpokenSendParser.shouldCancelCountdownForVoiceActivity(
+                countdownStartedAt: startedAt,
+                voiceActivityAt: startedAt + SpokenSendParser.immediateStopVoiceActivityGraceDuration
+            )
+        )
+    }
+
+    func testLiteralEscapeKeepsPhraseWithoutSending() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Please type literal send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Please type send it", shouldSend: false)
+        )
+    }
+
+    func testPhraseOnlySubmitsExistingDraftWithoutInsertingCommand() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Send it", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "", shouldSend: true)
+        )
+    }
+
+    func testCustomPhraseAllowsFlexibleWhitespaceAndCase() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Looks good PLEASE   SUBMIT", phrase: "please submit", enabled: true),
+            SpokenSendParseResult(text: "Looks good", shouldSend: true)
+        )
+    }
+
+    func testAvailableSendCommandsMapToExpectedFlags() {
+        XCTAssertEqual(SettingsStore.SpokenSendKey.enter.eventFlags, [])
+        XCTAssertEqual(SettingsStore.SpokenSendKey.shiftEnter.eventFlags, .maskShift)
+        XCTAssertEqual(SettingsStore.SpokenSendKey.commandEnter.eventFlags, .maskCommand)
+    }
+
+    func testGeneratedSendCommandsAreExcludedFromFluidVoiceHotkeys() throws {
+        for key in SettingsStore.SpokenSendKey.allCases {
+            let event = try XCTUnwrap(
+                CGEvent(
+                    keyboardEventSource: nil,
+                    virtualKey: 36,
+                    keyDown: true
+                )
+            )
+            event.flags = key.eventFlags
+            event.setIntegerValueField(
+                .eventSourceUserData,
+                value: TypingService.synthesizedEventUserData
+            )
+
+            XCTAssertTrue(
+                GlobalHotkeyManager.isSynthesizedTypingEvent(event),
+                "\(key.displayName) must bypass FluidVoice hotkey matching"
+            )
+        }
+
+        let physicalEvent = try XCTUnwrap(
+            CGEvent(
+                keyboardEventSource: nil,
+                virtualKey: 36,
+                keyDown: true
+            )
+        )
+        XCTAssertFalse(GlobalHotkeyManager.isSynthesizedTypingEvent(physicalEvent))
+    }
+
+    func testPostInsertionActionRequiresExactNonSecureFocus() {
+        XCTAssertTrue(
+            TypingService.canDispatchPostInsertionAction(
+                preferredTargetPID: 42,
+                requiredTargetPID: 42,
+                isSecureTextField: false,
+                modifiersReleased: true,
+                exactFocusIsActive: true
+            )
+        )
+        XCTAssertFalse(
+            TypingService.canDispatchPostInsertionAction(
+                preferredTargetPID: 42,
+                requiredTargetPID: 43,
+                isSecureTextField: false,
+                modifiersReleased: true,
+                exactFocusIsActive: true
+            )
+        )
+        XCTAssertFalse(
+            TypingService.canDispatchPostInsertionAction(
+                preferredTargetPID: 42,
+                requiredTargetPID: 42,
+                isSecureTextField: true,
+                modifiersReleased: true,
+                exactFocusIsActive: true
+            )
+        )
+        XCTAssertFalse(
+            TypingService.canDispatchPostInsertionAction(
+                preferredTargetPID: 42,
+                requiredTargetPID: 42,
+                isSecureTextField: false,
+                modifiersReleased: false,
+                exactFocusIsActive: true
+            )
+        )
+        XCTAssertFalse(
+            TypingService.canDispatchPostInsertionAction(
+                preferredTargetPID: 42,
+                requiredTargetPID: 42,
+                isSecureTextField: false,
+                modifiersReleased: true,
+                exactFocusIsActive: false
+            )
+        )
+    }
+
+    func testDeliveryOutcomesReportInsertionAndSendSeparately() {
+        XCTAssertTrue(TypingService.DeliveryOutcome.insertedAndActionDispatched.didInsert)
+        XCTAssertTrue(TypingService.DeliveryOutcome.insertedAndActionDispatched.didDispatchAction)
+        XCTAssertTrue(TypingService.DeliveryOutcome.actionDispatched.didDispatchAction)
+        XCTAssertFalse(TypingService.DeliveryOutcome.actionDispatched.didInsert)
+        XCTAssertTrue(TypingService.DeliveryOutcome.insertedActionSuppressed.didInsert)
+        XCTAssertFalse(TypingService.DeliveryOutcome.insertedActionSuppressed.didDispatchAction)
+    }
+
+    func testOverlayIndicatorVisibilityCoversEveryActiveState() {
+        XCTAssertFalse(SpokenSendIndicatorState.hidden.isVisible)
+        XCTAssertTrue(SpokenSendIndicatorState.detected.isVisible)
+        XCTAssertTrue(SpokenSendIndicatorState.countingDown.isVisible)
+        XCTAssertTrue(SpokenSendIndicatorState.sending.isVisible)
+        XCTAssertTrue(SpokenSendIndicatorState.sent.isVisible)
+        XCTAssertTrue(SpokenSendIndicatorState.failed.isVisible)
+    }
+
+    @MainActor
+    func testSettingsBackupIncludesSpokenSendConfiguration() async {
+        let settings = SettingsStore.shared
+        let originalEnabled = settings.spokenSendEnabled
+        let originalImmediate = settings.spokenSendImmediatelyEnabled
+        let originalPhrase = settings.spokenSendPhrase
+        let originalKey = settings.spokenSendKey
+        defer {
+            settings.spokenSendEnabled = originalEnabled
+            settings.spokenSendImmediatelyEnabled = originalImmediate
+            settings.spokenSendPhrase = originalPhrase
+            settings.spokenSendKey = originalKey
+        }
+
+        settings.spokenSendEnabled = true
+        settings.spokenSendImmediatelyEnabled = false
+        settings.spokenSendPhrase = "ship it"
+        settings.spokenSendKey = .commandEnter
+
+        let document = await BackupService.shared.makeBackupDocument()
+        XCTAssertEqual(document.settings.spokenSendEnabled, true)
+        XCTAssertEqual(document.settings.spokenSendImmediatelyEnabled, false)
+        XCTAssertEqual(document.settings.spokenSendPhrase, "ship it")
+        XCTAssertEqual(document.settings.spokenSendKey, .commandEnter)
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -463,6 +463,41 @@ final class SpokenSendTests: XCTestCase {
         XCTAssertFalse(TypingService.DeliveryOutcome.insertedActionSuppressed.didDispatchAction)
     }
 
+    func testCompletedRecordingIsSuppressedAfterANewerSessionStarts() {
+        let stoppedSessionID = UUID()
+
+        XCTAssertTrue(
+            ContentView.canDeliverCompletedRecording(
+                stoppedSessionID: stoppedSessionID,
+                currentSessionID: stoppedSessionID
+            )
+        )
+        XCTAssertFalse(
+            ContentView.canDeliverCompletedRecording(
+                stoppedSessionID: stoppedSessionID,
+                currentSessionID: UUID()
+            )
+        )
+    }
+
+    func testOlderStopOperationCannotClearNewerStopGuard() {
+        let olderOperationID = UUID()
+        let newerOperationID = UUID()
+
+        XCTAssertTrue(
+            ContentView.canFinishStopProcessingOperation(
+                completingOperationID: newerOperationID,
+                currentOperationID: newerOperationID
+            )
+        )
+        XCTAssertFalse(
+            ContentView.canFinishStopProcessingOperation(
+                completingOperationID: olderOperationID,
+                currentOperationID: newerOperationID
+            )
+        )
+    }
+
     func testExactTargetInsertionPreservesUnselectedDraftText() {
         XCTAssertEqual(
             TypingService.valueByInserting(

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -256,6 +256,40 @@ final class SpokenSendTests: XCTestCase {
         XCTAssertEqual(SettingsStore.SpokenSendKey.commandEnter.eventFlags, .maskCommand)
     }
 
+    func testTerminalClassifierBlocksEveryRecognizedTerminal() {
+        let terminals = [
+            ("Terminal", "com.apple.Terminal"),
+            ("iTerm2", "com.googlecode.iterm2"),
+            ("Warp", "dev.warp.Warp-Stable"),
+            ("Ghostty", "com.mitchellh.ghostty"),
+            ("kitty", "net.kovidgoyal.kitty"),
+            ("Alacritty", "org.alacritty"),
+            ("WezTerm", "com.github.wez.wezterm"),
+        ]
+
+        for (name, bundleID) in terminals {
+            XCTAssertTrue(
+                TerminalAppClassifier.isTerminal(appName: name, bundleID: bundleID),
+                "Spoken Send must stay disabled in \(name)"
+            )
+        }
+    }
+
+    func testTerminalClassifierDoesNotBlockOrdinaryEditors() {
+        XCTAssertFalse(
+            TerminalAppClassifier.isTerminal(
+                appName: "TextEdit",
+                bundleID: "com.apple.TextEdit"
+            )
+        )
+        XCTAssertFalse(
+            TerminalAppClassifier.isTerminal(
+                appName: "Codex",
+                bundleID: "com.openai.codex"
+            )
+        )
+    }
+
     func testGeneratedSendCommandsAreExcludedFromFluidVoiceHotkeys() throws {
         for key in SettingsStore.SpokenSendKey.allCases {
             let event = try XCTUnwrap(
@@ -331,6 +365,16 @@ final class SpokenSendTests: XCTestCase {
                 isSecureTextField: false,
                 modifiersReleased: true,
                 exactFocusIsActive: false
+            )
+        )
+        XCTAssertFalse(
+            TypingService.canDispatchPostInsertionAction(
+                preferredTargetPID: 42,
+                requiredTargetPID: 42,
+                isSecureTextField: false,
+                modifiersReleased: true,
+                exactFocusIsActive: true,
+                insertionConfirmed: false
             )
         )
     }

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -339,6 +339,22 @@ final class SpokenSendTests: XCTestCase {
         )
     }
 
+    func testTerminalClassifierRecognizesHostedTerminalContext() {
+        XCTAssertTrue(
+            TerminalAppClassifier.isTerminalContext(
+                labels: ["Visual Studio Code", "Integrated Terminal", "AXTextArea"]
+            )
+        )
+        XCTAssertTrue(
+            TerminalAppClassifier.isTerminalContext(labels: ["Web SSH Console"])
+        )
+        XCTAssertFalse(
+            TerminalAppClassifier.isTerminalContext(
+                labels: ["Visual Studio Code", "Source Editor", "AXTextArea"]
+            )
+        )
+    }
+
     func testGeneratedSendCommandsAreExcludedFromFluidVoiceHotkeys() throws {
         for key in SettingsStore.SpokenSendKey.allCases {
             let event = try XCTUnwrap(
@@ -394,6 +410,16 @@ final class SpokenSendTests: XCTestCase {
                 preferredTargetPID: 42,
                 requiredTargetPID: 42,
                 isSecureTextField: true,
+                modifiersReleased: true,
+                exactFocusIsActive: true
+            )
+        )
+        XCTAssertFalse(
+            TypingService.canDispatchPostInsertionAction(
+                preferredTargetPID: 42,
+                requiredTargetPID: 42,
+                isSecureTextField: false,
+                isTerminalLikeContext: true,
                 modifiersReleased: true,
                 exactFocusIsActive: true
             )

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -31,6 +31,28 @@ final class SpokenSendTests: XCTestCase {
         )
     }
 
+    func testPairedDelimitersAroundTerminalPhraseAreRemoved() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Ready (send it)", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready.", shouldSend: true)
+        )
+        XCTAssertEqual(
+            SpokenSendParser.parse("Ready “send it”", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready.", shouldSend: true)
+        )
+        XCTAssertEqual(
+            SpokenSendParser.parse(#"Ready ["send it"]"#, phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready.", shouldSend: true)
+        )
+    }
+
+    func testClosingQuoteBeforeTerminalPhraseIsPreserved() {
+        XCTAssertEqual(
+            SpokenSendParser.parse(#"He said "Ready" send it"#, phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: #"He said "Ready"."#, shouldSend: true)
+        )
+    }
+
     func testPhraseInMiddleDoesNotArmSend() {
         XCTAssertEqual(
             SpokenSendParser.parse("Send it when you are ready", phrase: "send it", enabled: true),

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -38,27 +38,41 @@ final class SpokenSendTests: XCTestCase {
         )
     }
 
-    func testNaturalSentenceEndingWithPhraseDoesNotArmSend() {
+    func testTerminalPhraseDoesNotRequireLeadingOrTrailingPunctuation() {
         XCTAssertEqual(
-            SpokenSendParser.parse("I wanna send it.", phrase: "send it", enabled: true),
-            SpokenSendParseResult(text: "I wanna send it.", shouldSend: false)
+            SpokenSendParser.parse("Ready to go send it", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready to go.", shouldSend: true)
         )
     }
 
-    func testPunctuationBreakDisambiguatesTerminalCommand() {
+    func testRepeatedTerminalPhrasesAreAllRemoved() {
         XCTAssertEqual(
             SpokenSendParser.parse("I wanna send it, send it.", phrase: "send it", enabled: true),
-            SpokenSendParseResult(text: "I wanna send it.", shouldSend: true)
+            SpokenSendParseResult(text: "I wanna.", shouldSend: true)
+        )
+        XCTAssertEqual(
+            SpokenSendParser.parse("Ready SEND IT send it", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready.", shouldSend: true)
+        )
+        XCTAssertEqual(
+            SpokenSendParser.parse("send it, send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "", shouldSend: true)
         )
     }
 
-    func testOpeningPunctuationDoesNotDisambiguateTerminalCommand() {
-        for text in ["I wanna (send it.", #"I wanna "send it.""#, "I_wanna_send it."] {
-            XCTAssertEqual(
-                SpokenSendParser.parse(text, phrase: "send it", enabled: true),
-                SpokenSendParseResult(text: text, shouldSend: false)
-            )
-        }
+    func testRepeatedTrailingSeparatorsCollapseToOneSentenceEnding() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Ready,,,,; — send it", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready.", shouldSend: true)
+        )
+        XCTAssertEqual(
+            SpokenSendParser.parse("Ready.,,,;— send it, send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready.", shouldSend: true)
+        )
+        XCTAssertEqual(
+            SpokenSendParser.parse("Ready?,,, send it", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Ready?", shouldSend: true)
+        )
     }
 
     func testFinalQuestionOrExclamationMarkIsPreserved() {
@@ -212,6 +226,13 @@ final class SpokenSendTests: XCTestCase {
         XCTAssertEqual(
             SpokenSendParser.parse("Please type literal send it.", phrase: "send it", enabled: true),
             SpokenSendParseResult(text: "Please type send it", shouldSend: false)
+        )
+    }
+
+    func testLiteralEscapeBeforeRepeatedCommandKeepsOnePhraseAndSends() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Please type literal send it, send it.", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Please type send it.", shouldSend: true)
         )
     }
 

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -258,6 +258,31 @@ final class SpokenSendTests: XCTestCase {
         )
     }
 
+    func testLiteralEscapeIsStrippedWhenPhraseIsNotTerminal() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("I said literal send it to him", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "I said send it to him", shouldSend: false)
+        )
+    }
+
+    func testEarlierLiteralEscapeIsStrippedWhenFinalCommandSends() {
+        XCTAssertEqual(
+            SpokenSendParser.parse(
+                "I said literal send it to him and then send it",
+                phrase: "send it",
+                enabled: true
+            ),
+            SpokenSendParseResult(text: "I said send it to him and then.", shouldSend: true)
+        )
+    }
+
+    func testMidSentencePhraseWithoutLiteralMarkerIsUnchanged() {
+        XCTAssertEqual(
+            SpokenSendParser.parse("Please send it to Dana", phrase: "send it", enabled: true),
+            SpokenSendParseResult(text: "Please send it to Dana", shouldSend: false)
+        )
+    }
+
     func testPhraseOnlySubmitsExistingDraftWithoutInsertingCommand() {
         XCTAssertEqual(
             SpokenSendParser.parse("Send it", phrase: "send it", enabled: true),
@@ -287,6 +312,8 @@ final class SpokenSendTests: XCTestCase {
             ("kitty", "net.kovidgoyal.kitty"),
             ("Alacritty", "org.alacritty"),
             ("WezTerm", "com.github.wez.wezterm"),
+            ("Hyper", "co.zeit.hyper"),
+            ("Termius", "com.termius-dmg.mac"),
         ]
 
         for (name, bundleID) in terminals {

--- a/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SpokenSendTests.swift
@@ -463,6 +463,32 @@ final class SpokenSendTests: XCTestCase {
         XCTAssertFalse(TypingService.DeliveryOutcome.insertedActionSuppressed.didDispatchAction)
     }
 
+    func testExactTargetInsertionPreservesUnselectedDraftText() {
+        XCTAssertEqual(
+            TypingService.valueByInserting(
+                "new ",
+                into: "existing draft",
+                selectedRange: CFRange(location: 9, length: 0)
+            ),
+            "existing new draft"
+        )
+        XCTAssertEqual(
+            TypingService.valueByInserting(
+                "replacement",
+                into: "keep old keep",
+                selectedRange: CFRange(location: 5, length: 3)
+            ),
+            "keep replacement keep"
+        )
+        XCTAssertNil(
+            TypingService.valueByInserting(
+                "unsafe",
+                into: "draft",
+                selectedRange: CFRange(location: 99, length: 0)
+            )
+        )
+    }
+
     func testOverlayIndicatorVisibilityCoversEveryActiveState() {
         XCTAssertFalse(SpokenSendIndicatorState.hidden.isVisible)
         XCTAssertTrue(SpokenSendIndicatorState.detected.isVisible)


### PR DESCRIPTION
## Description
Adds optional Spoken Send: say a configurable phrase at the end of dictation to remove the command phrase, stop recording, insert the text, and dispatch Enter, Shift+Enter, or Command+Enter. Delivery is suppressed for secure fields, terminal apps, held modifiers, changed focus targets, or unconfirmed insertion.

## Type of Change
- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #518

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: 245/245 passed, including 34 Spoken Send tests

Live dogfood through BlackHole 2ch and macOS speech:
- The Codex composer removed trailing `send it`, inserted the remaining text, and dispatched Enter.
- `literal send it` inserted the phrase without dispatching Enter.
- `send it` in the middle of a sentence remained normal dictated text.

## Screenshots / Video
Spoken Send settings were visually inspected in the installed FluidVoice 1.6.8 app.
<img width="883" height="215" alt="Spoken Send settings" src="https://github.com/user-attachments/assets/ed882f2f-0b5f-4eb6-81ed-226cda553604" />

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes
The feature is disabled by default. Audio-level monitoring is active only during the 1.5-second Spoken Send countdown. Text insertion and Enter dispatch remain bound to the exact captured field; Enter is suppressed unless insertion is confirmed.
