### PR TITLE
fix: preserve streamed tool calls with reasoning content

### DIFF
--- a/Sources/Fluid/Services/LLMClient.swift
+++ b/Sources/Fluid/Services/LLMClient.swift
@@ -75,6 +75,11 @@ final class LLMClient {
         self.session = URLSession(configuration: config)
     }
 
+    /// Test seam for deterministic transport fixtures; callers own the session configuration.
+    init(session: URLSession) {
+        self.session = session
+    }
+
     // MARK: - Response Types
 
     struct Response {
@@ -678,52 +683,51 @@ final class LLMClient {
                     }
                     contentBuffer.append(content)
                     config.onContentChunk?(content)
-                    continue
-                }
+                } else {
+                    // If we were in thinking mode via a separate field (not tag-based),
+                    // receiving "content" usually means the thinking phase is over.
+                    if state == .inThinking && reasoningField == nil && tagDetectionBuffer.isEmpty {
+                        // This is a subtle heuristic: if we were thinking, didn't just get a reasoning field chunk,
+                        // and have no partial tags buffered, we should check if this content chunk
+                        // is the start of the final answer.
+                        // For safety with tag-based parsers, we let the parser decide unless it's a known separate-field model.
+                    }
 
-                // If we were in thinking mode via a separate field (not tag-based),
-                // receiving "content" usually means the thinking phase is over.
-                if state == .inThinking && reasoningField == nil && tagDetectionBuffer.isEmpty {
-                    // This is a subtle heuristic: if we were thinking, didn't just get a reasoning field chunk,
-                    // and have no partial tags buffered, we should check if this content chunk
-                    // is the start of the final answer.
-                    // For safety with tag-based parsers, we let the parser decide unless it's a known separate-field model.
-                }
+                    // Debug: Log first few chunks and any chunk containing think tags
+                    let containsThinkTag = content.contains("<think") || content.contains("</think") || content.contains("<thinking") || content.contains("</thinking")
+                    if thinkingBuffer.count + contentBuffer.count < 8 || containsThinkTag {
+                        let escaped = content.replacingOccurrences(of: "\n", with: "\\n")
+                        let marker = containsThinkTag ? " [HAS THINK TAG!]" : ""
+                        DebugLogger.shared.debug("LLMClient: Chunk '\(escaped)'\(marker)", source: "LLMClient")
+                    }
 
-                // Debug: Log first few chunks and any chunk containing think tags
-                let containsThinkTag = content.contains("<think") || content.contains("</think") || content.contains("<thinking") || content.contains("</thinking")
-                if thinkingBuffer.count + contentBuffer.count < 8 || containsThinkTag {
-                    let escaped = content.replacingOccurrences(of: "\n", with: "\\n")
-                    let marker = containsThinkTag ? " [HAS THINK TAG!]" : ""
-                    DebugLogger.shared.debug("LLMClient: Chunk '\(escaped)'\(marker)", source: "LLMClient")
-                }
+                    let previousState = state
+                    let (newState, thinkChunk, contentChunk) = parser.processChunk(
+                        content,
+                        currentState: state,
+                        tagBuffer: &tagDetectionBuffer
+                    )
 
-                let previousState = state
-                let (newState, thinkChunk, contentChunk) = parser.processChunk(
-                    content,
-                    currentState: state,
-                    tagBuffer: &tagDetectionBuffer
-                )
+                    // Handle state transitions for callbacks
+                    if previousState != .inThinking && newState == .inThinking {
+                        DebugLogger.shared.debug("LLMClient: State transition → inThinking", source: "LLMClient")
+                        config.onThinkingStart?()
+                    }
+                    if previousState == .inThinking && newState == .inContent {
+                        DebugLogger.shared.debug("LLMClient: State transition → inContent", source: "LLMClient")
+                        config.onThinkingEnd?()
+                    }
+                    state = newState
 
-                // Handle state transitions for callbacks
-                if previousState != .inThinking && newState == .inThinking {
-                    DebugLogger.shared.debug("LLMClient: State transition → inThinking", source: "LLMClient")
-                    config.onThinkingStart?()
-                }
-                if previousState == .inThinking && newState == .inContent {
-                    DebugLogger.shared.debug("LLMClient: State transition → inContent", source: "LLMClient")
-                    config.onThinkingEnd?()
-                }
-                state = newState
-
-                // Accumulate and callback
-                if !thinkChunk.isEmpty {
-                    thinkingBuffer.append(thinkChunk)
-                    config.onThinkingChunk?(thinkChunk)
-                }
-                if !contentChunk.isEmpty {
-                    contentBuffer.append(contentChunk)
-                    config.onContentChunk?(contentChunk)
+                    // Accumulate and callback
+                    if !thinkChunk.isEmpty {
+                        thinkingBuffer.append(thinkChunk)
+                        config.onThinkingChunk?(thinkChunk)
+                    }
+                    if !contentChunk.isEmpty {
+                        contentBuffer.append(contentChunk)
+                        config.onContentChunk?(contentChunk)
+                    }
                 }
             }
 

--- a/Tests/FluidDictationIntegrationTests/LLMClientRequestBodyTests.swift
+++ b/Tests/FluidDictationIntegrationTests/LLMClientRequestBodyTests.swift
@@ -1,4 +1,5 @@
 @testable import FluidVoice_Debug
+import Foundation
 import XCTest
 
 // Regression tests for https://github.com/altic-dev/FluidVoice/issues/295
@@ -196,4 +197,112 @@ final class LLMClientRequestBodyTests: XCTestCase {
         guard let messages = body["messages"] as? [[String: Any]] else { return [] }
         return messages.compactMap { $0["content"] as? String }
     }
+}
+
+@MainActor
+final class LLMClientStreamingTests: XCTestCase {
+    // Regression test for https://github.com/altic-dev/FluidVoice/issues/445
+    func testReasoningContentDeltaPreservesChunkedToolCall() async throws {
+        let client = makeClient()
+        var config = LLMClient.Config(
+            messages: [["role": "user", "content": "Show the working directory"]],
+            model: "qwen3.5:9b",
+            baseURL: "https://issue-445.test/v1",
+            apiKey: "",
+            streaming: true
+        )
+        config.maxRetries = 1
+        config.timeoutSeconds = 5
+
+        let response = try await client.call(config)
+
+        XCTAssertEqual(response.thinking, "I should inspect the current directory.")
+        XCTAssertEqual(response.content, "")
+        XCTAssertEqual(response.toolCalls.count, 1)
+        XCTAssertEqual(response.toolCalls.first?.id, "call_445")
+        XCTAssertEqual(response.toolCalls.first?.name, "run_terminal")
+        XCTAssertEqual(response.toolCalls.first?.getString("command"), "pwd")
+    }
+
+    func testTagBasedReasoningStillPreservesChunkedToolCall() async throws {
+        let client = makeClient()
+        var config = LLMClient.Config(
+            messages: [["role": "user", "content": "Show the working directory"]],
+            model: "qwen-thinking",
+            baseURL: "https://issue-445.test/tag-parser/v1",
+            apiKey: "",
+            streaming: true
+        )
+        config.maxRetries = 1
+        config.timeoutSeconds = 5
+
+        let response = try await client.call(config)
+
+        XCTAssertEqual(response.thinking, "Inspecting.")
+        XCTAssertEqual(response.content, "Ready.")
+        XCTAssertEqual(response.toolCalls.count, 1)
+        XCTAssertEqual(response.toolCalls.first?.id, "call_tag_control")
+        XCTAssertEqual(response.toolCalls.first?.name, "run_terminal")
+        XCTAssertEqual(response.toolCalls.first?.getString("command"), "pwd")
+    }
+
+    private func makeClient() -> LLMClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [Issue445StreamURLProtocol.self]
+        return LLMClient(session: URLSession(configuration: configuration))
+    }
+}
+
+private class Issue445StreamURLProtocol: URLProtocol {
+    // The empty-string `content` fields are load-bearing: HEAD skips tool calls only
+    // when `delta["content"] as? String` succeeds, so replacing them with null defangs the regression.
+    private static let separateReasoningFixture = #"""
+    data: {"choices":[{"index":0,"delta":{"reasoning_content":"I should inspect the current directory.","content":"","tool_calls":[{"index":0,"id":"call_445","type":"function","function":{"name":"run_terminal","arguments":"{\"command\":\""}}]}}]}
+
+    data: {"choices":[{"index":0,"delta":{"content":"","tool_calls":[{"index":0,"function":{"arguments":"pwd\"}"}}]},"finish_reason":"tool_calls"}]}
+
+    data: [DONE]
+
+    """#
+
+    private static let tagParserFixture = #"""
+    data: {"choices":[{"index":0,"delta":{"content":"<think>Inspecting.</think>Ready.","tool_calls":[{"index":0,"id":"call_tag_control","type":"function","function":{"name":"run_terminal","arguments":"{\"command\":\""}}]}}]}
+
+    data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"pwd\"}"}}]},"finish_reason":"tool_calls"}]}
+
+    data: [DONE]
+
+    """#
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "issue-445.test"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"]
+        ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        let fixture = url.path.contains("tag-parser") ? Self.tagParserFixture : Self.separateReasoningFixture
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(fixture.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }


### PR DESCRIPTION
## Description
Some chat-completions providers stream reasoning content, an empty content string, and tool calls in the same delta. The parser advanced to the next SSE event after handling content, so the sibling tool call was dropped. This keeps the reasoning/content paths mutually exclusive while still parsing tool calls from the same delta.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Fixes #445.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 15.7.7
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources` (SwiftFormat is not installed locally)
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' -only-testing:FluidDictationIntegrationTests/LLMClientStreamingTests CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

The two focused regression tests pass. Reintroducing the skipped-event behavior makes the same-delta tool-call test fail, and restoring this patch makes both tests pass again.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
This intentionally addresses the streamed tool-call loss without changing provider-specific reasoning settings.
