### PR TITLE
fix(transcription): accept every filename extension a decodable type declares (#868)

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */; };
 		A11A00000000000000000002 /* AnalyticsDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A00000000000000000001 /* AnalyticsDatabaseTests.swift */; };
 		A62300000000000000000002 /* AudioBufferConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62300000000000000000001 /* AudioBufferConverterTests.swift */; };
+		A62300000000000000000004 /* SupportedFileExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62300000000000000000003 /* SupportedFileExtensionsTests.swift */; };
 		D1A600000000000000000202 /* SpeakerTurnMergingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A600000000000000000201 /* SpeakerTurnMergingTests.swift */; };
 		F1BD00000000000000000002 /* StripThinkingTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BD00000000000000000001 /* StripThinkingTagsTests.swift */; };
 		C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */; };
@@ -62,6 +63,7 @@
 		980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSupportTests.swift; sourceTree = "<group>"; };
 		A11A00000000000000000001 /* AnalyticsDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsDatabaseTests.swift; sourceTree = "<group>"; };
 		A62300000000000000000001 /* AudioBufferConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioBufferConverterTests.swift; sourceTree = "<group>"; };
+		A62300000000000000000003 /* SupportedFileExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedFileExtensionsTests.swift; sourceTree = "<group>"; };
 		D1A600000000000000000201 /* SpeakerTurnMergingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerTurnMergingTests.swift; sourceTree = "<group>"; };
 		F1BD00000000000000000001 /* StripThinkingTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripThinkingTagsTests.swift; sourceTree = "<group>"; };
 		C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineRetirementDrainTests.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				980330F3CE464336ADCE3E23 /* TemperatureSupportTests.swift */,
 				A11A00000000000000000001 /* AnalyticsDatabaseTests.swift */,
 				A62300000000000000000001 /* AudioBufferConverterTests.swift */,
+				A62300000000000000000003 /* SupportedFileExtensionsTests.swift */,
 				D1A600000000000000000201 /* SpeakerTurnMergingTests.swift */,
 				F1BD00000000000000000001 /* StripThinkingTagsTests.swift */,
 				C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */,
@@ -318,6 +321,7 @@
 				272BFB5CB271489892CAE50C /* TemperatureSupportTests.swift in Sources */,
 				A11A00000000000000000002 /* AnalyticsDatabaseTests.swift in Sources */,
 				A62300000000000000000002 /* AudioBufferConverterTests.swift in Sources */,
+				A62300000000000000000004 /* SupportedFileExtensionsTests.swift in Sources */,
 				D1A600000000000000000202 /* SpeakerTurnMergingTests.swift in Sources */,
 				F1BD00000000000000000002 /* StripThinkingTagsTests.swift in Sources */,
 				C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */,

--- a/Sources/Fluid/Services/MeetingTranscriptionService.swift
+++ b/Sources/Fluid/Services/MeetingTranscriptionService.swift
@@ -334,12 +334,22 @@ final class MeetingTranscriptionService: ObservableObject {
 
     /// File extensions the OS can actually decode, queried dynamically from AVFoundation.
     /// Filtered to audio/video types only — excludes subtitles, playlists, etc.
+    ///
+    /// Every filename extension a type declares is collected, not just the
+    /// preferred one: the Ogg audio type (`org.xiph.ogg-audio`) tags
+    /// `["ogg", "oga", "opus"]` with `ogg` preferred, so a preferred-only set
+    /// silently rejected `.opus` (WhatsApp voice notes) and `.oga` even though
+    /// macOS decodes them natively (#868).
     static let supportedFileExtensions: Set<String> = {
         let avTypes = AVURLAsset.audiovisualTypes()
-        let extensions = avTypes.compactMap { fileType -> String? in
-            guard let utType = UTType(fileType.rawValue) else { return nil }
-            guard utType.conforms(to: .audio) || utType.conforms(to: .movie) else { return nil }
-            return utType.preferredFilenameExtension
+        let extensions = avTypes.flatMap { fileType -> [String] in
+            guard let utType = UTType(fileType.rawValue) else { return [] }
+            guard utType.conforms(to: .audio) || utType.conforms(to: .movie) else { return [] }
+            var tags = utType.tags.filter { $0.isFilenameExtension }
+            if let preferred = utType.preferredFilenameExtension, !tags.contains(preferred) {
+                tags.append(preferred)
+            }
+            return tags
         }
         return Set(extensions)
     }()

--- a/Tests/FluidDictationIntegrationTests/SupportedFileExtensionsTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SupportedFileExtensionsTests.swift
@@ -1,0 +1,49 @@
+import AVFoundation
+import UniformTypeIdentifiers
+@testable import FluidVoice_Debug
+import XCTest
+
+/// #868: the accepted-extension set is built from every filename extension a
+/// type declares, not just its preferred one — the Ogg audio type tags
+/// `["ogg", "oga", "opus"]` with `ogg` preferred, so a preferred-only set
+/// rejected WhatsApp `.opus` voice notes (and `.oga`) even though macOS
+/// decodes them natively.
+final class SupportedFileExtensionsTests: XCTestCase {
+    func testOggFamilyExtensionsAreAccepted() throws {
+        let supported = MeetingTranscriptionService.supportedFileExtensions
+        XCTAssertTrue(supported.contains("ogg"), "preferred Ogg extension must stay accepted")
+        XCTAssertTrue(supported.contains("opus"), ".opus (WhatsApp voice notes) must be accepted")
+        XCTAssertTrue(supported.contains("oga"), ".oga must be accepted")
+    }
+
+    func testWellKnownExtensionsStayAccepted() throws {
+        let supported = MeetingTranscriptionService.supportedFileExtensions
+        for ext in ["wav", "mp3", "m4a", "mp4", "mov"] {
+            XCTAssertTrue(supported.contains(ext), "\(ext) must remain accepted")
+        }
+    }
+
+    func testEveryAcceptedExtensionComesFromADecodableAVType() throws {
+        // Build the full tag set the same way the service does and confirm
+        // the service's set is exactly it — no hand-maintained drift.
+        let avTypes = AVURLAsset.audiovisualTypes()
+        var expected = Set<String>()
+        for fileType in avTypes {
+            guard let utType = UTType(fileType.rawValue) else { continue }
+            guard utType.conforms(to: .audio) || utType.conforms(to: .movie) else { continue }
+            for tag in utType.tags where tag.isFilenameExtension {
+                expected.insert(tag)
+            }
+            if let preferred = utType.preferredFilenameExtension {
+                expected.insert(preferred)
+            }
+        }
+        XCTAssertEqual(MeetingTranscriptionService.supportedFileExtensions, expected)
+    }
+
+    func testNonMediaExtensionsStayRejected() throws {
+        let supported = MeetingTranscriptionService.supportedFileExtensions
+        XCTAssertFalse(supported.contains("txt"))
+        XCTAssertFalse(supported.contains("pdf"))
+    }
+}


### PR DESCRIPTION
Closes #868.

## Root cause

`supportedFileExtensions` kept only each UTType's `preferredFilenameExtension`. The Ogg audio type (`org.xiph.ogg-audio`) declares the extensions `["ogg", "oga", "opus"]` with `ogg` preferred — so `.opus` (WhatsApp voice notes arrive as Ogg Opus) and `.oga` were rejected by both the drop zone and the file picker, even though macOS decodes them natively (`AVAudioFile`/`AVAsset` read them fine; renaming the same file to `.ogg` made it work).

## Fix

The set is now built from **all** of a type's filename-extension tags (`utType.tags.filter { $0.isFilenameExtension }`), plus the preferred one as a safety net for types where it is occasionally absent from `tags`. The defining property is preserved: everything accepted is something `AVURLAsset.audiovisualTypes()` says AVFoundation can decode — the set just no longer loses decodable extensions to the preferred-only projection.

## Tests

Four in `Tests/FluidDictationIntegrationTests/SupportedFileExtensionsTests.swift` (XCTest, matching the existing integration-test target):

- the Ogg family (`ogg`, `opus`, `oga`) is accepted;
- well-known formats (`wav`, `mp3`, `m4a`, `mp4`, `mov`) stay accepted;
- the service's set **exactly equals** the tag-derived set recomputed the same way — pins the construction so it cannot silently drift back to preferred-only;
- non-media extensions (`txt`, `pdf`) stay rejected.

(No Swift toolchain on this Windows machine, so the compile/test gate is CI; the change uses only `UTType.tags`/`isFilenameExtension`, both public `UniformTypeIdentifiers` API on macOS 11+.)