### PR TITLE
fix(audio): keep built-in mic capture alive on Apple Silicon

### DIFF
--- a/Sources/Fluid/Services/DirectCoreAudioInput.swift
+++ b/Sources/Fluid/Services/DirectCoreAudioInput.swift
@@ -385,6 +385,30 @@ nonisolated protocol DirectCoreAudioInputControlling: AnyObject, Sendable {
     func invalidate() -> OSStatus
 }
 
+nonisolated enum BuiltInOutputKeepAlivePolicy {
+    static func start(
+        inputDeviceID: AudioObjectID,
+        devices: [AudioDevice.Device],
+        isAppleSilicon: Bool,
+        startDevice: (AudioObjectID) -> OSStatus
+    ) -> AudioObjectID? {
+        guard isAppleSilicon,
+              let input = devices.first(where: { $0.id == inputDeviceID }),
+              input.hasInput,
+              input.isUnavailableWhenClamshellClosed
+        else {
+            return nil
+        }
+
+        for output in devices where output.hasOutput && output.isBuiltIn {
+            if startDevice(output.id) == noErr {
+                return output.id
+            }
+        }
+        return nil
+    }
+}
+
 private final nonisolated class DirectCoreAudioInput: DirectCoreAudioInputControlling, @unchecked Sendable {
     private struct SendableCaptureHandle: @unchecked Sendable {
         let rawValue: FVCoreAudioCaptureRef
@@ -397,6 +421,7 @@ private final nonisolated class DirectCoreAudioInput: DirectCoreAudioInputContro
 
     private var capture: FVCoreAudioCaptureRef?
     private var poisonedStopStatus: OSStatus?
+    private var outputKeepAliveDeviceID: AudioObjectID?
     private let packetHandler: DirectCoreAudioPacketHandler
     private let workerQueue = DispatchQueue(
         label: "com.fluidvoice.audio.direct-input-consumer",
@@ -465,8 +490,10 @@ private final nonisolated class DirectCoreAudioInput: DirectCoreAudioInputContro
         guard fv_core_audio_capture_is_running(capture) == false else { return }
 
         fv_core_audio_capture_clear(capture)
+        self.startOutputKeepAlive()
         let status = fv_core_audio_capture_start(capture)
         guard status == noErr else {
+            self.stopOutputKeepAlive()
             throw Self.error(status: status, operation: "start direct Core Audio input")
         }
 
@@ -501,6 +528,7 @@ private final nonisolated class DirectCoreAudioInput: DirectCoreAudioInputContro
         let status = fv_core_audio_capture_stop(capture)
         fv_core_audio_capture_wake(capture)
         self.workerGroup.wait()
+        self.stopOutputKeepAlive()
         if status != noErr {
             self.poisonedStopStatus = status
         }
@@ -526,6 +554,24 @@ private final nonisolated class DirectCoreAudioInput: DirectCoreAudioInputContro
         }
         self.capture = nil
         return noErr
+    }
+
+    private func startOutputKeepAlive() {
+        #if arch(arm64)
+        guard self.outputKeepAliveDeviceID == nil else { return }
+        self.outputKeepAliveDeviceID = BuiltInOutputKeepAlivePolicy.start(
+            inputDeviceID: self.deviceID,
+            devices: AudioDevice.listAllDevices(),
+            isAppleSilicon: true,
+            startDevice: { AudioDeviceStart($0, nil) }
+        )
+        #endif
+    }
+
+    private func stopOutputKeepAlive() {
+        guard let deviceID = self.outputKeepAliveDeviceID else { return }
+        self.outputKeepAliveDeviceID = nil
+        _ = AudioDeviceStop(deviceID, nil)
     }
 
     private nonisolated static func consumePackets(

--- a/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
+++ b/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
@@ -758,6 +758,71 @@ final class DirectAudioReliabilityTests: XCTestCase {
         XCTAssertTrue(completionSection.contains("dictionary_tracking_scheduled afterDeliveryCallback=true"))
     }
 
+    func testOutputKeepAliveStartsBuiltInOutputForAppleSiliconInternalInput() {
+        var startedDevices: [AudioObjectID] = []
+
+        let deviceID = BuiltInOutputKeepAlivePolicy.start(
+            inputDeviceID: 100,
+            devices: [Self.internalMicrophone, Self.builtInSpeaker(id: 200)],
+            isAppleSilicon: true,
+            startDevice: {
+                startedDevices.append($0)
+                return noErr
+            }
+        )
+
+        XCTAssertEqual(deviceID, 200)
+        XCTAssertEqual(startedDevices, [200])
+    }
+
+    func testOutputKeepAliveLeavesIntelAndOtherInputsUntouched() {
+        let devices = [
+            Self.internalMicrophone,
+            Self.externalMicrophone,
+            Self.builtInSpeaker(id: 200),
+        ]
+        var startedDevices: [AudioObjectID] = []
+        let startDevice: (AudioObjectID) -> OSStatus = {
+            startedDevices.append($0)
+            return noErr
+        }
+
+        XCTAssertNil(BuiltInOutputKeepAlivePolicy.start(
+            inputDeviceID: 100,
+            devices: devices,
+            isAppleSilicon: false,
+            startDevice: startDevice
+        ))
+        XCTAssertNil(BuiltInOutputKeepAlivePolicy.start(
+            inputDeviceID: 101,
+            devices: devices,
+            isAppleSilicon: true,
+            startDevice: startDevice
+        ))
+        XCTAssertTrue(startedDevices.isEmpty)
+    }
+
+    func testOutputKeepAliveReturnsNilWhenBuiltInOutputsFailToStart() {
+        var startedDevices: [AudioObjectID] = []
+
+        let deviceID = BuiltInOutputKeepAlivePolicy.start(
+            inputDeviceID: 100,
+            devices: [
+                Self.internalMicrophone,
+                Self.builtInSpeaker(id: 200),
+                Self.builtInSpeaker(id: 201),
+            ],
+            isAppleSilicon: true,
+            startDevice: {
+                startedDevices.append($0)
+                return kAudioHardwareNotReadyError
+            }
+        )
+
+        XCTAssertNil(deviceID)
+        XCTAssertEqual(startedDevices, [200, 201])
+    }
+
     func testReadinessGatePreservesFirstPCMThatArrivesBeforeWait() async {
         let gate = AudioCaptureReadinessGate()
         gate.arm(sessionID: 41, attemptID: 1)
@@ -1255,6 +1320,35 @@ final class DirectAudioReliabilityTests: XCTestCase {
         XCTAssertEqual(factory.creationCount, 2)
         XCTAssertEqual(recorder.events, ["quarantine", "make:24000"])
         await controller.shutdown(reason: "test_complete")
+    }
+
+    private static let internalMicrophone = AudioDevice.Device(
+        id: 100,
+        uid: "BuiltInMicrophoneDevice",
+        name: "MacBook Pro Microphone",
+        hasInput: true,
+        hasOutput: false,
+        transportType: kAudioDeviceTransportTypeBuiltIn
+    )
+
+    private static let externalMicrophone = AudioDevice.Device(
+        id: 101,
+        uid: "ExternalMicrophoneDevice",
+        name: "USB Microphone",
+        hasInput: true,
+        hasOutput: false,
+        transportType: kAudioDeviceTransportTypeUSB
+    )
+
+    private static func builtInSpeaker(id: AudioObjectID) -> AudioDevice.Device {
+        AudioDevice.Device(
+            id: id,
+            uid: "BuiltInSpeakerDevice",
+            name: "MacBook Pro Speakers",
+            hasInput: false,
+            hasOutput: true,
+            transportType: kAudioDeviceTransportTypeBuiltIn
+        )
     }
 }
 


### PR DESCRIPTION
## Description

On Apple Silicon, direct Core Audio capture from the built-in microphone can go silent after dictation starts and truncate the transcription.

This change starts the built-in output device with `AudioDeviceStart(deviceID, nil)` during built-in microphone capture, then stops it with `AudioDeviceStop`. It does not play audio or change the selected devices. If the output fails to start, microphone capture continues normally.

## Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion

Closes #852

## Testing

- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.6.2
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: 15/15 `DirectAudioReliabilityTests` passed

Debug builds pass for arm64 and x86_64. The full test run did not finish because the test host repeatedly tried to download a Whisper model and set up Accessibility. The changed files pass SwiftLint and SwiftFormat; repository-wide checks still report existing issues outside this PR.

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes

The workaround only runs for direct Core Audio capture with the internal microphone on Apple Silicon. Intel and external microphone paths are unchanged.
