### PR TITLE
fix(media): align Now Playing query timeout

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */; };
 		DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */; };
 		7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */; };
+		803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803000000000000000000001 /* MediaPlaybackServiceTests.swift */; };
+		803000000000000000000003 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 803000000000000000000004 /* MediaRemoteAdapter */; };
 		7CDB0A2F2F3C4D5600FB7CAD /* dictation_fixture.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */; };
 		7CDB0A302F3C4D5600FB7CAD /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */; };
 		7CE006BD2E80EBE600DDCCD6 /* AppUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = 7CE006BC2E80EBE600DDCCD6 /* AppUpdater */; };
@@ -64,6 +66,7 @@
 		7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluidDictationIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
 		7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingServiceTransientPasteboardTests.swift; sourceTree = "<group>"; };
+		803000000000000000000001 /* MediaPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackServiceTests.swift; sourceTree = "<group>"; };
 		7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFixtureLoader.swift; sourceTree = "<group>"; };
 		7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = dictation_fixture.wav; sourceTree = "<group>"; };
 		7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -94,6 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				803000000000000000000003 /* MediaRemoteAdapter in Frameworks */,
 				7CDB0A302F3C4D5600FB7CAD /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -141,6 +145,7 @@
 				C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */,
 				DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */,
 				7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */,
+				803000000000000000000001 /* MediaPlaybackServiceTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
 			sourceTree = "<group>";
@@ -214,6 +219,9 @@
 				7CDB0A312F3C4D5600FB7CAD /* PBXTargetDependency */,
 			);
 			name = FluidDictationIntegrationTests;
+			packageProductDependencies = (
+				803000000000000000000004 /* MediaRemoteAdapter */,
+			);
 			productName = FluidDictationIntegrationTests;
 			productReference = 7CDB0A202F3C4D5600FB7CAD /* FluidDictationIntegrationTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -303,6 +311,7 @@
 				C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */,
 				DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */,
 				7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */,
+				803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -688,6 +697,11 @@
 			productName = DynamicNotchKit;
 		};
 		7C5AF14A2F15041600DE21B0 /* MediaRemoteAdapter */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7C5AF1492F15041600DE21B0 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */;
+			productName = MediaRemoteAdapter;
+		};
+		803000000000000000000004 /* MediaRemoteAdapter */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7C5AF1492F15041600DE21B0 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */;
 			productName = MediaRemoteAdapter;

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -3,6 +3,17 @@ import Foundation
 import MediaRemoteAdapter
 #endif
 
+#if arch(arm64)
+@MainActor
+protocol MediaPlaybackControlling {
+    func getTrackInfo(_ onReceive: @escaping (TrackInfo?) -> Void)
+    func pause()
+    func play()
+}
+
+extension MediaController: MediaPlaybackControlling {}
+#endif
+
 /// Service that wraps MediaRemoteAdapter's MediaController to provide
 /// controlled pause/resume functionality during transcription.
 ///
@@ -10,21 +21,54 @@ import MediaRemoteAdapter
 /// and only resume if we were the ones who paused it.
 @MainActor
 final class MediaPlaybackService {
+    #if arch(arm64)
+    typealias TimeoutScheduler = (
+        _ delay: TimeInterval,
+        _ action: @escaping @MainActor @Sendable () -> Void
+    ) -> Void
+
+    /// The pinned adapter's two-second deadline can occupy roughly 2.1 seconds
+    /// in run-loop slices. Leave additional time for process and callback delivery.
+    static let nowPlayingQueryTimeoutSeconds: TimeInterval = 2.5
+
+    private static let productionTimeoutScheduler: TimeoutScheduler = { delay, action in
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: action)
+    }
+
+    static let shared = MediaPlaybackService(
+        mediaController: MediaController(),
+        queryTimeoutSeconds: MediaPlaybackService.nowPlayingQueryTimeoutSeconds,
+        timeoutScheduler: MediaPlaybackService.productionTimeoutScheduler
+    )
+
+    private let mediaController: any MediaPlaybackControlling
+    private let queryTimeoutSeconds: TimeInterval
+    private let timeoutScheduler: TimeoutScheduler
+
+    /// Creates an isolated service with injectable dependencies for deterministic tests.
+    init(
+        mediaController: any MediaPlaybackControlling,
+        queryTimeoutSeconds: TimeInterval,
+        timeoutScheduler: @escaping TimeoutScheduler
+    ) {
+        self.mediaController = mediaController
+        self.queryTimeoutSeconds = queryTimeoutSeconds
+        self.timeoutScheduler = timeoutScheduler
+    }
+    #else
     static let shared = MediaPlaybackService()
 
-    #if arch(arm64)
-    private let mediaController = MediaController()
-    #endif
-
     private init() {}
+    #endif
 
     // MARK: - Public API
 
     #if arch(arm64)
     /// Pauses system media playback if something is currently playing.
     ///
-    /// - Returns: `true` if we successfully paused playback, `false` if nothing was playing
-    ///   or if we couldn't determine playback state.
+    /// - Returns: `true` if a pause request was issued, `false` if nothing was playing or
+    ///   if we couldn't determine playback state. The media adapter does not acknowledge
+    ///   command completion.
     ///
     /// - Note: Uses a local one-shot gate to protect against `MediaRemoteAdapter`
     ///   firing the `getTrackInfo` callback more than once, which would otherwise
@@ -32,10 +76,17 @@ final class MediaPlaybackService {
     ///   `CheckedContinuation`.
     func pauseIfPlaying() async -> Bool {
         return await withCheckedContinuation { continuation in
+            let queryStartedAt = DispatchTime.now().uptimeNanoseconds
             let resumeLock = NSLock()
             var didResume = false
 
+            @MainActor
+            func elapsedMilliseconds() -> UInt64 {
+                (DispatchTime.now().uptimeNanoseconds - queryStartedAt) / 1_000_000
+            }
+
             @discardableResult
+            @MainActor
             func resumeOnce(
                 _ value: Bool,
                 logDuplicate: Bool = true,
@@ -53,7 +104,10 @@ final class MediaPlaybackService {
                 guard shouldResume else {
                     if logDuplicate {
                         DebugLogger.shared.warning(
-                            "MediaPlaybackService: Suppressed late or duplicate media callback",
+                            """
+                            MediaPlaybackService: Suppressed late or duplicate media callback \
+                            (elapsedMs: \(elapsedMilliseconds()))
+                            """,
                             source: "MediaPlaybackService"
                         )
                     }
@@ -65,10 +119,13 @@ final class MediaPlaybackService {
                 return true
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            self.timeoutScheduler(self.queryTimeoutSeconds) {
                 if resumeOnce(false, logDuplicate: false) {
                     DebugLogger.shared.warning(
-                        "MediaPlaybackService: Now Playing query timed out; leaving playback unchanged",
+                        """
+                        MediaPlaybackService: Now Playing query timed out; leaving playback unchanged \
+                        (elapsedMs: \(elapsedMilliseconds()))
+                        """,
                         source: "MediaPlaybackService"
                     )
                 }
@@ -76,6 +133,13 @@ final class MediaPlaybackService {
 
             self.mediaController.getTrackInfo { [weak self] trackInfo in
                 guard let self = self else {
+                    DebugLogger.shared.warning(
+                        """
+                        MediaPlaybackService: Service released before query completed \
+                        (elapsedMs: \(elapsedMilliseconds()))
+                        """,
+                        source: "MediaPlaybackService"
+                    )
                     resumeOnce(false)
                     return
                 }
@@ -83,7 +147,10 @@ final class MediaPlaybackService {
                 // If no track info is available, nothing is playing
                 guard let trackInfo = trackInfo else {
                     DebugLogger.shared.debug(
-                        "MediaPlaybackService: No track info available, nothing to pause",
+                        """
+                        MediaPlaybackService: No track info available, nothing to pause \
+                        (elapsedMs: \(elapsedMilliseconds()))
+                        """,
                         source: "MediaPlaybackService"
                     )
                     resumeOnce(false)
@@ -110,6 +177,7 @@ final class MediaPlaybackService {
                     - isPlaying: \(trackInfo.payload.isPlaying?.description ?? "nil")
                     - playbackRate: \(trackInfo.payload.playbackRate?.description ?? "nil")
                     - Determined playing: \(isPlaying)
+                    - elapsedMs: \(elapsedMilliseconds())
                     """,
                     source: "MediaPlaybackService"
                 )
@@ -117,14 +185,20 @@ final class MediaPlaybackService {
                 if isPlaying {
                     resumeOnce(true) {
                         DebugLogger.shared.info(
-                            "MediaPlaybackService: Media is playing, sending pause command",
+                            """
+                            MediaPlaybackService: Media is playing, sending pause command \
+                            (elapsedMs: \(elapsedMilliseconds()))
+                            """,
                             source: "MediaPlaybackService"
                         )
                         self.mediaController.pause()
                     }
                 } else {
                     DebugLogger.shared.debug(
-                        "MediaPlaybackService: Media is not playing, no action needed",
+                        """
+                        MediaPlaybackService: Media is not playing, no action needed \
+                        (elapsedMs: \(elapsedMilliseconds()))
+                        """,
                         source: "MediaPlaybackService"
                     )
                     resumeOnce(false)

--- a/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
+++ b/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
@@ -1,0 +1,215 @@
+@testable import FluidVoice_Debug
+import Foundation
+#if arch(arm64)
+import MediaRemoteAdapter
+#endif
+import XCTest
+
+#if arch(arm64)
+@MainActor
+final class MediaPlaybackServiceTests: XCTestCase {
+    func testPlayingCallbackBeforeTimeoutRequestsPause() async throws {
+        let (service, controller, scheduler) = self.makeService()
+        let pauseTask = Task { await service.pauseIfPlaying() }
+
+        await controller.waitUntilQueryRegistered()
+        XCTAssertEqual(scheduler.scheduledDelays, [2.5])
+        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+
+        let didPause = await pauseTask.value
+        XCTAssertTrue(didPause)
+        XCTAssertEqual(controller.pauseCallCount, 1)
+
+        scheduler.advance(by: 2.5)
+        XCTAssertEqual(controller.pauseCallCount, 1)
+    }
+
+    func testCallbackAfterFormerOneSecondBoundaryStillRequestsPause() async throws {
+        let (service, controller, scheduler) = self.makeService()
+        let pauseTask = Task { await service.pauseIfPlaying() }
+
+        await controller.waitUntilQueryRegistered()
+        XCTAssertEqual(scheduler.scheduledDelays, [MediaPlaybackService.nowPlayingQueryTimeoutSeconds])
+        XCTAssertGreaterThan(MediaPlaybackService.nowPlayingQueryTimeoutSeconds, 2)
+
+        scheduler.advance(by: 1.1)
+        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+
+        let didPause = await pauseTask.value
+        XCTAssertTrue(didPause)
+        XCTAssertEqual(controller.pauseCallCount, 1)
+
+        scheduler.advance(by: 1.4)
+        XCTAssertEqual(controller.pauseCallCount, 1)
+    }
+
+    func testTimeoutThenLatePlayingCallbackNeverPauses() async throws {
+        let (service, controller, scheduler) = self.makeService()
+        let pauseTask = Task { await service.pauseIfPlaying() }
+
+        await controller.waitUntilQueryRegistered()
+        scheduler.advance(by: 2.5)
+
+        let didPause = await pauseTask.value
+        XCTAssertFalse(didPause)
+        XCTAssertEqual(controller.pauseCallCount, 0)
+
+        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
+        XCTAssertEqual(controller.pauseCallCount, 0)
+    }
+
+    func testDuplicatePlayingCallbacksIssueOnePause() async throws {
+        let (service, controller, _) = self.makeService()
+        let pauseTask = Task { await service.pauseIfPlaying() }
+        let playingTrack = try self.makeTrackInfo(isPlaying: true, playbackRate: 1)
+
+        await controller.waitUntilQueryRegistered()
+        controller.complete(with: playingTrack, retainingCallback: true)
+        controller.complete(with: playingTrack)
+
+        let didPause = await pauseTask.value
+        XCTAssertTrue(didPause)
+        XCTAssertEqual(controller.pauseCallCount, 1)
+    }
+
+    func testPlaybackStateResolutionDoesNotPauseFalseCasesAndUsesRateFallback() async throws {
+        let nilResult = await self.pauseResult(for: nil)
+        XCTAssertFalse(nilResult.didPause)
+        XCTAssertEqual(nilResult.pauseCallCount, 0)
+
+        let explicitlyPaused = await self.pauseResult(
+            for: try self.makeTrackInfo(isPlaying: false, playbackRate: 1)
+        )
+        XCTAssertFalse(explicitlyPaused.didPause)
+        XCTAssertEqual(explicitlyPaused.pauseCallCount, 0)
+
+        let zeroRate = await self.pauseResult(
+            for: try self.makeTrackInfo(isPlaying: nil, playbackRate: 0)
+        )
+        XCTAssertFalse(zeroRate.didPause)
+        XCTAssertEqual(zeroRate.pauseCallCount, 0)
+
+        let positiveRate = await self.pauseResult(
+            for: try self.makeTrackInfo(isPlaying: nil, playbackRate: 1)
+        )
+        XCTAssertTrue(positiveRate.didPause)
+        XCTAssertEqual(positiveRate.pauseCallCount, 1)
+    }
+
+    func testResumeOnlyPlaysWhenPauseOwnershipIsTrue() async {
+        let (service, controller, _) = self.makeService()
+
+        await service.resumeIfWePaused(false)
+        XCTAssertEqual(controller.playCallCount, 0)
+
+        await service.resumeIfWePaused(true)
+        XCTAssertEqual(controller.playCallCount, 1)
+    }
+
+    private func makeService() -> (
+        service: MediaPlaybackService,
+        controller: FakeMediaPlaybackController,
+        scheduler: ManualTimeoutScheduler
+    ) {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = ManualTimeoutScheduler()
+        let service = MediaPlaybackService(
+            mediaController: controller,
+            queryTimeoutSeconds: MediaPlaybackService.nowPlayingQueryTimeoutSeconds,
+            timeoutScheduler: scheduler.schedule
+        )
+        return (service, controller, scheduler)
+    }
+
+    private func pauseResult(for trackInfo: TrackInfo?) async -> (
+        didPause: Bool,
+        pauseCallCount: Int
+    ) {
+        let (service, controller, _) = self.makeService()
+        let pauseTask = Task { await service.pauseIfPlaying() }
+
+        await controller.waitUntilQueryRegistered()
+        controller.complete(with: trackInfo)
+
+        return (await pauseTask.value, controller.pauseCallCount)
+    }
+
+    private func makeTrackInfo(isPlaying: Bool?, playbackRate: Double?) throws -> TrackInfo {
+        var payload: [String: Any] = [:]
+        if let isPlaying {
+            payload["isPlaying"] = isPlaying
+        }
+        if let playbackRate {
+            payload["playbackRate"] = playbackRate
+        }
+        let data = try JSONSerialization.data(withJSONObject: ["payload": payload])
+        return try JSONDecoder().decode(TrackInfo.self, from: data)
+    }
+}
+
+@MainActor
+private final class FakeMediaPlaybackController: MediaPlaybackControlling {
+    private var callback: ((TrackInfo?) -> Void)?
+    private var registrationWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var pauseCallCount = 0
+    private(set) var playCallCount = 0
+
+    func getTrackInfo(_ onReceive: @escaping (TrackInfo?) -> Void) {
+        self.callback = onReceive
+        let waiters = self.registrationWaiters
+        self.registrationWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func pause() {
+        self.pauseCallCount += 1
+    }
+
+    func play() {
+        self.playCallCount += 1
+    }
+
+    func waitUntilQueryRegistered() async {
+        guard self.callback == nil else { return }
+        await withCheckedContinuation { continuation in
+            self.registrationWaiters.append(continuation)
+        }
+    }
+
+    func complete(with trackInfo: TrackInfo?, retainingCallback: Bool = false) {
+        let callback = self.callback
+        if !retainingCallback {
+            self.callback = nil
+        }
+        callback?(trackInfo)
+    }
+}
+
+@MainActor
+private final class ManualTimeoutScheduler {
+    private struct ScheduledAction {
+        let deadline: TimeInterval
+        let action: @MainActor @Sendable () -> Void
+    }
+
+    private var currentTime: TimeInterval = 0
+    private var scheduledActions: [ScheduledAction] = []
+
+    var scheduledDelays: [TimeInterval] {
+        self.scheduledActions.map(\.deadline)
+    }
+
+    func schedule(after delay: TimeInterval, action: @escaping @MainActor @Sendable () -> Void) {
+        self.scheduledActions.append(
+            ScheduledAction(deadline: self.currentTime + delay, action: action)
+        )
+    }
+
+    func advance(by interval: TimeInterval) {
+        self.currentTime += interval
+        let readyActions = self.scheduledActions.filter { $0.deadline <= self.currentTime }
+        self.scheduledActions.removeAll { $0.deadline <= self.currentTime }
+        readyActions.forEach { $0.action() }
+    }
+}
+#endif


### PR DESCRIPTION
## Description
FluidVoice gave the Now Playing query one second to finish, while the pinned media adapter can legitimately wait about two seconds before returning. A valid playing result arriving after the outer timeout was discarded, so no pause request was sent.

This aligns the outer timeout to 2.5 seconds, records elapsed query time in terminal diagnostics, and adds deterministic coverage around timeout and pause ownership behavior. It keeps pause requests inside the existing one-shot gate so a late callback cannot leave media paused after the session has moved on.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Related to #803.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 15.7.7
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources` (SwiftFormat is not installed locally)
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS,arch=arm64' -only-testing:FluidDictationIntegrationTests/MediaPlaybackServiceTests CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` (6 tests passed)

Also ran an unsigned Apple Silicon `build-for-testing` successfully.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
This fixes the premature timeout contract. It does not assume that timeout is the only cause of #803; the elapsed-time diagnostics will help distinguish future failures.
