### PR TITLE
Fix microphone, Dock, and locked-screen behavior

### DIFF
--- a/Sources/Fluid/AppDelegate.swift
+++ b/Sources/Fluid/AppDelegate.swift
@@ -118,7 +118,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             return true
         }
 
-        // Ensure dock-icon reopen always foregrounds FluidVoice.
+        // LaunchServices can restore the bundle's regular activation policy when
+        // reopening a running app, so reapply the user's Dock preference first.
+        self.applyDockVisibilityPolicy()
         sender.activate(ignoringOtherApps: true)
 
         return !self.bringMainWindowToFrontIfPresent()

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -1956,10 +1956,7 @@ final class SettingsStore: ObservableObject {
     func reconcileMicrophonePriority(with devices: [AudioDevice.Device]) {
         var entries = self.microphonePriority
         let preferredUID = self.preferredInputDeviceUID
-        let connectedUIDs = Set(devices.map(\.uid))
-        var suppressedUIDs = self.suppressedMicrophoneUIDs
-        suppressedUIDs.formIntersection(connectedUIDs)
-        self.suppressedMicrophoneUIDs = suppressedUIDs
+        let suppressedUIDs = self.suppressedMicrophoneUIDs
 
         if entries.isEmpty,
            let preferredUID,

--- a/Sources/Fluid/Services/GlobalHotkeyManager.swift
+++ b/Sources/Fluid/Services/GlobalHotkeyManager.swift
@@ -698,6 +698,14 @@ final class GlobalHotkeyManager: NSObject {
         self.clearPrimaryShortcutPressState()
     }
 
+    nonisolated static func sessionIsLocked(sessionInfo: [String: Any]) -> Bool {
+        sessionInfo["CGSSessionScreenIsLocked"] as? Bool ?? false
+    }
+
+    private nonisolated static func currentSessionIsLocked() -> Bool {
+        self.sessionIsLocked(sessionInfo: CGSessionCopyCurrentDictionary() as? [String: Any] ?? [:])
+    }
+
     private nonisolated func clearPrimaryShortcutPressState() {
         let task = self.state.withLock { () -> Task<Void, Never>? in
             guard self.state.activePrimaryShortcutPress != nil || self.state.isKeyPressed else { return nil }
@@ -1897,6 +1905,10 @@ final class GlobalHotkeyManager: NSObject {
     }
 
     private func canTriggerRecordingAction(_ label: String) -> Bool {
+        guard !Self.currentSessionIsLocked() else {
+            DebugLogger.shared.info("Ignoring \(label) - screen is locked", source: "GlobalHotkeyManager")
+            return false
+        }
         guard !self.isProcessingStop else {
             DebugLogger.shared.debug("Ignoring \(label) - stop already processing", source: "GlobalHotkeyManager")
             return false

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -1790,7 +1790,7 @@ final class HotkeyShortcutTests: XCTestCase {
     }
 
     @MainActor
-    func testRemovedConnectedMicrophoneReturnsAtSecondAfterReconnect() throws {
+    func testRemovedConnectedMicrophoneStaysRemovedAfterReconnect() throws {
         try self.withRestoredDefaults(keys: [
             self.preferredInputDeviceUIDKey,
             self.microphonePriorityKey,
@@ -1813,8 +1813,11 @@ final class HotkeyShortcutTests: XCTestCase {
             XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), [usb.uid])
 
             SettingsStore.shared.reconcileMicrophonePriority(with: [usb])
+            XCTAssertTrue(SettingsStore.shared.suppressedMicrophoneUIDs.contains(builtIn.uid))
+
             SettingsStore.shared.reconcileMicrophonePriority(with: [builtIn, usb])
-            XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), [usb.uid, builtIn.uid])
+            XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), [usb.uid])
+            XCTAssertEqual(coordinator.inputDeviceForCapture(), usb)
         }
     }
 

--- a/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
+++ b/Tests/FluidDictationIntegrationTests/HotkeyShortcutTests.swift
@@ -19,6 +19,12 @@ final class HotkeyShortcutTests: XCTestCase {
     private let experimentalDirectAudioCaptureEnabledKey = "ExperimentalDirectAudioCaptureEnabled"
     private let incrementalParakeetEnabledKey = "ExperimentalParakeetUnifiedFinalEnabled"
 
+    func testHotkeySessionLockDetection() {
+        XCTAssertTrue(GlobalHotkeyManager.sessionIsLocked(sessionInfo: ["CGSSessionScreenIsLocked": true]))
+        XCTAssertFalse(GlobalHotkeyManager.sessionIsLocked(sessionInfo: ["CGSSessionScreenIsLocked": false]))
+        XCTAssertFalse(GlobalHotkeyManager.sessionIsLocked(sessionInfo: [:]))
+    }
+
     @MainActor
     func testBottomOverlayRapidStopStartStopDoesNotDropFinalHide() async {
         let audioPublisher = Just(CGFloat.zero).eraseToAnyPublisher()


### PR DESCRIPTION
## Description
Fix ignored microphones returning after reconnect, restore the saved Dock visibility on reopen, and prevent shortcuts while the Mac is locked.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Closes #933
Closes #753
Closes #884

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: focused microphone reconnect and session-lock tests

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
None.