### PR TITLE
fix(dictionary): allow whitespace-only replacements (e.g. a pasted newline)

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7C9A71022F58B00000FB7CAF /* TranscribeCpp in Frameworks */ = {isa = PBXBuildFile; productRef = 7C9A71012F58B00000FB7CAF /* TranscribeCpp */; };
 		7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */; };
 		7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */; };
+		CD1C7A0000000000000000B2 /* CustomDictionaryManualEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */; };
 		7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */; };
 		86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */; };
 		272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */; };
@@ -63,6 +64,7 @@
 		7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
 		7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidDictationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
+		CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDictionaryManualEntryTests.swift; sourceTree = "<group>"; };
 		7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingServiceTransientPasteboardTests.swift; sourceTree = "<group>"; };
 		7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFixtureLoader.swift; sourceTree = "<group>"; };
 		7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = dictation_fixture.wav; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 				7CDB0A262F3C4D5600FB7CAD /* Helpers */,
 				7CDB0A272F3C4D5600FB7CAD /* Resources */,
 				7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */,
+				CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */,
 				7C91B0022F42AA0100C0DEF0 /* HotkeyShortcutTests.swift */,
 				343B29013F4441D6A797D12D /* LLMClientRequestBodyTests.swift */,
 				980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */,
@@ -295,6 +298,7 @@
 			files = (
 				7CDB0A2E2F3C4D5600FB7CAD /* AudioFixtureLoader.swift in Sources */,
 				7CDB0A2D2F3C4D5600FB7CAD /* DictationE2ETests.swift in Sources */,
+				CD1C7A0000000000000000B2 /* CustomDictionaryManualEntryTests.swift in Sources */,
 				7C91B0012F42AA0100C0DEF0 /* HotkeyShortcutTests.swift in Sources */,
 				86CAA2D4EF18433096185602 /* LLMClientRequestBodyTests.swift in Sources */,
 				272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */,

--- a/Sources/Fluid/Services/DictionaryTransferService.swift
+++ b/Sources/Fluid/Services/DictionaryTransferService.swift
@@ -325,14 +325,14 @@ final class DictionaryTransferService {
 
     private static func exportReplacement(from entry: SettingsStore.CustomDictionaryEntry) -> DictionaryTransferReplacement? {
         let from = self.normalizedUniqueStrings(entry.triggers, lowercased: true)
-        let to = entry.replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+        let to = CustomDictionaryManualEntry.sanitizedReplacement(entry.replacement)
         guard !from.isEmpty, !to.isEmpty else { return nil }
         return DictionaryTransferReplacement(from: from, to: to)
     }
 
     private static func exportReplacement(from replacement: DictionaryTransferReplacement) -> DictionaryTransferReplacement? {
         let from = self.normalizedUniqueStrings(replacement.from, lowercased: true)
-        let to = replacement.to.trimmingCharacters(in: .whitespacesAndNewlines)
+        let to = CustomDictionaryManualEntry.sanitizedReplacement(replacement.to)
         guard !from.isEmpty, !to.isEmpty else { return nil }
         return DictionaryTransferReplacement(from: from, to: to)
     }
@@ -341,7 +341,7 @@ final class DictionaryTransferService {
         from replacement: DictionaryTransferReplacement
     ) -> SettingsStore.CustomDictionaryEntry? {
         let from = self.normalizedUniqueStrings(replacement.from, lowercased: true)
-        let to = replacement.to.trimmingCharacters(in: .whitespacesAndNewlines)
+        let to = CustomDictionaryManualEntry.sanitizedReplacement(replacement.to)
         guard !from.isEmpty, !to.isEmpty else { return nil }
         return SettingsStore.CustomDictionaryEntry(triggers: from, replacement: to)
     }

--- a/Sources/Fluid/UI/CustomDictionaryView.swift
+++ b/Sources/Fluid/UI/CustomDictionaryView.swift
@@ -189,9 +189,13 @@ struct CustomDictionaryView: View {
         self.manualTriggers.filter { self.allExistingTriggers().contains($0) }
     }
 
+    private var sanitizedManualReplacement: String {
+        CustomDictionaryManualEntry.sanitizedReplacement(self.manualReplacement)
+    }
+
     private var canAddManualReplacement: Bool {
         !self.manualTriggers.isEmpty &&
-            !self.manualReplacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !self.sanitizedManualReplacement.isEmpty &&
             self.manualDuplicateTriggers.isEmpty
     }
 
@@ -580,7 +584,7 @@ struct CustomDictionaryView: View {
                         .font(self.theme.typography.caption)
                         .foregroundStyle(self.theme.palette.tertiaryText)
 
-                    Text(self.manualReplacement.trimmingCharacters(in: .whitespacesAndNewlines))
+                    Text(CustomDictionaryManualEntry.replacementDisplayText(self.sanitizedManualReplacement))
                         .font(self.theme.typography.captionStrong)
                         .foregroundStyle(self.theme.palette.accent)
                 }
@@ -1603,7 +1607,7 @@ struct CustomDictionaryView: View {
         guard self.canAddManualReplacement else { return }
         let entry = SettingsStore.CustomDictionaryEntry(
             triggers: self.manualTriggers,
-            replacement: self.manualReplacement.trimmingCharacters(in: .whitespacesAndNewlines)
+            replacement: self.sanitizedManualReplacement
         )
         self.addReplacementEntry(entry)
         self.manualTriggerDraft = ""
@@ -2667,6 +2671,28 @@ enum CustomDictionaryManualEntry {
 
         return self.normalizedTriggers(trimmed.split(separator: ",").map(String.init))
     }
+
+    /// A replacement that is entirely whitespace (e.g. a pasted newline or space)
+    /// is a deliberate payload — keep it verbatim instead of trimming it to empty.
+    static func sanitizedReplacement(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? text : trimmed
+    }
+
+    /// Whitespace-only replacements render as invisible/blank text, so show
+    /// them as symbols (⏎ ␣ ⇥) in previews and entry rows.
+    static func replacementDisplayText(_ replacement: String) -> String {
+        guard !replacement.isEmpty, replacement.allSatisfy(\.isWhitespace) else { return replacement }
+        return replacement.map { character -> String in
+            if character.isNewline {
+                return "⏎"
+            }
+            if character == "\t" {
+                return "⇥"
+            }
+            return "␣"
+        }.joined()
+    }
 }
 
 enum PronunciationProfileEditPolicy {
@@ -3081,7 +3107,7 @@ struct DictionaryEntryRow: View {
                 .font(self.theme.typography.caption)
                 .foregroundStyle(self.theme.palette.tertiaryText)
 
-            Text(self.entry.replacement)
+            Text(CustomDictionaryManualEntry.replacementDisplayText(self.entry.replacement))
                 .font(self.theme.typography.bodySmallStrong)
                 .foregroundStyle(self.theme.palette.accent)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -3352,7 +3378,7 @@ struct EditDictionaryEntrySheet: View {
 
     private var canSave: Bool {
         !self.parseTriggers().isEmpty &&
-            !self.replacement.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !CustomDictionaryManualEntry.sanitizedReplacement(self.replacement).isEmpty &&
             self.duplicateTriggers.isEmpty
     }
 
@@ -3434,9 +3460,11 @@ struct EditDictionaryEntrySheet: View {
                             .font(.caption)
                             .foregroundStyle(.tertiary)
 
-                        Text(self.replacement)
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(self.theme.palette.accent)
+                        Text(CustomDictionaryManualEntry.replacementDisplayText(
+                            CustomDictionaryManualEntry.sanitizedReplacement(self.replacement)
+                        ))
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(self.theme.palette.accent)
                     }
                 }
                 .padding(10)
@@ -3483,7 +3511,7 @@ struct EditDictionaryEntrySheet: View {
         let updatedEntry = SettingsStore.CustomDictionaryEntry(
             id: self.entry.id,
             triggers: self.parseTriggers(),
-            replacement: self.replacement.trimmingCharacters(in: .whitespaces)
+            replacement: CustomDictionaryManualEntry.sanitizedReplacement(self.replacement)
         )
         self.onSave(updatedEntry)
         self.dismiss()

--- a/Tests/FluidDictationIntegrationTests/CustomDictionaryManualEntryTests.swift
+++ b/Tests/FluidDictationIntegrationTests/CustomDictionaryManualEntryTests.swift
@@ -1,6 +1,7 @@
 @testable import FluidVoice_Debug
 import XCTest
 
+@MainActor
 final class CustomDictionaryManualEntryTests: XCTestCase {
     func testKeepsWhitespaceOnlyReplacements() {
         XCTAssertEqual(CustomDictionaryManualEntry.sanitizedReplacement("\n"), "\n")
@@ -17,5 +18,22 @@ final class CustomDictionaryManualEntryTests: XCTestCase {
         XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText(" \n"), "␣⏎")
         XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText("FluidVoice"), "FluidVoice")
         XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText(""), "")
+    }
+
+    func testTransferImportPreservesWhitespaceOnlyReplacements() throws {
+        let document = DictionaryTransferDocument(
+            replacements: [DictionaryTransferReplacement(from: ["new line"], to: "\n")],
+            customWords: []
+        )
+
+        let state = try DictionaryTransferService.importState(
+            document: document,
+            mode: .replace,
+            currentReplacements: [],
+            currentCustomWords: []
+        )
+
+        XCTAssertEqual(state.replacements.map(\.replacement), ["\n"])
+        XCTAssertEqual(state.replacements.first?.triggers, ["new line"])
     }
 }

--- a/Tests/FluidDictationIntegrationTests/CustomDictionaryManualEntryTests.swift
+++ b/Tests/FluidDictationIntegrationTests/CustomDictionaryManualEntryTests.swift
@@ -1,0 +1,21 @@
+@testable import FluidVoice_Debug
+import XCTest
+
+final class CustomDictionaryManualEntryTests: XCTestCase {
+    func testKeepsWhitespaceOnlyReplacements() {
+        XCTAssertEqual(CustomDictionaryManualEntry.sanitizedReplacement("\n"), "\n")
+        XCTAssertEqual(CustomDictionaryManualEntry.sanitizedReplacement(" "), " ")
+        XCTAssertEqual(CustomDictionaryManualEntry.sanitizedReplacement("\t"), "\t")
+        XCTAssertEqual(CustomDictionaryManualEntry.sanitizedReplacement(""), "")
+        XCTAssertEqual(CustomDictionaryManualEntry.sanitizedReplacement("  FluidVoice \n"), "FluidVoice")
+    }
+
+    func testRendersWhitespaceReplacementsVisibly() {
+        XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText("\n"), "⏎")
+        XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText(" "), "␣")
+        XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText("\t"), "⇥")
+        XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText(" \n"), "␣⏎")
+        XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText("FluidVoice"), "FluidVoice")
+        XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText(""), "")
+    }
+}


### PR DESCRIPTION
## Description

Restores the ability to add a Custom Dictionary entry whose replacement is a whitespace character — e.g. pasting a newline (U+000A) into "Change it to" so that saying "new line" inserts a line break (the workaround from #153).

Commit 808a08d changed the manual-entry validation and save from trimming `.whitespaces` to `.whitespacesAndNewlines`, so a whitespace-only replacement now trims to empty and **+ Add Replacement** stays disabled. The replacement engine is unaffected (`ASRService` inserts stored replacements verbatim via `NSRegularExpression.escapedTemplate`; entries created before the regression still work), so this was purely a UI-validation regression.

Changes:
- New `CustomDictionaryManualEntry.sanitizedReplacement`: trims surrounding whitespace as before, but keeps a replacement that is *entirely* whitespace verbatim — a pasted newline/space/tab is a deliberate payload, not accidental padding.
- Used in the manual composer (button gate + save) and in `EditDictionaryEntrySheet` (which still trimmed with the pre-808a08d `.whitespaces`, inconsistently).
- Whitespace-only replacements render as blank text, so they now display as symbols (⏎ ␣ ⇥) in the composer preview, edit-sheet preview, and dictionary entry rows via `replacementDisplayText`.
- Unit tests in a new `CustomDictionaryManualEntryTests` (kept out of `DictationE2ETests`, which is at the SwiftLint `type_body_length` cap).

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #841. Refs #153 (the closed feature request whose paste-a-newline workaround this regression broke).

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.6
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml` — 0 violations on changed files
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources` (not run repo-wide: my local SwiftFormat version reformats ~60 unrelated files; changed files follow existing style)
- [x] Ran tests locally: full suite via `xcodebuild test` (TEST SUCCEEDED) plus targeted `CustomDictionaryManualEntryTests`

## Screenshots / Video

**Composer with a pasted newline — + Add Replacement enabled, preview shows ⏎:**

_(screenshot placeholder — drag image here)_

**Your Dictionary list — whitespace replacements render visibly (`space → ␣`, `new line → ⏎`):**

_(screenshot placeholder — drag image here)_

## Notes

- Behavior for normal text is unchanged: surrounding whitespace is still trimmed.
- A single space also works now; before 808a08d only newline-only worked (the old `.whitespaces` trim stripped a lone space but not `\n`).
- Old whitespace entries saved before the regression continue to work and now render visibly (⏎) in the dictionary list instead of as a blank.
