### PR TITLE
fix: Bound memory use for long dictation recordings

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -87,6 +87,111 @@ enum AudioCaptureStartOutcome: Equatable {
 /// Models are cached locally to avoid repeated downloads.
 @MainActor
 final class ASRService: ObservableObject {
+    private nonisolated static let longDictationChunkDurationSeconds = 20 * 60
+
+    nonisolated static func shouldProcessStreamingPreview(
+        sampleCount: Int,
+        sampleRate: Int = 16_000
+    ) -> Bool {
+        guard sampleCount >= 0, sampleRate > 0 else { return false }
+        return sampleCount < self.longDictationChunkDurationSeconds * sampleRate
+    }
+
+    nonisolated static func finalTranscriptionRanges(
+        samples: [Float],
+        sampleRate: Int = 16_000
+    ) -> [Range<Int>] {
+        let sampleCount = samples.count
+        guard sampleCount > 0, sampleRate > 0 else { return [] }
+
+        let maximumSampleCount = Self.longDictationChunkDurationSeconds * sampleRate
+        guard sampleCount > maximumSampleCount else { return [0..<sampleCount] }
+
+        var ranges: [Range<Int>] = []
+        var start = 0
+        while sampleCount - start > maximumSampleCount {
+            let preferredEnd = start + maximumSampleCount
+            let latestEndWithValidTail = sampleCount - sampleRate
+            let upperBound = min(preferredEnd, latestEndWithValidTail)
+            let searchRadius = 2 * sampleRate
+            let lowerBound = max(start + sampleRate, upperBound - searchRadius)
+            let end = Self.quietestBoundary(
+                in: samples,
+                lowerBound: lowerBound,
+                upperBound: upperBound,
+                preferredEnd: preferredEnd,
+                sampleRate: sampleRate
+            ) ?? upperBound
+            ranges.append(start..<end)
+            start = end
+        }
+
+        ranges.append(start..<sampleCount)
+        return ranges
+    }
+
+    private nonisolated static func quietestBoundary(
+        in samples: [Float],
+        lowerBound: Int,
+        upperBound: Int,
+        preferredEnd: Int,
+        sampleRate: Int
+    ) -> Int? {
+        guard lowerBound <= upperBound else { return nil }
+
+        let analysisWindow = max(1, sampleRate * 80 / 1000)
+        let halfWindow = max(1, analysisWindow / 2)
+        let stride = max(1, sampleRate * 20 / 1000)
+        let searchRadius = max(1, 2 * sampleRate)
+        var bestBoundary: Int?
+        var bestScore = Float.greatestFiniteMagnitude
+        var boundary = lowerBound
+
+        while boundary <= upperBound {
+            let windowStart = max(0, boundary - halfWindow)
+            let windowEnd = min(samples.count, boundary + halfWindow)
+            var energy: Float = 0
+            for index in windowStart..<windowEnd {
+                energy += abs(samples[index])
+            }
+
+            let windowSampleCount = max(1, windowEnd - windowStart)
+            let distancePenalty = Float(abs(boundary - preferredEnd)) / Float(searchRadius) * 0.0001
+            let score = energy / Float(windowSampleCount) + distancePenalty
+            if score < bestScore {
+                bestScore = score
+                bestBoundary = boundary
+            }
+            boundary += stride
+        }
+
+        return bestBoundary
+    }
+
+    static func transcribeFinalChunks(
+        ranges: [Range<Int>],
+        transcribe: (Int, Range<Int>) async throws -> ASRTranscriptionResult
+    ) async rethrows -> ASRTranscriptionResult {
+        var transcriptions: [String] = []
+        var totalConfidence: Float = 0
+
+        for (index, range) in ranges.enumerated() where !range.isEmpty {
+            let result = try await transcribe(index + 1, range)
+            let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            transcriptions.append(text)
+            totalConfidence += result.confidence
+        }
+
+        let confidence = transcriptions.isEmpty
+            ? 0
+            : totalConfidence / Float(transcriptions.count)
+        return ASRTranscriptionResult(
+            text: transcriptions.joined(separator: " "),
+            confidence: confidence
+        )
+    }
+
     nonisolated static func shouldAssessShortAudioSilence(
         isEnabled: Bool,
         useDictionaryTrainingPath: Bool,
@@ -1108,6 +1213,7 @@ final class ASRService: ObservableObject {
     private var benchmarkStreamingChunkIndex: Int = 0
     private var benchmarkCompletedStreamingChunks: Int = 0
     private var benchmarkLastChunkSampleCount: Int = 0
+    private var hasLoggedLongDictationPreviewBound = false
     private let transcriptionExecutor = TranscriptionExecutor() // Serializes all CoreML access
     private var providerResetDrain: (id: UUID, task: Task<Void, Never>)?
     private var engineConfigurationChangeObserver: NSObjectProtocol?
@@ -1774,6 +1880,7 @@ final class ASRService: ObservableObject {
         self.benchmarkStreamingChunkIndex = 0
         self.benchmarkCompletedStreamingChunks = 0
         self.benchmarkLastChunkSampleCount = 0
+        self.hasLoggedLongDictationPreviewBound = false
         (self.transcriptionProvider as? FluidAudioProvider)?.resetStreamingPreviewCache()
         self.audioCapturePipeline.setRecordingEnabled(
             true,
@@ -2520,10 +2627,48 @@ final class ASRService: ObservableObject {
                 self.lastDictionaryTrainingResult = result
                 finalSource = "dictionaryTraining"
             } else {
-                result = try await self.transcriptionExecutor.run { [provider] in
-                    try await provider.transcribeFinal(pcm)
+                let ranges = Self.finalTranscriptionRanges(samples: pcm)
+                let isChunked = ranges.count > 1
+                let finalPCM = pcm
+                finalSource = isChunked ? "chunked" : "full"
+                self.benchmarkLog(
+                    "final_policy mode=\(isChunked ? "chunked" : "single_pass") " +
+                        "ranges=\(ranges.count) samples=\(finalPCM.count) " +
+                        "limitSamples=\(Self.longDictationChunkDurationSeconds * 16_000)"
+                )
+                if isChunked {
+                    result = try await Self.transcribeFinalChunks(ranges: ranges) { chunkNumber, range in
+                        let chunk = Array(finalPCM[range])
+                        let chunkStartedAt = Date().timeIntervalSince1970
+                        self.benchmarkLog(
+                            "final_chunk_start index=\(chunkNumber) ranges=\(ranges.count) " +
+                                "startSample=\(range.lowerBound) endSample=\(range.upperBound) samples=\(chunk.count)"
+                        )
+                        let chunkResult: ASRTranscriptionResult
+                        do {
+                            chunkResult = try await self.transcriptionExecutor.run { [provider] in
+                                try await provider.transcribeFinal(chunk)
+                            }
+                        } catch {
+                            self.benchmarkLog(
+                                "final_chunk_fail index=\(chunkNumber) ranges=\(ranges.count) " +
+                                    "elapsedMs=\(self.elapsedMilliseconds(since: chunkStartedAt)) " +
+                                    "samples=\(chunk.count) error=\(error.localizedDescription)"
+                            )
+                            throw error
+                        }
+                        self.benchmarkLog(
+                            "final_chunk_done index=\(chunkNumber) ranges=\(ranges.count) " +
+                                "elapsedMs=\(self.elapsedMilliseconds(since: chunkStartedAt)) samples=\(chunk.count) " +
+                                "textChars=\(chunkResult.text.trimmingCharacters(in: .whitespacesAndNewlines).count)"
+                        )
+                        return chunkResult
+                    }
+                } else {
+                    result = try await self.transcriptionExecutor.run { [provider] in
+                        try await provider.transcribeFinal(finalPCM)
+                    }
                 }
-                finalSource = "full"
             }
             let finalElapsedMs = self.elapsedMilliseconds(since: finalStartedAt)
             let finalAudioSeconds = Double(pcm.count) / 16_000.0
@@ -4600,10 +4745,10 @@ final class ASRService: ObservableObject {
 
         while !Task.isCancelled {
             DebugLogger.shared.debug("🔄 runStreamingLoop() - calling processStreamingChunk()", source: "ASRService")
-            await self.processStreamingChunk()
+            let shouldContinue = await self.processStreamingChunk()
             DebugLogger.shared.debug("🔄 runStreamingLoop() - processStreamingChunk() returned", source: "ASRService")
 
-            if Task.isCancelled || self.isRunning == false {
+            if !shouldContinue || Task.isCancelled || self.isRunning == false {
                 break
             }
 
@@ -4632,8 +4777,8 @@ final class ASRService: ObservableObject {
     }
 
     @MainActor
-    private func processStreamingChunk() async {
-        guard self.isRunning else { return }
+    private func processStreamingChunk() async -> Bool {
+        guard self.isRunning else { return false }
         self.benchmarkStreamingChunkIndex += 1
         let chunkIndex = self.benchmarkStreamingChunkIndex
         let chunkAgeMs = self.elapsedMilliseconds(since: self.benchmarkRecordingStartedAt)
@@ -4643,23 +4788,38 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.debug("⚠️ Skipping chunk - previous transcription still in progress", source: "ASRService")
             self.benchmarkLog("chunk_skip index=\(chunkIndex) reason=busy ageMs=\(chunkAgeMs)")
             self.skipNextChunk = true
-            return
+            return true
         }
 
         if self.skipNextChunk {
             DebugLogger.shared.debug("⚠️ Skipping chunk for ANE recovery", source: "ASRService")
             self.benchmarkLog("chunk_skip index=\(chunkIndex) reason=recovery ageMs=\(chunkAgeMs)")
             self.skipNextChunk = false
-            return
+            return true
         }
 
         guard self.isAsrReady, self.transcriptionProvider.isReady else {
             self.benchmarkLog("chunk_skip index=\(chunkIndex) reason=not_ready ageMs=\(chunkAgeMs) isAsrReady=\(self.isAsrReady) providerReady=\(self.transcriptionProvider.isReady)")
-            return
+            return true
         }
 
         // Thread-safe count check
         let currentSampleCount = self.audioBuffer.count
+        guard Self.shouldProcessStreamingPreview(sampleCount: currentSampleCount) else {
+            if !self.hasLoggedLongDictationPreviewBound {
+                self.hasLoggedLongDictationPreviewBound = true
+                DebugLogger.shared.info(
+                    "Streaming preview paused after reaching the 20-minute dictation bound; retaining the last preview",
+                    source: "ASRService"
+                )
+                self.benchmarkLog(
+                    "chunk_skip index=\(chunkIndex) reason=long_dictation_preview_bound " +
+                        "ageMs=\(chunkAgeMs) samples=\(currentSampleCount) " +
+                        "limitSamples=\(Self.longDictationChunkDurationSeconds * 16_000)"
+                )
+            }
+            return false
+        }
         // Most ASR models require at least 1 second of 16kHz audio (16,000 samples) to transcribe
         let minSamples = self.minimumStreamingPreviewSamples
         guard currentSampleCount >= minSamples else {
@@ -4671,7 +4831,7 @@ final class ASRService: ObservableObject {
                 )
                 self.benchmarkLog("chunk_wait index=\(chunkIndex) ageMs=\(chunkAgeMs) samples=\(currentSampleCount) minSamples=\(minSamples)")
             }
-            return
+            return true
         }
 
         // Thread-safe copy of the data
@@ -4681,7 +4841,7 @@ final class ASRService: ObservableObject {
         guard !chunk.isEmpty else {
             DebugLogger.shared.warning("Audio buffer returned empty chunk despite count > 0. Skipping transcription.", source: "ASRService")
             self.benchmarkLog("chunk_skip index=\(chunkIndex) reason=empty ageMs=\(chunkAgeMs)")
-            return
+            return true
         }
 
         self.isProcessingChunk = true
@@ -4751,6 +4911,7 @@ final class ASRService: ObservableObject {
             self.benchmarkLog("chunk_fail index=\(chunkIndex) elapsedMs=\(self.elapsedMilliseconds(since: startedAt)) samples=\(chunk.count) error=\(error.localizedDescription)")
             self.skipNextChunk = true
         }
+        return true
     }
 
     /// Smart diff to prevent text from jumping around

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -119,6 +119,128 @@ final class HotkeyShortcutTests: XCTestCase {
         ))
     }
 
+    func testLongDictationPolicyKeepsShortRecordingsOnSinglePassPath() {
+        let sampleRate = 10
+        let sampleCount = (20 * 60 * sampleRate) - 1
+        let samples = [Float](repeating: 0, count: sampleCount)
+
+        XCTAssertTrue(ASRService.shouldProcessStreamingPreview(
+            sampleCount: sampleCount,
+            sampleRate: sampleRate
+        ))
+        XCTAssertEqual(
+            ASRService.finalTranscriptionRanges(samples: samples, sampleRate: sampleRate),
+            [0..<sampleCount]
+        )
+    }
+
+    func testLongDictationPolicyBoundsPreviewAndCoversFiftyMinutesExactlyOnce() {
+        let sampleRate = 10
+        let maximumRangeCount = 20 * 60 * sampleRate
+        let sampleCount = 50 * 60 * sampleRate
+        let samples = [Float](repeating: 0, count: sampleCount)
+        let ranges = ASRService.finalTranscriptionRanges(
+            samples: samples,
+            sampleRate: sampleRate
+        )
+
+        XCTAssertFalse(ASRService.shouldProcessStreamingPreview(
+            sampleCount: maximumRangeCount,
+            sampleRate: sampleRate
+        ))
+        XCTAssertEqual(ranges, [
+            0..<maximumRangeCount,
+            maximumRangeCount..<(maximumRangeCount * 2),
+            (maximumRangeCount * 2)..<sampleCount,
+        ])
+        XCTAssertTrue(ranges.allSatisfy { !$0.isEmpty && $0.count <= maximumRangeCount })
+        XCTAssertEqual(ranges.first?.lowerBound, 0)
+        XCTAssertEqual(ranges.last?.upperBound, sampleCount)
+        XCTAssertTrue(zip(ranges, ranges.dropFirst()).allSatisfy { $0.upperBound == $1.lowerBound })
+    }
+
+    func testLongDictationPolicyAvoidsSubsecondTailAtBoundary() {
+        let sampleRate = 10
+        let maximumRangeCount = 20 * 60 * sampleRate
+
+        XCTAssertEqual(
+            ASRService.finalTranscriptionRanges(
+                samples: [Float](repeating: 0, count: maximumRangeCount),
+                sampleRate: sampleRate
+            ),
+            [0..<maximumRangeCount]
+        )
+
+        let ranges = ASRService.finalTranscriptionRanges(
+            samples: [Float](repeating: 0, count: maximumRangeCount + 1),
+            sampleRate: sampleRate
+        )
+        XCTAssertEqual(ranges.first?.lowerBound, 0)
+        XCTAssertEqual(ranges.last?.upperBound, maximumRangeCount + 1)
+        XCTAssertTrue(ranges.allSatisfy { !$0.isEmpty && $0.count <= maximumRangeCount })
+        XCTAssertGreaterThanOrEqual(ranges.last?.count ?? 0, sampleRate)
+        XCTAssertTrue(zip(ranges, ranges.dropFirst()).allSatisfy { $0.upperBound == $1.lowerBound })
+    }
+
+    func testLongDictationPolicyChoosesQuietBoundaryNearChunkLimit() {
+        let sampleRate = 100
+        let maximumRangeCount = 20 * 60 * sampleRate
+        let quietBoundary = maximumRangeCount - sampleRate
+        var samples = [Float](repeating: 1, count: maximumRangeCount + (10 * sampleRate))
+        for index in (quietBoundary - 4)..<(quietBoundary + 4) {
+            samples[index] = 0
+        }
+
+        let ranges = ASRService.finalTranscriptionRanges(samples: samples, sampleRate: sampleRate)
+
+        XCTAssertEqual(ranges.first?.upperBound, quietBoundary)
+        XCTAssertEqual(ranges.last?.lowerBound, quietBoundary)
+    }
+
+    @MainActor
+    func testLongDictationPolicyCombinesOnlyUsableChunkResults() async throws {
+        let results = [
+            ASRTranscriptionResult(text: " first ", confidence: 0.8),
+            ASRTranscriptionResult(text: " \n\t ", confidence: 0.1),
+            ASRTranscriptionResult(text: "second", confidence: 0.6),
+        ]
+        var requestedRanges: [Range<Int>] = []
+
+        let result = try await ASRService.transcribeFinalChunks(
+            ranges: [0..<10, 10..<20, 20..<30]
+        ) { _, range in
+            requestedRanges.append(range)
+            return results[requestedRanges.count - 1]
+        }
+
+        XCTAssertEqual(requestedRanges, [0..<10, 10..<20, 20..<30])
+        XCTAssertEqual(result.text, "first second")
+        XCTAssertEqual(result.confidence, 0.7, accuracy: 0.0001)
+    }
+
+    @MainActor
+    func testLongDictationPolicyStopsSerialFinalizationOnFirstError() async {
+        struct ExpectedError: Error {}
+        var requestedRanges: [Range<Int>] = []
+
+        do {
+            _ = try await ASRService.transcribeFinalChunks(
+                ranges: [0..<10, 10..<20, 20..<30]
+            ) { _, range in
+                requestedRanges.append(range)
+                if requestedRanges.count == 2 {
+                    throw ExpectedError()
+                }
+                return ASRTranscriptionResult(text: "partial", confidence: 1)
+            }
+            XCTFail("Expected chunk finalization to throw")
+        } catch is ExpectedError {
+            XCTAssertEqual(requestedRanges, [0..<10, 10..<20])
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     @MainActor
     func testSilentRecordingSettingRoundTripsAndOlderBackupsStillDecode() async throws {
         let settingsStore = SettingsStore.shared


### PR DESCRIPTION
## Description

Add a production-used long-dictation policy inside `ASRService` that applies the existing 20-minute file-transcription bound to live preview and final dictation work, while leaving shorter recordings on their current single-pass path. Once a recording reaches that bound, retain the last successful live preview but skip further full-prefix preview copies/inference; at stop, split normal dictation PCM into ordered, non-empty ranges no larger than the bound, fold any sub-second tail into the preceding range, and run `transcribeFinal` serially for each range through the existing `TranscriptionExecutor`. Combine non-empty chunk results in order, derive aggregate confidence from completed chunks, and apply filler removal, dictionary replacement, spoken-punctuation formatting, audio snapshot handling, and the existing `ContentView` history flow once to the combined result.

FluidVoice can terminate while finalizing a roughly 50–80 minute local dictation, leaving no transcription history entry because `ContentView` only persists history after `ASRService.stop()` returns text. The issue thread provides a repeatable long-recording case on Apple Silicon, and the maintainer identifies memory pressure from retaining and processing the growing recording as the likely cause. The current streaming path repeatedly obtains the entire accumulated PCM prefix, while the final path sends the full recording through one provider inference; both operations grow without a duration bound. File transcription already avoids the same class of failure by processing long audio in 20-minute chunks.

Closes #843

## Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #(issue number), or links to an accepted Discussion/roadmap item.

## Testing

- [ ] Tested on Intel Mac
  Not verified: this needs a person on the named hardware or environment.
- [ ] Tested on Apple Silicon Mac
  Not verified: this needs a person on the named hardware or environment.
- [ ] Tested on macOS version:
  Not verified: this needs a person on the named hardware or environment.
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] Ran tests locally:
- A recording below 20 minutes remains eligible for streaming preview and produces one final range covering every sample, preserving the existing short-recording path. - A 50-minute, 16 kHz sample count becomes three ordered final ranges whose union covers every sample exactly once and whose individual sizes never exceed 20 minutes; preview work is rejected after the bound instead of requesting the whole prefix again. - A recording exactly on the boundary produces one range, while a recording just over the boundary does not create a sub-second final request: the short remainder is folded into the prior range without dropping or duplicating samples.

## Screenshots / Video

Attach screenshots or a video for UI, UX, settings, onboarding, overlay, menu bar, or visual behavior changes.

- [ ] No UI/visual changes; screenshots/video are not applicable.
  Not verified: this needs a person on the named hardware or environment.

## Notes

Add reviewer context, rollout notes, or known tradeoffs here.
