### PR TITLE
Fix Instant Replacement vocabulary boost leak

### DIFF
--- a/Sources/Fluid/Services/ParakeetVocabularyStore.swift
+++ b/Sources/Fluid/Services/ParakeetVocabularyStore.swift
@@ -192,9 +192,9 @@ final class ParakeetVocabularyStore {
             source: "ParakeetVocabularyStore"
         )
 
-        let mergedTerms = self.mergeAndNormalizeTerms(jsonTerms: parsed.terms, dictionaryEntries: SettingsStore.shared.customDictionaryEntries)
+        let mergedTerms = Self.normalizedBoostTerms(parsed.terms)
         DebugLogger.shared.debug(
-            "ParakeetVocabularyStore: merged terms=\(mergedTerms.count), dictionaryEntries=\(SettingsStore.shared.customDictionaryEntries.count)",
+            "ParakeetVocabularyStore: normalized explicit boost terms=\(mergedTerms.count)",
             source: "ParakeetVocabularyStore"
         )
 
@@ -209,14 +209,10 @@ final class ParakeetVocabularyStore {
         )
     }
 
-    private func mergeAndNormalizeTerms(
-        jsonTerms: [VocabularyConfig.Term],
-        dictionaryEntries: [SettingsStore.CustomDictionaryEntry]
-    ) -> [VocabularyConfig.Term] {
-        DebugLogger.shared.debug(
-            "ParakeetVocabularyStore: merge input jsonTerms=\(jsonTerms.count), dictionaryEntries=\(dictionaryEntries.count)",
-            source: "ParakeetVocabularyStore"
-        )
+    /// Normalizes only terms explicitly added to Custom Words Boosting.
+    /// Basic Instant Replacements are deterministic post-ASR rules and must never
+    /// become fuzzy Parakeet vocabulary candidates.
+    static func normalizedBoostTerms(_ jsonTerms: [VocabularyConfig.Term]) -> [VocabularyConfig.Term] {
         var mergedByText: [String: VocabularyConfig.Term] = [:]
 
         func normalizeAliases(_ aliases: [String], excluding text: String) -> [String] {
@@ -255,23 +251,9 @@ final class ParakeetVocabularyStore {
             upsert(term)
         }
 
-        for entry in dictionaryEntries {
-            let replacement = entry.replacement.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !replacement.isEmpty else { continue }
-            let aliases = entry.triggers
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }
-            upsert(VocabularyConfig.Term(text: replacement, weight: 8.0, aliases: aliases))
-        }
-
-        let merged = mergedByText.values.sorted { lhs, rhs in
+        return mergedByText.values.sorted { lhs, rhs in
             lhs.text.localizedCaseInsensitiveCompare(rhs.text) == .orderedAscending
         }
-        DebugLogger.shared.debug(
-            "ParakeetVocabularyStore: merge output count=\(merged.count)",
-            source: "ParakeetVocabularyStore"
-        )
-        return merged
     }
 
     private static func normalizeUserTerms(_ terms: [VocabularyConfig.Term], maxTerms: Int) -> [VocabularyConfig.Term] {

--- a/Tests/FluidDictationIntegrationTests/CustomDictionaryManualEntryTests.swift
+++ b/Tests/FluidDictationIntegrationTests/CustomDictionaryManualEntryTests.swift
@@ -21,6 +21,39 @@ final class CustomDictionaryManualEntryTests: XCTestCase {
         XCTAssertEqual(CustomDictionaryManualEntry.replacementDisplayText(""), "")
     }
 
+    func testInstantReplacementDoesNotEnterParakeetBoostVocabulary() {
+        let replacement = SettingsStore.CustomDictionaryEntry(
+            triggers: ["sean"],
+            replacement: "Shaun"
+        )
+        let explicitBoost = ParakeetVocabularyStore.VocabularyConfig.Term(
+            text: "FluidVoice",
+            weight: 10,
+            aliases: ["fluid voice"]
+        )
+
+        self.withRestoredDictionary([replacement]) {
+            let terms = ParakeetVocabularyStore.normalizedBoostTerms([explicitBoost])
+
+            XCTAssertEqual(terms.map(\.text), ["FluidVoice"])
+            XCTAssertEqual(terms.first?.aliases, ["fluid voice"])
+            XCTAssertFalse(terms.contains { $0.text.caseInsensitiveCompare("Shaun") == .orderedSame })
+            XCTAssertFalse(terms.contains { $0.aliases.contains("sean") })
+        }
+    }
+
+    func testInstantReplacementStillRequiresExactWholeWordTrigger() {
+        let replacement = SettingsStore.CustomDictionaryEntry(
+            triggers: ["sean"],
+            replacement: "Shaun"
+        )
+
+        self.withRestoredDictionary([replacement]) {
+            XCTAssertEqual(ASRService.applyCustomDictionary("Did you mean Monday?"), "Did you mean Monday?")
+            XCTAssertEqual(ASRService.applyCustomDictionary("Ask sean Monday."), "Ask Shaun Monday.")
+        }
+    }
+
     func testWhitespaceReplacementSurvivesTransferAndReplacement() throws {
         let document = DictionaryTransferDocument(
             replacements: [DictionaryTransferReplacement(from: ["new line"], to: "\n")],


### PR DESCRIPTION
## Description
Stops Basic Instant Replacements from entering Parakeet fuzzy vocabulary boosting. Only terms explicitly added under Custom Words Boosting are now passed into the boost vocabulary, while exact whole-word replacements remain unchanged.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #880

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: focused regression tests, 2 passed
- [x] Built, signed, installed, and launched the private Fluid Intelligence app successfully

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
The regression tests verify both invariants: similar words such as `mean` are not replaced by `sean → Shaun`, while an exact `sean` trigger still becomes `Shaun`.
