### PR TITLE
Fix microphone, hotkey, and Dock reliability

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -118,7 +118,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             return true
         }
 
-        // Ensure dock-icon reopen always foregrounds FluidVoice.
+        // LaunchServices can restore the bundle's regular activation policy when
+        // reopening a running app, so reapply the user's Dock preference first.
+        self.applyDockVisibilityPolicy()
         sender.activate(ignoringOtherApps: true)
 
         return !self.bringMainWindowToFrontIfPresent()

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -474,8 +474,8 @@ struct ContentView: View {
                 self.handleRewriteShortcutEnabledChange(newValue)
             }
             .onChange(of: self.pasteLastTranscriptionHotkeyShortcut) { _, newValue in
-                // The hotkey manager reads this value live from SettingsStore, so persisting is enough.
                 SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut = newValue
+                self.hotkeyManager?.refreshMouseShortcutMonitoringIfNeeded()
             }
             .onChange(of: self.isPasteLastTranscriptionShortcutEnabled) { newValue in
                 self.handlePasteLastTranscriptionShortcutEnabledChange(newValue)
@@ -484,6 +484,7 @@ struct ContentView: View {
 
     private func handlePasteLastTranscriptionShortcutEnabledChange(_ isEnabled: Bool) {
         SettingsStore.shared.pasteLastTranscriptionShortcutEnabled = isEnabled
+        self.hotkeyManager?.refreshMouseShortcutMonitoringIfNeeded()
         if !isEnabled, self.activeShortcutRecordingTarget == .pasteLast {
             self.clearShortcutRecordingMode()
         }

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1956,10 +1956,7 @@ final class SettingsStore: ObservableObject {
     func reconcileMicrophonePriority(with devices: [AudioDevice.Device]) {
         var entries = self.microphonePriority
         let preferredUID = self.preferredInputDeviceUID
-        let connectedUIDs = Set(devices.map(\.uid))
-        var suppressedUIDs = self.suppressedMicrophoneUIDs
-        suppressedUIDs.formIntersection(connectedUIDs)
-        self.suppressedMicrophoneUIDs = suppressedUIDs
+        let suppressedUIDs = self.suppressedMicrophoneUIDs
 
         if entries.isEmpty,
            let preferredUID,

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -231,6 +231,7 @@ final class GlobalHotkeyManager: NSObject {
     private nonisolated(unsafe) var state = HotkeyState()
     private nonisolated(unsafe) var eventTap: CFMachPort?
     private nonisolated(unsafe) var runLoopSource: CFRunLoopSource?
+    private nonisolated(unsafe) var monitoredMouseButtons: Set<Int> = []
     private let asrService: ASRService
     private var primaryShortcuts: [HotkeyShortcut]
     private var promptModeShortcut: HotkeyShortcut
@@ -510,11 +511,17 @@ final class GlobalHotkeyManager: NSObject {
     private func initializeWithDelay() {
         DebugLogger.shared.debug("Starting delayed initialization...", source: "GlobalHotkeyManager")
 
-        self.initializationTask = Task {
-            try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 second delay
+        self.initializationTask = Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 second delay
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled else { return }
 
             await MainActor.run {
-                self.setupGlobalHotkeyWithRetry()
+                self?.setupGlobalHotkeyWithRetry()
             }
         }
     }
@@ -529,7 +536,27 @@ final class GlobalHotkeyManager: NSObject {
 
     func updatePrimaryShortcuts(_ newShortcuts: [HotkeyShortcut]) {
         self.primaryShortcuts = newShortcuts
+        self.refreshMouseShortcutMonitoringIfNeeded()
         DebugLogger.shared.info("Updated transcription hotkeys", source: "GlobalHotkeyManager")
+    }
+
+    func refreshMouseShortcutMonitoringIfNeeded() {
+        guard self.isInitialized else { return }
+
+        let mouseButtons = self.configuredMouseButtons()
+        guard mouseButtons != self.monitoredMouseButtons else { return }
+
+        DebugLogger.shared.info(
+            "Mouse shortcut configuration changed; rebuilding event tap",
+            source: "GlobalHotkeyManager"
+        )
+        if !self.setupGlobalHotkey() {
+            self.isInitialized = false
+            DebugLogger.shared.error(
+                "Failed to rebuild event tap after mouse shortcut change",
+                source: "GlobalHotkeyManager"
+            )
+        }
     }
 
     func updateCommandModeShortcut(_ newShortcut: HotkeyShortcut?) {
@@ -636,15 +663,8 @@ final class GlobalHotkeyManager: NSObject {
             return false
         }
 
-        let eventMask = (1 << CGEventType.keyDown.rawValue)
-            | (1 << CGEventType.keyUp.rawValue)
-            | (1 << CGEventType.flagsChanged.rawValue)
-            | (1 << CGEventType.leftMouseDown.rawValue)
-            | (1 << CGEventType.leftMouseUp.rawValue)
-            | (1 << CGEventType.rightMouseDown.rawValue)
-            | (1 << CGEventType.rightMouseUp.rawValue)
-            | (1 << CGEventType.otherMouseDown.rawValue)
-            | (1 << CGEventType.otherMouseUp.rawValue)
+        let mouseButtons = self.configuredMouseButtons()
+        let eventMask = Self.eventMask(mouseButtons: mouseButtons)
 
         self.eventTap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
@@ -680,21 +700,76 @@ final class GlobalHotkeyManager: NSObject {
             return false
         }
 
-        DebugLogger.shared.info("Event tap successfully created and enabled", source: "GlobalHotkeyManager")
+        self.monitoredMouseButtons = mouseButtons
+        let mouseButtonSummary = mouseButtons.isEmpty
+            ? "none"
+            : mouseButtons.sorted().map(String.init).joined(separator: ",")
+        DebugLogger.shared.info(
+            "Event tap successfully created and enabled [mouseButtons=\(mouseButtonSummary)]",
+            source: "GlobalHotkeyManager"
+        )
         return true
+    }
+
+    nonisolated static func eventMask(mouseButtons: Set<Int>) -> CGEventMask {
+        var mask = (CGEventMask(1) << CGEventType.keyDown.rawValue)
+            | (CGEventMask(1) << CGEventType.keyUp.rawValue)
+            | (CGEventMask(1) << CGEventType.flagsChanged.rawValue)
+
+        if mouseButtons.contains(0) {
+            mask |= (CGEventMask(1) << CGEventType.leftMouseDown.rawValue)
+                | (CGEventMask(1) << CGEventType.leftMouseUp.rawValue)
+        }
+        if mouseButtons.contains(1) {
+            mask |= (CGEventMask(1) << CGEventType.rightMouseDown.rawValue)
+                | (CGEventMask(1) << CGEventType.rightMouseUp.rawValue)
+        }
+        if mouseButtons.contains(where: { $0 >= 2 }) {
+            mask |= (CGEventMask(1) << CGEventType.otherMouseDown.rawValue)
+                | (CGEventMask(1) << CGEventType.otherMouseUp.rawValue)
+        }
+
+        return mask
+    }
+
+    nonisolated static func sessionIsLocked(sessionInfo: [String: Any]) -> Bool {
+        sessionInfo["CGSSessionScreenIsLocked"] as? Bool ?? false
+    }
+
+    private nonisolated static func currentSessionIsLocked() -> Bool {
+        self.sessionIsLocked(sessionInfo: CGSessionCopyCurrentDictionary() as? [String: Any] ?? [:])
+    }
+
+    private func configuredMouseButtons() -> Set<Int> {
+        var buttons = Set(self.primaryShortcuts.compactMap { shortcut in
+            shortcut.isMouseShortcut ? shortcut.mouseButton : nil
+        })
+
+        if SettingsStore.shared.pasteLastTranscriptionShortcutEnabled,
+           let shortcut = SettingsStore.shared.pasteLastTranscriptionHotkeyShortcut,
+           shortcut.isMouseShortcut,
+           let mouseButton = shortcut.mouseButton
+        {
+            buttons.insert(mouseButton)
+        }
+
+        return buttons
     }
 
     private nonisolated func cleanupEventTap() {
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
         }
 
         if let source = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            CFRunLoopSourceInvalidate(source)
         }
 
         self.eventTap = nil
         self.runLoopSource = nil
+        self.monitoredMouseButtons = []
         self.clearPrimaryShortcutPressState()
     }
 
@@ -1195,6 +1270,8 @@ final class GlobalHotkeyManager: NSObject {
         if !self.isEventTapEnabled() {
             DebugLogger.shared.warning("Event tap re-enable failed — recreating tap", source: "GlobalHotkeyManager")
             self.setupGlobalHotkeyWithRetry()
+        } else {
+            DebugLogger.shared.info("Event tap re-enabled immediately", source: "GlobalHotkeyManager")
         }
 
         return Unmanaged.passUnretained(event)
@@ -1725,12 +1802,20 @@ final class GlobalHotkeyManager: NSObject {
         case .ignore:
             return false
         case .start:
+            DebugLogger.shared.debug(
+                "Modifier shortcut matched | phase=start | target=\(self.label(for: behavior.holdModeType)) | keyCode=\(keyCode) | flags=\(modifiers.rawValue) | shortcut=\(behavior.shortcut.displayString)",
+                source: "GlobalHotkeyManager"
+            )
             self.modifierOnlyKeyDown = true
             self.modifierPressStartTime = Date()
 
             self.scheduleModifierOnlyStart(for: behavior)
             return true
         case let .finish(wasCleanPress):
+            DebugLogger.shared.debug(
+                "Modifier shortcut matched | phase=finish | target=\(self.label(for: behavior.holdModeType)) | keyCode=\(keyCode) | flags=\(modifiers.rawValue) | clean=\(wasCleanPress)",
+                source: "GlobalHotkeyManager"
+            )
             self.modifierOnlyKeyDown = false
             self.modifierPressStartTime = nil
 
@@ -1897,6 +1982,10 @@ final class GlobalHotkeyManager: NSObject {
     }
 
     private func canTriggerRecordingAction(_ label: String) -> Bool {
+        guard !Self.currentSessionIsLocked() else {
+            DebugLogger.shared.info("Ignoring \(label) - screen is locked", source: "GlobalHotkeyManager")
+            return false
+        }
         guard !self.isProcessingStop else {
             DebugLogger.shared.debug("Ignoring \(label) - stop already processing", source: "GlobalHotkeyManager")
             return false

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -19,6 +19,34 @@ final class HotkeyShortcutTests: XCTestCase {
     private let experimentalDirectAudioCaptureEnabledKey = "ExperimentalDirectAudioCaptureEnabled"
     private let incrementalParakeetEnabledKey = "ExperimentalParakeetUnifiedFinalEnabled"
 
+    func testHotkeyEventMaskExcludesMouseEventsWithoutMouseShortcuts() {
+        let mask = GlobalHotkeyManager.eventMask(mouseButtons: [])
+
+        XCTAssertNotEqual(mask & (CGEventMask(1) << CGEventType.keyDown.rawValue), 0)
+        XCTAssertNotEqual(mask & (CGEventMask(1) << CGEventType.flagsChanged.rawValue), 0)
+        XCTAssertEqual(mask & (CGEventMask(1) << CGEventType.leftMouseDown.rawValue), 0)
+        XCTAssertEqual(mask & (CGEventMask(1) << CGEventType.rightMouseDown.rawValue), 0)
+        XCTAssertEqual(mask & (CGEventMask(1) << CGEventType.otherMouseDown.rawValue), 0)
+    }
+
+    func testHotkeyEventMaskIncludesOnlyConfiguredMouseButtonFamilies() {
+        let leftMask = GlobalHotkeyManager.eventMask(mouseButtons: [0])
+        XCTAssertNotEqual(leftMask & (CGEventMask(1) << CGEventType.leftMouseDown.rawValue), 0)
+        XCTAssertEqual(leftMask & (CGEventMask(1) << CGEventType.rightMouseDown.rawValue), 0)
+        XCTAssertEqual(leftMask & (CGEventMask(1) << CGEventType.otherMouseDown.rawValue), 0)
+
+        let auxiliaryMask = GlobalHotkeyManager.eventMask(mouseButtons: [3])
+        XCTAssertEqual(auxiliaryMask & (CGEventMask(1) << CGEventType.leftMouseDown.rawValue), 0)
+        XCTAssertEqual(auxiliaryMask & (CGEventMask(1) << CGEventType.rightMouseDown.rawValue), 0)
+        XCTAssertNotEqual(auxiliaryMask & (CGEventMask(1) << CGEventType.otherMouseDown.rawValue), 0)
+    }
+
+    func testHotkeySessionLockDetection() {
+        XCTAssertTrue(GlobalHotkeyManager.sessionIsLocked(sessionInfo: ["CGSSessionScreenIsLocked": true]))
+        XCTAssertFalse(GlobalHotkeyManager.sessionIsLocked(sessionInfo: ["CGSSessionScreenIsLocked": false]))
+        XCTAssertFalse(GlobalHotkeyManager.sessionIsLocked(sessionInfo: [:]))
+    }
+
     @MainActor
     func testBottomOverlayRapidStopStartStopDoesNotDropFinalHide() async {
         let audioPublisher = Just(CGFloat.zero).eraseToAnyPublisher()

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -1790,7 +1790,7 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
-    func testRemovedConnectedMicrophoneReturnsAtSecondAfterReconnect() throws {
+    func testRemovedConnectedMicrophoneStaysRemovedAfterReconnect() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,
             self.microphonePriorityKey,
@@ -1813,8 +1813,11 @@ final class HotkeyShortcutTests: XCTestCase {
             XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), [usb.uid])
 
             SettingsStore.shared.reconcileMicrophonePriority(with: [usb])
+            XCTAssertTrue(SettingsStore.shared.suppressedMicrophoneUIDs.contains(builtIn.uid))
+
             SettingsStore.shared.reconcileMicrophonePriority(with: [builtIn, usb])
-            XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), [usb.uid, builtIn.uid])
+            XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), [usb.uid])
+            XCTAssertEqual(coordinator.inputDeviceForCapture(), usb)
         }
     }
 


### PR DESCRIPTION
## Description
- Keep ignored microphones suppressed after disconnecting and reconnecting.
- Stop monitoring global mouse clicks when no mouse shortcut is configured, and harden event-tap cleanup and recovery diagnostics.
- Ignore recording shortcuts while macOS is locked.
- Preserve the hidden-Dock preference when reopening an already-running app.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #933
Closes #921
Closes #753
Addresses #884
Related to #657 and #789.

#891 is the separate configured mouse-shortcut ownership case and is not fixed by this PR.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: 83 targeted integration tests passed
- [x] Built and installed with `sh build_with_FI_incremental.sh`
- [x] Verified locked-screen shortcuts do not start recording
- [x] Verified the event tap excludes mouse events when no mouse shortcut is configured

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
The event tap remains filter-mode because configured shortcuts must be suppressible. This PR narrows its event mask to the configured mouse-button families and recreates it only when that configuration changes. #657 still needs affected-machine soak testing; this PR adds clearer immediate recovery diagnostics and safer tap lifecycle cleanup without claiming full resolution.