### PR TITLE
Honor "Send Custom Prompt Only" for dictation-shortcut prompt overrides

### DIFF
--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -3877,10 +3877,7 @@ extension ContentView {
                 return
             }
 
-            self.promptModeOverrideText = SettingsStore.combineBasePrompt(
-                for: .dictate,
-                with: SettingsStore.stripBasePrompt(for: .dictate, from: profile.prompt)
-            )
+            self.promptModeOverrideText = settings.shortcutOverrideSystemPrompt(for: profile, mode: .dictate)
             NotchContentState.shared.promptModeOverrideProfileName = profile.name
             NotchContentState.shared.promptModeOverrideProfileID = profile.id
         }

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1333,6 +1333,15 @@ final class SettingsStore: ObservableObject {
         return Self.combineBasePrompt(for: normalizedMode, with: trimmedBody)
     }
 
+    /// System prompt for a dictation-shortcut prompt override, honoring
+    /// "Send Custom Prompt Only" the same way the effective-prompt paths do.
+    func shortcutOverrideSystemPrompt(for profile: DictationPromptProfile, mode: PromptMode = .dictate) -> String {
+        self.systemPrompt(
+            forCustomProfileBody: Self.stripBasePrompt(for: mode, from: profile.prompt),
+            mode: mode
+        )
+    }
+
     // MARK: - Model Reasoning Configuration
 
     /// Configuration for model-specific reasoning/thinking parameters

--- a/Tests/FluidDictationIntegrationTests/LLMClientRequestBodyTests.swift
+++ b/Tests/FluidDictationIntegrationTests/LLMClientRequestBodyTests.swift
@@ -158,6 +158,32 @@ final class LLMClientRequestBodyTests: XCTestCase {
         }
     }
 
+    func testCustomPromptOnly_shortcutProfileOverrideOmitsBasePrompt() {
+        self.withPromptSettingsRestored {
+            let settings = SettingsStore.shared
+            self.resetPromptSettings(settings)
+
+            let profile = SettingsStore.DictationPromptProfile(
+                name: "Cleaner",
+                prompt: "Normalize the transcript. Output only the cleaned text.",
+                mode: .dictate
+            )
+            settings.dictationPromptProfiles = [profile]
+            settings.sendCustomPromptOnly = true
+
+            XCTAssertEqual(
+                settings.shortcutOverrideSystemPrompt(for: profile),
+                profile.prompt
+            )
+
+            settings.sendCustomPromptOnly = false
+            XCTAssertEqual(
+                settings.shortcutOverrideSystemPrompt(for: profile),
+                SettingsStore.combineBasePrompt(for: .dictate, with: profile.prompt)
+            )
+        }
+    }
+
     private static let basePromptMarker = "You are a voice-to-text dictation cleaner"
 
     private func resetPromptSettings(_ settings: SettingsStore) {


### PR DESCRIPTION
## Description

When a custom prompt profile is selected for a dictation shortcut, `applyDictationShortcutSelectionContext(for:)` precomputes `promptModeOverrideText` with `SettingsStore.combineBasePrompt(...)` unconditionally, ignoring **Send Custom Prompt Only**. The override then short-circuits `processTextWithAI(overrideSystemPrompt:)` before the correctly-gated `SettingsStore` paths (`effectiveDictationSystemPrompt` et al.) ever run — so the built-in base prompt is prepended on the path every normal dictation with a selected profile takes.

This PR routes the override through a new `SettingsStore.shortcutOverrideSystemPrompt(for:mode:)` helper that applies the same `sendCustomPromptOnly` gate as the effective-prompt paths, and adds a regression test alongside the existing `testCustomPromptOnly_*` coverage.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #918

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.6.2
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources` — touched files report 0 violations (a newer local SwiftLint flags 7 pre-existing issues in unrelated files; CI's pinned 0.63.2 is authoritative)
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources` — not applied: without a `.swift-version` in the repo it reformats many untouched files; kept the diff minimal instead
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -only-testing:FluidDictationIntegrationTests/LLMClientRequestBodyTests` — 9/9 passed, including the new `testCustomPromptOnly_shortcutProfileOverrideOmitsBasePrompt`

## Screenshots / Video

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes

Found while pointing dictation cleanup at a narrow text-normalizer fine-tune (Superwhisper s1-mini) through a local gateway: with the base rule-list prepended the model deterministically dropped leading sentences; with the custom prompt alone it cleans correctly. Request-level evidence and `[PromptTrace][Dictate] Prompt override in use: yes` traces are in #918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SmpFBuhCzgoPjakR3e9B7