### PR TITLE
fix: skip forced capitalization when the cursor context is unknown

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -242,7 +242,7 @@ struct ContentView: View {
     @State private var previousSidebarItem: SidebarItem? = nil // Track previous for mode transitions
     @State private var playgroundUsed: Bool = SettingsStore.shared.playgroundUsed
     @State private var recordingAppInfo: (name: String, bundleId: String, windowTitle: String)? = nil
-    @State private var recordingPrecedingText: String = ""
+    @State private var recordingPrecedingText: String?
 
     // Command Mode State
     // @State private var showCommandMode: Bool = false
@@ -1646,11 +1646,11 @@ struct ContentView: View {
         if SettingsStore.shared.needsDictationFormattingContext {
             self.recordingPrecedingText = TypingService.textBeforeCursorInFocusedField()
             DebugLogger.shared.debug(
-                "Captured preceding text for continuous dictation (chars=\(self.recordingPrecedingText.count))",
+                "Captured preceding text for continuous dictation (chars=\(self.recordingPrecedingText?.count ?? -1))",
                 source: "ContentView"
             )
         } else {
-            self.recordingPrecedingText = ""
+            self.recordingPrecedingText = nil
         }
     }
 
@@ -2284,7 +2284,7 @@ struct ContentView: View {
             bundleID: appInfo.bundleId,
             windowTitle: appInfo.windowTitle
         )
-        self.recordingPrecedingText = ""
+        self.recordingPrecedingText = nil
         self.asr.finalText = finalText
         if route == .onboardingSandbox,
            self.isOnboardingVoicePlaygroundStepActive,
@@ -2689,7 +2689,7 @@ struct ContentView: View {
         let gaavText = ASRService.applyGAAVFormatting(literalFormattedText)
         let precedingText = SettingsStore.shared.needsDictationFormattingContext
             ? TypingService.textBeforeCursorInFocusedField()
-            : ""
+            : nil
         var finalText = ASRService.applyContinuousDictationFormatting(gaavText, precedingText: precedingText)
         finalText = ASRService.applyTerminalLiteralAutocompleteSpacing(
             finalText,
@@ -2796,7 +2796,7 @@ struct ContentView: View {
         finalText = ASRService.applyGAAVFormatting(finalText)
         let precedingText = SettingsStore.shared.needsDictationFormattingContext
             ? TypingService.textBeforeCursorInFocusedField()
-            : ""
+            : nil
         finalText = ASRService.applyContinuousDictationFormatting(finalText, precedingText: precedingText)
         finalText = ASRService.applyTerminalLiteralAutocompleteSpacing(
             finalText,
@@ -2804,7 +2804,7 @@ struct ContentView: View {
             bundleID: appInfo.bundleId,
             windowTitle: appInfo.windowTitle
         )
-        self.recordingPrecedingText = ""
+        self.recordingPrecedingText = nil
         let outputPlan = ASRService.makeDictationLiteralOutputPlan(
             for: finalText,
             appName: appInfo.name,

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -4679,11 +4679,11 @@ final class ASRService: ObservableObject {
     /// Spacing and context-aware capitalization are independently controlled.
     ///
     /// Implements the chaining behavior requested in GitHub issue #390.
-    static func applyContinuousDictationFormatting(_ text: String, precedingText: String) -> String {
+    static func applyContinuousDictationFormatting(_ text: String, precedingText: String?) -> String {
         guard !text.isEmpty else { return text }
         let spacingEnabled = SettingsStore.shared.continuousDictationSpacingEnabled
         let smartCapsEnabled = SettingsStore.shared.contextAwareCapitalizationEnabled
-        guard spacingEnabled || smartCapsEnabled else { return text }
+        guard spacingEnabled || smartCapsEnabled, let precedingText else { return text }
 
         var result = text
 

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -172,8 +172,8 @@ final class TypingService {
 
     /// Best-effort: returns the text immediately before the caret in the currently focused
     /// text field. Used by Continuous Dictation Mode to decide capitalization when chaining
-    /// transcribed segments. Returns "" when the focused field/context is unavailable.
-    static func textBeforeCursorInFocusedField() -> String {
+    /// transcribed segments. Returns nil when the focused field/context is unavailable.
+    static func textBeforeCursorInFocusedField() -> String? {
         TypingService().captureTextBeforeCursorInFocusedField()
     }
 
@@ -1077,8 +1077,8 @@ final class TypingService {
         )
     }
 
-    private func captureTextBeforeCursorInFocusedField() -> String {
-        guard let snapshot = self.captureFocusedTextSnapshot() else { return "" }
+    private func captureTextBeforeCursorInFocusedField() -> String? {
+        guard let snapshot = self.captureFocusedTextSnapshot() else { return nil }
 
         if let scriptValue = snapshot.appScriptValue,
            let scriptRange = snapshot.appScriptSelectedRange
@@ -1092,7 +1092,7 @@ final class TypingService {
             return Self.prefix(in: value, before: selectedRange.location)
         }
 
-        return ""
+        return nil
     }
 
     private static func prefix(in text: String, before location: Int) -> String {

--- a/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
+++ b/Tests/FluidDictationIntegrationTests/DictationE2ETests.swift
@@ -377,6 +377,29 @@ final class DictationE2ETests: XCTestCase {
         }
     }
 
+    func testContinuousDictationFormattingSkipsCapitalizationWhenPrecedingTextUnknown() {
+        self.withRestoredDefaults(keys: [
+            "ContinuousDictationSpacingEnabled",
+            "ContextAwareCapitalizationEnabled",
+        ]) {
+            UserDefaults.standard.set(false, forKey: "ContinuousDictationSpacingEnabled")
+            UserDefaults.standard.set(true, forKey: "ContextAwareCapitalizationEnabled")
+
+            XCTAssertEqual(
+                ASRService.applyContinuousDictationFormatting("and then i continued", precedingText: nil),
+                "and then i continued"
+            )
+            XCTAssertEqual(
+                ASRService.applyContinuousDictationFormatting("and then i continued", precedingText: "i am speaking"),
+                "and then i continued"
+            )
+            XCTAssertEqual(
+                ASRService.applyContinuousDictationFormatting("and then i continued", precedingText: ""),
+                "And then i continued"
+            )
+        }
+    }
+
     func testMentionFormattingLeavesProseAlone() {
         let text = "I am at the store. Meet me at lunch. I am at Paul. Look at Paul's message."
 


### PR DESCRIPTION
<!--
PRs that do not follow this template will be blocked by the PR Policy check.
If the missing information is not fixed after 48 hours, the PR may be closed.
-->

## Description
Smart capitalization was always uppercasing the first dictated word, even while in mid-sentence, bc TypingService.textBeforeCursorInFocusedField() returned "" both when there wasnt any text before the cursor and also when it couldn’t read the focused field at all, which is common in apps that don’t expose the AX value or selected range (example, Slack). 

my PR changes the capture method to return nil when the preceding text can’t be read, and skips capitalization and spacing adjustments when that context is unavailable so the transcription is inserted as-is.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #840

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.5.2 (25F84)
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: xcodebuild test (full suite excluding flaky Tiny Whisper E2E) with 244 tests and 0 failures

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
pretty minimal update