### PR TITLE
fix(updater): stop the update prompt from blocking the main actor

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -19,7 +19,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var wasLaunchedAsLoginItem = false
     private var analyticsActivationSuppressionDeadline: Date?
     private var hasDeferredMLXUpgradeOffer = false
-    private var updatePromptWindow: NSWindow?
+    private var floatingPromptWindow: NSWindow?
+    private var floatingPromptTitle: String?
 
     var shouldPresentStartupMicrophoneNotice: Bool {
         !self.wasLaunchedAsLoginItem || SettingsStore.shared.showMainWindowAtLoginLaunch
@@ -237,20 +238,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     @MainActor
     private func showMLXUpgradeOffer() {
-        let alert = NSAlert()
-        alert.messageText = "Fluid-1 is now 2.2x faster"
-        alert.informativeText = "A new 3.77 GB MLX model is available for Apple silicon. Continue to AI Enhancement to download and verify it. Your current slower model will keep working unless you choose to upgrade."
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "Continue to Download")
-        alert.addButton(withTitle: "Keep Current Model")
-
-        if alert.runModal() == .alertFirstButtonReturn {
-            PrivateAIMLXUpgradeCoordinator.beginUpgrade()
-            AppNavigationRouter.shared.request(.aiEnhancements)
-            self.bringMainWindowToFront()
-        } else {
-            PrivateAIMLXUpgradeCoordinator.keepCurrentModel()
-        }
+        // Offered unattended after launch, so it must never block the main actor - see
+        // presentFloatingPrompt(title:message:actions:).
+        self.presentFloatingPrompt(
+            title: "Fluid-1 is now 2.2x faster",
+            message: "A new 3.77 GB MLX model is available for Apple silicon. Continue to AI Enhancement to download and verify it. Your current slower model will keep working unless you choose to upgrade.",
+            actions: [
+                FloatingPromptAction(title: "Continue to Download") { [weak self] in
+                    PrivateAIMLXUpgradeCoordinator.beginUpgrade()
+                    AppNavigationRouter.shared.request(.aiEnhancements)
+                    self?.bringMainWindowToFront()
+                },
+                FloatingPromptAction(title: "Keep Current Model") {
+                    PrivateAIMLXUpgradeCoordinator.keepCurrentModel()
+                },
+            ]
+        )
     }
 
     /// Realize the main window invisibly so ContentView's startup runs, then order it out.
@@ -469,71 +472,119 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
     }
 
-    /// Offers the available update from a floating panel instead of a modal alert.
+    @MainActor
+    private func showUpdateNotification(version: String) {
+        DebugLogger.shared.info("Showing update notification for version \(version)", source: "AppDelegate")
+        self.presentFloatingPrompt(
+            title: "Update Available",
+            message: "FluidVoice \(version) is now available. The app will restart automatically after installation.",
+            actions: [
+                FloatingPromptAction(title: "Install Now") { [weak self] in
+                    self?.installOfferedUpdate()
+                },
+                FloatingPromptAction(title: "Later") { [weak self] in
+                    self?.postponeOfferedUpdate(version: version)
+                },
+            ]
+        )
+    }
+
+    @MainActor
+    private func installOfferedUpdate() {
+        DebugLogger.shared.info("User chose to install update now", source: "AppDelegate")
+        SettingsStore.shared.clearUpdateSnooze() // Clear snooze since they're installing
+        // Installing restarts the app, so taking focus here costs nothing and keeps the updater's
+        // own install status window in front of the user.
+        NSApp.activate(ignoringOtherApps: true)
+        self.checkForUpdatesManually()
+    }
+
+    @MainActor
+    private func postponeOfferedUpdate(version: String) {
+        DebugLogger.shared.info("User postponed update for 24 hours", source: "AppDelegate")
+        SettingsStore.shared.snoozeUpdatePrompt(forVersion: version)
+    }
+
+    @MainActor
+    private func showUpdateAlert(title: String, message: String) {
+        self.presentFloatingPrompt(
+            title: title,
+            message: message,
+            actions: [FloatingPromptAction(title: "OK") {}]
+        )
+    }
+
+    // MARK: - Floating Prompts
+
+    /// Presents a prompt from a floating panel instead of a modal alert.
     ///
-    /// This prompt used to be an `NSAlert.runModal()`. That call never returns until the alert is
+    /// These prompts used to be `NSAlert.runModal()`. That call never returns until the alert is
     /// dismissed, and it runs inside a main actor job, so every other `@MainActor` job queues up
     /// behind it - including the dictation callbacks `GlobalHotkeyManager` posts from its event
     /// tap. FluidVoice is a menu bar app that is rarely frontmost, so the alert also came up
     /// unactivated behind other windows: dictation stayed dead until the user found the hidden
     /// dialog (#564, #745). The panel keeps the main actor free and floats above other apps
     /// without stealing focus, and matches the install status panel in SimpleUpdater.
+    ///
+    /// `actions` is ordered like `NSAlert.addButton(withTitle:)`: the first action is laid out
+    /// where the alert's default button used to sit. Choosing one dismisses the panel before its
+    /// handler runs, so a handler is free to present the next prompt.
+    ///
+    /// Only one prompt is on screen at a time. The title identifies the prompt: a repeat of the one
+    /// already showing is dropped (checks that used to be blocked by the modal now really do run
+    /// while a prompt is up), and a different prompt replaces it rather than stacking on top.
     @MainActor
-    private func showUpdateNotification(version: String) {
-        DebugLogger.shared.info("Showing update notification for version \(version)", source: "AppDelegate")
+    private func presentFloatingPrompt(title: String, message: String, actions: [FloatingPromptAction]) {
+        DebugLogger.shared.info("🔔 Showing prompt: \(title)", source: "AppDelegate")
 
-        // Hourly checks keep running now that the prompt no longer blocks them, so never stack panels.
-        guard self.updatePromptWindow == nil else {
-            DebugLogger.shared.debug("Update prompt already on screen, skipping duplicate", source: "AppDelegate")
+        guard self.floatingPromptTitle != title else {
+            DebugLogger.shared.debug("Prompt \"\(title)\" already on screen, skipping duplicate", source: "AppDelegate")
             return
         }
+        self.dismissFloatingPrompt()
 
-        let panelWidth: CGFloat = 420
         let margin: CGFloat = 22
         let textLeading: CGFloat = 92
+        let buttonHeight: CGFloat = 30
+        let buttonSpacing: CGFloat = 10
+
+        let buttons = actions.map { action in
+            FloatingPromptButton(title: action.title) { [weak self] in
+                self?.dismissFloatingPrompt()
+                action.handler()
+            }
+        }
+        // The leading action is the default one, so give it the wider minimum an alert would use.
+        let buttonWidths = buttons.enumerated().map { index, button in
+            max(ceil(button.fittingSize.width), index == 0 ? 96 : 80)
+        }
+        let buttonsWidth = buttonWidths.reduce(0, +) + buttonSpacing * CGFloat(max(buttons.count - 1, 0))
+        let panelWidth = max(420, margin * 2 + buttonsWidth)
         let textWidth = panelWidth - textLeading - margin
 
-        let title = NSTextField(labelWithString: "Update Available")
-        title.font = .systemFont(ofSize: 16, weight: .semibold)
-        let titleHeight = ceil(title.fittingSize.height)
+        let titleLabel = NSTextField(labelWithString: title)
+        titleLabel.font = .systemFont(ofSize: 16, weight: .semibold)
+        let titleHeight = ceil(titleLabel.fittingSize.height)
 
-        let detail = NSTextField(
-            wrappingLabelWithString: "FluidVoice \(version) is now available. The app will restart automatically after installation."
-        )
+        let detail = NSTextField(wrappingLabelWithString: message)
         detail.font = .systemFont(ofSize: 13)
         detail.textColor = .secondaryLabelColor
         detail.preferredMaxLayoutWidth = textWidth
         let detailHeight = ceil(detail.fittingSize.height)
 
-        let installButton = UpdatePromptButton(title: "Install Now") { [weak self] in
-            self?.installOfferedUpdate()
-        }
-        let laterButton = UpdatePromptButton(title: "Later") { [weak self] in
-            self?.postponeOfferedUpdate(version: version)
-        }
-
-        let buttonHeight: CGFloat = 30
-        let installWidth = max(ceil(installButton.fittingSize.width), 96)
-        let laterWidth = max(ceil(laterButton.fittingSize.width), 80)
         let buttonsY = margin - 2
         let detailY = buttonsY + buttonHeight + 16
         let titleY = detailY + detailHeight + 8
         let panelHeight = titleY + titleHeight + margin
 
-        title.frame = NSRect(x: textLeading, y: titleY, width: textWidth, height: titleHeight)
+        titleLabel.frame = NSRect(x: textLeading, y: titleY, width: textWidth, height: titleHeight)
         detail.frame = NSRect(x: textLeading, y: detailY, width: textWidth, height: detailHeight)
-        installButton.frame = NSRect(
-            x: panelWidth - margin - installWidth,
-            y: buttonsY,
-            width: installWidth,
-            height: buttonHeight
-        )
-        laterButton.frame = NSRect(
-            x: installButton.frame.minX - 10 - laterWidth,
-            y: buttonsY,
-            width: laterWidth,
-            height: buttonHeight
-        )
+
+        var buttonTrailing = panelWidth - margin
+        for (button, width) in zip(buttons, buttonWidths) {
+            button.frame = NSRect(x: buttonTrailing - width, y: buttonsY, width: width, height: buttonHeight)
+            buttonTrailing -= width + buttonSpacing
+        }
 
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
@@ -541,7 +592,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             backing: .buffered,
             defer: false
         )
-        panel.title = "Update Available"
+        panel.title = title
         panel.isFloatingPanel = true
         panel.level = .floating
         panel.isOpaque = false
@@ -549,7 +600,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         panel.hasShadow = true
         panel.isMovableByWindowBackground = true
         panel.hidesOnDeactivate = false
-        // The panel is owned by updatePromptWindow, so let ARC release it after close().
+        // The panel is owned by floatingPromptWindow, so let ARC release it after close().
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
@@ -566,61 +617,40 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         icon.image = NSApp.applicationIconImage
         icon.imageScaling = .scaleProportionallyUpOrDown
         content.addSubview(icon)
-        content.addSubview(title)
+        content.addSubview(titleLabel)
         content.addSubview(detail)
-        content.addSubview(laterButton)
-        content.addSubview(installButton)
+        for button in buttons {
+            content.addSubview(button)
+        }
 
         panel.contentView = content
         panel.center()
         // Floating level plus orderFrontRegardless puts the prompt above the frontmost app without
         // activating FluidVoice, so an in-flight dictation is never interrupted to show it.
         panel.orderFrontRegardless()
-        self.updatePromptWindow = panel
+        self.floatingPromptWindow = panel
+        self.floatingPromptTitle = title
     }
 
     @MainActor
-    private func installOfferedUpdate() {
-        DebugLogger.shared.info("User chose to install update now", source: "AppDelegate")
-        self.dismissUpdatePrompt()
-        SettingsStore.shared.clearUpdateSnooze() // Clear snooze since they're installing
-        // The manual check still reports failures through a modal alert, so activate first to keep
-        // that alert in front of the user instead of behind other windows. Installing restarts the
-        // app anyway, so taking focus here costs nothing.
-        NSApp.activate(ignoringOtherApps: true)
-        self.checkForUpdatesManually()
-    }
-
-    @MainActor
-    private func postponeOfferedUpdate(version: String) {
-        DebugLogger.shared.info("User postponed update for 24 hours", source: "AppDelegate")
-        self.dismissUpdatePrompt()
-        SettingsStore.shared.snoozeUpdatePrompt(forVersion: version)
-    }
-
-    @MainActor
-    private func dismissUpdatePrompt() {
-        self.updatePromptWindow?.close()
-        self.updatePromptWindow = nil
-    }
-
-    @MainActor
-    private func showUpdateAlert(title: String, message: String) {
-        DebugLogger.shared.info("🔔 Showing alert: \(title)", source: "AppDelegate")
-        let alert = NSAlert()
-        alert.messageText = title
-        alert.informativeText = message
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "OK")
-        alert.runModal()
+    private func dismissFloatingPrompt() {
+        self.floatingPromptWindow?.close()
+        self.floatingPromptWindow = nil
+        self.floatingPromptTitle = nil
     }
 }
 
-/// Push button for the update prompt panel.
+/// One button on a floating prompt panel.
+private struct FloatingPromptAction {
+    let title: String
+    let handler: @MainActor () -> Void
+}
+
+/// Push button for a floating prompt panel.
 ///
 /// The panel is a non-activating panel of a menu bar app, so it never becomes key; accepting the
 /// first mouse keeps a single click on the button working while another app stays frontmost.
-private final class UpdatePromptButton: NSButton {
+private final class FloatingPromptButton: NSButton {
     private let onClick: @MainActor () -> Void
 
     init(title: String, onClick: @escaping @MainActor () -> Void) {
@@ -635,7 +665,7 @@ private final class UpdatePromptButton: NSButton {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("UpdatePromptButton is created in code only")
+        fatalError("FloatingPromptButton is created in code only")
     }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
@@ -643,6 +673,8 @@ private final class UpdatePromptButton: NSButton {
     }
 
     @objc private func handleClick() {
-        self.onClick()
+        // The handler closes the panel that owns this button, so hold the closure for the call.
+        let onClick = self.onClick
+        onClick()
     }
 }

--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -19,8 +19,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var wasLaunchedAsLoginItem = false
     private var analyticsActivationSuppressionDeadline: Date?
     private var hasDeferredMLXUpgradeOffer = false
-    private var floatingPromptWindow: NSWindow?
-    private var floatingPromptTitle: String?
+    private var floatingPromptWindow: FloatingPromptPanel?
+    /// Prompts waiting their turn. The head is the one on screen once a panel exists.
+    private var floatingPromptQueue: [FloatingPrompt] = []
+    /// Only the automatic update check, the manual check's result and the one-time MLX offer
+    /// enqueue prompts, so anything beyond a handful means something is looping.
+    private static let maxQueuedFloatingPrompts = 4
 
     var shouldPresentStartupMicrophoneNotice: Bool {
         !self.wasLaunchedAsLoginItem || SettingsStore.shared.showMainWindowAtLoginLaunch
@@ -147,6 +151,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             self.hasDeferredMLXUpgradeOffer = false
             self.scheduleMLXUpgradeOffer()
         }
+        self.focusFloatingPromptOnActivation()
     }
 
     func userNotificationCenter(
@@ -526,33 +531,57 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     /// dialog (#564, #745). The panel keeps the main actor free and floats above other apps
     /// without stealing focus, and matches the install status panel in SimpleUpdater.
     ///
-    /// `actions` is ordered like `NSAlert.addButton(withTitle:)`: the first action is laid out
-    /// where the alert's default button used to sit. Choosing one dismisses the panel before its
-    /// handler runs, so a handler is free to present the next prompt.
+    /// `actions` is ordered like `NSAlert.addButton(withTitle:)`: the first action is the default
+    /// one and is laid out where the alert's default button used to sit; the last is the cancelling
+    /// one. Choosing one dismisses the panel before its handler runs, so a handler is free to
+    /// enqueue the next prompt.
     ///
-    /// Only one prompt is on screen at a time. The title identifies the prompt: a repeat of the one
-    /// already showing is dropped (checks that used to be blocked by the modal now really do run
-    /// while a prompt is up), and a different prompt replaces it rather than stacking on top.
+    /// Only one prompt is on screen at a time, and prompts *queue* rather than replace each other.
+    /// Replacing would close a prompt without either handler running, which for a one-time offer
+    /// like the MLX upgrade means it is never recorded as answered and never shown again. A prompt
+    /// whose title is already on screen or already queued is still dropped, so the checks that the
+    /// modal used to block cannot pile up duplicates.
     @MainActor
     private func presentFloatingPrompt(title: String, message: String, actions: [FloatingPromptAction]) {
-        DebugLogger.shared.info("🔔 Showing prompt: \(title)", source: "AppDelegate")
-
-        guard self.floatingPromptTitle != title else {
-            DebugLogger.shared.debug("Prompt \"\(title)\" already on screen, skipping duplicate", source: "AppDelegate")
+        guard !self.floatingPromptQueue.contains(where: { $0.title == title }) else {
+            DebugLogger.shared.debug("Prompt \"\(title)\" already queued, skipping duplicate", source: "AppDelegate")
             return
         }
-        self.dismissFloatingPrompt()
+        guard self.floatingPromptQueue.count < Self.maxQueuedFloatingPrompts else {
+            DebugLogger.shared.error("Dropping prompt \"\(title)\": prompt queue is full", source: "AppDelegate")
+            return
+        }
 
+        self.floatingPromptQueue.append(FloatingPrompt(title: title, message: message, actions: actions))
+        self.showNextFloatingPromptIfIdle()
+    }
+
+    /// Builds and orders in the panel for the queue head, if nothing is on screen already.
+    @MainActor
+    private func showNextFloatingPromptIfIdle() {
+        guard self.floatingPromptWindow == nil, let prompt = self.floatingPromptQueue.first else { return }
+
+        let title = prompt.title
+        DebugLogger.shared.info("🔔 Showing prompt: \(title)", source: "AppDelegate")
+
+        let message = prompt.message
+        let actions = prompt.actions
         let margin: CGFloat = 22
         let textLeading: CGFloat = 92
         let buttonHeight: CGFloat = 30
         let buttonSpacing: CGFloat = 10
 
-        let buttons = actions.map { action in
-            FloatingPromptButton(title: action.title) { [weak self] in
-                self?.dismissFloatingPrompt()
+        let buttons = actions.enumerated().map { index, action in
+            let button = FloatingPromptButton(title: action.title) { [weak self] in
+                self?.finishVisibleFloatingPrompt()
                 action.handler()
             }
+            // Mirror NSAlert: Return triggers the first action. Escape is handled by the panel so
+            // that a single-button prompt answers to both keys, as the alert it replaced did.
+            if index == 0 {
+                button.keyEquivalent = "\r"
+            }
+            return button
         }
         // The leading action is the default one, so give it the wider minimum an alert would use.
         let buttonWidths = buttons.enumerated().map { index, button in
@@ -586,13 +615,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             buttonTrailing -= width + buttonSpacing
         }
 
-        let panel = NSPanel(
+        let panel = FloatingPromptPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
         panel.title = title
+        // Escape picks the cancelling action, the way it dismissed the alert this replaced.
+        if let cancelButton = buttons.last {
+            panel.onCancel = { [weak cancelButton] in cancelButton?.performClick(nil) }
+        }
         panel.isFloatingPanel = true
         panel.level = .floating
         panel.isOpaque = false
@@ -624,19 +657,39 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
 
         panel.contentView = content
+        panel.initialFirstResponder = buttons.first
         panel.center()
         // Floating level plus orderFrontRegardless puts the prompt above the frontmost app without
-        // activating FluidVoice, so an in-flight dictation is never interrupted to show it.
+        // activating FluidVoice, so an in-flight dictation is never interrupted to show it. Note
+        // this deliberately does not make the panel key: taking key here would pull focus off
+        // whatever the user is typing into, which is the whole point of not using a modal. The
+        // panel becomes key when the user clicks it, or when FluidVoice itself is activated.
         panel.orderFrontRegardless()
+        if NSApp.isActive {
+            // FluidVoice is already frontmost, so taking key costs no other app its focus and the
+            // prompt is immediately answerable from the keyboard.
+            panel.makeKey()
+        }
         self.floatingPromptWindow = panel
-        self.floatingPromptTitle = title
     }
 
+    /// Closes the prompt on screen, drops it from the queue and shows whatever queued behind it.
     @MainActor
-    private func dismissFloatingPrompt() {
+    private func finishVisibleFloatingPrompt() {
         self.floatingPromptWindow?.close()
         self.floatingPromptWindow = nil
-        self.floatingPromptTitle = nil
+        if !self.floatingPromptQueue.isEmpty {
+            self.floatingPromptQueue.removeFirst()
+        }
+        self.showNextFloatingPromptIfIdle()
+    }
+
+    /// Gives the prompt keyboard focus once FluidVoice is frontmost, so a keyboard-only user who
+    /// activates the app can answer it. Never called while another app is frontmost.
+    @MainActor
+    private func focusFloatingPromptOnActivation() {
+        guard let panel = self.floatingPromptWindow else { return }
+        panel.makeKey()
     }
 }
 
@@ -646,9 +699,36 @@ private struct FloatingPromptAction {
     let handler: @MainActor () -> Void
 }
 
+/// A prompt on screen or waiting behind one.
+private struct FloatingPrompt {
+    let title: String
+    let message: String
+    let actions: [FloatingPromptAction]
+}
+
+/// Panel hosting a floating prompt.
+///
+/// Borderless windows refuse to become key by default, which would leave the prompt unanswerable
+/// without a mouse. A `.nonactivatingPanel` can take key from a click without activating the app,
+/// so opting in restores the keyboard path the replaced `NSAlert` had without stealing focus:
+/// nothing here makes the panel key on presentation.
+private final class FloatingPromptPanel: NSPanel {
+    var onCancel: (@MainActor () -> Void)?
+
+    override var canBecomeKey: Bool {
+        return true
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        // The handler closes this panel, so hold the closure for the call.
+        let onCancel = self.onCancel
+        onCancel?()
+    }
+}
+
 /// Push button for a floating prompt panel.
 ///
-/// The panel is a non-activating panel of a menu bar app, so it never becomes key; accepting the
+/// The panel belongs to a menu bar app and is not key until the user clicks it, so accepting the
 /// first mouse keeps a single click on the button working while another app stays frontmost.
 private final class FloatingPromptButton: NSButton {
     private let onClick: @MainActor () -> Void

--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -19,6 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     private var wasLaunchedAsLoginItem = false
     private var analyticsActivationSuppressionDeadline: Date?
     private var hasDeferredMLXUpgradeOffer = false
+    private var updatePromptWindow: NSWindow?
 
     var shouldPresentStartupMicrophoneNotice: Bool {
         !self.wasLaunchedAsLoginItem || SettingsStore.shared.showMainWindowAtLoginLaunch
@@ -468,27 +469,139 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
     }
 
+    /// Offers the available update from a floating panel instead of a modal alert.
+    ///
+    /// This prompt used to be an `NSAlert.runModal()`. That call never returns until the alert is
+    /// dismissed, and it runs inside a main actor job, so every other `@MainActor` job queues up
+    /// behind it - including the dictation callbacks `GlobalHotkeyManager` posts from its event
+    /// tap. FluidVoice is a menu bar app that is rarely frontmost, so the alert also came up
+    /// unactivated behind other windows: dictation stayed dead until the user found the hidden
+    /// dialog (#564, #745). The panel keeps the main actor free and floats above other apps
+    /// without stealing focus, and matches the install status panel in SimpleUpdater.
     @MainActor
     private func showUpdateNotification(version: String) {
         DebugLogger.shared.info("Showing update notification for version \(version)", source: "AppDelegate")
 
-        let alert = NSAlert()
-        alert.messageText = "Update Available"
-        alert.informativeText = "FluidVoice \(version) is now available. Would you like to install it now?\n\nThe app will restart automatically after installation."
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "Install Now")
-        alert.addButton(withTitle: "Later")
-
-        let response = alert.runModal()
-
-        if response == .alertFirstButtonReturn {
-            DebugLogger.shared.info("User chose to install update now", source: "AppDelegate")
-            SettingsStore.shared.clearUpdateSnooze() // Clear snooze since they're installing
-            self.checkForUpdatesManually()
-        } else {
-            DebugLogger.shared.info("User postponed update for 24 hours", source: "AppDelegate")
-            SettingsStore.shared.snoozeUpdatePrompt(forVersion: version)
+        // Hourly checks keep running now that the prompt no longer blocks them, so never stack panels.
+        guard self.updatePromptWindow == nil else {
+            DebugLogger.shared.debug("Update prompt already on screen, skipping duplicate", source: "AppDelegate")
+            return
         }
+
+        let panelWidth: CGFloat = 420
+        let margin: CGFloat = 22
+        let textLeading: CGFloat = 92
+        let textWidth = panelWidth - textLeading - margin
+
+        let title = NSTextField(labelWithString: "Update Available")
+        title.font = .systemFont(ofSize: 16, weight: .semibold)
+        let titleHeight = ceil(title.fittingSize.height)
+
+        let detail = NSTextField(
+            wrappingLabelWithString: "FluidVoice \(version) is now available. The app will restart automatically after installation."
+        )
+        detail.font = .systemFont(ofSize: 13)
+        detail.textColor = .secondaryLabelColor
+        detail.preferredMaxLayoutWidth = textWidth
+        let detailHeight = ceil(detail.fittingSize.height)
+
+        let installButton = UpdatePromptButton(title: "Install Now") { [weak self] in
+            self?.installOfferedUpdate()
+        }
+        let laterButton = UpdatePromptButton(title: "Later") { [weak self] in
+            self?.postponeOfferedUpdate(version: version)
+        }
+
+        let buttonHeight: CGFloat = 30
+        let installWidth = max(ceil(installButton.fittingSize.width), 96)
+        let laterWidth = max(ceil(laterButton.fittingSize.width), 80)
+        let buttonsY = margin - 2
+        let detailY = buttonsY + buttonHeight + 16
+        let titleY = detailY + detailHeight + 8
+        let panelHeight = titleY + titleHeight + margin
+
+        title.frame = NSRect(x: textLeading, y: titleY, width: textWidth, height: titleHeight)
+        detail.frame = NSRect(x: textLeading, y: detailY, width: textWidth, height: detailHeight)
+        installButton.frame = NSRect(
+            x: panelWidth - margin - installWidth,
+            y: buttonsY,
+            width: installWidth,
+            height: buttonHeight
+        )
+        laterButton.frame = NSRect(
+            x: installButton.frame.minX - 10 - laterWidth,
+            y: buttonsY,
+            width: laterWidth,
+            height: buttonHeight
+        )
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Update Available"
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.isMovableByWindowBackground = true
+        panel.hidesOnDeactivate = false
+        // The panel is owned by updatePromptWindow, so let ARC release it after close().
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        let content = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight))
+        content.material = .popover
+        content.blendingMode = .behindWindow
+        content.state = .active
+        content.wantsLayer = true
+        content.layer?.cornerRadius = 16
+        content.layer?.masksToBounds = true
+        content.autoresizingMask = [.width, .height]
+
+        let icon = NSImageView(frame: NSRect(x: margin, y: panelHeight - margin - 52, width: 52, height: 52))
+        icon.image = NSApp.applicationIconImage
+        icon.imageScaling = .scaleProportionallyUpOrDown
+        content.addSubview(icon)
+        content.addSubview(title)
+        content.addSubview(detail)
+        content.addSubview(laterButton)
+        content.addSubview(installButton)
+
+        panel.contentView = content
+        panel.center()
+        // Floating level plus orderFrontRegardless puts the prompt above the frontmost app without
+        // activating FluidVoice, so an in-flight dictation is never interrupted to show it.
+        panel.orderFrontRegardless()
+        self.updatePromptWindow = panel
+    }
+
+    @MainActor
+    private func installOfferedUpdate() {
+        DebugLogger.shared.info("User chose to install update now", source: "AppDelegate")
+        self.dismissUpdatePrompt()
+        SettingsStore.shared.clearUpdateSnooze() // Clear snooze since they're installing
+        // The manual check still reports failures through a modal alert, so activate first to keep
+        // that alert in front of the user instead of behind other windows. Installing restarts the
+        // app anyway, so taking focus here costs nothing.
+        NSApp.activate(ignoringOtherApps: true)
+        self.checkForUpdatesManually()
+    }
+
+    @MainActor
+    private func postponeOfferedUpdate(version: String) {
+        DebugLogger.shared.info("User postponed update for 24 hours", source: "AppDelegate")
+        self.dismissUpdatePrompt()
+        SettingsStore.shared.snoozeUpdatePrompt(forVersion: version)
+    }
+
+    @MainActor
+    private func dismissUpdatePrompt() {
+        self.updatePromptWindow?.close()
+        self.updatePromptWindow = nil
     }
 
     @MainActor
@@ -500,5 +613,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         alert.alertStyle = .informational
         alert.addButton(withTitle: "OK")
         alert.runModal()
+    }
+}
+
+/// Push button for the update prompt panel.
+///
+/// The panel is a non-activating panel of a menu bar app, so it never becomes key; accepting the
+/// first mouse keeps a single click on the button working while another app stays frontmost.
+private final class UpdatePromptButton: NSButton {
+    private let onClick: @MainActor () -> Void
+
+    init(title: String, onClick: @escaping @MainActor () -> Void) {
+        self.onClick = onClick
+        super.init(frame: .zero)
+        self.title = title
+        self.bezelStyle = .rounded
+        self.target = self
+        self.action = #selector(self.handleClick)
+        self.sizeToFit()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("UpdatePromptButton is created in code only")
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        return true
+    }
+
+    @objc private func handleClick() {
+        self.onClick()
     }
 }


### PR DESCRIPTION
## Description
The "Update Available" prompt is an `NSAlert.runModal()` on the main actor. `runModal()`
does not return until the alert is dismissed, and it runs inside a main actor job, so every
other `@MainActor` job queues behind it — including the dictation callbacks
`GlobalHotkeyManager.triggerDictationMode()` posts from its CGEventTap thread
(`GlobalHotkeyManager.swift:1843`). FluidVoice is a menu bar app that is almost never
frontmost, so the alert also comes up unactivated behind other windows.

Both halves together mean that when a release ships, dictation silently stops working and
stays dead until the user stumbles on the hidden dialog. The event tap keeps running on its
own thread, so the app still logs every hotkey press — it just can never act on one.

This PR presents the same offer from a floating, non-activating `NSPanel` styled like the
install status panel in `SimpleUpdater.showUpdateInstallStatus` (SimpleUpdater.swift:471).
The main actor stays free, and `.floating` + `orderFrontRegardless()` +
`[.canJoinAllSpaces, .fullScreenAuxiliary]` puts the prompt above the frontmost app without
stealing focus — so it is visible without interrupting an in-flight dictation (#745).

Install Now / Later semantics are unchanged: Install Now clears the snooze and runs the
existing manual update path, Later snoozes the version for 24 hours. Two small related
changes: a re-entrancy guard, because the hourly check can now actually run while the prompt
is on screen and would otherwise stack panels; and `NSApp.activate(ignoringOtherApps:)`
before the manual install call, because that path still reports failures through a modal
alert which must not end up hidden behind other windows.

### Deadlock evidence
macOS 26.6 (25G70), FluidVoice 1.6.7 (build 18), Apple Silicon, prompt for v1.6.8.

`sample` of the wedged process — 1744 of 1744 samples on the main thread:

```
1744 Thread_9557897   DispatchQueue_1: com.apple.main-thread  (serial)
+ 1744 completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*)  (in libswift_Concurrency.dylib)
+   1744 closure #1 in AppDelegate.checkForUpdatesAutomatically()  (in FluidVoice)
+     1744 AppDelegate.showUpdateNotification(version:)  (in FluidVoice)
+       1744 -[NSAlert runModal]  (in AppKit)
+         1744 -[NSApplication runModalForWindow:]  (in AppKit)
+           1744 -[NSApplication _doModalLoop:peek:]  (in AppKit)
```

The main thread is inside a Swift concurrency job that never returns, which is why the modal
run loop keeps pumping AppKit events while every queued `@MainActor` job starves.

Matching cutover in `~/Library/Logs/Fluid/Fluid.log`:

```
[10:50:11.370] [INFO] [AppDelegate] ✅ Update available: v1.6.8
[10:50:11.370] [INFO] [AppDelegate] Showing update notification for version v1.6.8
```

- Before that line: hotkey presses served normally, 6 completed ASR sessions.
- After it, until the app was force-restarted 89 minutes later: **30 hotkey presses
  logged by the event tap, 30 matching "Transcription release stop deferred until recording
  starts", and zero log lines from `ASRService` or `ContentView`** — no main-actor work of any
  kind ran.

Every dead press looks like this, with nothing following it:

```
[12:15:33.759] [INFO] [GlobalHotkeyManager] Transcription modifier held (hold mode) - starting
[12:15:33.857] [INFO] [GlobalHotkeyManager] Transcription modifier released (hold mode) - stopping
[12:15:33.857] [DEBUG] [GlobalHotkeyManager] Transcription release stop deferred until recording starts
```

### Reproduction
1. Run FluidVoice as a menu bar app with automatic update checks enabled, while a release
   newer than the running build exists.
2. Keep another app frontmost and let the automatic check fire.
3. Press the dictation hotkey. Nothing happens; the log records the press and nothing else.
4. `sample FluidVoice` shows the main thread parked in `showUpdateNotification` → `runModal`.
5. Activating FluidVoice reveals the hidden "Update Available" dialog; dismissing it restores
   dictation immediately.

## Update (2026-08-18)
**The bug bit again on the shipped build, and v1.6.9 as released still contains it.**

The installed v1.6.8 sat wedged for **4+ hours** on the invisible v1.6.9 prompt. Same
signature as above, sampled live on the hung process:

```
AppDelegate.checkForUpdatesAutomatically()
  AppDelegate.showUpdateNotification(version:)
    -[NSAlert runModal]
```

Recording and the HUD were both dead for the whole window; dismissing the hidden dialog
restored them instantly. So this is not a one-off: it reproduces on every release that ships
while the previous build is running, and it will keep doing so on v1.6.9.

Two changes since the first review:

1. **Rebased onto `main`** (33 commits, no conflicts). Checked against the updater work that
   landed in the meantime — #782's duplicate-prompt guard and the signing-transition change —
   and the panel composes with both; neither touched `showUpdateNotification`.
2. **Hardened the two remaining unattended `runModal()` call sites** (second commit). The
   update prompt was not the only alert an automatic path could reach:
   - `showMLXUpgradeOffer()` fires 1.2s after launch, or on first activation when the launch
     was a login item. Completely unattended, and the exact same deadlock — it was the next
     instance of this bug waiting to happen.
   - `showUpdateAlert(title:message:)` is reached without a click whenever the offered
     update's install attempt fails, because **Install Now** routes through
     `checkForUpdatesManually()`. So a failed install from the new panel could still wedge
     the app on a hidden alert.

   The panel presentation is now extracted into
   `presentFloatingPrompt(title:message:actions:)` and both call sites go through it. Button
   labels, order and handlers are unchanged, as are `clearUpdateSnooze` /
   `snoozeUpdatePrompt` and the MLX coordinator calls. The panel sizes its width to the
   buttons, since the MLX offer's buttons are wider than Install Now / Later. The
   re-entrancy guard is now keyed on the prompt title instead of "a window exists": the same
   prompt asked twice is still dropped, but a *different* prompt replaces it rather than
   being swallowed, so a failed install still reports itself.

   `installOfferedUpdate()` keeps its `NSApp.activate(...)` — the reason changed (that path's
   failure alert is no longer modal) but installing restarts the app anyway, and it keeps the
   updater's own install status window in front.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Relates to #564 ("Update-check popup blocks app/hotkey access") and #745 ("Automatic update
prompt interrupts active dictation and can discard transcript"). Both were auto-closed as
stale rather than fixed; the root cause is still present on `main`. Happy to open a
Discussion first if maintainers prefer that route — filing this with the thread sample and
logs attached since the cause is pinned to a specific line.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.6
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: `xcodebuild test -scheme Fluid` (CI's skip list) — 277 tests, 0 failures

Re-verified after the review fixes (third commit): **BUILD SUCCEEDED**, **TEST SUCCEEDED**
(277 tests, 0 failures), SwiftLint `--strict` 0 violations, SwiftFormat `--lint` clean. The
panel's focus and keyboard behaviour was checked with a harness built from `FloatingPromptPanel`
and `FloatingPromptButton` taken verbatim from the source: presenting leaves the frontmost app
and the key window untouched, mouse clicks and Escape fire the right actions, and Return fires
the default action once the panel is key.

Verification performed (re-run after the rebase and the second commit):
- `xcodebuild -project Fluid.xcodeproj -scheme Fluid -configuration Debug build` on
  macOS 26.6 (Apple Silicon): **BUILD SUCCEEDED**, no new warnings.
- `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64'`
  with CI's `-skip-testing` for the flaky Tiny Whisper E2E: **TEST SUCCEEDED**, 277 tests,
  0 failures.
- SwiftLint 0.63.2 `--strict` via the same container image CI uses: 0 violations in 154 files.
- SwiftFormat 0.62.1 `--lint`: no changes required.
- The bug was reproduced and diagnosed twice on macOS 26.6 — with v1.6.7 prompting for v1.6.8
  (sample + logs above), and again with v1.6.8 prompting for v1.6.9 (Update section).
- Ran the patched Debug build on macOS 26.6 (Apple Silicon): the panel presents at floating
  level without activating the app (screenshots below), and Install Now correctly invokes the
  existing manual update path.
- No unit test added: `Tests/FluidDictationIntegrationTests` has no existing pattern for
  driving `AppDelegate` or the updater, and the behaviour here is AppKit window presentation.

## Screenshots / Video
Captured from the patched Debug build on macOS 26.6 (Apple Silicon), 2x retina:

| Light | Dark |
|---|---|
| ![Update panel — light mode](https://raw.githubusercontent.com/nishantkumar1292/FluidVoice/pr-assets/assets/update-panel-light.png) | ![Update panel — dark mode](https://raw.githubusercontent.com/nishantkumar1292/FluidVoice/pr-assets/assets/update-panel-dark.png) |

In context — floating above the frontmost window without activating the app:

![Update panel floating over another window](https://raw.githubusercontent.com/nishantkumar1292/FluidVoice/pr-assets/assets/update-panel-context.png)

The second commit adds **no new visual design**. `showMLXUpgradeOffer()` and the
"No Updates" / "Update Check Failed" alerts now render through the *same*
`presentFloatingPrompt` shown above, keeping their existing titles, messages and button
labels — only the container changes, from a system `NSAlert` to the panel pictured here.

I did not capture a live screenshot of those two prompts: neither has a debug hook to force
it, and exercising them would mean running a second instance of the app, which shares the
`com.FluidApp.app` bundle id (and therefore `UserDefaults`, the event tap and the local API
port) with the running install on this machine. Happy to add captures if a maintainer wants
them.

## Notes
- All three prompts an *unattended* code path can reach are now panels:
  `showUpdateNotification`, `showMLXUpgradeOffer`, `showUpdateAlert`.
- `runModal()` elsewhere is deliberately left alone. Every remaining call is reachable only
  from an explicit click inside an already-visible window — `SettingsView`,
  `CustomDictionaryView`, `TranscriptionHistoryView`, `AIEnhancementSettingsViewModel`, and
  the menu items in `MenuBarManager`. The app is active and frontmost in all of those, so the
  alert is visible and short-lived, and a modal there is the expected macOS behaviour.
- The panel does not activate the app, by design: a dictation app should not steal focus
  mid-typing. Visibility comes from the floating window level instead. `FloatingPromptButton`
  overrides `acceptsFirstMouse` so a single click works while another app is frontmost. The
  flip side is that a stray first click over the panel acts immediately; if that trade-off is
  unwanted, dropping the override makes the first click focus the panel instead.
- The update prompt's informative text dropped "Would you like to install it now?" (redundant
  beside the buttons, and the blank line made the panel unnecessarily tall). Easy to restore
  if preferred.
- Prompts **queue** rather than replace each other (third commit, from review). An earlier
  revision replaced the visible prompt, which closed it without running either handler — for
  the one-time MLX offer that loses it permanently, since `prepareOfferIfNeeded()` clears the
  prepared flag once the app version no longer matches its `1.6.3` offer version. The
  collision is reachable: the MLX offer is scheduled at ~1.2s after launch and the automatic
  update check can present at ~3s. The queue is deduped by title and capped, so a looping
  caller cannot grow it without bound.
- Keyboard access is preserved (third commit, from review): `FloatingPromptPanel` overrides
  `canBecomeKey` — a `.nonactivating` panel can take key from a click without activating the
  app — the first action takes Return, and `cancelOperation(_:)` routes Escape to the last
  action so a single-button prompt answers to both keys, as its alert did. **Presentation
  still never takes key**; the panel is made key only when FluidVoice is already frontmost, or
  when the app is activated. Note Return only lights up once the panel is key, because AppKit
  disables a window's default button cell while it is not key — that is why the activation
  hook exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
