### PR TITLE
fix(ci): post the archive link on pull requests from forks

### DIFF
--- a/.github/workflows/pr-archive-comment.yml
+++ b/.github/workflows/pr-archive-comment.yml
@@ -20,6 +20,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RUN_ID: ${{ github.event.workflow_run.id }}
       EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
     steps:
       # This trusted workflow reads artifact metadata only. Never download or
@@ -27,6 +28,20 @@ jobs:
       - name: Post archive download link
         run: |
           set -euo pipefail
+
+          # workflow_run.pull_requests is populated only for same-repository pull
+          # requests and is empty for pull requests from forks, so fork builds never
+          # got past the check below. Match the head SHA from the trusted event
+          # payload against the open pull requests instead. The artifact name also
+          # encodes the number, but it is produced by the untrusted pull_request
+          # workflow, so it is not trusted to select the comment target here.
+          if [[ ! "$EVENT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            EVENT_PR_NUMBER=$(
+              gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" --paginate \
+                --jq '.[] | select(.head.sha == env.HEAD_SHA) | .number' \
+                | sed -n '1p'
+            )
+          fi
 
           if [[ ! "$EVENT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
             echo "The completed workflow run is not associated with a pull request." >&2


### PR DESCRIPTION
## Description
The PR Archive Comment workflow fails on every pull request opened from a fork, so outside contributors never get the build download link.

`workflow_run.pull_requests` is populated only for same-repository pull requests and is empty for pull requests from forks. The job reads `pull_requests[0].number`, so for a fork PR the number is blank, the guard rejects it, and the job exits 1 with "The completed workflow run is not associated with a pull request."

Across the last 40 runs of this workflow: 10 failures, all fork PRs; 16 successes, all same-repo PRs; no exceptions either way. The 14 skipped runs are the job's own `if: workflow_run.conclusion == 'success'` condition and are unrelated.

Worth noting the archive itself is fine. The "PR Archive" job builds and uploads the artifact correctly for fork PRs, so the only thing lost is the comment linking to it. That is also why this has stayed invisible: it works for branches pushed to this repo, which is the path you would normally see.

This falls back to matching the head SHA from the `workflow_run` payload against the open pull requests when the event does not carry a number. Same-repo PRs keep taking the existing path.

One thing I deliberately did not do: the artifact name already encodes the PR number, which would have been a shorter fix. But that name is produced by the untrusted `pull_request` workflow, and this workflow is trusted and has `issues: write`, so a fork could name an artifact to steer the comment onto an unrelated PR. `workflow_run.head_sha` comes from the event payload instead.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
No existing issue. #847 is a concrete instance: it merged, and the contributor never received an archive comment.

## Testing
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 15.7.7
- [ ] Tested on Intel Mac
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [ ] Ran tests locally:

No Swift changed, so the Swift toolchain checks do not apply here. I ran the resolution logic against this repository's live API instead:

| Case | PR | Resolved |
|---|---|---|
| Open fork PR | #387 | 387 |
| Open fork PR | #468 | 468 |
| Open fork PR | #429 | 429 |
| Same-repo PR | #856 | 856 |
| Nonexistent SHA | n/a | empty, falls through to the existing guard |

I first tried `repos/{repo}/commits/{sha}/pulls`, which is the more obvious fallback, and it does not work here. It resolves merged fork PRs (#847) but returns empty for open ones, because the head commit lives in the fork rather than this repository. That is the case the fix is for, so it is matched against the open pull requests instead.

The paginated call is one request at the current volume (48 open PRs at `per_page=100`). YAML validated; `sed -n '1p'` matches the idiom already used further down and avoids a SIGPIPE under `pipefail`.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
Only the fork path changes. Same-repo PRs never enter the new branch, since `pull_requests[0].number` is already set for them.

Happy to add a debug line logging which path resolved the number if that would help when this is running in anger.
