### PR TITLE
fix(transcription): accept WhatsApp .opus voice notes in file transcription

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */; };
 		7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */; };
 		803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803000000000000000000001 /* MediaPlaybackServiceTests.swift */; };
+		0B05F11E000000000000A002 /* SupportedFileExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */; };
 		803000000000000000000003 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 803000000000000000000004 /* MediaRemoteAdapter */; };
 		B51800000000000000000002 /* SpokenSendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51800000000000000000001 /* SpokenSendTests.swift */; };
 		B51900000000000000000002 /* PrivateAIProviderPromptFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51900000000000000000001 /* PrivateAIProviderPromptFormatTests.swift */; };
@@ -81,6 +82,7 @@
 		CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDictionaryManualEntryTests.swift; sourceTree = "<group>"; };
 		7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingServiceTransientPasteboardTests.swift; sourceTree = "<group>"; };
 		803000000000000000000001 /* MediaPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackServiceTests.swift; sourceTree = "<group>"; };
+		0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedFileExtensionsTests.swift; sourceTree = "<group>"; };
 		7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFixtureLoader.swift; sourceTree = "<group>"; };
 		7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = dictation_fixture.wav; sourceTree = "<group>"; };
 		7CDB0A2C2F3C4D5600FB7CAD /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -167,6 +169,7 @@
 				B51900000000000000000001 /* PrivateAIProviderPromptFormatTests.swift */,
 				B52000000000000000000001 /* PrivateAIDictationTokenBudgetTests.swift */,
 				C0DE63700000000000000001 /* WhisperLanguageSelectionTests.swift */,
+				0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */,
 			);
 			path = FluidDictationIntegrationTests;
 			sourceTree = "<group>";
@@ -340,6 +343,7 @@
 				B51800000000000000000002 /* SpokenSendTests.swift in Sources */,
 				B51900000000000000000002 /* PrivateAIProviderPromptFormatTests.swift in Sources */,
 				C0DE63700000000000000002 /* WhisperLanguageSelectionTests.swift in Sources */,
+				0B05F11E000000000000A002 /* SupportedFileExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Fluid/Services/MeetingTranscriptionService.swift
+++ b/Sources/Fluid/Services/MeetingTranscriptionService.swift
@@ -334,24 +334,26 @@ final class MeetingTranscriptionService: ObservableObject {
 
     /// File extensions the OS can actually decode, queried dynamically from AVFoundation.
     /// Filtered to audio/video types only — excludes subtitles, playlists, etc.
+    /// Uses every extension tag of each type, not just the preferred one: `.opus`/`.oga`
+    /// (e.g. WhatsApp voice notes) map to the same UTType as `.ogg` and decode natively.
     static let supportedFileExtensions: Set<String> = {
         let avTypes = AVURLAsset.audiovisualTypes()
-        let extensions = avTypes.compactMap { fileType -> String? in
-            guard let utType = UTType(fileType.rawValue) else { return nil }
-            guard utType.conforms(to: .audio) || utType.conforms(to: .movie) else { return nil }
-            return utType.preferredFilenameExtension
+        let extensions = avTypes.flatMap { fileType -> [String] in
+            guard let utType = UTType(fileType.rawValue) else { return [] }
+            guard utType.conforms(to: .audio) || utType.conforms(to: .movie) else { return [] }
+            return utType.tags[.filenameExtension] ?? []
         }
-        return Set(extensions)
+        return Set(extensions.map { $0.lowercased() })
     }()
 
     /// Content types accepted by the file picker — broad categories so the OS filters naturally.
     static let allowedContentTypes: [UTType] = [.audio, .movie]
 
     /// User-facing description of supported formats (curated for readability).
-    static let supportedFormatsDescription = "Supported: WAV, MP3, M4A, OGG, MP4, MOV, and more"
+    static let supportedFormatsDescription = "Supported: WAV, MP3, M4A, OGG, OPUS, MP4, MOV, and more"
 
     /// Error copy shown when a dropped file is not accepted.
-    static let dropErrorCopy = "Accepted file types: WAV, MP3, M4A, OGG, MP4, MOV, and more."
+    static let dropErrorCopy = "Accepted file types: WAV, MP3, M4A, OGG, OPUS, MP4, MOV, and more."
 
     /// Share the ASR service instance to avoid loading models twice
     private let asrService: ASRService

--- a/Tests/FluidDictationIntegrationTests/SupportedFileExtensionsTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SupportedFileExtensionsTests.swift
@@ -1,0 +1,38 @@
+@testable import FluidVoice_Debug
+import XCTest
+
+// Regression tests for file-type acceptance in meeting/file transcription.
+// WhatsApp voice notes are Ogg Opus files with a `.opus` extension. macOS maps
+// `.opus` (and `.oga`) to the same UTType as `.ogg` (`org.xiph.ogg-audio`) and can
+// decode them natively, but the accepted-extension set was built from each UTType's
+// single `preferredFilenameExtension`, which dropped every alternate extension —
+// so drag-and-dropping a WhatsApp `.opus` file was rejected as unsupported.
+
+@MainActor
+final class SupportedFileExtensionsTests: XCTestCase {
+    func testWhatsAppOpusExtensionsAreAccepted() {
+        let supported = MeetingTranscriptionService.supportedFileExtensions
+
+        XCTAssertTrue(supported.contains("opus"), "WhatsApp voice notes use .opus — macOS decodes them as Ogg Opus")
+        XCTAssertTrue(supported.contains("oga"), ".oga is an alternate Ogg audio extension macOS decodes natively")
+        XCTAssertTrue(supported.contains("ogg"), ".ogg must remain accepted")
+    }
+
+    func testCommonFormatsRemainAccepted() {
+        let supported = MeetingTranscriptionService.supportedFileExtensions
+
+        for ext in ["wav", "mp3", "m4a", "mp4", "mov", "flac", "aac"] {
+            XCTAssertTrue(supported.contains(ext), ".\(ext) must remain accepted")
+        }
+    }
+
+    func testOnlyDecodableExtensionsAreAccepted() {
+        let supported = MeetingTranscriptionService.supportedFileExtensions
+
+        // Every accepted extension must map to a UTType AVFoundation reports as decodable
+        // audio/video — the set must not drift into subtitles, playlists, or arbitrary types.
+        XCTAssertFalse(supported.contains("srt"), "subtitle files are not transcribable audio")
+        XCTAssertFalse(supported.contains("m3u"), "playlists are not transcribable audio")
+        XCTAssertFalse(supported.contains("txt"))
+    }
+}


### PR DESCRIPTION
## Description
Drag-and-dropping a WhatsApp voice note (`.opus`) onto the file-transcription drop zone shows "Accepted file types…" and rejects the file, even though macOS decodes Ogg Opus natively.

Root cause: `MeetingTranscriptionService.supportedFileExtensions` is built from `AVURLAsset.audiovisualTypes()`, but only keeps each UTType's single `preferredFilenameExtension`. The Ogg audio type (`org.xiph.ogg-audio`) declares the extension tags `["ogg", "oga", "opus"]` with `ogg` as preferred, so `.opus` and `.oga` were dropped from the accepted set while the decoder fully supports them (verified with a real WhatsApp `.opus` file: `AVAudioFile`/`AVAsset` read it fine — mono, 48 kHz, 24 s).

Fix: build the set from **every** `filenameExtension` tag of each decodable audio/video UTType instead of just the preferred one, and mention OPUS in the supported-formats copy. No transcoding or special-casing needed — the existing pipeline handles the file once the extension check stops rejecting it. Every previously accepted extension is still accepted (verified: old set ⊆ new set); the set still derives only from what AVFoundation reports as decodable, so subtitles/playlists remain excluded.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #868

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26 (Darwin 25.5.0)
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` (not installed locally — relying on CI)
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources` (not installed locally — relying on CI)
- [x] Ran tests locally: added `SupportedFileExtensionsTests` (regression: `.opus`/`.oga` accepted, common formats kept, non-audio types still excluded). Local machine has no full Xcode, so XCTest runs in CI; the exact old-vs-new set logic was verified locally with a standalone Swift script against AVFoundation, and the real WhatsApp `.opus` file was verified decodable via `AVAudioFile`/`AVAsset`.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

No layout or visual behavior changes. For full transparency, the supported-formats caption/error string constant gains one word:
before — "Supported: WAV, MP3, M4A, OGG, MP4, MOV, and more"
after — "Supported: WAV, MP3, M4A, OGG, OPUS, MP4, MOV, and more"

## Notes
`UTType.tags[.filenameExtension]` also picks up other alternate extensions macOS already decodes (`.wave`, `.bwf`, `.aif`, `.mpeg`, `.m2ts`, `.3gpp`, …), which is strictly more permissive but still bounded by `AVURLAsset.audiovisualTypes()` — i.e. only formats the OS decoder claims to support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
