### PR TITLE
fix(typing): make dictation work in Windows App / Microsoft Remote Desktop

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */; };
 		7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */; };
 		7CFA1D0B2F500000C0DEF101 /* RemoteDesktopPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF102 /* RemoteDesktopPasteTests.swift */; };
+		7CFA1D0B2F500000C0DEF201 /* RemoteDesktopTypingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF202 /* RemoteDesktopTypingTests.swift */; };
 		803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803000000000000000000001 /* MediaPlaybackServiceTests.swift */; };
 		0B05F11E000000000000A002 /* SupportedFileExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */; };
 		803000000000000000000003 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 803000000000000000000004 /* MediaRemoteAdapter */; };
@@ -87,6 +88,7 @@
 		CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDictionaryManualEntryTests.swift; sourceTree = "<group>"; };
 		7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingServiceTransientPasteboardTests.swift; sourceTree = "<group>"; };
 		7CFA1D0B2F500000C0DEF102 /* RemoteDesktopPasteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDesktopPasteTests.swift; sourceTree = "<group>"; };
+		7CFA1D0B2F500000C0DEF202 /* RemoteDesktopTypingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDesktopTypingTests.swift; sourceTree = "<group>"; };
 		803000000000000000000001 /* MediaPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackServiceTests.swift; sourceTree = "<group>"; };
 		0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedFileExtensionsTests.swift; sourceTree = "<group>"; };
 		7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFixtureLoader.swift; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 				DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */,
 				7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */,
 				7CFA1D0B2F500000C0DEF102 /* RemoteDesktopPasteTests.swift */,
+				7CFA1D0B2F500000C0DEF202 /* RemoteDesktopTypingTests.swift */,
 				803000000000000000000001 /* MediaPlaybackServiceTests.swift */,
 				B51800000000000000000001 /* SpokenSendTests.swift */,
 				B51900000000000000000001 /* PrivateAIProviderPromptFormatTests.swift */,
@@ -350,6 +353,7 @@
 				DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */,
 				7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */,
 				7CFA1D0B2F500000C0DEF101 /* RemoteDesktopPasteTests.swift in Sources */,
+				7CFA1D0B2F500000C0DEF201 /* RemoteDesktopTypingTests.swift in Sources */,
 				803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */,
 				B51800000000000000000002 /* SpokenSendTests.swift in Sources */,
 				B51900000000000000000002 /* PrivateAIProviderPromptFormatTests.swift in Sources */,

--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */; };
 		DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */; };
 		7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */; };
+		7CFA1D0B2F500000C0DEF101 /* RemoteDesktopPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF102 /* RemoteDesktopPasteTests.swift */; };
 		803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803000000000000000000001 /* MediaPlaybackServiceTests.swift */; };
 		0B05F11E000000000000A002 /* SupportedFileExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */; };
 		803000000000000000000003 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 803000000000000000000004 /* MediaRemoteAdapter */; };
@@ -85,6 +86,7 @@
 		7CDB0A292F3C4D5600FB7CAD /* DictationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationE2ETests.swift; sourceTree = "<group>"; };
 		CD1C7A0000000000000000B1 /* CustomDictionaryManualEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDictionaryManualEntryTests.swift; sourceTree = "<group>"; };
 		7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingServiceTransientPasteboardTests.swift; sourceTree = "<group>"; };
+		7CFA1D0B2F500000C0DEF102 /* RemoteDesktopPasteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDesktopPasteTests.swift; sourceTree = "<group>"; };
 		803000000000000000000001 /* MediaPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackServiceTests.swift; sourceTree = "<group>"; };
 		0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedFileExtensionsTests.swift; sourceTree = "<group>"; };
 		7CDB0A2A2F3C4D5600FB7CAD /* AudioFixtureLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFixtureLoader.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */,
 				DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */,
 				7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */,
+				7CFA1D0B2F500000C0DEF102 /* RemoteDesktopPasteTests.swift */,
 				803000000000000000000001 /* MediaPlaybackServiceTests.swift */,
 				B51800000000000000000001 /* SpokenSendTests.swift */,
 				B51900000000000000000001 /* PrivateAIProviderPromptFormatTests.swift */,
@@ -346,6 +349,7 @@
 				C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */,
 				DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */,
 				7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */,
+				7CFA1D0B2F500000C0DEF101 /* RemoteDesktopPasteTests.swift in Sources */,
 				803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */,
 				B51800000000000000000002 /* SpokenSendTests.swift in Sources */,
 				B51900000000000000000002 /* PrivateAIProviderPromptFormatTests.swift in Sources */,

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -3569,6 +3569,12 @@ struct ContentView: View {
     }
 
     private func applyHistoryTextOutput(_ text: String, saveToHistory: Bool) async {
+        // Records this insertion's own modifiers - an empty reading included. Without it the
+        // snapshot from an earlier dictation stays pending (nothing consumes it unless that
+        // dictation went to a remote session) and this insertion would decide the guest's menu
+        // state from it.
+        TypingService.noteDictationHotkeyModifiers()
+
         // Keep hotkey/recording state deterministic before applying output text.
         if self.asr.isRunning {
             DebugLogger.shared.info("Actions: stopping active recording before history action output", source: "ContentView")
@@ -3636,6 +3642,12 @@ struct ContentView: View {
     }
 
     private func reprocessDictationText(_ transcribedText: String) async {
+        // Records this insertion's own modifiers - an empty reading included. Without it the
+        // snapshot from an earlier dictation stays pending (nothing consumes it unless that
+        // dictation went to a remote session) and this insertion would decide the guest's menu
+        // state from it.
+        TypingService.noteDictationHotkeyModifiers()
+
         // If live recording is still active, stop it first so reprocess does not
         // leave ASR running in the background (which causes the next hotkey press
         // to behave like a stop instead of start).

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2080,6 +2080,9 @@ struct ContentView: View {
     private func captureRecordingTargetContext() {
         // Capture the focused target PID BEFORE any overlay/UI changes.
         // Used to restore focus when the user interacts with overlay dropdowns.
+        // Sampled here because the hotkey's modifiers are still held at recording start; by
+        // insertion time they have been released and cannot be observed.
+        TypingService.noteDictationHotkeyModifiers()
         let focusTarget = TypingService.captureSystemFocusTarget()
         self.recordingFocusTarget = focusTarget
         let focusedPID = focusTarget?.pid

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -3454,6 +3454,10 @@ struct ContentView: View {
     /// system clipboard, and unlike reprocess, it pastes the existing text verbatim (no new
     /// history entry, no reformatting). Useful when the original auto-insert dropped the tail.
     private func pasteLastDictationFromHistory() {
+        // Records this shortcut's own modifiers. Without it the insertion would decide the
+        // guest's menu state from whatever the previous dictation recorded.
+        TypingService.noteDictationHotkeyModifiers()
+
         guard let last = TranscriptionHistoryStore.shared.entries.first else {
             DebugLogger.shared.info("Actions: Paste requested but history is empty", source: "ContentView")
             return
@@ -4196,8 +4200,6 @@ struct ContentView: View {
             },
             commandModeCallback: {
                 DebugLogger.shared.info("Command mode triggered", source: "ContentView")
-                self.captureRecordingContext()
-
                 // Set flag so stopAndProcessTranscription knows to process as command
                 self.setActiveRecordingMode(.command)
 
@@ -4205,6 +4207,11 @@ struct ContentView: View {
                 self.menuBarManager.setOverlayMode(.command)
 
                 guard !self.asr.isRunningOrStarting else { return }
+
+                // Captured only once the start is going ahead. Before this guard, a rejected
+                // start overwrote the modifier snapshot belonging to the dictation already in
+                // flight, which decides whether the remote session needs its keyboard reset.
+                self.captureRecordingContext()
 
                 self.advanceOverlayLifecycle()
 

--- a/Sources/Fluid/Models/HotkeyShortcut.swift
+++ b/Sources/Fluid/Models/HotkeyShortcut.swift
@@ -92,7 +92,14 @@ struct HotkeyShortcut: Codable, Equatable {
     ]
 
     /// Uses the current keyboard layout to resolve a key code to its displayed character.
+    ///
+    /// Main thread only: this reads the input source, and doing that from a background queue can
+    /// trap inside HIToolbox with no frame of ours on the stack. Every caller today is
+    /// main-actor (SwiftUI bodies, `MenuBarManager`, `GlobalHotkeyManager`), but the chain runs
+    /// through the non-isolated `SettingsStore.primaryDictationShortcutDisplayString`, so
+    /// nothing in the type system enforces it. Fail here rather than in Carbon.
     static func characterForKeyCode(_ keyCode: UInt16) -> String? {
+        precondition(Thread.isMainThread)
         guard let sourceRef = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
               let rawPtr = TISGetInputSourceProperty(sourceRef, kTISPropertyUnicodeKeyLayoutData)
         else { return nil }

--- a/Sources/Fluid/Services/KeyboardLayoutSnapshotCache.swift
+++ b/Sources/Fluid/Services/KeyboardLayoutSnapshotCache.swift
@@ -1,20 +1,31 @@
 import AppKit
 import Carbon.HIToolbox
 
-/// One process-wide snapshot, refreshed at launch and on input-source notifications.
-/// Paste requests only read the snapshot and never dispatch to the main queue.
-final class PasteKeyCodeCache: @unchecked Sendable {
+/// One process-wide snapshot of a value derived from the active keyboard layout, refreshed
+/// at launch and on input-source notifications.
+///
+/// Carbon's Text Input Source APIs are main-thread-only. Reading one from a background queue
+/// can trap inside HIToolbox - `TISGetInputSourceProperty` validates the source against the
+/// input-source list, and rebuilding that list calls `dispatch_assert_queue`. The trap is not
+/// reliable enough to catch in testing: the same binary read the layout off the main thread
+/// successfully for weeks before an input-source change made every call fatal.
+///
+/// So the resolve closure runs on the main thread only, and readers take the snapshot and
+/// never dispatch to the main queue.
+final class KeyboardLayoutSnapshotCache<Value>: @unchecked Sendable {
     private let lock = NSLock()
-    private var keyCode: CGKeyCode = 9
+    private var value: Value
     private var observer: NSObjectProtocol?
-    private let resolve: () -> CGKeyCode
+    private let resolve: () -> Value
     private let notificationName: Notification.Name
     private var refreshScheduled = false
 
     init(
+        initialValue: Value,
         notificationName: Notification.Name = Notification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
-        resolve: @escaping () -> CGKeyCode
+        resolve: @escaping () -> Value
     ) {
+        self.value = initialValue
         self.notificationName = notificationName
         self.resolve = resolve
     }
@@ -48,14 +59,14 @@ final class PasteKeyCodeCache: @unchecked Sendable {
         precondition(Thread.isMainThread)
         let updated = self.resolve()
         self.lock.lock()
-        self.keyCode = updated
+        self.value = updated
         self.lock.unlock()
     }
 
-    func snapshot() -> CGKeyCode {
+    func snapshot() -> Value {
         self.lock.lock()
         defer { self.lock.unlock() }
-        return self.keyCode
+        return self.value
     }
 
     deinit {

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -105,18 +105,37 @@ enum RemoteDesktopKeyMapResolver {
         (50, "`", "~"),
     ]
 
+    /// The ANSI position of `v`, used as the Ctrl+V position when the local layout has no `v`
+    /// of its own to compare against.
+    static let ansiPasteKeyCode: CGKeyCode = 9
+
     /// The position to press for `v` in a Ctrl+V chord forwarded to the guest, or nil when no
     /// position can be trusted.
     ///
     /// Deliberately not `PasteKeyCodeResolver`, which answers a different question: that
     /// resolves the *local* Command+V shortcut, which the client handles itself. This chord is
-    /// forwarded as a scan code and translated by the guest, so it is subject to exactly the
-    /// same ambiguity as ``layoutSafeMap`` - on a Dvorak guest the ANSI position of `v` is a
-    /// different letter, and Ctrl plus that letter may be an unrelated shortcut. So the position
-    /// has to be one both readings agree on, and when they do not, the caller declines rather
-    /// than pressing something unknown.
-    static func layoutSafePasteKeyCode(map: [Character: RemoteDesktopKeyStroke]) -> CGKeyCode? {
-        map["v"]?.keyCode
+    /// forwarded as a scan code and translated by the guest, so it is subject to the same
+    /// ambiguity as ``layoutSafeMap(local:)``.
+    ///
+    /// Three cases, and the middle one is the reason this is not just a lookup:
+    ///
+    /// - The local layout agrees with ANSI on `v`. Use that position; both readings concur.
+    /// - The local layout has no `v` **at all** - Hebrew, Russian, any non-Latin script. There
+    ///   is no rearrangement to disagree about: such a layout is a script layered onto the
+    ///   standard physical arrangement, and the guest's Latin sublayout puts `v` where ANSI
+    ///   does. Use the ANSI position. Returning nil here is what made dictation into a remote
+    ///   session insert *nothing* while Hebrew was selected, because the typing path has
+    ///   already declined by then and this is the lossless fallback.
+    /// - The local layout has a `v`, in a different place - Dvorak and friends. Now the
+    ///   disagreement is a genuine rearrangement, the ANSI position is some other letter, and
+    ///   Ctrl plus that letter may be an unrelated shortcut in the guest. Decline.
+    static func layoutSafePasteKeyCode(
+        local: [Character: RemoteDesktopKeyStroke],
+        safe: [Character: RemoteDesktopKeyStroke]
+    ) -> CGKeyCode? {
+        if let agreed = safe["v"]?.keyCode { return agreed }
+        guard local.isEmpty == false else { return nil }
+        return local["v"] == nil ? self.ansiPasteKeyCode : nil
     }
 
     /// Character to key press, built from ``ansiKeyPositions``. Unshifted wins where a
@@ -154,13 +173,26 @@ enum RemoteDesktopKeyMapResolver {
     /// nothing is offered for direct typing and the caller takes the lossless path. Returning
     /// the full ANSI map here would mean a transient input-source lookup failure silently
     /// changed correct behaviour into mistyped text on a non-ANSI setup.
-    /// Resolves the active layout and applies ``layoutSafeMap(local:)``.
+    /// Everything the remote-desktop paths need from the active layout, resolved together.
+    ///
+    /// One value rather than two lookups so the typable set and the paste position always come
+    /// from the same reading of the layout.
+    struct Snapshot: Equatable {
+        /// Characters safe to type regardless of which layout the guest applies.
+        var typable: [Character: RemoteDesktopKeyStroke] = [:]
+        /// The position to press for `v` in a forwarded Ctrl+V, or nil to decline.
+        var pasteKeyCode: CGKeyCode?
+    }
+
+    /// Resolves the active layout into a ``Snapshot``.
     ///
     /// Main thread only, because it reads the input source - see ``localLayoutMap()``. This is
     /// the resolve closure for the process-wide snapshot; the typing path reads that snapshot
     /// rather than calling this, so it never touches Carbon off the main thread.
-    static func currentLayoutSafeMap() -> [Character: RemoteDesktopKeyStroke] {
-        self.layoutSafeMap(local: self.localLayoutMap())
+    static func currentSnapshot() -> Snapshot {
+        let local = self.localLayoutMap()
+        let safe = self.layoutSafeMap(local: local)
+        return Snapshot(typable: safe, pasteKeyCode: self.layoutSafePasteKeyCode(local: local, safe: safe))
     }
 
     /// Pure form: the agreement filter, given an already-resolved local layout.

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -105,6 +105,16 @@ enum RemoteDesktopKeyMapResolver {
         (50, "`", "~"),
     ]
 
+    /// The ANSI position of `v`, for a Ctrl+V chord forwarded to the guest.
+    ///
+    /// Deliberately not `PasteKeyCodeResolver`, which answers a different question: that
+    /// resolves the *local* Command+V shortcut, which the client handles itself. A chord
+    /// forwarded to the guest as scan codes has to use the position `v` occupies on the guest,
+    /// so on a Dvorak local layout the two differ and the local answer is wrong here.
+    static var ansiPasteKeyCode: CGKeyCode {
+        self.ansiKeyMap["v"]?.keyCode ?? 9
+    }
+
     /// Character to key press, built from ``ansiKeyPositions``. Unshifted wins where a
     /// character is reachable both ways.
     static let ansiKeyMap: [Character: RemoteDesktopKeyStroke] = {

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -1,0 +1,190 @@
+import AppKit
+import Carbon.HIToolbox
+
+/// One key press: a virtual key code, optionally with shift held.
+struct RemoteDesktopKeyStroke: Equatable {
+    let keyCode: CGKeyCode
+    let needsShift: Bool
+}
+
+/// Maps characters to the key presses that produce them on the active keyboard layout, for
+/// typing into a remote-desktop session.
+///
+/// Remote-desktop clients in Scancode mode forward key *positions* to the guest, so text can
+/// only be delivered as real key codes - a unicode payload on a `virtualKey: 0` event has no
+/// position to forward. That restricts what can be typed to characters the local layout can
+/// produce with at most shift, which for a Latin layout is printable ASCII.
+///
+/// It also means the guest applies its *own* layout to those positions, so this is only correct
+/// when the local and remote layouts agree. Non-Latin dictation needs the client's Unicode
+/// keyboard mode instead, which is outside what this can influence.
+enum RemoteDesktopKeyMapResolver {
+    /// Substitutions applied before mapping, for characters that have an unambiguous ASCII
+    /// spelling. Transcripts pick these up from AI enhancement rather than from speech, and
+    /// normalising them is standard practice when the destination only accepts plain input.
+    static let transliterations: [Character: String] = [
+        "\u{2018}": "'", // left single quote
+        "\u{2019}": "'", // right single quote / curly apostrophe
+        "\u{201A}": "'",
+        "\u{201B}": "'",
+        "\u{201C}": "\"", // left double quote
+        "\u{201D}": "\"", // right double quote
+        "\u{201E}": "\"",
+        "\u{2032}": "'", // prime
+        "\u{2033}": "\"", // double prime
+        "\u{2013}": "-", // en dash
+        "\u{2014}": "--", // em dash
+        "\u{2015}": "--",
+        "\u{2212}": "-", // minus sign
+        "\u{2026}": "...", // ellipsis
+        "\u{00A0}": " ", // non-breaking space
+        "\u{202F}": " ", // narrow no-break space
+        "\u{2009}": " ", // thin space
+        "\u{2022}": "-", // bullet
+        "\u{00B7}": "-", // middle dot
+        "\u{2043}": "-",
+    ]
+
+    /// Applies ``transliterations``, leaving everything else untouched.
+    static func transliterate(_ text: String) -> String {
+        guard text.contains(where: { self.transliterations[$0] != nil }) else { return text }
+        var out = ""
+        out.reserveCapacity(text.count)
+        for character in text {
+            out += self.transliterations[character] ?? String(character)
+        }
+        return out
+    }
+
+    static func current() -> [Character: RemoteDesktopKeyStroke] {
+        precondition(Thread.isMainThread)
+        guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let pointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
+        else { return [:] }
+        let data = Unmanaged<CFData>.fromOpaque(pointer).takeUnretainedValue() as Data
+        return self.resolve(layoutData: data, keyboardType: UInt32(LMGetKbdType()))
+    }
+
+    static func resolve(layoutData: Data?, keyboardType: UInt32) -> [Character: RemoteDesktopKeyStroke] {
+        guard let layoutData, !layoutData.isEmpty else { return [:] }
+        return layoutData.withUnsafeBytes { bytes -> [Character: RemoteDesktopKeyStroke] in
+            guard let layout = bytes.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else {
+                return [:]
+            }
+
+            var map: [Character: RemoteDesktopKeyStroke] = [:]
+            // Unshifted first, so a character reachable both ways prefers the simpler stroke.
+            for needsShift in [false, true] {
+                let modifiers = needsShift ? UInt32(shiftKey >> 8) : 0
+                for key: UInt16 in 0..<128 {
+                    var dead: UInt32 = 0
+                    var length = 0
+                    var characters = [UniChar](repeating: 0, count: 4)
+                    let status = UCKeyTranslate(
+                        layout,
+                        key,
+                        UInt16(kUCKeyActionDisplay),
+                        modifiers,
+                        keyboardType,
+                        UInt32(kUCKeyTranslateNoDeadKeysMask),
+                        &dead,
+                        characters.count,
+                        &length,
+                        &characters
+                    )
+                    guard status == noErr, length == 1 else { continue }
+                    let scalarValue = characters[0]
+                    // Printable only: control codes and delete are delivered as their own keys.
+                    guard scalarValue >= 0x20, scalarValue != 0x7f,
+                          let scalar = UnicodeScalar(scalarValue)
+                    else { continue }
+                    let character = Character(scalar)
+                    if map[character] == nil {
+                        map[character] = RemoteDesktopKeyStroke(keyCode: CGKeyCode(key), needsShift: needsShift)
+                    }
+                }
+            }
+            return map
+        }
+    }
+
+    /// The characters in `text` that no key press on this layout can produce.
+    static func unmappableCharacters(
+        in text: String,
+        map: [Character: RemoteDesktopKeyStroke]
+    ) -> [Character] {
+        var seen: Set<Character> = []
+        var result: [Character] = []
+        for character in text where map[character] == nil {
+            // Newlines and tabs are typed as their own key codes, not through the layout map.
+            if character == "\n" || character == "\r" || character == "\t" { continue }
+            if seen.insert(character).inserted { result.append(character) }
+        }
+        return result
+    }
+}
+
+/// Process-wide snapshot of the layout map, refreshed at launch and on input-source changes.
+/// Mirrors `PasteKeyCodeCache`: typing requests only read the snapshot and never touch the
+/// main queue.
+final class RemoteDesktopKeyMapCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var map: [Character: RemoteDesktopKeyStroke] = [:]
+    private var observer: NSObjectProtocol?
+    private let resolve: () -> [Character: RemoteDesktopKeyStroke]
+    private let notificationName: Notification.Name
+    private var refreshScheduled = false
+
+    init(
+        notificationName: Notification.Name = Notification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
+        resolve: @escaping () -> [Character: RemoteDesktopKeyStroke] = { RemoteDesktopKeyMapResolver.current() }
+    ) {
+        self.notificationName = notificationName
+        self.resolve = resolve
+    }
+
+    func start() {
+        precondition(Thread.isMainThread)
+        guard self.observer == nil else { return }
+        self.observer = DistributedNotificationCenter.default().addObserver(
+            forName: self.notificationName,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleRefresh()
+        }
+        self.refresh()
+    }
+
+    private func scheduleRefresh() {
+        precondition(Thread.isMainThread)
+        guard !self.refreshScheduled else { return }
+        self.refreshScheduled = true
+        // Let TIS process the source-change event before reading its current layout.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.refreshScheduled = false
+            self.refresh()
+        }
+    }
+
+    private func refresh() {
+        precondition(Thread.isMainThread)
+        let updated = self.resolve()
+        self.lock.lock()
+        self.map = updated
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [Character: RemoteDesktopKeyStroke] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.map
+    }
+
+    deinit {
+        if let observer {
+            DistributedNotificationCenter.default().removeObserver(observer)
+        }
+    }
+}

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -115,8 +115,8 @@ enum RemoteDesktopKeyMapResolver {
     /// different letter, and Ctrl plus that letter may be an unrelated shortcut. So the position
     /// has to be one both readings agree on, and when they do not, the caller declines rather
     /// than pressing something unknown.
-    static func layoutSafePasteKeyCode() -> CGKeyCode? {
-        self.layoutSafeMap()["v"]?.keyCode
+    static func layoutSafePasteKeyCode(map: [Character: RemoteDesktopKeyStroke]) -> CGKeyCode? {
+        map["v"]?.keyCode
     }
 
     /// Character to key press, built from ``ansiKeyPositions``. Unshifted wins where a
@@ -154,8 +154,17 @@ enum RemoteDesktopKeyMapResolver {
     /// nothing is offered for direct typing and the caller takes the lossless path. Returning
     /// the full ANSI map here would mean a transient input-source lookup failure silently
     /// changed correct behaviour into mistyped text on a non-ANSI setup.
-    static func layoutSafeMap() -> [Character: RemoteDesktopKeyStroke] {
-        let local = self.localLayoutMap()
+    /// Resolves the active layout and applies ``layoutSafeMap(local:)``.
+    ///
+    /// Main thread only, because it reads the input source - see ``localLayoutMap()``. This is
+    /// the resolve closure for the process-wide snapshot; the typing path reads that snapshot
+    /// rather than calling this, so it never touches Carbon off the main thread.
+    static func currentLayoutSafeMap() -> [Character: RemoteDesktopKeyStroke] {
+        self.layoutSafeMap(local: self.localLayoutMap())
+    }
+
+    /// Pure form: the agreement filter, given an already-resolved local layout.
+    static func layoutSafeMap(local: [Character: RemoteDesktopKeyStroke]) -> [Character: RemoteDesktopKeyStroke] {
         guard local.isEmpty == false else { return [:] }
         return self.ansiKeyMap.filter { character, ansiStroke in local[character] == ansiStroke }
     }
@@ -163,7 +172,13 @@ enum RemoteDesktopKeyMapResolver {
     /// The active layout's own character-to-position map, used only to confirm agreement with
     /// ``ansiKeyMap``. Dead keys are excluded: they compose the following character rather than
     /// emitting a glyph, so treating them as typeable would corrupt text.
+    /// Main thread only. `TISGetInputSourceProperty` validates the source against HIToolbox's
+    /// input-source list, and rebuilding that list asserts the main queue - so calling this from
+    /// a background queue can trap inside HIToolbox with no frame of ours on the stack. The
+    /// precondition mirrors ``PasteKeyCodeResolver/current()`` and fails at the real call site
+    /// instead. Off-main callers want the cached snapshot, not this.
     static func localLayoutMap() -> [Character: RemoteDesktopKeyStroke] {
+        precondition(Thread.isMainThread)
         guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
               let pointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
         else { return [:] }

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -132,6 +132,69 @@ enum RemoteDesktopKeyMapResolver {
         return map
     }()
 
+    /// Characters safe to type regardless of which layout the guest applies.
+    ///
+    /// Two plausible guest layouts have to agree. A client in Scancode mode forwards key
+    /// positions and the guest applies its own layout, and RDP normally sends the *client's*
+    /// layout to the session - so the guest is usually a mirror of the local layout, but may
+    /// equally be plain ANSI (a pre-existing session, an unrecognised layout, or one set
+    /// administratively). A fixed ANSI table alone is therefore wrong for an AZERTY or QWERTZ
+    /// guest, where the ANSI position of `a` yields `q`; a purely local table is wrong for an
+    /// ANSI guest.
+    ///
+    /// So only characters whose position is *identical* under both readings are offered. On a US
+    /// or ABC layout that is all of printable ASCII; on AZERTY the transposed keys drop out and
+    /// take the lossless fallback instead of being silently mistyped. The guest's layout cannot
+    /// be interrogated through the client, so agreement is the strongest guarantee available.
+    static func layoutSafeMap() -> [Character: RemoteDesktopKeyStroke] {
+        let local = self.localLayoutMap()
+        guard local.isEmpty == false else { return self.ansiKeyMap }
+        return self.ansiKeyMap.filter { character, ansiStroke in local[character] == ansiStroke }
+    }
+
+    /// The active layout's own character-to-position map, used only to confirm agreement with
+    /// ``ansiKeyMap``. Dead keys are excluded: they compose the following character rather than
+    /// emitting a glyph, so treating them as typeable would corrupt text.
+    static func localLayoutMap() -> [Character: RemoteDesktopKeyStroke] {
+        guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let pointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
+        else { return [:] }
+        let data = Unmanaged<CFData>.fromOpaque(pointer).takeUnretainedValue() as Data
+        return self.localLayoutMap(layoutData: data, keyboardType: UInt32(LMGetKbdType()))
+    }
+
+    static func localLayoutMap(layoutData: Data?, keyboardType: UInt32) -> [Character: RemoteDesktopKeyStroke] {
+        guard let layoutData, layoutData.isEmpty == false else { return [:] }
+        return layoutData.withUnsafeBytes { bytes -> [Character: RemoteDesktopKeyStroke] in
+            guard let layout = bytes.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else {
+                return [:]
+            }
+            var map: [Character: RemoteDesktopKeyStroke] = [:]
+            for needsShift in [false, true] {
+                let modifiers = needsShift ? UInt32(shiftKey >> 8) : 0
+                for key: UInt16 in 0..<128 {
+                    guard self.keypadKeyCodeRange.contains(key) == false, key != self.isoSectionKeyCode
+                    else { continue }
+                    var deadKeyState: UInt32 = 0
+                    var length = 0
+                    var characters = [UniChar](repeating: 0, count: 4)
+                    let status = UCKeyTranslate(
+                        layout, key, UInt16(kUCKeyActionDisplay), modifiers, keyboardType,
+                        0, &deadKeyState, characters.count, &length, &characters
+                    )
+                    guard status == noErr, deadKeyState == 0, length == 1 else { continue }
+                    let value = characters[0]
+                    guard value >= 0x20, value != 0x7f, let scalar = UnicodeScalar(value) else { continue }
+                    let character = Character(scalar)
+                    if map[character] == nil {
+                        map[character] = RemoteDesktopKeyStroke(keyCode: CGKeyCode(key), needsShift: needsShift)
+                    }
+                }
+            }
+            return map
+        }
+    }
+
     /// Spells `text` out as key presses, or reports every character that has no key on this
     /// layout.
     ///

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -78,63 +78,49 @@ enum RemoteDesktopKeyMapResolver {
         return out
     }
 
-    static func current() -> [Character: RemoteDesktopKeyStroke] {
-        guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
-              let pointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
-        else { return [:] }
-        let data = Unmanaged<CFData>.fromOpaque(pointer).takeUnretainedValue() as Data
-        return self.resolve(layoutData: data, keyboardType: UInt32(LMGetKbdType()))
-    }
+    /// Physical key positions on a US/ANSI keyboard, as `(keyCode, unshifted, shifted)`.
+    ///
+    /// This is deliberately a fixed table rather than a lookup of the *local* layout. A client
+    /// in Scancode mode forwards key positions and the guest applies its own layout: per
+    /// Microsoft's documentation, scancode input "uses the keyboard layout of the remote
+    /// session, not the keyboard of the local device". So the question is not "which local key
+    /// produces this character" but "which position produces it on the guest", and the only
+    /// answer available without inspecting the guest is the standard ANSI arrangement.
+    ///
+    /// Deriving the map from the local layout instead would silently corrupt text whenever the
+    /// two disagree - a Cyrillic or Dvorak local layout would report characters as typeable
+    /// whose positions mean something else in the guest. Using a fixed reference means such
+    /// characters are simply absent from the map and take the lossless fallback.
+    private static let ansiKeyPositions: [(keyCode: CGKeyCode, unshifted: Character, shifted: Character)] = [
+        (0, "a", "A"), (1, "s", "S"), (2, "d", "D"), (3, "f", "F"), (4, "h", "H"),
+        (5, "g", "G"), (6, "z", "Z"), (7, "x", "X"), (8, "c", "C"), (9, "v", "V"),
+        (11, "b", "B"), (12, "q", "Q"), (13, "w", "W"), (14, "e", "E"), (15, "r", "R"),
+        (16, "y", "Y"), (17, "t", "T"), (31, "o", "O"), (32, "u", "U"), (34, "i", "I"),
+        (35, "p", "P"), (37, "l", "L"), (38, "j", "J"), (40, "k", "K"), (45, "n", "N"),
+        (46, "m", "M"),
+        (18, "1", "!"), (19, "2", "@"), (20, "3", "#"), (21, "4", "$"), (23, "5", "%"),
+        (22, "6", "^"), (26, "7", "&"), (28, "8", "*"), (25, "9", "("), (29, "0", ")"),
+        (24, "=", "+"), (27, "-", "_"), (30, "]", "}"), (33, "[", "{"), (39, "'", "\""),
+        (41, ";", ":"), (42, "\\", "|"), (43, ",", "<"), (44, "/", "?"), (47, ".", ">"),
+        (50, "`", "~"),
+    ]
 
-    static func resolve(layoutData: Data?, keyboardType: UInt32) -> [Character: RemoteDesktopKeyStroke] {
-        guard let layoutData, !layoutData.isEmpty else { return [:] }
-        return layoutData.withUnsafeBytes { bytes -> [Character: RemoteDesktopKeyStroke] in
-            guard let layout = bytes.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else {
-                return [:]
+    /// Character to key press, built from ``ansiKeyPositions``. Unshifted wins where a
+    /// character is reachable both ways.
+    static let ansiKeyMap: [Character: RemoteDesktopKeyStroke] = {
+        var map: [Character: RemoteDesktopKeyStroke] = [
+            " ": RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Space), needsShift: false),
+        ]
+        for position in Self.ansiKeyPositions {
+            if map[position.unshifted] == nil {
+                map[position.unshifted] = RemoteDesktopKeyStroke(keyCode: position.keyCode, needsShift: false)
             }
-
-            var map: [Character: RemoteDesktopKeyStroke] = [:]
-            // Unshifted first, so a character reachable both ways prefers the simpler stroke.
-            for needsShift in [false, true] {
-                let modifiers = needsShift ? UInt32(shiftKey >> 8) : 0
-                for key: UInt16 in 0..<128 {
-                    guard self.keypadKeyCodeRange.contains(key) == false,
-                          key != self.isoSectionKeyCode
-                    else { continue }
-
-                    var deadKeyState: UInt32 = 0
-                    var length = 0
-                    var characters = [UniChar](repeating: 0, count: 4)
-                    // Deliberately not `kUCKeyTranslateNoDeadKeysMask`: that mask reports a dead
-                    // key's standalone glyph, which would map e.g. `"` on US-International to a
-                    // key that actually composes the next character instead of typing a quote.
-                    let status = UCKeyTranslate(
-                        layout,
-                        key,
-                        UInt16(kUCKeyActionDisplay),
-                        modifiers,
-                        keyboardType,
-                        0,
-                        &deadKeyState,
-                        characters.count,
-                        &length,
-                        &characters
-                    )
-                    guard status == noErr, deadKeyState == 0, length == 1 else { continue }
-                    let scalarValue = characters[0]
-                    // Printable only: control codes and delete are delivered as their own keys.
-                    guard scalarValue >= 0x20, scalarValue != 0x7f,
-                          let scalar = UnicodeScalar(scalarValue)
-                    else { continue }
-                    let character = Character(scalar)
-                    if map[character] == nil {
-                        map[character] = RemoteDesktopKeyStroke(keyCode: CGKeyCode(key), needsShift: needsShift)
-                    }
-                }
+            if map[position.shifted] == nil {
+                map[position.shifted] = RemoteDesktopKeyStroke(keyCode: position.keyCode, needsShift: true)
             }
-            return map
         }
-    }
+        return map
+    }()
 
     /// Spells `text` out as key presses, or reports every character that has no key on this
     /// layout.
@@ -152,9 +138,14 @@ enum RemoteDesktopKeyMapResolver {
     /// through the client, so there is no way to confirm where keystrokes are landing before
     /// sending them. Refusing to send an activating key bounds the worst case to "wrong text
     /// typed somewhere" rather than "an action taken in the guest".
+    /// - Parameter capsLockActive: inverts shift for alphabetic characters. RDP synchronises
+    ///   lock state between client and guest (`TS_SYNCHRONIZE_EVENT`), so when Caps Lock is on
+    ///   the guest applies it to the forwarded scan codes and an unshifted `a` position arrives
+    ///   as `A`. Without this the case of every letter is inverted.
     static func plan(
         for text: String,
-        map: [Character: RemoteDesktopKeyStroke]
+        map: [Character: RemoteDesktopKeyStroke],
+        capsLockActive: Bool = false
     ) -> RemoteDesktopTypingPlan {
         var strokes: [RemoteDesktopKeyStroke] = []
         strokes.reserveCapacity(text.count)
@@ -172,76 +163,17 @@ enum RemoteDesktopKeyMapResolver {
                     if seenUnmappable.insert(character).inserted { unmappable.append(character) }
                     continue
                 }
-                strokes.append(stroke)
+                if capsLockActive, character.isLetter {
+                    strokes.append(
+                        RemoteDesktopKeyStroke(keyCode: stroke.keyCode, needsShift: !stroke.needsShift)
+                    )
+                } else {
+                    strokes.append(stroke)
+                }
             }
         }
 
         guard unmappable.isEmpty else { return .unmappable(unmappable) }
         return .strokes(strokes)
-    }
-}
-
-/// Process-wide snapshot of the layout map, refreshed at launch and on input-source changes.
-/// Mirrors `PasteKeyCodeCache`: typing requests only read the snapshot and never touch the
-/// main queue.
-final class RemoteDesktopKeyMapCache: @unchecked Sendable {
-    private let lock = NSLock()
-    private var map: [Character: RemoteDesktopKeyStroke] = [:]
-    private var observer: NSObjectProtocol?
-    private let resolve: () -> [Character: RemoteDesktopKeyStroke]
-    private let notificationName: Notification.Name
-    private var refreshScheduled = false
-
-    init(
-        notificationName: Notification.Name = Notification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
-        resolve: @escaping () -> [Character: RemoteDesktopKeyStroke] = { RemoteDesktopKeyMapResolver.current() }
-    ) {
-        self.notificationName = notificationName
-        self.resolve = resolve
-    }
-
-    func start() {
-        precondition(Thread.isMainThread)
-        guard self.observer == nil else { return }
-        self.observer = DistributedNotificationCenter.default().addObserver(
-            forName: self.notificationName,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.scheduleRefresh()
-        }
-        self.refresh()
-    }
-
-    private func scheduleRefresh() {
-        precondition(Thread.isMainThread)
-        guard !self.refreshScheduled else { return }
-        self.refreshScheduled = true
-        // Let TIS process the source-change event before reading its current layout.
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.refreshScheduled = false
-            self.refresh()
-        }
-    }
-
-    private func refresh() {
-        precondition(Thread.isMainThread)
-        let updated = self.resolve()
-        self.lock.lock()
-        self.map = updated
-        self.lock.unlock()
-    }
-
-    func snapshot() -> [Character: RemoteDesktopKeyStroke] {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self.map
-    }
-
-    deinit {
-        if let observer {
-            DistributedNotificationCenter.default().removeObserver(observer)
-        }
     }
 }

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -105,14 +105,18 @@ enum RemoteDesktopKeyMapResolver {
         (50, "`", "~"),
     ]
 
-    /// The ANSI position of `v`, for a Ctrl+V chord forwarded to the guest.
+    /// The position to press for `v` in a Ctrl+V chord forwarded to the guest, or nil when no
+    /// position can be trusted.
     ///
     /// Deliberately not `PasteKeyCodeResolver`, which answers a different question: that
-    /// resolves the *local* Command+V shortcut, which the client handles itself. A chord
-    /// forwarded to the guest as scan codes has to use the position `v` occupies on the guest,
-    /// so on a Dvorak local layout the two differ and the local answer is wrong here.
-    static var ansiPasteKeyCode: CGKeyCode {
-        self.ansiKeyMap["v"]?.keyCode ?? 9
+    /// resolves the *local* Command+V shortcut, which the client handles itself. This chord is
+    /// forwarded as a scan code and translated by the guest, so it is subject to exactly the
+    /// same ambiguity as ``layoutSafeMap`` - on a Dvorak guest the ANSI position of `v` is a
+    /// different letter, and Ctrl plus that letter may be an unrelated shortcut. So the position
+    /// has to be one both readings agree on, and when they do not, the caller declines rather
+    /// than pressing something unknown.
+    static func layoutSafePasteKeyCode() -> CGKeyCode? {
+        self.layoutSafeMap()["v"]?.keyCode
     }
 
     /// Character to key press, built from ``ansiKeyPositions``. Unshifted wins where a
@@ -146,9 +150,13 @@ enum RemoteDesktopKeyMapResolver {
     /// or ABC layout that is all of printable ASCII; on AZERTY the transposed keys drop out and
     /// take the lossless fallback instead of being silently mistyped. The guest's layout cannot
     /// be interrogated through the client, so agreement is the strongest guarantee available.
+    /// Fails closed: when the local layout cannot be read, no agreement can be established, so
+    /// nothing is offered for direct typing and the caller takes the lossless path. Returning
+    /// the full ANSI map here would mean a transient input-source lookup failure silently
+    /// changed correct behaviour into mistyped text on a non-ANSI setup.
     static func layoutSafeMap() -> [Character: RemoteDesktopKeyStroke] {
         let local = self.localLayoutMap()
-        guard local.isEmpty == false else { return self.ansiKeyMap }
+        guard local.isEmpty == false else { return [:] }
         return self.ansiKeyMap.filter { character, ansiStroke in local[character] == ansiStroke }
     }
 

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -7,6 +7,15 @@ struct RemoteDesktopKeyStroke: Equatable {
     let needsShift: Bool
 }
 
+/// The result of spelling text out as key presses.
+///
+/// Modelled as a sum type rather than an optional array so the unmappable characters travel
+/// with the failure and the caller can distinguish "cannot type this" from "did not try".
+enum RemoteDesktopTypingPlan: Equatable {
+    case strokes([RemoteDesktopKeyStroke])
+    case unmappable([Character])
+}
+
 /// Maps characters to the key presses that produce them on the active keyboard layout, for
 /// typing into a remote-desktop session.
 ///
@@ -19,30 +28,43 @@ struct RemoteDesktopKeyStroke: Equatable {
 /// when the local and remote layouts agree. Non-Latin dictation needs the client's Unicode
 /// keyboard mode instead, which is outside what this can influence.
 enum RemoteDesktopKeyMapResolver {
-    /// Substitutions applied before mapping, for characters that have an unambiguous ASCII
-    /// spelling. Transcripts pick these up from AI enhancement rather than from speech, and
-    /// normalising them is standard practice when the destination only accepts plain input.
+    /// Virtual key codes for the numeric keypad. Excluded because they carry a different scan
+    /// code class than the character keys a person would use for the same glyph, and nothing on
+    /// a Latin layout is reachable only through them.
+    private static let keypadKeyCodeRange: ClosedRange<UInt16> = 65...92
+
+    /// `kVK_ISO_Section`. Excluded because ANSI Windows maps that position to backslash, so
+    /// typing the glyph it produces on a Mac ISO layout would emit the wrong character.
+    private static let isoSectionKeyCode: UInt16 = 10
+
+    /// Substitutions applied before mapping, for characters that have an unambiguous plain-text
+    /// spelling. These reach transcripts through AI enhancement rather than through speech, and
+    /// normalising them is standard practice for destinations that only accept plain input.
+    ///
+    /// Every character left unmapped costs a focus-stealing clipboard fallback, so breadth here
+    /// is worth having. Note for anyone extending this: two canonically-equivalent keys in a
+    /// dictionary literal trap at runtime, so keep the keys to distinct single scalars.
     static let transliterations: [Character: String] = [
-        "\u{2018}": "'", // left single quote
-        "\u{2019}": "'", // right single quote / curly apostrophe
-        "\u{201A}": "'",
-        "\u{201B}": "'",
-        "\u{201C}": "\"", // left double quote
-        "\u{201D}": "\"", // right double quote
-        "\u{201E}": "\"",
-        "\u{2032}": "'", // prime
-        "\u{2033}": "\"", // double prime
-        "\u{2013}": "-", // en dash
-        "\u{2014}": "--", // em dash
-        "\u{2015}": "--",
-        "\u{2212}": "-", // minus sign
-        "\u{2026}": "...", // ellipsis
-        "\u{00A0}": " ", // non-breaking space
-        "\u{202F}": " ", // narrow no-break space
-        "\u{2009}": " ", // thin space
-        "\u{2022}": "-", // bullet
-        "\u{00B7}": "-", // middle dot
-        "\u{2043}": "-",
+        // Quotes and apostrophes
+        "\u{2018}": "'", "\u{2019}": "'", "\u{201A}": "'", "\u{201B}": "'",
+        "\u{201C}": "\"", "\u{201D}": "\"", "\u{201E}": "\"", "\u{201F}": "\"",
+        "\u{2032}": "'", "\u{2033}": "\"",
+        "\u{00AB}": "\"", "\u{00BB}": "\"",
+        // Dashes and hyphens
+        "\u{2010}": "-", "\u{2011}": "-", "\u{2012}": "-",
+        "\u{2013}": "-", "\u{2014}": "--", "\u{2015}": "--",
+        "\u{2212}": "-",
+        // Spaces
+        "\u{00A0}": " ", "\u{2002}": " ", "\u{2003}": " ", "\u{2004}": " ",
+        "\u{2005}": " ", "\u{2006}": " ", "\u{2007}": " ", "\u{2008}": " ",
+        "\u{2009}": " ", "\u{200A}": " ", "\u{202F}": " ", "\u{3000}": " ",
+        // Invisible characters that would otherwise force the fallback for no visible gain
+        "\u{00AD}": "", "\u{200B}": "", "\u{200C}": "", "\u{200D}": "", "\u{FEFF}": "",
+        // Line and paragraph separators
+        "\u{2028}": "\n", "\u{2029}": "\n",
+        // Miscellaneous
+        "\u{2026}": "...", "\u{2022}": "-", "\u{00B7}": "-", "\u{2043}": "-",
+        "\u{2192}": "->",
     ]
 
     /// Applies ``transliterations``, leaving everything else untouched.
@@ -57,7 +79,6 @@ enum RemoteDesktopKeyMapResolver {
     }
 
     static func current() -> [Character: RemoteDesktopKeyStroke] {
-        precondition(Thread.isMainThread)
         guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
               let pointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
         else { return [:] }
@@ -77,22 +98,29 @@ enum RemoteDesktopKeyMapResolver {
             for needsShift in [false, true] {
                 let modifiers = needsShift ? UInt32(shiftKey >> 8) : 0
                 for key: UInt16 in 0..<128 {
-                    var dead: UInt32 = 0
+                    guard self.keypadKeyCodeRange.contains(key) == false,
+                          key != self.isoSectionKeyCode
+                    else { continue }
+
+                    var deadKeyState: UInt32 = 0
                     var length = 0
                     var characters = [UniChar](repeating: 0, count: 4)
+                    // Deliberately not `kUCKeyTranslateNoDeadKeysMask`: that mask reports a dead
+                    // key's standalone glyph, which would map e.g. `"` on US-International to a
+                    // key that actually composes the next character instead of typing a quote.
                     let status = UCKeyTranslate(
                         layout,
                         key,
                         UInt16(kUCKeyActionDisplay),
                         modifiers,
                         keyboardType,
-                        UInt32(kUCKeyTranslateNoDeadKeysMask),
-                        &dead,
+                        0,
+                        &deadKeyState,
                         characters.count,
                         &length,
                         &characters
                     )
-                    guard status == noErr, length == 1 else { continue }
+                    guard status == noErr, deadKeyState == 0, length == 1 else { continue }
                     let scalarValue = characters[0]
                     // Printable only: control codes and delete are delivered as their own keys.
                     guard scalarValue >= 0x20, scalarValue != 0x7f,
@@ -108,19 +136,44 @@ enum RemoteDesktopKeyMapResolver {
         }
     }
 
-    /// The characters in `text` that no key press on this layout can produce.
-    static func unmappableCharacters(
-        in text: String,
+    /// Spells `text` out as key presses, or reports every character that has no key on this
+    /// layout.
+    ///
+    /// All-or-nothing on purpose: a partially typed transcript is worse than none, so the caller
+    /// falls back rather than emitting a prefix.
+    ///
+    /// Newline is typed as **Shift+Return**, not Return. A bare Return submits in most chat
+    /// clients, so a multi-paragraph transcript typed with Return would send one partial message
+    /// per line; Shift+Return is a line break in every mainstream chat client and a soft break
+    /// in word processors.
+    static func plan(
+        for text: String,
         map: [Character: RemoteDesktopKeyStroke]
-    ) -> [Character] {
-        var seen: Set<Character> = []
-        var result: [Character] = []
-        for character in text where map[character] == nil {
-            // Newlines and tabs are typed as their own key codes, not through the layout map.
-            if character == "\n" || character == "\r" || character == "\t" { continue }
-            if seen.insert(character).inserted { result.append(character) }
+    ) -> RemoteDesktopTypingPlan {
+        var strokes: [RemoteDesktopKeyStroke] = []
+        strokes.reserveCapacity(text.count)
+        var unmappable: [Character] = []
+        var seenUnmappable: Set<Character> = []
+
+        for character in text {
+            switch character {
+            case "\n", "\r", "\r\n":
+                // "\r\n" is a single grapheme cluster in Swift and is not equal to "\n",
+                // so it has to be matched explicitly.
+                strokes.append(RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Return), needsShift: true))
+            case "\t":
+                strokes.append(RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Tab), needsShift: false))
+            default:
+                guard let stroke = map[character] else {
+                    if seenUnmappable.insert(character).inserted { unmappable.append(character) }
+                    continue
+                }
+                strokes.append(stroke)
+            }
         }
-        return result
+
+        guard unmappable.isEmpty else { return .unmappable(unmappable) }
+        return .strokes(strokes)
     }
 }
 

--- a/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
+++ b/Sources/Fluid/Services/RemoteDesktopKeyMap.swift
@@ -142,10 +142,16 @@ enum RemoteDesktopKeyMapResolver {
     /// All-or-nothing on purpose: a partially typed transcript is worse than none, so the caller
     /// falls back rather than emitting a prefix.
     ///
-    /// Newline is typed as **Shift+Return**, not Return. A bare Return submits in most chat
-    /// clients, so a multi-paragraph transcript typed with Return would send one partial message
-    /// per line; Shift+Return is a line break in every mainstream chat client and a soft break
-    /// in word processors.
+    /// Return and Tab are deliberately **never typed** into a remote session; text containing
+    /// them is reported as unmappable instead.
+    ///
+    /// Every other key this can press (codes 0-50: letters, digits, punctuation) only inserts a
+    /// character. Return *commits* and Tab *moves focus*, so if the guest's focus is not a text
+    /// field - a dialog, a menu, a search field - a transcript containing a newline can activate
+    /// whatever happens to be highlighted. The guest exposes no accessibility information
+    /// through the client, so there is no way to confirm where keystrokes are landing before
+    /// sending them. Refusing to send an activating key bounds the worst case to "wrong text
+    /// typed somewhere" rather than "an action taken in the guest".
     static func plan(
         for text: String,
         map: [Character: RemoteDesktopKeyStroke]
@@ -157,12 +163,10 @@ enum RemoteDesktopKeyMapResolver {
 
         for character in text {
             switch character {
-            case "\n", "\r", "\r\n":
-                // "\r\n" is a single grapheme cluster in Swift and is not equal to "\n",
-                // so it has to be matched explicitly.
-                strokes.append(RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Return), needsShift: true))
-            case "\t":
-                strokes.append(RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Tab), needsShift: false))
+            case "\n", "\r", "\r\n", "\t":
+                // Never typed - see the note above. "\r\n" is a single grapheme cluster in
+                // Swift and is not equal to "\n", so it has to be matched explicitly.
+                if seenUnmappable.insert(character).inserted { unmappable.append(character) }
             default:
                 guard let stroke = map[character] else {
                     if seenUnmappable.insert(character).inserted { unmappable.append(character) }

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -914,6 +914,13 @@ final class TypingService {
 
             if resetKeyboardState {
                 self.resyncRemoteDesktopKeyboardState()
+                // The reset sleeps for well over 150ms and posts Escape globally, so the
+                // destination has to be re-confirmed before Return - which activates whatever
+                // now holds focus - rather than trusting the check made before the reset.
+                guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
+                    self.log("[TypingService] ERROR: Target lost focus during the keyboard reset; not sending \(key.displayName)")
+                    return false
+                }
             }
             self.log("[TypingService] Spoken Send: posting \(key.displayName) chord via HID tap for remote-desktop target")
             self.postRemoteDesktopChord(chord)
@@ -1372,6 +1379,22 @@ final class TypingService {
             return .declined
         }
 
+        // Captured *before* the reset and the warm-up below, not after. Those take up to three
+        // seconds together, and a PID cannot tell one connection window of this client from
+        // another - so a baseline taken afterwards would adopt whichever session the user had
+        // switched to during the wait, and every later check would then agree with it and send
+        // the whole transcript to the wrong remote machine.
+        //
+        // Required, not optional. Without an element there is nothing but the PID to check, and
+        // the PID cannot see a connection switch at all. Only insist on it when Accessibility is
+        // actually trusted: untrusted is a different failure that is already refused upstream,
+        // and a nil element there says nothing about the destination.
+        let focusTarget = Self.captureSystemFocusTarget()
+        if focusTarget == nil, AXIsProcessTrusted() {
+            self.log("[TypingService] ERROR: No focused element for the remote session; refusing to type blind")
+            return .declined
+        }
+
         // The hotkey that started this dictation is very often a modifier (the default is
         // modifier-only), and the client forwards that modifier's press and release to the guest
         // independently. Until the guest processes the release it still believes the modifier is
@@ -1401,11 +1424,13 @@ final class TypingService {
             chords.append(chord)
         }
 
-        // A PID cannot distinguish one connection window of the same client from another, so
-        // capture the focused element too and re-confirm it periodically. The element check is
-        // an Accessibility round trip, so it runs on an interval while the cheap PID check runs
-        // before every chord.
-        let focusTarget = Self.captureSystemFocusTarget()
+        // Re-confirmed here because the baseline was taken before the reset and warm-up: this is
+        // the check that catches a connection switch made during that window.
+        if let focusTarget, Self.isExactFocusTargetActive(focusTarget) == false {
+            self.log("[TypingService] ERROR: Focused element changed during the reset or warm-up; not typing")
+            return .declined
+        }
+
         let perCharacterDelay = Self.remoteDesktopTypeDelay
         self.log("[TypingService] Typing \(chords.count) character(s) via HID tap at \(perCharacterDelay / 1000)ms/char")
 
@@ -1463,7 +1488,18 @@ final class TypingService {
         // Prefer what was actually held when this dictation started. Asking whether *any*
         // configured shortcut uses Option or Command would send Escape for a dictation begun
         // with a mouse or a plain-key shortcut, where there is no menu to dismiss.
-        if let observed = Self.consumeDictationHotkeyModifiers() {
+        // A non-empty reading is trustworthy: something was genuinely held. An *empty* one is
+        // not, because the sample is taken when capture starts rather than when the hotkey
+        // fires - and a modifier-only shortcut in toggle mode only starts recording once the
+        // modifier is released, so the flags are already gone by then. Treating empty as "no
+        // modifier" would skip Escape for exactly the default shortcut that needs it most, so
+        // it falls through to the configured-shortcut check instead.
+        // Caps Lock and the numeric-pad bit can be set without any key being held, so compare
+        // against the modifiers a shortcut can actually use rather than against an empty set.
+        let heldModifiers: CGEventFlags = [.maskShift, .maskControl, .maskAlternate, .maskCommand, .maskSecondaryFn]
+        if let observed = Self.consumeDictationHotkeyModifiers(),
+           observed.intersection(heldModifiers).isEmpty == false
+        {
             return observed.contains(.maskAlternate) || observed.contains(.maskCommand)
         }
 

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -717,7 +717,8 @@ final class TypingService {
                       self.postReturnKey(
                           postInsertionKey,
                           targetPID: preferredTargetPID,
-                          resetKeyboardState: hasTextToInsert == false
+                          resetKeyboardState: hasTextToInsert == false,
+                          requiredFocusTarget: requiredFocusTarget
                       )
                 else {
                     outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
@@ -894,7 +895,8 @@ final class TypingService {
     private func postReturnKey(
         _ key: SettingsStore.SpokenSendKey,
         targetPID: pid_t,
-        resetKeyboardState: Bool
+        resetKeyboardState: Bool,
+        requiredFocusTarget: CapturedFocusTarget?
     ) -> Bool {
         let returnKeyCode = CGKeyCode(kVK_Return)
 
@@ -917,8 +919,21 @@ final class TypingService {
                 // The reset sleeps for well over 150ms and posts Escape globally, so the
                 // destination has to be re-confirmed before Return - which activates whatever
                 // now holds focus - rather than trusting the check made before the reset.
+                //
+                // The PID alone is not enough here: it cannot tell one connection window or
+                // field of this client from another, and Return submits whatever it lands on.
+                // So the exact element is required, matching the check the caller makes before
+                // this and the one the typing path makes after its own reset.
                 guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
                     self.log("[TypingService] ERROR: Target lost focus during the keyboard reset; not sending \(key.displayName)")
+                    return false
+                }
+                guard let requiredFocusTarget else {
+                    self.log("[TypingService] ERROR: No focus target to re-confirm after the keyboard reset; not sending \(key.displayName)")
+                    return false
+                }
+                guard Self.isExactFocusTargetActive(requiredFocusTarget) else {
+                    self.log("[TypingService] ERROR: Focused element changed during the keyboard reset; not sending \(key.displayName)")
                     return false
                 }
             }

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -152,7 +152,9 @@ final class TypingService {
     static let remoteDesktopTypeDelayDefaultMs = 16
     static let remoteDesktopTypeDelayMaximumMs = 200
     static let remoteDesktopTypeDelayOverrideKey = "RemoteDesktopTypeDelayMs"
-    static let remoteDesktopFocusRecheckInterval = 10
+    /// How often the focused *element* is re-confirmed while typing. The per-chord check
+    /// compares only the PID, which cannot tell two windows of the same client apart.
+    static let remoteDesktopElementRecheckInterval = 10
 
     static let remoteDesktopWarmupDefaultMs = 250
     static let remoteDesktopWarmupMaximumMs = 3000
@@ -219,8 +221,6 @@ final class TypingService {
 
     // MARK: - Layout-aware key code lookup
 
-    private static let remoteDesktopKeyMapCache = RemoteDesktopKeyMapCache()
-
     private static let pasteKeyCache = PasteKeyCodeCache {
         let key = PasteKeyCodeResolver.current()
         DebugLogger.shared.benchmark("TYPING_BENCH", message: "paste_key_cache_refresh keyCode=\(key)", source: "TypingBenchmark")
@@ -230,7 +230,6 @@ final class TypingService {
     /// Called during application launch, before any paste requests can arrive.
     static func startKeyboardLayoutTracking() {
         self.pasteKeyCache.start()
-        self.remoteDesktopKeyMapCache.start()
     }
 
     /// The virtual key code for "v" in the current keyboard layout (used for Cmd+V paste).
@@ -851,6 +850,10 @@ final class TypingService {
                 return false
             }
 
+            // Reached without any preceding insertion when the transcript was only the send
+            // phrase, in which case the typing path's reset never ran and the guest may still
+            // be in menu mode - where Return activates a menu item instead of submitting.
+            self.resyncRemoteDesktopKeyboardState()
             self.log("[TypingService] Spoken Send: posting \(key.displayName) chord via HID tap for remote-desktop target")
             self.postRemoteDesktopChord(chord)
             return true
@@ -1261,15 +1264,15 @@ final class TypingService {
         targetPID: pid_t
     ) -> RemoteDesktopTypingOutcome {
         let normalized = RemoteDesktopKeyMapResolver.transliterate(text)
-        let map = Self.remoteDesktopKeyMapCache.snapshot()
-
-        guard map.isEmpty == false else {
-            self.log("[TypingService] ERROR: Remote-desktop key map unavailable; cannot type")
-            return .declined
-        }
+        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
 
         let strokes: [RemoteDesktopKeyStroke]
-        switch RemoteDesktopKeyMapResolver.plan(for: normalized, map: map) {
+        let capsLockActive = CGEventSource.flagsState(.combinedSessionState).contains(.maskAlphaShift)
+        if capsLockActive {
+            self.log("[TypingService] Caps Lock is active; inverting shift for alphabetic keys")
+        }
+
+        switch RemoteDesktopKeyMapResolver.plan(for: normalized, map: map, capsLockActive: capsLockActive) {
         case let .strokes(planned):
             strokes = planned
         case let .unmappable(characters):
@@ -1287,10 +1290,6 @@ final class TypingService {
             return .declined
         }
 
-        guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
-            self.log("[TypingService] ERROR: Target is no longer frontmost; skipping remote-desktop typing")
-            return .declined
-        }
 
         // The hotkey that started this dictation is very often a modifier (the default is
         // modifier-only), and the client forwards that modifier's press and release to the guest
@@ -1321,17 +1320,27 @@ final class TypingService {
             chords.append(chord)
         }
 
+        // A PID cannot distinguish one connection window of the same client from another, so
+        // capture the focused element too and re-confirm it periodically. The element check is
+        // an Accessibility round trip, so it runs on an interval while the cheap PID check runs
+        // before every chord.
+        let focusTarget = Self.captureSystemFocusTarget()
         let perCharacterDelay = Self.remoteDesktopTypeDelay
         self.log("[TypingService] Typing \(chords.count) character(s) via HID tap at \(perCharacterDelay / 1000)ms/char")
 
+        // Checked before *every* chord, not on an interval. These events are delivered by the
+        // window server to whatever holds key focus, so any unchecked gap is a window in which
+        // transcript characters land in another application. `frontmostApplication` is a local
+        // lookup, not an Accessibility round trip, so this is cheap enough to do per character.
         for (index, chord) in chords.enumerated() {
-            // HID events go to whatever holds key focus, and a long transcript takes seconds.
-            // Without re-checking, clicking away mid-run sprays the remainder into another app -
-            // including Return presses that would confirm whatever dialog is focused there.
-            if index > 0, index % Self.remoteDesktopFocusRecheckInterval == 0,
-               self.isRemoteDesktopTargetStillFrontmost(targetPID) == false
-            {
+            guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
                 self.log("[TypingService] ERROR: Target lost focus after \(index) character(s); stopping")
+                return .declined
+            }
+            if let focusTarget, index > 0, index % Self.remoteDesktopElementRecheckInterval == 0,
+               Self.isExactFocusTargetActive(focusTarget) == false
+            {
+                self.log("[TypingService] ERROR: Focused window changed after \(index) character(s); stopping")
                 return .declined
             }
             self.postRemoteDesktopChord(chord, keyGapMicros: 1500)
@@ -1363,6 +1372,20 @@ final class TypingService {
     ///
     /// Escape is sent here as a deliberate reset, which is separate from the rule that Return
     /// and Tab are never typed as transcript *content*.
+    /// Whether the configured dictation hotkey can leave the guest in a menu state.
+    ///
+    /// A bare Alt tap activates the menu bar and a bare Windows-key tap opens the Start menu, so
+    /// only Option- and Command-based hotkeys create something for Escape to dismiss. For any
+    /// other hotkey an unconditional Escape would be a gratuitous keypress into the guest, where
+    /// it can cancel a dialog or abandon an in-progress operation.
+    private var remoteDesktopHotkeyCanEnterMenuMode: Bool {
+        let shortcuts = SettingsStore.shared.primaryDictationShortcuts
+        guard shortcuts.isEmpty == false else { return true }
+        return shortcuts.contains { shortcut in
+            shortcut.modifierFlags.contains(.option) || shortcut.modifierFlags.contains(.command)
+        }
+    }
+
     private func resyncRemoteDesktopKeyboardState() {
         for keyCode in Self.remoteDesktopResyncModifierKeyCodes {
             guard let release = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
@@ -1372,6 +1395,11 @@ final class TypingService {
             // event tap ignores it.
             release.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
             release.post(tap: .cghidEventTap)
+        }
+
+        guard self.remoteDesktopHotkeyCanEnterMenuMode else {
+            self.log("[TypingService] Reset remote keyboard state (modifier releases only; hotkey cannot enter menu mode)")
+            return
         }
 
         usleep(Self.remoteDesktopEscapeGapMicros)
@@ -1426,6 +1454,11 @@ final class TypingService {
             return false
         }
 
+        // The bounce below deliberately takes focus away for roughly two seconds. A PID alone
+        // cannot tell one window or session of the same client from another, so capture the
+        // focused element itself and require the *same* element afterwards.
+        let focusTargetBeforeBounce = Self.captureSystemFocusTarget()
+
         return self.withTemporaryPasteboardString(text, restoreDelayMicros: 5_000_000) {
             usleep(Self.remoteDesktopClipboardSettleMicros)
 
@@ -1450,6 +1483,19 @@ final class TypingService {
 
             guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
                 self.log("[TypingService] ERROR: Target not frontmost after focus bounce; skipping paste")
+                return false
+            }
+
+            // Same application is not enough: the paste is a single global chord carrying the
+            // whole transcript, so require the identical focused element we captured. If it
+            // cannot be confirmed, abort - `withTemporaryPasteboardString` restores the
+            // clipboard, and the transcript is still in History.
+            guard let focusTargetBeforeBounce else {
+                self.log("[TypingService] ERROR: No focus target was captured; refusing to paste blind")
+                return false
+            }
+            guard Self.isExactFocusTargetActive(focusTargetBeforeBounce) else {
+                self.log("[TypingService] ERROR: Focused element changed across the bounce; skipping paste")
                 return false
             }
 

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -123,6 +123,10 @@ final class TypingService {
     private static let pasteboardSessionSemaphore = DispatchSemaphore(value: 1)
     private static let pasteboardRestoreQueue = DispatchQueue(label: "TypingService.PasteboardRestore", qos: .utility)
     private static var focusSnapshot: FocusSnapshot?
+
+    /// Modifier flags observed when dictation started, used to decide whether the guest may
+    /// have been left in a menu state. `nil` when nothing recorded it for this dictation.
+    private static var dictationHotkeyModifiers: CGEventFlags?
     private static let ghosttyBundleIdentifier = "com.mitchellh.ghostty"
 
     /// Windows App, formerly Microsoft Remote Desktop. Both ship this bundle identifier.
@@ -249,6 +253,21 @@ final class TypingService {
 
     /// Best-effort: returns the PID owning the currently focused accessibility element.
     /// This is more reliable than NSWorkspace.frontmostApplication for floating overlays/launchers.
+    /// Records the modifiers held as dictation begins.
+    ///
+    /// Called at recording start, before any overlay or focus changes. The hotkey's own
+    /// modifiers are still down at that point, which is the only moment they can be observed -
+    /// by insertion time they have been released, and the *configured* shortcut list cannot
+    /// say which of several shortcuts actually fired, or whether a mouse shortcut was used.
+    nonisolated static func noteDictationHotkeyModifiers() {
+        let flags = CGEventSource.flagsState(.combinedSessionState)
+        self.focusSnapshotQueue.sync { self.dictationHotkeyModifiers = flags }
+    }
+
+    private static func recordedDictationHotkeyModifiers() -> CGEventFlags? {
+        self.focusSnapshotQueue.sync { self.dictationHotkeyModifiers }
+    }
+
     static func captureSystemFocusTarget() -> CapturedFocusTarget? {
         // Accessibility is required to query system-focused AX element.
         guard AXIsProcessTrusted() else {
@@ -664,7 +683,11 @@ final class TypingService {
 
                 usleep(50_000)
                 guard Self.isExactFocusTargetActive(requiredFocusTarget),
-                      self.postReturnKey(postInsertionKey, targetPID: preferredTargetPID)
+                      self.postReturnKey(
+                          postInsertionKey,
+                          targetPID: preferredTargetPID,
+                          resetKeyboardState: hasTextToInsert == false
+                      )
                 else {
                     outcome = hasTextToInsert ? .insertedActionSuppressed : .actionSuppressed
                     return
@@ -833,7 +856,15 @@ final class TypingService {
         return false
     }
 
-    private func postReturnKey(_ key: SettingsStore.SpokenSendKey, targetPID: pid_t) -> Bool {
+    /// - Parameter resetKeyboardState: only for the action-only path, where no text was
+    ///   inserted and the typing path's reset therefore never ran. After text *has* been typed
+    ///   the guest is already out of menu mode, and an Escape there would dismiss the control
+    ///   that is about to receive Return - cancelling an autocomplete, or reverting a field.
+    private func postReturnKey(
+        _ key: SettingsStore.SpokenSendKey,
+        targetPID: pid_t,
+        resetKeyboardState: Bool
+    ) -> Bool {
         let returnKeyCode = CGKeyCode(kVK_Return)
 
         // Remote-desktop clients do not act on `postToPid` keyboard events, so a Spoken Send
@@ -850,10 +881,9 @@ final class TypingService {
                 return false
             }
 
-            // Reached without any preceding insertion when the transcript was only the send
-            // phrase, in which case the typing path's reset never ran and the guest may still
-            // be in menu mode - where Return activates a menu item instead of submitting.
-            self.resyncRemoteDesktopKeyboardState()
+            if resetKeyboardState {
+                self.resyncRemoteDesktopKeyboardState()
+            }
             self.log("[TypingService] Spoken Send: posting \(key.displayName) chord via HID tap for remote-desktop target")
             self.postRemoteDesktopChord(chord)
             return true
@@ -1379,6 +1409,16 @@ final class TypingService {
     /// other hotkey an unconditional Escape would be a gratuitous keypress into the guest, where
     /// it can cancel a dialog or abandon an in-progress operation.
     private var remoteDesktopHotkeyCanEnterMenuMode: Bool {
+        // Prefer what was actually held when this dictation started. Asking whether *any*
+        // configured shortcut uses Option or Command would send Escape for a dictation begun
+        // with a mouse or a plain-key shortcut, where there is no menu to dismiss.
+        if let observed = Self.recordedDictationHotkeyModifiers() {
+            return observed.contains(.maskAlternate) || observed.contains(.maskCommand)
+        }
+
+        // Nothing recorded (a caller that does not go through the recording path). Fall back to
+        // the configured shortcuts, which is over-broad but keeps the first character from being
+        // eaten when a menu really was opened.
         let shortcuts = SettingsStore.shared.primaryDictationShortcuts
         guard shortcuts.isEmpty == false else { return true }
         return shortcuts.contains { shortcut in
@@ -1506,7 +1546,7 @@ final class TypingService {
 
             guard let chord = Self.makeRemoteDesktopChord(
                 modifierKeyCode: CGKeyCode(kVK_Control),
-                keyCode: Self.pasteVirtualKeyCode
+                keyCode: RemoteDesktopKeyMapResolver.ansiPasteKeyCode
             ) else {
                 self.log("[TypingService] ERROR: Failed to create remote-desktop paste chord")
                 return false

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -179,6 +179,9 @@ final class TypingService {
         )
     }
 
+    /// Pause between the modifier releases and the Escape that exits Windows menu mode.
+    static let remoteDesktopEscapeGapMicros: useconds_t = 150_000
+
     /// Modifier key codes explicitly released before typing into a remote session.
     private static let remoteDesktopResyncModifierKeyCodes: [CGKeyCode] = [
         CGKeyCode(kVK_Shift), CGKeyCode(kVK_RightShift),
@@ -1294,7 +1297,7 @@ final class TypingService {
         // independently. Until the guest processes the release it still believes the modifier is
         // held, so post an explicit release for every modifier and then wait before typing.
         // Without this the first character arrives as a modifier chord and is swallowed.
-        self.resyncRemoteDesktopModifiers()
+        self.resyncRemoteDesktopKeyboardState()
         let warmupMicros = Self.remoteDesktopWarmup
         if warmupMicros > 0 {
             self.log("[TypingService] Warming up remote keyboard channel for \(warmupMicros / 1000)ms")
@@ -1339,12 +1342,28 @@ final class TypingService {
         return .typed
     }
 
-    /// Posts a release for every modifier so the guest cannot be left believing one is held.
+    /// Puts the guest's keyboard back into a state where plain characters insert text.
     ///
-    /// A latched modifier in the guest is worse than a lost character: every subsequent letter
-    /// becomes a chord, and `Alt+<letter>` walks the focused application's menus rather than
-    /// inserting text.
-    private func resyncRemoteDesktopModifiers() {
+    /// Two things have to be undone, both caused by the dictation hotkey rather than by us:
+    ///
+    /// 1. A held modifier. The client forwards the hotkey modifier's press and release to the
+    ///    guest independently, so a lost release leaves the guest believing it is still down and
+    ///    every subsequent letter becomes a chord.
+    /// 2. Windows menu mode. This is the one that actually bites. An Option-based hotkey looks
+    ///    to the guest like a *bare Alt tap* - FluidVoice swallows the accompanying key as its
+    ///    hotkey, so the guest sees Alt down then Alt up with nothing between - and a bare Alt
+    ///    tap activates the focused window's menu bar. The transcript then navigates menus
+    ///    instead of typing: measured, `E` opens the Edit menu and the rest of the text is
+    ///    consumed. Escape exits menu mode.
+    ///
+    /// Escape rather than a second Alt tap on purpose. Both were measured to fix it, but an Alt
+    /// tap is a *toggle*: if menu mode were not active it would switch it on and cause exactly
+    /// the bug it is meant to prevent. Escape only ever exits, so it cannot create the bad
+    /// state. Waiting does not help - measured - because this is a mode, not latency.
+    ///
+    /// Escape is sent here as a deliberate reset, which is separate from the rule that Return
+    /// and Tab are never typed as transcript *content*.
+    private func resyncRemoteDesktopKeyboardState() {
         for keyCode in Self.remoteDesktopResyncModifierKeyCodes {
             guard let release = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
                 continue
@@ -1354,7 +1373,20 @@ final class TypingService {
             release.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
             release.post(tap: .cghidEventTap)
         }
-        self.log("[TypingService] Posted modifier resync before remote-desktop typing")
+
+        usleep(Self.remoteDesktopEscapeGapMicros)
+
+        if let escapeDown = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Escape), keyDown: true),
+           let escapeUp = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Escape), keyDown: false)
+        {
+            escapeDown.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
+            escapeUp.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
+            escapeDown.post(tap: .cghidEventTap)
+            usleep(10_000)
+            escapeUp.post(tap: .cghidEventTap)
+        }
+
+        self.log("[TypingService] Reset remote keyboard state (modifier releases + Escape)")
     }
 
     private func isRemoteDesktopTargetStillFrontmost(_ targetPID: pid_t) -> Bool {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -1255,13 +1255,19 @@ final class TypingService {
         return chord
     }
 
-    /// The modifier key code that produces `key`'s flags as a real chord, so a remote-desktop
-    /// client has a modifier scan code to forward. Returns nil for plain Return.
+    /// The modifier key code that produces `key`'s intent as a real chord in the *guest*, so a
+    /// remote-desktop client has a modifier scan code to forward. Returns nil for plain Return.
+    ///
+    /// Command is deliberately translated to Control rather than forwarded as-is. The client
+    /// forwards the Command position as the Windows key, so a literal Command+Enter arrives as
+    /// Win+Enter - which is an operating-system shortcut in Windows and never submits. Control
+    /// is the modifier that carries the same meaning in the guest, and is the mapping the client
+    /// itself applies for copy, cut and paste.
     nonisolated static func spokenSendModifierKeyCode(for key: SettingsStore.SpokenSendKey) -> CGKeyCode? {
         switch key {
         case .enter: nil
         case .shiftEnter: CGKeyCode(kVK_Shift)
-        case .commandEnter: CGKeyCode(kVK_Command)
+        case .commandEnter: CGKeyCode(kVK_Control)
         }
     }
 
@@ -1562,9 +1568,14 @@ final class TypingService {
                 return false
             }
 
+            guard let pasteKeyCode = RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode() else {
+                self.log("[TypingService] ERROR: No agreed position for the paste key; refusing to press an unknown key")
+                return false
+            }
+
             guard let chord = Self.makeRemoteDesktopChord(
                 modifierKeyCode: CGKeyCode(kVK_Control),
-                keyCode: RemoteDesktopKeyMapResolver.ansiPasteKeyCode
+                keyCode: pasteKeyCode
             ) else {
                 self.log("[TypingService] ERROR: Failed to create remote-desktop paste chord")
                 return false

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -264,8 +264,17 @@ final class TypingService {
         self.focusSnapshotQueue.sync { self.dictationHotkeyModifiers = flags }
     }
 
-    private static func recordedDictationHotkeyModifiers() -> CGEventFlags? {
-        self.focusSnapshotQueue.sync { self.dictationHotkeyModifiers }
+    /// Reads and clears the recorded modifiers.
+    ///
+    /// One-shot on purpose. The value describes a single dictation, and insertion paths that do
+    /// not record it - Paste Last Transcription, for one - would otherwise read whatever the
+    /// previous dictation left behind and decide the guest's menu state from stale input.
+    private static func consumeDictationHotkeyModifiers() -> CGEventFlags? {
+        self.focusSnapshotQueue.sync {
+            let flags = self.dictationHotkeyModifiers
+            self.dictationHotkeyModifiers = nil
+            return flags
+        }
     }
 
     static func captureSystemFocusTarget() -> CapturedFocusTarget? {
@@ -1294,7 +1303,7 @@ final class TypingService {
         targetPID: pid_t
     ) -> RemoteDesktopTypingOutcome {
         let normalized = RemoteDesktopKeyMapResolver.transliterate(text)
-        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
+        let map = RemoteDesktopKeyMapResolver.layoutSafeMap()
 
         let strokes: [RemoteDesktopKeyStroke]
         let capsLockActive = CGEventSource.flagsState(.combinedSessionState).contains(.maskAlphaShift)
@@ -1320,6 +1329,15 @@ final class TypingService {
             return .declined
         }
 
+
+        // The reset is itself a batch of global HID events, including possibly Escape, so the
+        // destination has to be confirmed before it is posted - otherwise a focus change between
+        // resolving the target and starting the run sends Escape to some other application and
+        // cancels whatever it had open. The per-chord checks below cover only the typing.
+        guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
+            self.log("[TypingService] ERROR: Target is not frontmost; skipping remote-desktop reset and typing")
+            return .declined
+        }
 
         // The hotkey that started this dictation is very often a modifier (the default is
         // modifier-only), and the client forwards that modifier's press and release to the guest
@@ -1412,13 +1430,13 @@ final class TypingService {
         // Prefer what was actually held when this dictation started. Asking whether *any*
         // configured shortcut uses Option or Command would send Escape for a dictation begun
         // with a mouse or a plain-key shortcut, where there is no menu to dismiss.
-        if let observed = Self.recordedDictationHotkeyModifiers() {
+        if let observed = Self.consumeDictationHotkeyModifiers() {
             return observed.contains(.maskAlternate) || observed.contains(.maskCommand)
         }
 
-        // Nothing recorded (a caller that does not go through the recording path). Fall back to
-        // the configured shortcuts, which is over-broad but keeps the first character from being
-        // eaten when a menu really was opened.
+        // Nothing recorded, or already consumed. Fall back to the configured shortcuts, which
+        // is over-broad but errs the safer way: failing to leave menu mode means the transcript
+        // navigates menus and can act on the guest, whereas an unnecessary Escape only cancels.
         let shortcuts = SettingsStore.shared.primaryDictationShortcuts
         guard shortcuts.isEmpty == false else { return true }
         return shortcuts.contains { shortcut in

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -147,6 +147,25 @@ final class TypingService {
         return useconds_t(clamped * 1000)
     }
 
+    static let remoteDesktopTypeDelayDefaultMs = 16
+    static let remoteDesktopTypeDelayMaximumMs = 200
+    static let remoteDesktopTypeDelayOverrideKey = "RemoteDesktopTypeDelayMs"
+
+    /// Pause after each character when typing into a remote-desktop session. The remote
+    /// keyboard channel drops characters if they arrive faster than it forwards them.
+    /// Overridable via the `RemoteDesktopTypeDelayMs` user default (no Settings UI).
+    nonisolated static func remoteDesktopTypeDelayMicros(override: NSNumber?) -> useconds_t {
+        let requested = override.map { Int($0.intValue) } ?? self.remoteDesktopTypeDelayDefaultMs
+        let clamped = min(max(0, requested), self.remoteDesktopTypeDelayMaximumMs)
+        return useconds_t(clamped * 1000)
+    }
+
+    private static var remoteDesktopTypeDelay: useconds_t {
+        self.remoteDesktopTypeDelayMicros(
+            override: UserDefaults.standard.object(forKey: self.remoteDesktopTypeDelayOverrideKey) as? NSNumber
+        )
+    }
+
     /// Overridable via the `RemoteDesktopClipboardSettleMs` user default (no Settings UI) so a
     /// slow link can be tuned without a rebuild.
     private static var remoteDesktopClipboardSettleMicros: useconds_t {
@@ -161,6 +180,8 @@ final class TypingService {
 
     // MARK: - Layout-aware key code lookup
 
+    private static let remoteDesktopKeyMapCache = RemoteDesktopKeyMapCache()
+
     private static let pasteKeyCache = PasteKeyCodeCache {
         let key = PasteKeyCodeResolver.current()
         DebugLogger.shared.benchmark("TYPING_BENCH", message: "paste_key_cache_refresh keyCode=\(key)", source: "TypingBenchmark")
@@ -170,6 +191,7 @@ final class TypingService {
     /// Called during application launch, before any paste requests can arrive.
     static func startKeyboardLayoutTracking() {
         self.pasteKeyCache.start()
+        self.remoteDesktopKeyMapCache.start()
     }
 
     /// The virtual key code for "v" in the current keyboard layout (used for Cmd+V paste).
@@ -634,12 +656,20 @@ final class TypingService {
         // `postToPid`, which these clients do not act on, with no settle time for the client to
         // ship the clipboard to the guest.
         if let remoteDesktopPID = self.remoteDesktopTargetPID(preferredTargetPID: preferredTargetPID) {
-            self.log("[TypingService] Remote desktop target detected (PID \(remoteDesktopPID)); using remote-desktop paste path")
+            self.log("[TypingService] Remote desktop target detected (PID \(remoteDesktopPID)); typing directly")
+            if self.insertTextViaRemoteDesktopTyping(text, targetPID: remoteDesktopPID) {
+                self.log("[TypingService] SUCCESS: Remote-desktop typing path completed")
+                return true
+            }
+
+            // Only reached when the transcript contains characters this layout cannot type.
+            // Paste is lossless but needs a focus bounce, so it is the fallback, not the default.
+            self.log("[TypingService] Falling back to remote-desktop clipboard paste")
             if self.insertTextViaRemoteDesktopPaste(text, targetPID: remoteDesktopPID) {
                 self.log("[TypingService] SUCCESS: Remote-desktop paste path completed")
                 return true
             }
-            self.log("[TypingService] Remote-desktop paste path failed; continuing fallback pipeline")
+            self.log("[TypingService] Remote-desktop paths failed; continuing fallback pipeline")
         }
 
         if self.textInsertionMode == .standard,
@@ -1140,7 +1170,7 @@ final class TypingService {
     }
 
     /// Posts a chord to the HID tap. These clients do not act on `postToPid` keyboard events.
-    private func postRemoteDesktopChord(_ chord: SyntheticChord) {
+    private func postRemoteDesktopChord(_ chord: SyntheticChord, keyGapMicros: useconds_t = 10_000) {
         // Release the modifier no matter how we leave this scope. A stuck synthetic modifier
         // shows up in `CGEventSource.flagsState(.combinedSessionState)` and would make the next
         // dictation's `waitForPhysicalModifiersToRelease` time out.
@@ -1148,8 +1178,97 @@ final class TypingService {
 
         chord.modifierDown?.post(tap: .cghidEventTap)
         chord.keyDown.post(tap: .cghidEventTap)
-        usleep(10_000)
+        usleep(keyGapMicros)
         chord.keyUp.post(tap: .cghidEventTap)
+    }
+
+    /// The key presses that spell `text`, or nil if any character has no key on this layout.
+    ///
+    /// All-or-nothing on purpose: a partially typed transcript is worse than none, so the
+    /// caller falls back rather than emitting a prefix.
+    nonisolated static func remoteDesktopKeyStrokes(
+        for text: String,
+        map: [Character: RemoteDesktopKeyStroke]
+    ) -> [RemoteDesktopKeyStroke]? {
+        var strokes: [RemoteDesktopKeyStroke] = []
+        strokes.reserveCapacity(text.count)
+        for character in text {
+            switch character {
+            case "\n", "\r":
+                strokes.append(RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Return), needsShift: false))
+            case "\t":
+                strokes.append(RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Tab), needsShift: false))
+            default:
+                guard let stroke = map[character] else { return nil }
+                strokes.append(stroke)
+            }
+        }
+        return strokes
+    }
+
+    /// Types `text` into a remote-desktop session as real key presses, never touching the
+    /// clipboard.
+    ///
+    /// This is the primary path for these targets because clipboard redirection is not usable:
+    /// the client only re-advertises its clipboard to the guest after a focus change, so a
+    /// programmatic pasteboard write followed by a paste makes the guest insert whatever it
+    /// last synced. Typing has no such dependency - the guest receives key positions directly.
+    ///
+    /// The cost is reach: the guest applies its own layout to those positions, and only
+    /// characters the local layout can produce with at most shift can be expressed at all.
+    /// Anything else returns false so the caller can fall back without losing characters.
+    private func insertTextViaRemoteDesktopTyping(_ text: String, targetPID: pid_t) -> Bool {
+        let normalized = RemoteDesktopKeyMapResolver.transliterate(text)
+        let map = Self.remoteDesktopKeyMapCache.snapshot()
+
+        guard map.isEmpty == false else {
+            self.log("[TypingService] ERROR: Remote-desktop key map unavailable; cannot type")
+            return false
+        }
+
+        guard let strokes = Self.remoteDesktopKeyStrokes(for: normalized, map: map) else {
+            let unmappable = RemoteDesktopKeyMapResolver.unmappableCharacters(in: normalized, map: map)
+            let described = unmappable
+                .map { "U+" + String($0.unicodeScalars.first?.value ?? 0, radix: 16, uppercase: true) }
+                .joined(separator: " ")
+            self.log("[TypingService] Remote-desktop typing skipped: \(unmappable.count) character(s) have no key on this layout (\(described))")
+            return false
+        }
+
+        // Posting a chord while the user still physically holds a modifier merges the two, and
+        // over a whole transcript that would corrupt every character.
+        guard self.waitForPhysicalModifiersToRelease(timeout: 2) else {
+            self.log("[TypingService] ERROR: Physical modifiers still held; skipping remote-desktop typing")
+            return false
+        }
+
+        guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID else {
+            self.log("[TypingService] ERROR: Target is no longer frontmost; skipping remote-desktop typing")
+            return false
+        }
+
+        // Built up front so a creation failure aborts before anything is typed.
+        var chords: [SyntheticChord] = []
+        chords.reserveCapacity(strokes.count)
+        for stroke in strokes {
+            guard let chord = Self.makeRemoteDesktopChord(
+                modifierKeyCode: stroke.needsShift ? CGKeyCode(kVK_Shift) : nil,
+                keyCode: stroke.keyCode
+            ) else {
+                self.log("[TypingService] ERROR: Failed to create remote-desktop typing events")
+                return false
+            }
+            chords.append(chord)
+        }
+
+        let perCharacterDelay = Self.remoteDesktopTypeDelay
+        self.log("[TypingService] Typing \(chords.count) character(s) via HID tap at \(perCharacterDelay / 1000)ms/char")
+        for chord in chords {
+            self.postRemoteDesktopChord(chord, keyGapMicros: 1500)
+            usleep(perCharacterDelay)
+        }
+        self.log("[TypingService] Remote-desktop typing completed")
+        return true
     }
 
     /// Clipboard paste for a remote-desktop session.
@@ -1188,6 +1307,23 @@ final class TypingService {
 
             guard self.waitForPhysicalModifiersToRelease(timeout: 0.5) else {
                 self.log("[TypingService] ERROR: Physical modifiers held after settle; skipping remote-desktop paste")
+                return false
+            }
+
+            // These clients only re-advertise their clipboard to the guest after a focus
+            // change, so without this the guest pastes whatever it last synced. Measured: a
+            // re-activation of the already-frontmost client is not enough; focus has to
+            // actually leave and come back, and it needs time to settle before the chord.
+            if let target = NSRunningApplication(processIdentifier: targetPID) {
+                NSRunningApplication.current.activate()
+                usleep(400_000)
+                target.activate(options: Self.focusRestoreActivationOptions)
+                usleep(1_500_000)
+                self.log("[TypingService] Bounced focus to force clipboard re-advertise")
+            }
+
+            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID else {
+                self.log("[TypingService] ERROR: Target not frontmost after focus bounce; skipping paste")
                 return false
             }
 

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -128,21 +128,23 @@ final class TypingService {
     /// Windows App, formerly Microsoft Remote Desktop. Both ship this bundle identifier.
     private static let remoteDesktopBundleIdentifier = "com.microsoft.rdc.macos"
 
-    static let remoteDesktopClipboardSettleDefaultMs = 600
+    static let remoteDesktopClipboardSettleDefaultMs = 200
     static let remoteDesktopClipboardSettleMaximumMs = 10_000
     static let remoteDesktopClipboardSettleOverrideKey = "RemoteDesktopClipboardSettleMs"
 
-    /// Delay between writing the pasteboard and posting the paste chord for a remote-desktop
-    /// target. These clients appear to *poll* `NSPasteboard.changeCount` (AppKit publishes no
-    /// change notification) and only advertise a clipboard Format List once they notice; the
-    /// guest then fetches the data at paste time (MS-RDPECLIP delayed rendering). FreeRDP's
-    /// macOS client polls at 500ms, so if Windows App is comparable this needs to exceed one
-    /// poll interval.
+    /// Grace period between writing the pasteboard and starting the focus bounce that makes
+    /// the client re-advertise its clipboard.
+    ///
+    /// Measured against a live session: no settle length alone is sufficient. Four pastes over
+    /// 43 seconds, across four distinct pasteboard writes 8 seconds apart, all delivered the
+    /// *first* value, with plain and transient items behaving identically and a 2.5s settle
+    /// changing nothing. The focus change is the mechanism, not elapsed time - so this is only
+    /// a short grace to let the write land before focus moves.
     ///
     /// Clamped, because the value is multiplied into a `useconds_t` and an unclamped user
     /// default would trap.
     nonisolated static func remoteDesktopSettleMicros(override: NSNumber?) -> useconds_t {
-        let requested = override.map { Int($0.intValue) } ?? self.remoteDesktopClipboardSettleDefaultMs
+        let requested = override.map(\.intValue) ?? self.remoteDesktopClipboardSettleDefaultMs
         let clamped = min(max(0, requested), self.remoteDesktopClipboardSettleMaximumMs)
         return useconds_t(clamped * 1000)
     }
@@ -150,12 +152,13 @@ final class TypingService {
     static let remoteDesktopTypeDelayDefaultMs = 16
     static let remoteDesktopTypeDelayMaximumMs = 200
     static let remoteDesktopTypeDelayOverrideKey = "RemoteDesktopTypeDelayMs"
+    static let remoteDesktopFocusRecheckInterval = 10
 
     /// Pause after each character when typing into a remote-desktop session. The remote
     /// keyboard channel drops characters if they arrive faster than it forwards them.
     /// Overridable via the `RemoteDesktopTypeDelayMs` user default (no Settings UI).
     nonisolated static func remoteDesktopTypeDelayMicros(override: NSNumber?) -> useconds_t {
-        let requested = override.map { Int($0.intValue) } ?? self.remoteDesktopTypeDelayDefaultMs
+        let requested = override.map(\.intValue) ?? self.remoteDesktopTypeDelayDefaultMs
         let clamped = min(max(0, requested), self.remoteDesktopTypeDelayMaximumMs)
         return useconds_t(clamped * 1000)
     }
@@ -401,22 +404,26 @@ final class TypingService {
     /// frontmost app: the chord is delivered by the window server to whatever holds key focus,
     /// so treating a frontmost remote-desktop window as the target while something else owns
     /// the focused element would paste into the wrong place.
+    /// `focusedPID` and `frontmostPID` are autoclosures because resolving the focused element
+    /// is a synchronous Accessibility round trip to another process. This runs on every
+    /// dictation into every app, so it must not be paid when the preferred PID already decides
+    /// the answer.
     nonisolated static func resolveRemoteDesktopPID(
         preferredTargetPID: pid_t?,
-        focusedPID: pid_t?,
-        frontmostPID: pid_t?,
+        focusedPID: @autoclosure () -> pid_t?,
+        frontmostPID: @autoclosure () -> pid_t?,
         isRemoteDesktop: (pid_t) -> Bool
     ) -> pid_t? {
         if let preferredTargetPID, preferredTargetPID > 0 {
             return isRemoteDesktop(preferredTargetPID) ? preferredTargetPID : nil
         }
 
-        if let focusedPID {
-            return isRemoteDesktop(focusedPID) ? focusedPID : nil
+        if let focused = focusedPID() {
+            return isRemoteDesktop(focused) ? focused : nil
         }
 
-        if let frontmostPID, isRemoteDesktop(frontmostPID) {
-            return frontmostPID
+        if let frontmost = frontmostPID(), isRemoteDesktop(frontmost) {
+            return frontmost
         }
 
         return nil
@@ -657,19 +664,30 @@ final class TypingService {
         // ship the clipboard to the guest.
         if let remoteDesktopPID = self.remoteDesktopTargetPID(preferredTargetPID: preferredTargetPID) {
             self.log("[TypingService] Remote desktop target detected (PID \(remoteDesktopPID)); typing directly")
-            if self.insertTextViaRemoteDesktopTyping(text, targetPID: remoteDesktopPID) {
+            switch self.insertTextViaRemoteDesktopTyping(text, targetPID: remoteDesktopPID) {
+            case .typed:
                 self.log("[TypingService] SUCCESS: Remote-desktop typing path completed")
                 return true
+
+            case .unmappable:
+                // Paste is lossless but needs a focus bounce, so it is only worth the
+                // disruption when the layout genuinely cannot express the transcript.
+                self.log("[TypingService] Falling back to remote-desktop clipboard paste")
+                if self.insertTextViaRemoteDesktopPaste(text, targetPID: remoteDesktopPID) {
+                    self.log("[TypingService] SUCCESS: Remote-desktop paste path completed")
+                    return true
+                }
+
+            case .declined:
+                break
             }
 
-            // Only reached when the transcript contains characters this layout cannot type.
-            // Paste is lossless but needs a focus bounce, so it is the fallback, not the default.
-            self.log("[TypingService] Falling back to remote-desktop clipboard paste")
-            if self.insertTextViaRemoteDesktopPaste(text, targetPID: remoteDesktopPID) {
-                self.log("[TypingService] SUCCESS: Remote-desktop paste path completed")
-                return true
-            }
-            self.log("[TypingService] Remote-desktop paths failed; continuing fallback pipeline")
+            // Deliberately not falling through to the generic cascade. Those paths post via
+            // `postToPid`, which this client ignores while still reporting success, and the
+            // clipboard ones would re-activate the target and hold the user's clipboard for
+            // five seconds to no effect.
+            self.log("[TypingService] Remote-desktop insertion failed; not attempting generic fallbacks")
+            return false
         }
 
         if self.textInsertionMode == .standard,
@@ -1182,28 +1200,14 @@ final class TypingService {
         chord.keyUp.post(tap: .cghidEventTap)
     }
 
-    /// The key presses that spell `text`, or nil if any character has no key on this layout.
-    ///
-    /// All-or-nothing on purpose: a partially typed transcript is worse than none, so the
-    /// caller falls back rather than emitting a prefix.
-    nonisolated static func remoteDesktopKeyStrokes(
-        for text: String,
-        map: [Character: RemoteDesktopKeyStroke]
-    ) -> [RemoteDesktopKeyStroke]? {
-        var strokes: [RemoteDesktopKeyStroke] = []
-        strokes.reserveCapacity(text.count)
-        for character in text {
-            switch character {
-            case "\n", "\r":
-                strokes.append(RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Return), needsShift: false))
-            case "\t":
-                strokes.append(RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Tab), needsShift: false))
-            default:
-                guard let stroke = map[character] else { return nil }
-                strokes.append(stroke)
-            }
-        }
-        return strokes
+    /// Why a remote-desktop typing attempt did not produce text.
+    enum RemoteDesktopTypingOutcome {
+        /// The transcript was typed in full.
+        case typed
+        /// The layout cannot express some characters; the lossless clipboard path is worth trying.
+        case unmappable
+        /// Something else prevented typing. Trying the clipboard path would not help.
+        case declined
     }
 
     /// Types `text` into a remote-desktop session as real key presses, never touching the
@@ -1216,38 +1220,46 @@ final class TypingService {
     ///
     /// The cost is reach: the guest applies its own layout to those positions, and only
     /// characters the local layout can produce with at most shift can be expressed at all.
-    /// Anything else returns false so the caller can fall back without losing characters.
-    private func insertTextViaRemoteDesktopTyping(_ text: String, targetPID: pid_t) -> Bool {
+    private func insertTextViaRemoteDesktopTyping(
+        _ text: String,
+        targetPID: pid_t
+    ) -> RemoteDesktopTypingOutcome {
         let normalized = RemoteDesktopKeyMapResolver.transliterate(text)
         let map = Self.remoteDesktopKeyMapCache.snapshot()
 
         guard map.isEmpty == false else {
             self.log("[TypingService] ERROR: Remote-desktop key map unavailable; cannot type")
-            return false
+            return .declined
         }
 
-        guard let strokes = Self.remoteDesktopKeyStrokes(for: normalized, map: map) else {
-            let unmappable = RemoteDesktopKeyMapResolver.unmappableCharacters(in: normalized, map: map)
-            let described = unmappable
+        let strokes: [RemoteDesktopKeyStroke]
+        switch RemoteDesktopKeyMapResolver.plan(for: normalized, map: map) {
+        case let .strokes(planned):
+            strokes = planned
+        case let .unmappable(characters):
+            let described = characters
                 .map { "U+" + String($0.unicodeScalars.first?.value ?? 0, radix: 16, uppercase: true) }
                 .joined(separator: " ")
-            self.log("[TypingService] Remote-desktop typing skipped: \(unmappable.count) character(s) have no key on this layout (\(described))")
-            return false
+            self.log("[TypingService] Remote-desktop typing skipped: \(characters.count) character(s) have no key on this layout (\(described))")
+            return .unmappable
         }
 
         // Posting a chord while the user still physically holds a modifier merges the two, and
         // over a whole transcript that would corrupt every character.
         guard self.waitForPhysicalModifiersToRelease(timeout: 2) else {
             self.log("[TypingService] ERROR: Physical modifiers still held; skipping remote-desktop typing")
-            return false
+            return .declined
         }
 
-        guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID else {
+        guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
             self.log("[TypingService] ERROR: Target is no longer frontmost; skipping remote-desktop typing")
-            return false
+            return .declined
         }
 
-        // Built up front so a creation failure aborts before anything is typed.
+        // Built up front for two reasons: a creation failure aborts before anything is typed,
+        // and a nil-source CGEvent captures the combined-session modifier flags at creation, so
+        // building them all now - after the modifier wait - guarantees every event carries clean
+        // flags rather than picking up a previous synthetic shift that is still in flight.
         var chords: [SyntheticChord] = []
         chords.reserveCapacity(strokes.count)
         for stroke in strokes {
@@ -1256,19 +1268,34 @@ final class TypingService {
                 keyCode: stroke.keyCode
             ) else {
                 self.log("[TypingService] ERROR: Failed to create remote-desktop typing events")
-                return false
+                return .declined
             }
             chords.append(chord)
         }
 
         let perCharacterDelay = Self.remoteDesktopTypeDelay
         self.log("[TypingService] Typing \(chords.count) character(s) via HID tap at \(perCharacterDelay / 1000)ms/char")
-        for chord in chords {
+
+        for (index, chord) in chords.enumerated() {
+            // HID events go to whatever holds key focus, and a long transcript takes seconds.
+            // Without re-checking, clicking away mid-run sprays the remainder into another app -
+            // including Return presses that would confirm whatever dialog is focused there.
+            if index > 0, index % Self.remoteDesktopFocusRecheckInterval == 0,
+               self.isRemoteDesktopTargetStillFrontmost(targetPID) == false
+            {
+                self.log("[TypingService] ERROR: Target lost focus after \(index) character(s); stopping")
+                return .declined
+            }
             self.postRemoteDesktopChord(chord, keyGapMicros: 1500)
             usleep(perCharacterDelay)
         }
+
         self.log("[TypingService] Remote-desktop typing completed")
-        return true
+        return .typed
+    }
+
+    private func isRemoteDesktopTargetStillFrontmost(_ targetPID: pid_t) -> Bool {
+        NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID
     }
 
     /// Clipboard paste for a remote-desktop session.
@@ -1292,38 +1319,47 @@ final class TypingService {
             return false
         }
 
+        // Checked before the pasteboard is written so a doomed attempt does not churn the
+        // user's clipboard.
+        guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
+            self.log("[TypingService] ERROR: Target is not frontmost; skipping remote-desktop paste")
+            return false
+        }
+
+        guard let target = NSRunningApplication(processIdentifier: targetPID) else {
+            self.log("[TypingService] ERROR: Remote-desktop target no longer running")
+            return false
+        }
+
         return self.withTemporaryPasteboardString(text, restoreDelayMicros: 5_000_000) {
-            let settleMicros = Self.remoteDesktopClipboardSettleMicros
-            usleep(settleMicros)
-
-            // The chord is delivered by the window server to whatever holds key focus, not to
-            // `targetPID`, and the settle delay opens a window in which the user can switch
-            // apps. Re-check both the target and the modifier state, which the pre-write check
-            // has now left stale, rather than pasting into the wrong app.
-            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID else {
-                self.log("[TypingService] ERROR: Frontmost app changed during settle; skipping remote-desktop paste")
-                return false
-            }
-
-            guard self.waitForPhysicalModifiersToRelease(timeout: 0.5) else {
-                self.log("[TypingService] ERROR: Physical modifiers held after settle; skipping remote-desktop paste")
-                return false
-            }
+            usleep(Self.remoteDesktopClipboardSettleMicros)
 
             // These clients only re-advertise their clipboard to the guest after a focus
             // change, so without this the guest pastes whatever it last synced. Measured: a
             // re-activation of the already-frontmost client is not enough; focus has to
-            // actually leave and come back, and it needs time to settle before the chord.
-            if let target = NSRunningApplication(processIdentifier: targetPID) {
-                NSRunningApplication.current.activate()
-                usleep(400_000)
-                target.activate(options: Self.focusRestoreActivationOptions)
-                usleep(1_500_000)
-                self.log("[TypingService] Bounced focus to force clipboard re-advertise")
+            // actually leave and come back, and it needs over a second to settle.
+            NSRunningApplication.current.activate(options: Self.focusRestoreActivationOptions)
+            usleep(400_000)
+
+            // If focus never actually left, the client has not re-advertised anything and the
+            // chord would paste whatever the guest last synced - someone else's clipboard
+            // content, into their session. Refuse rather than paste the wrong text.
+            guard self.isRemoteDesktopTargetStillFrontmost(targetPID) == false else {
+                self.log("[TypingService] ERROR: Focus never left the target; refusing to paste possibly stale content")
+                return false
             }
 
-            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID else {
+            target.activate(options: Self.focusRestoreActivationOptions)
+            usleep(1_500_000)
+            self.log("[TypingService] Bounced focus to force clipboard re-advertise")
+
+            guard self.isRemoteDesktopTargetStillFrontmost(targetPID) else {
                 self.log("[TypingService] ERROR: Target not frontmost after focus bounce; skipping paste")
+                return false
+            }
+
+            guard self.waitForPhysicalModifiersToRelease(timeout: 0.5) else {
+                self.log("[TypingService] ERROR: Physical modifiers held after bounce; skipping remote-desktop paste")
                 return false
             }
 
@@ -1335,7 +1371,7 @@ final class TypingService {
                 return false
             }
 
-            self.log("[TypingService] Posting Ctrl+V chord via HID tap after \(settleMicros / 1000)ms settle")
+            self.log("[TypingService] Posting Ctrl+V chord via HID tap")
             self.postRemoteDesktopChord(chord)
             return true
         }

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -154,6 +154,39 @@ final class TypingService {
     static let remoteDesktopTypeDelayOverrideKey = "RemoteDesktopTypeDelayMs"
     static let remoteDesktopFocusRecheckInterval = 10
 
+    static let remoteDesktopWarmupDefaultMs = 250
+    static let remoteDesktopWarmupMaximumMs = 3000
+    static let remoteDesktopWarmupOverrideKey = "RemoteDesktopWarmupMs"
+
+    /// Pause between releasing the hotkey's modifiers and the first typed character.
+    ///
+    /// `waitForPhysicalModifiersToRelease` only observes the *local* flag state. The client
+    /// still has to forward the modifier release across the remote keyboard channel, and until
+    /// the guest processes it the guest believes the modifier is held - so the first character
+    /// arrives as a modifier chord (`Alt+a` is a menu accelerator, which inserts nothing) and is
+    /// lost. This is the dropped-leading-character behaviour reported in discussion #563.
+    ///
+    /// Overridable via the `RemoteDesktopWarmupMs` user default (no Settings UI).
+    nonisolated static func remoteDesktopWarmupMicros(override: NSNumber?) -> useconds_t {
+        let requested = override.map(\.intValue) ?? self.remoteDesktopWarmupDefaultMs
+        let clamped = min(max(0, requested), self.remoteDesktopWarmupMaximumMs)
+        return useconds_t(clamped * 1000)
+    }
+
+    private static var remoteDesktopWarmup: useconds_t {
+        self.remoteDesktopWarmupMicros(
+            override: UserDefaults.standard.object(forKey: self.remoteDesktopWarmupOverrideKey) as? NSNumber
+        )
+    }
+
+    /// Modifier key codes explicitly released before typing into a remote session.
+    private static let remoteDesktopResyncModifierKeyCodes: [CGKeyCode] = [
+        CGKeyCode(kVK_Shift), CGKeyCode(kVK_RightShift),
+        CGKeyCode(kVK_Control), CGKeyCode(kVK_RightControl),
+        CGKeyCode(kVK_Option), CGKeyCode(kVK_RightOption),
+        CGKeyCode(kVK_Command), CGKeyCode(kVK_RightCommand),
+    ]
+
     /// Pause after each character when typing into a remote-desktop session. The remote
     /// keyboard channel drops characters if they arrive faster than it forwards them.
     /// Overridable via the `RemoteDesktopTypeDelayMs` user default (no Settings UI).
@@ -1256,6 +1289,18 @@ final class TypingService {
             return .declined
         }
 
+        // The hotkey that started this dictation is very often a modifier (the default is
+        // modifier-only), and the client forwards that modifier's press and release to the guest
+        // independently. Until the guest processes the release it still believes the modifier is
+        // held, so post an explicit release for every modifier and then wait before typing.
+        // Without this the first character arrives as a modifier chord and is swallowed.
+        self.resyncRemoteDesktopModifiers()
+        let warmupMicros = Self.remoteDesktopWarmup
+        if warmupMicros > 0 {
+            self.log("[TypingService] Warming up remote keyboard channel for \(warmupMicros / 1000)ms")
+            usleep(warmupMicros)
+        }
+
         // Built up front for two reasons: a creation failure aborts before anything is typed,
         // and a nil-source CGEvent captures the combined-session modifier flags at creation, so
         // building them all now - after the modifier wait - guarantees every event carries clean
@@ -1292,6 +1337,24 @@ final class TypingService {
 
         self.log("[TypingService] Remote-desktop typing completed")
         return .typed
+    }
+
+    /// Posts a release for every modifier so the guest cannot be left believing one is held.
+    ///
+    /// A latched modifier in the guest is worse than a lost character: every subsequent letter
+    /// becomes a chord, and `Alt+<letter>` walks the focused application's menus rather than
+    /// inserting text.
+    private func resyncRemoteDesktopModifiers() {
+        for keyCode in Self.remoteDesktopResyncModifierKeyCodes {
+            guard let release = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
+                continue
+            }
+            // Created as a `flagsChanged` already; only the tag is added so FluidVoice's own
+            // event tap ignores it.
+            release.setIntegerValueField(.eventSourceUserData, value: Self.synthesizedEventUserData)
+            release.post(tap: .cghidEventTap)
+        }
+        self.log("[TypingService] Posted modifier resync before remote-desktop typing")
     }
 
     private func isRemoteDesktopTargetStillFrontmost(_ targetPID: pid_t) -> Bool {

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -225,15 +225,33 @@ final class TypingService {
 
     // MARK: - Layout-aware key code lookup
 
-    private static let pasteKeyCache = PasteKeyCodeCache {
+    private static let pasteKeyCache = KeyboardLayoutSnapshotCache(initialValue: CGKeyCode(9)) {
         let key = PasteKeyCodeResolver.current()
         DebugLogger.shared.benchmark("TYPING_BENCH", message: "paste_key_cache_refresh keyCode=\(key)", source: "TypingBenchmark")
         return key
     }
 
+    /// The characters that can be typed into a remote-desktop session on the active layout.
+    ///
+    /// Snapshotted for the same reason as the paste key code, but the consequence of getting it
+    /// wrong is worse: the remote-desktop typing path runs on a background queue, and resolving
+    /// this inline there reads the input source off the main thread, which can trap inside
+    /// HIToolbox and kill the app mid-dictation.
+    ///
+    /// Starts empty so that a cache which never started declines to type rather than typing from
+    /// a layout it has not actually read.
+    private static let remoteDesktopLayoutCache = KeyboardLayoutSnapshotCache(
+        initialValue: [Character: RemoteDesktopKeyStroke]()
+    ) {
+        let map = RemoteDesktopKeyMapResolver.currentLayoutSafeMap()
+        DebugLogger.shared.benchmark("TYPING_BENCH", message: "remote_layout_cache_refresh characters=\(map.count)", source: "TypingBenchmark")
+        return map
+    }
+
     /// Called during application launch, before any paste requests can arrive.
     static func startKeyboardLayoutTracking() {
         self.pasteKeyCache.start()
+        self.remoteDesktopLayoutCache.start()
     }
 
     /// The virtual key code for "v" in the current keyboard layout (used for Cmd+V paste).
@@ -1309,7 +1327,12 @@ final class TypingService {
         targetPID: pid_t
     ) -> RemoteDesktopTypingOutcome {
         let normalized = RemoteDesktopKeyMapResolver.transliterate(text)
-        let map = RemoteDesktopKeyMapResolver.layoutSafeMap()
+        // Snapshot, never a live lookup: this runs on a background queue and reading the input
+        // source from here can trap inside HIToolbox.
+        let map = Self.remoteDesktopLayoutCache.snapshot()
+        if map.isEmpty {
+            self.log("[TypingService] ERROR: Layout snapshot is empty - nothing can be typed or pasted into this session. Either layout tracking never started, or the local layout shares no positions with ANSI.")
+        }
 
         let strokes: [RemoteDesktopKeyStroke]
         let capsLockActive = CGEventSource.flagsState(.combinedSessionState).contains(.maskAlphaShift)
@@ -1568,7 +1591,9 @@ final class TypingService {
                 return false
             }
 
-            guard let pasteKeyCode = RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode() else {
+            guard let pasteKeyCode = RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(
+                map: Self.remoteDesktopLayoutCache.snapshot()
+            ) else {
                 self.log("[TypingService] ERROR: No agreed position for the paste key; refusing to press an unknown key")
                 return false
             }

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -241,11 +241,15 @@ final class TypingService {
     /// Starts empty so that a cache which never started declines to type rather than typing from
     /// a layout it has not actually read.
     private static let remoteDesktopLayoutCache = KeyboardLayoutSnapshotCache(
-        initialValue: [Character: RemoteDesktopKeyStroke]()
+        initialValue: RemoteDesktopKeyMapResolver.Snapshot()
     ) {
-        let map = RemoteDesktopKeyMapResolver.currentLayoutSafeMap()
-        DebugLogger.shared.benchmark("TYPING_BENCH", message: "remote_layout_cache_refresh characters=\(map.count)", source: "TypingBenchmark")
-        return map
+        let snapshot = RemoteDesktopKeyMapResolver.currentSnapshot()
+        DebugLogger.shared.benchmark(
+            "TYPING_BENCH",
+            message: "remote_layout_cache_refresh characters=\(snapshot.typable.count) pasteKey=\(snapshot.pasteKeyCode.map(String.init) ?? "none")",
+            source: "TypingBenchmark"
+        )
+        return snapshot
     }
 
     /// Called during application launch, before any paste requests can arrive.
@@ -1329,9 +1333,9 @@ final class TypingService {
         let normalized = RemoteDesktopKeyMapResolver.transliterate(text)
         // Snapshot, never a live lookup: this runs on a background queue and reading the input
         // source from here can trap inside HIToolbox.
-        let map = Self.remoteDesktopLayoutCache.snapshot()
+        let map = Self.remoteDesktopLayoutCache.snapshot().typable
         if map.isEmpty {
-            self.log("[TypingService] ERROR: Layout snapshot is empty - nothing can be typed or pasted into this session. Either layout tracking never started, or the local layout shares no positions with ANSI.")
+            self.log("[TypingService] Layout offers no directly typable characters; the paste fallback will carry this transcript")
         }
 
         let strokes: [RemoteDesktopKeyStroke]
@@ -1541,6 +1545,15 @@ final class TypingService {
             return false
         }
 
+        // Resolved before anything below has an effect. This used to be checked after the
+        // pasteboard had been written and focus had been bounced away for two seconds, so a
+        // layout with no usable paste position churned the user's clipboard and stole focus
+        // and then inserted nothing at all.
+        guard let pasteKeyCode = Self.remoteDesktopLayoutCache.snapshot().pasteKeyCode else {
+            self.log("[TypingService] ERROR: No trustworthy position for the paste key on this layout; refusing to press an unknown key")
+            return false
+        }
+
         // The bounce below deliberately takes focus away for roughly two seconds. A PID alone
         // cannot tell one window or session of the same client from another, so capture the
         // focused element itself and require the *same* element afterwards.
@@ -1588,13 +1601,6 @@ final class TypingService {
 
             guard self.waitForPhysicalModifiersToRelease(timeout: 0.5) else {
                 self.log("[TypingService] ERROR: Physical modifiers held after bounce; skipping remote-desktop paste")
-                return false
-            }
-
-            guard let pasteKeyCode = RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(
-                map: Self.remoteDesktopLayoutCache.snapshot()
-            ) else {
-                self.log("[TypingService] ERROR: No agreed position for the paste key; refusing to press an unknown key")
                 return false
             }
 

--- a/Sources/Fluid/Services/TypingService.swift
+++ b/Sources/Fluid/Services/TypingService.swift
@@ -125,6 +125,36 @@ final class TypingService {
     private static var focusSnapshot: FocusSnapshot?
     private static let ghosttyBundleIdentifier = "com.mitchellh.ghostty"
 
+    /// Windows App, formerly Microsoft Remote Desktop. Both ship this bundle identifier.
+    private static let remoteDesktopBundleIdentifier = "com.microsoft.rdc.macos"
+
+    static let remoteDesktopClipboardSettleDefaultMs = 600
+    static let remoteDesktopClipboardSettleMaximumMs = 10_000
+    static let remoteDesktopClipboardSettleOverrideKey = "RemoteDesktopClipboardSettleMs"
+
+    /// Delay between writing the pasteboard and posting the paste chord for a remote-desktop
+    /// target. These clients appear to *poll* `NSPasteboard.changeCount` (AppKit publishes no
+    /// change notification) and only advertise a clipboard Format List once they notice; the
+    /// guest then fetches the data at paste time (MS-RDPECLIP delayed rendering). FreeRDP's
+    /// macOS client polls at 500ms, so if Windows App is comparable this needs to exceed one
+    /// poll interval.
+    ///
+    /// Clamped, because the value is multiplied into a `useconds_t` and an unclamped user
+    /// default would trap.
+    nonisolated static func remoteDesktopSettleMicros(override: NSNumber?) -> useconds_t {
+        let requested = override.map { Int($0.intValue) } ?? self.remoteDesktopClipboardSettleDefaultMs
+        let clamped = min(max(0, requested), self.remoteDesktopClipboardSettleMaximumMs)
+        return useconds_t(clamped * 1000)
+    }
+
+    /// Overridable via the `RemoteDesktopClipboardSettleMs` user default (no Settings UI) so a
+    /// slow link can be tuned without a rebuild.
+    private static var remoteDesktopClipboardSettleMicros: useconds_t {
+        self.remoteDesktopSettleMicros(
+            override: UserDefaults.standard.object(forKey: self.remoteDesktopClipboardSettleOverrideKey) as? NSNumber
+        )
+    }
+
     private var textInsertionMode: SettingsStore.TextInsertionMode {
         SettingsStore.shared.textInsertionMode
     }
@@ -331,6 +361,52 @@ final class TypingService {
         }
 
         return nil
+    }
+
+    private func isRemoteDesktopApplication(pid: pid_t) -> Bool {
+        guard pid > 0,
+              let app = NSRunningApplication(processIdentifier: pid)
+        else {
+            return false
+        }
+
+        return app.bundleIdentifier == Self.remoteDesktopBundleIdentifier
+    }
+
+    /// Resolution order, extracted so it can be tested without a running app.
+    ///
+    /// Unlike ``ghosttyTargetPID`` this does not fall through from a known focused PID to the
+    /// frontmost app: the chord is delivered by the window server to whatever holds key focus,
+    /// so treating a frontmost remote-desktop window as the target while something else owns
+    /// the focused element would paste into the wrong place.
+    nonisolated static func resolveRemoteDesktopPID(
+        preferredTargetPID: pid_t?,
+        focusedPID: pid_t?,
+        frontmostPID: pid_t?,
+        isRemoteDesktop: (pid_t) -> Bool
+    ) -> pid_t? {
+        if let preferredTargetPID, preferredTargetPID > 0 {
+            return isRemoteDesktop(preferredTargetPID) ? preferredTargetPID : nil
+        }
+
+        if let focusedPID {
+            return isRemoteDesktop(focusedPID) ? focusedPID : nil
+        }
+
+        if let frontmostPID, isRemoteDesktop(frontmostPID) {
+            return frontmostPID
+        }
+
+        return nil
+    }
+
+    private func remoteDesktopTargetPID(preferredTargetPID: pid_t?) -> pid_t? {
+        Self.resolveRemoteDesktopPID(
+            preferredTargetPID: preferredTargetPID,
+            focusedPID: self.getSystemFocusedElementAndPID()?.pid,
+            frontmostPID: NSWorkspace.shared.frontmostApplication?.processIdentifier,
+            isRemoteDesktop: { self.isRemoteDesktopApplication(pid: $0) }
+        )
     }
 
     /// Activation options used to restore focus to the external target app after dictation.
@@ -552,6 +628,20 @@ final class TypingService {
         self.log("[TypingService] insertTextInstantly called with \(text.count) characters")
         self.log("[TypingService] Attempting to type text: \"\(text.prefix(50))\(text.count > 50 ? "..." : "")\"")
 
+        // Remote-desktop sessions come first and apply in both insertion modes, because both
+        // of the normal paths fail there: the unicode path posts `virtualKey: 0` events that a
+        // client translating scan codes cannot forward, and the clipboard path posts Cmd+V via
+        // `postToPid`, which these clients do not act on, with no settle time for the client to
+        // ship the clipboard to the guest.
+        if let remoteDesktopPID = self.remoteDesktopTargetPID(preferredTargetPID: preferredTargetPID) {
+            self.log("[TypingService] Remote desktop target detected (PID \(remoteDesktopPID)); using remote-desktop paste path")
+            if self.insertTextViaRemoteDesktopPaste(text, targetPID: remoteDesktopPID) {
+                self.log("[TypingService] SUCCESS: Remote-desktop paste path completed")
+                return true
+            }
+            self.log("[TypingService] Remote-desktop paste path failed; continuing fallback pipeline")
+        }
+
         if self.textInsertionMode == .standard,
            let ghosttyTargetPID = self.ghosttyTargetPID(preferredTargetPID: preferredTargetPID)
         {
@@ -662,6 +752,26 @@ final class TypingService {
 
     private func postReturnKey(_ key: SettingsStore.SpokenSendKey, targetPID: pid_t) -> Bool {
         let returnKeyCode = CGKeyCode(kVK_Return)
+
+        // Remote-desktop clients do not act on `postToPid` keyboard events, so a Spoken Send
+        // Return would otherwise be dropped while the UI reported it as sent. Build it as a
+        // real chord: assigning `key.eventFlags` would give Shift+Enter and Command+Enter no
+        // modifier scan code to forward, and a Shift+Enter that arrives as a bare Enter sends
+        // a message the user meant to add a newline to.
+        if self.isRemoteDesktopApplication(pid: targetPID) {
+            guard let chord = Self.makeRemoteDesktopChord(
+                modifierKeyCode: Self.spokenSendModifierKeyCode(for: key),
+                keyCode: returnKeyCode
+            ) else {
+                self.log("[TypingService] ERROR: Failed to create remote-desktop \(key.displayName) chord")
+                return false
+            }
+
+            self.log("[TypingService] Spoken Send: posting \(key.displayName) chord via HID tap for remote-desktop target")
+            self.postRemoteDesktopChord(chord)
+            return true
+        }
+
         guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true),
               let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
         else {
@@ -939,6 +1049,158 @@ final class TypingService {
                     "totalMs=\((keyUpFinishedAt - dispatchStartedAt) * 1000)"
             )
             self.log("[TypingService] Cmd+V posted to PID \(targetPID)")
+            return true
+        }
+    }
+
+    // MARK: - Remote desktop targets (Windows App / Microsoft Remote Desktop)
+
+    /// A synthetic chord: an optional modifier held across one key press.
+    struct SyntheticChord {
+        let modifierDown: CGEvent?
+        let keyDown: CGEvent
+        let keyUp: CGEvent
+        let modifierUp: CGEvent?
+
+        var ordered: [CGEvent] {
+            [self.modifierDown, self.keyDown, self.keyUp, self.modifierUp].compactMap { $0 }
+        }
+    }
+
+    /// Builds a chord for a remote-desktop target.
+    ///
+    /// Three details matter, and all three differ from the other paste paths in this file:
+    ///
+    /// 1. The chord includes the modifier's *own* key events. A client in Scancode mode
+    ///    forwards key positions to the guest, so it has to see the modifier go down and up -
+    ///    a key event that merely carries `.maskControl` gives it nothing to forward, which
+    ///    matches the long-reported "pasting into RDP types the letter V" behaviour.
+    /// 2. The modifier events are used exactly as created. `CGEvent(keyboardEventSource:
+    ///    virtualKey:keyDown:)` already returns a `.flagsChanged` event for a modifier key
+    ///    code, carrying the modifier flag, the device-side bit identifying which physical key
+    ///    it is, and `.maskNonCoalesced`. Assigning `type` is a no-op and assigning `flags`
+    ///    discards those bits, so we do neither - the held-modifier flags are copied off the
+    ///    modifier event and *inserted* into the key events, reproducing what hardware sends
+    ///    while a modifier is held.
+    /// 3. Every event is tagged with ``synthesizedEventUserData``. FluidVoice's own event tap
+    ///    listens for `flagsChanged` (`GlobalHotkeyManager.keyboardEventMask()`) and only lets
+    ///    tagged events through untouched, so without the tag a modifier-only dictation
+    ///    shortcut would read our synthetic modifier press as its own hotkey and start a
+    ///    phantom recording on every dictation.
+    nonisolated static func makeRemoteDesktopChord(
+        modifierKeyCode: CGKeyCode?,
+        keyCode: CGKeyCode
+    ) -> SyntheticChord? {
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false)
+        else {
+            return nil
+        }
+
+        var modifierDown: CGEvent?
+        var modifierUp: CGEvent?
+
+        if let modifierKeyCode {
+            guard let down = CGEvent(keyboardEventSource: nil, virtualKey: modifierKeyCode, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: nil, virtualKey: modifierKeyCode, keyDown: false)
+            else {
+                return nil
+            }
+
+            // Copied off the modifier event rather than hard-coded: CoreGraphics has already
+            // put both the modifier flag and the correct device-side bit there, including for
+            // right-hand modifier key codes.
+            keyDown.flags.insert(down.flags)
+            keyUp.flags.insert(down.flags)
+
+            modifierDown = down
+            modifierUp = up
+        }
+
+        let chord = SyntheticChord(
+            modifierDown: modifierDown,
+            keyDown: keyDown,
+            keyUp: keyUp,
+            modifierUp: modifierUp
+        )
+        for event in chord.ordered {
+            event.setIntegerValueField(.eventSourceUserData, value: self.synthesizedEventUserData)
+        }
+        return chord
+    }
+
+    /// The modifier key code that produces `key`'s flags as a real chord, so a remote-desktop
+    /// client has a modifier scan code to forward. Returns nil for plain Return.
+    nonisolated static func spokenSendModifierKeyCode(for key: SettingsStore.SpokenSendKey) -> CGKeyCode? {
+        switch key {
+        case .enter: nil
+        case .shiftEnter: CGKeyCode(kVK_Shift)
+        case .commandEnter: CGKeyCode(kVK_Command)
+        }
+    }
+
+    /// Posts a chord to the HID tap. These clients do not act on `postToPid` keyboard events.
+    private func postRemoteDesktopChord(_ chord: SyntheticChord) {
+        // Release the modifier no matter how we leave this scope. A stuck synthetic modifier
+        // shows up in `CGEventSource.flagsState(.combinedSessionState)` and would make the next
+        // dictation's `waitForPhysicalModifiersToRelease` time out.
+        defer { chord.modifierUp?.post(tap: .cghidEventTap) }
+
+        chord.modifierDown?.post(tap: .cghidEventTap)
+        chord.keyDown.post(tap: .cghidEventTap)
+        usleep(10_000)
+        chord.keyUp.post(tap: .cghidEventTap)
+    }
+
+    /// Clipboard paste for a remote-desktop session.
+    ///
+    /// Differs from ``insertTextViaClipboardToPid`` in the three ways that make it work here:
+    /// the chord goes to the HID tap rather than `postToPid`, it is a complete Ctrl+V chord
+    /// rather than a flag-carrying `v`, and it waits for the client to notice the pasteboard
+    /// before firing.
+    ///
+    /// Ctrl+V rather than Cmd+V on purpose: Cmd+V depends on the client's "Use Mac shortcuts
+    /// for copy, cut, paste" setting being on, and if the chord ever lands on the client's own
+    /// local UI instead of the session canvas, Ctrl+V is a harmless no-op there whereas Cmd+V
+    /// would paste into it.
+    private func insertTextViaRemoteDesktopPaste(_ text: String, targetPID: pid_t) -> Bool {
+        self.log("[TypingService] Starting remote-desktop paste insertion to PID \(targetPID)")
+
+        // Posting a modifier chord while the user still physically holds a modifier merges the
+        // two into a different chord, so refuse rather than send something wrong.
+        guard self.waitForPhysicalModifiersToRelease(timeout: 2) else {
+            self.log("[TypingService] ERROR: Physical modifiers still held; skipping remote-desktop paste")
+            return false
+        }
+
+        return self.withTemporaryPasteboardString(text, restoreDelayMicros: 5_000_000) {
+            let settleMicros = Self.remoteDesktopClipboardSettleMicros
+            usleep(settleMicros)
+
+            // The chord is delivered by the window server to whatever holds key focus, not to
+            // `targetPID`, and the settle delay opens a window in which the user can switch
+            // apps. Re-check both the target and the modifier state, which the pre-write check
+            // has now left stale, rather than pasting into the wrong app.
+            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID else {
+                self.log("[TypingService] ERROR: Frontmost app changed during settle; skipping remote-desktop paste")
+                return false
+            }
+
+            guard self.waitForPhysicalModifiersToRelease(timeout: 0.5) else {
+                self.log("[TypingService] ERROR: Physical modifiers held after settle; skipping remote-desktop paste")
+                return false
+            }
+
+            guard let chord = Self.makeRemoteDesktopChord(
+                modifierKeyCode: CGKeyCode(kVK_Control),
+                keyCode: Self.pasteVirtualKeyCode
+            ) else {
+                self.log("[TypingService] ERROR: Failed to create remote-desktop paste chord")
+                return false
+            }
+
+            self.log("[TypingService] Posting Ctrl+V chord via HID tap after \(settleMicros / 1000)ms settle")
+            self.postRemoteDesktopChord(chord)
             return true
         }
     }

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopPasteTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopPasteTests.swift
@@ -1,0 +1,281 @@
+import Carbon.HIToolbox
+import CoreGraphics
+@testable import FluidVoice_Debug
+import XCTest
+
+/// Covers the remote-desktop (Windows App / Microsoft Remote Desktop) insertion path.
+///
+/// The assertions deliberately avoid absolute flag patterns and cross-call reference events:
+/// `CGEvent(keyboardEventSource: nil, ...)` derives part of its flags from ambient session
+/// modifier state and from event coalescing, so anything pinned to a literal bit pattern fails
+/// for reasons unrelated to the code under test. Everything here is either a bit this code sets
+/// itself or a comparison within a single chord.
+final class RemoteDesktopPasteTests: XCTestCase {
+    private let pasteKeyCode: CGKeyCode = 9
+
+    private func makeControlChord() throws -> TypingService.SyntheticChord {
+        try XCTUnwrap(
+            TypingService.makeRemoteDesktopChord(
+                modifierKeyCode: CGKeyCode(kVK_Control),
+                keyCode: self.pasteKeyCode
+            ),
+            "Chord construction must succeed in a plain unit-test process"
+        )
+    }
+
+    private func keyCode(_ event: CGEvent) -> Int64 {
+        event.getIntegerValueField(.keyboardEventKeycode)
+    }
+
+    // MARK: - Shape
+
+    func testControlChordIsModifierDownKeyDownKeyUpModifierUp() throws {
+        let chord = try self.makeControlChord()
+
+        XCTAssertEqual(chord.ordered.count, 4)
+        XCTAssertEqual(
+            chord.ordered.map(\.type),
+            [.flagsChanged, .keyDown, .keyUp, .flagsChanged],
+            "The modifier must arrive as flagsChanged either side of the key events"
+        )
+        XCTAssertEqual(
+            chord.ordered.map(self.keyCode),
+            [Int64(kVK_Control), Int64(self.pasteKeyCode), Int64(self.pasteKeyCode), Int64(kVK_Control)],
+            "A client translating scan codes needs the modifier key code preserved, not discarded"
+        )
+    }
+
+    func testChordWithoutModifierIsJustTheKeyPress() throws {
+        let chord = try XCTUnwrap(
+            TypingService.makeRemoteDesktopChord(modifierKeyCode: nil, keyCode: CGKeyCode(kVK_Return))
+        )
+
+        XCTAssertNil(chord.modifierDown)
+        XCTAssertNil(chord.modifierUp)
+        XCTAssertEqual(chord.ordered.count, 2)
+        XCTAssertEqual(chord.ordered.map(\.type), [.keyDown, .keyUp])
+        XCTAssertEqual(chord.ordered.map(self.keyCode), [Int64(kVK_Return), Int64(kVK_Return)])
+    }
+
+    func testModifierEventsAreCreatedAsFlagsChangedWithoutMutatingType() throws {
+        // Documents why the implementation never assigns `type`: CGEvent already does it.
+        let asCreated = try XCTUnwrap(
+            CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Control), keyDown: true)
+        )
+        XCTAssertEqual(asCreated.type, .flagsChanged)
+        XCTAssertEqual(self.keyCode(asCreated), Int64(kVK_Control))
+    }
+
+    func testChordUsesTheSuppliedKeyCode() throws {
+        // Dvorak-QWERTY and non-Latin layouts resolve "v" to a different key code, so the chord
+        // must carry whatever PasteKeyCodeResolver produced rather than a hard-coded 9.
+        let dvorakStyleKeyCode: CGKeyCode = 47
+        let chord = try XCTUnwrap(
+            TypingService.makeRemoteDesktopChord(
+                modifierKeyCode: CGKeyCode(kVK_Control),
+                keyCode: dvorakStyleKeyCode
+            )
+        )
+
+        XCTAssertEqual(self.keyCode(chord.keyDown), Int64(dvorakStyleKeyCode))
+        XCTAssertEqual(self.keyCode(chord.keyUp), Int64(dvorakStyleKeyCode))
+    }
+
+    // MARK: - Flag fidelity (guards assigning `flags` instead of inserting)
+
+    func testModifierIsHeldAcrossTheKeyEventsAndReleasedAfter() throws {
+        let chord = try self.makeControlChord()
+
+        for (label, event) in [("key down", chord.keyDown), ("key up", chord.keyUp)] {
+            XCTAssertTrue(event.flags.contains(.maskControl), "\(label) must report control held")
+        }
+        XCTAssertTrue(try XCTUnwrap(chord.modifierDown).flags.contains(.maskControl))
+
+        // Skipped rather than asserted when a physical control key is down: a nil-source
+        // CGEvent inherits the ambient combined-session modifier state, so the release event
+        // would legitimately still report control held and the assertion would say nothing
+        // about this code.
+        try XCTSkipIf(
+            CGEventSource.flagsState(.combinedSessionState).contains(.maskControl),
+            "A physical control key is held, so ambient state leaks into synthetic event flags"
+        )
+        XCTAssertFalse(
+            try XCTUnwrap(chord.modifierUp).flags.contains(.maskControl),
+            "The trailing flagsChanged must report control released"
+        )
+    }
+
+    func testKeyEventsCarryEveryHeldModifierBitIncludingTheDeviceSideBit() throws {
+        // Compared within one chord, so ambient state cannot skew it. The device-side bit
+        // (NX_DEVICELCTLKEYMASK) says which physical modifier is down and is what a
+        // remote-desktop client uses to pick a modifier scan code; assigning `flags` would
+        // drop it, which is what this guards.
+        //
+        // Do not "strengthen" this by asserting an absolute flag value such as
+        // `.maskNonCoalesced`: CoreGraphics sets that on a freshly created nil-source event in
+        // a standalone process but *not* inside the XCTest host, so such an assertion fails
+        // permanently in CI while telling you nothing about this code.
+        let chord = try self.makeControlChord()
+        let heldFlags = try XCTUnwrap(chord.modifierDown).flags
+
+        for (label, event) in [("key down", chord.keyDown), ("key up", chord.keyUp)] {
+            XCTAssertTrue(
+                event.flags.isSuperset(of: heldFlags),
+                """
+                \(label) is missing bits the modifier event carried \
+                (0x\(String(event.flags.rawValue, radix: 16)) does not contain \
+                0x\(String(heldFlags.rawValue, radix: 16))). Insert into `flags`, never assign it.
+                """
+            )
+        }
+    }
+
+    func testRightHandModifierContributesItsOwnDeviceBit() throws {
+        // Proves the held flags are copied off the modifier event rather than hard-coded:
+        // right control carries NX_DEVICERCTLKEYMASK, a different bit from left control.
+        let left = try self.makeControlChord()
+        let right = try XCTUnwrap(
+            TypingService.makeRemoteDesktopChord(
+                modifierKeyCode: CGKeyCode(kVK_RightControl),
+                keyCode: self.pasteKeyCode
+            )
+        )
+
+        let leftHeld = try XCTUnwrap(left.modifierDown).flags.rawValue
+        let rightHeld = try XCTUnwrap(right.modifierDown).flags.rawValue
+        XCTAssertNotEqual(leftHeld, rightHeld, "Left and right control differ in their device-side bit")
+        XCTAssertTrue(right.keyDown.flags.isSuperset(of: CGEventFlags(rawValue: rightHeld)))
+    }
+
+    // MARK: - Hotkey isolation (prevents a phantom recording on every dictation)
+
+    func testEveryChordEventIsExcludedFromFluidVoiceHotkeyMatching() throws {
+        let chords = [
+            try self.makeControlChord(),
+            try XCTUnwrap(TypingService.makeRemoteDesktopChord(modifierKeyCode: nil, keyCode: CGKeyCode(kVK_Return))),
+        ]
+
+        for chord in chords {
+            for (index, event) in chord.ordered.enumerated() {
+                XCTAssertTrue(
+                    GlobalHotkeyManager.isSynthesizedTypingEvent(event),
+                    """
+                    Event \(index) is untagged. GlobalHotkeyManager taps flagsChanged, so an \
+                    untagged synthetic modifier press is matched as a modifier-only dictation \
+                    shortcut and starts a phantom recording on every dictation.
+                    """
+                )
+            }
+        }
+    }
+
+    func testUntaggedControlEventWouldNotBeExcluded() throws {
+        // Proves the assertion above is load-bearing rather than vacuously true.
+        let untagged = try XCTUnwrap(
+            CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Control), keyDown: true)
+        )
+        XCTAssertFalse(GlobalHotkeyManager.isSynthesizedTypingEvent(untagged))
+    }
+
+    // MARK: - Spoken Send
+
+    func testSpokenSendModifiersMapToRealModifierKeyCodes() {
+        XCTAssertNil(TypingService.spokenSendModifierKeyCode(for: .enter))
+        XCTAssertEqual(TypingService.spokenSendModifierKeyCode(for: .shiftEnter), CGKeyCode(kVK_Shift))
+        XCTAssertEqual(TypingService.spokenSendModifierKeyCode(for: .commandEnter), CGKeyCode(kVK_Command))
+    }
+
+    func testShiftEnterProducesAShiftChordRatherThanABareReturn() throws {
+        // A Shift+Enter that reaches the guest as a bare Enter sends a message the user meant
+        // to add a newline to, so the modifier must be a real key event.
+        let chord = try XCTUnwrap(
+            TypingService.makeRemoteDesktopChord(
+                modifierKeyCode: TypingService.spokenSendModifierKeyCode(for: .shiftEnter),
+                keyCode: CGKeyCode(kVK_Return)
+            )
+        )
+
+        XCTAssertEqual(chord.ordered.count, 4)
+        XCTAssertEqual(self.keyCode(try XCTUnwrap(chord.modifierDown)), Int64(kVK_Shift))
+        XCTAssertTrue(chord.keyDown.flags.contains(.maskShift))
+    }
+
+    // MARK: - Settle delay parsing
+
+    func testSettleDelayDefaultsWhenNoOverrideIsSet() {
+        XCTAssertEqual(
+            TypingService.remoteDesktopSettleMicros(override: nil),
+            useconds_t(TypingService.remoteDesktopClipboardSettleDefaultMs * 1000)
+        )
+    }
+
+    func testSettleDelayHonoursAValidOverride() {
+        XCTAssertEqual(TypingService.remoteDesktopSettleMicros(override: NSNumber(value: 250)), 250_000)
+        XCTAssertEqual(TypingService.remoteDesktopSettleMicros(override: NSNumber(value: 0)), 0)
+    }
+
+    func testSettleDelayClampsInsteadOfTrapping() {
+        // `useconds_t` is UInt32; an unclamped override would trap on conversion or overflow
+        // the multiplication.
+        let maximum = useconds_t(TypingService.remoteDesktopClipboardSettleMaximumMs * 1000)
+
+        XCTAssertEqual(TypingService.remoteDesktopSettleMicros(override: NSNumber(value: Int32.max)), maximum)
+        XCTAssertEqual(TypingService.remoteDesktopSettleMicros(override: NSNumber(value: 5_000_000)), maximum)
+        XCTAssertEqual(TypingService.remoteDesktopSettleMicros(override: NSNumber(value: -1)), 0)
+        XCTAssertEqual(TypingService.remoteDesktopSettleMicros(override: NSNumber(value: Int32.min)), 0)
+    }
+
+    // MARK: - Target resolution
+
+    private func resolve(
+        preferred: pid_t?,
+        focused: pid_t?,
+        frontmost: pid_t?,
+        remoteDesktopPIDs: Set<pid_t>
+    ) -> pid_t? {
+        TypingService.resolveRemoteDesktopPID(
+            preferredTargetPID: preferred,
+            focusedPID: focused,
+            frontmostPID: frontmost,
+            isRemoteDesktop: { remoteDesktopPIDs.contains($0) }
+        )
+    }
+
+    func testPreferredTargetWinsWhenItIsARemoteDesktop() {
+        XCTAssertEqual(
+            self.resolve(preferred: 10, focused: 20, frontmost: 30, remoteDesktopPIDs: [10, 30]),
+            10
+        )
+    }
+
+    func testPreferredTargetThatIsNotARemoteDesktopDoesNotFallThrough() {
+        // The caller already knows which app it is inserting into; falling back to the
+        // frontmost window would paste into a different app entirely.
+        XCTAssertNil(
+            self.resolve(preferred: 10, focused: 30, frontmost: 30, remoteDesktopPIDs: [30])
+        )
+    }
+
+    func testNonPositivePreferredTargetIsTreatedAsAbsent() {
+        XCTAssertEqual(self.resolve(preferred: 0, focused: 30, frontmost: 40, remoteDesktopPIDs: [30]), 30)
+        XCTAssertEqual(self.resolve(preferred: -1, focused: 30, frontmost: 40, remoteDesktopPIDs: [30]), 30)
+    }
+
+    func testFocusedElementDecidesWhenThereIsNoPreferredTarget() {
+        XCTAssertEqual(self.resolve(preferred: nil, focused: 30, frontmost: 40, remoteDesktopPIDs: [30]), 30)
+    }
+
+    func testFocusedNonRemoteDesktopDoesNotFallThroughToFrontmost() {
+        // A floating launcher can own the focused element while a remote-desktop window is
+        // frontmost. Pasting into the frontmost window would lose the text.
+        XCTAssertNil(
+            self.resolve(preferred: nil, focused: 20, frontmost: 40, remoteDesktopPIDs: [40])
+        )
+    }
+
+    func testFrontmostIsUsedOnlyWhenNothingElseIsKnown() {
+        XCTAssertEqual(self.resolve(preferred: nil, focused: nil, frontmost: 40, remoteDesktopPIDs: [40]), 40)
+        XCTAssertNil(self.resolve(preferred: nil, focused: nil, frontmost: 40, remoteDesktopPIDs: [99]))
+        XCTAssertNil(self.resolve(preferred: nil, focused: nil, frontmost: nil, remoteDesktopPIDs: [40]))
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopPasteTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopPasteTests.swift
@@ -182,7 +182,12 @@ final class RemoteDesktopPasteTests: XCTestCase {
     func testSpokenSendModifiersMapToRealModifierKeyCodes() {
         XCTAssertNil(TypingService.spokenSendModifierKeyCode(for: .enter))
         XCTAssertEqual(TypingService.spokenSendModifierKeyCode(for: .shiftEnter), CGKeyCode(kVK_Shift))
-        XCTAssertEqual(TypingService.spokenSendModifierKeyCode(for: .commandEnter), CGKeyCode(kVK_Command))
+        // Command is translated to Control, not forwarded literally: the client forwards the
+        // Command position as the Windows key, so Command+Enter would arrive as Win+Enter - an
+        // operating-system shortcut that never submits. Control carries the same meaning in the
+        // guest and is the mapping the client itself applies for copy, cut and paste.
+        XCTAssertEqual(TypingService.spokenSendModifierKeyCode(for: .commandEnter), CGKeyCode(kVK_Control))
+        XCTAssertNotEqual(TypingService.spokenSendModifierKeyCode(for: .commandEnter), CGKeyCode(kVK_Command))
     }
 
     func testShiftEnterProducesAShiftChordRatherThanABareReturn() throws {

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -208,15 +208,22 @@ final class RemoteDesktopTypingTests: XCTestCase {
 
     // MARK: - Paste chord position
 
-    func testPasteChordUsesTheGuestPositionForV() {
-        // The chord is forwarded to the guest as scan codes, so it must use the position 'v'
-        // occupies on the guest, not the local Command+V shortcut key. On a Dvorak local layout
-        // PasteKeyCodeResolver returns 47 while the ANSI position of 'v' is 9.
-        XCTAssertEqual(RemoteDesktopKeyMapResolver.ansiPasteKeyCode, 9)
-        XCTAssertEqual(
-            RemoteDesktopKeyMapResolver.ansiKeyMap["v"],
-            RemoteDesktopKeyStroke(keyCode: 9, needsShift: false)
-        )
+    func testPasteChordKeyMustSurviveLayoutAgreement() {
+        // Forwarded as a scan code and translated by the guest, so it is subject to the same
+        // ambiguity as the typing map: it must be a position both readings agree on, or nil.
+        let safe = RemoteDesktopKeyMapResolver.layoutSafeMap()
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(), safe["v"]?.keyCode)
+        if safe["v"] != nil {
+            XCTAssertEqual(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(), 9,
+                           "on an agreeing Latin layout that is the ANSI position")
+        }
+    }
+
+    func testLayoutSafeMapFailsClosedWhenTheLocalLayoutIsUnreadable() {
+        // An unknown layout cannot establish agreement, so it must yield nothing rather than
+        // falling open to the full ANSI map.
+        XCTAssertTrue(RemoteDesktopKeyMapResolver.localLayoutMap(layoutData: nil, keyboardType: 0).isEmpty)
+        XCTAssertTrue(RemoteDesktopKeyMapResolver.localLayoutMap(layoutData: Data(), keyboardType: 0).isEmpty)
     }
 
     // MARK: - Caps Lock

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -185,7 +185,7 @@ final class RemoteDesktopTypingTests: XCTestCase {
         // A guest may mirror the local layout (RDP's default) or be plain ANSI. Only characters
         // whose position is identical under both are safe; the rest must take the lossless path.
         let ansi = RemoteDesktopKeyMapResolver.ansiKeyMap
-        let safe = RemoteDesktopKeyMapResolver.currentLayoutSafeMap()
+        let safe = RemoteDesktopKeyMapResolver.currentSnapshot().typable
 
         XCTAssertFalse(safe.isEmpty, "a Latin layout must retain a usable set")
         for (character, stroke) in safe {
@@ -211,12 +211,39 @@ final class RemoteDesktopTypingTests: XCTestCase {
     func testPasteChordKeyMustSurviveLayoutAgreement() {
         // Forwarded as a scan code and translated by the guest, so it is subject to the same
         // ambiguity as the typing map: it must be a position both readings agree on, or nil.
-        let safe = RemoteDesktopKeyMapResolver.currentLayoutSafeMap()
-        XCTAssertEqual(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(map: safe), safe["v"]?.keyCode)
+        let safe = RemoteDesktopKeyMapResolver.currentSnapshot().typable
+        let local = RemoteDesktopKeyMapResolver.localLayoutMap()
+        let resolved = RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(local: local, safe: safe)
         if safe["v"] != nil {
-            XCTAssertEqual(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(map: safe), 9,
-                           "on an agreeing Latin layout that is the ANSI position")
+            XCTAssertEqual(resolved, safe["v"]?.keyCode)
+            XCTAssertEqual(resolved, 9, "on an agreeing Latin layout that is the ANSI position")
         }
+    }
+
+    func testPasteChordFallsBackToAnsiOnlyForNonLatinLayouts() {
+        let ansiV = RemoteDesktopKeyMapResolver.ansiKeyMap["v"]!
+
+        // A non-Latin layout has no `v` to disagree about: the guest's Latin sublayout puts it
+        // where ANSI does, so the lossless paste stays available instead of inserting nothing.
+        let hebrewish: [Character: RemoteDesktopKeyStroke] = ["\u{05D5}": ansiV]
+        XCTAssertEqual(
+            RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(local: hebrewish, safe: [:]),
+            RemoteDesktopKeyMapResolver.ansiPasteKeyCode,
+            "a non-Latin layout must still be able to paste"
+        )
+
+        // A Latin rearrangement does have a `v`, somewhere else. The ANSI position is a
+        // different letter there, so Ctrl plus it could be an unrelated shortcut: decline.
+        let dvorakish: [Character: RemoteDesktopKeyStroke] = [
+            "v": RemoteDesktopKeyStroke(keyCode: 47, needsShift: false),
+        ]
+        XCTAssertNil(
+            RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(local: dvorakish, safe: [:]),
+            "a rearranged Latin layout must not press an unknown position"
+        )
+
+        // Nothing read at all establishes nothing.
+        XCTAssertNil(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(local: [:], safe: [:]))
     }
 
     func testLayoutSafeMapFailsClosedWhenTheLocalLayoutIsUnreadable() {

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -185,7 +185,7 @@ final class RemoteDesktopTypingTests: XCTestCase {
         // A guest may mirror the local layout (RDP's default) or be plain ANSI. Only characters
         // whose position is identical under both are safe; the rest must take the lossless path.
         let ansi = RemoteDesktopKeyMapResolver.ansiKeyMap
-        let safe = RemoteDesktopKeyMapResolver.layoutSafeMap()
+        let safe = RemoteDesktopKeyMapResolver.currentLayoutSafeMap()
 
         XCTAssertFalse(safe.isEmpty, "a Latin layout must retain a usable set")
         for (character, stroke) in safe {
@@ -211,10 +211,10 @@ final class RemoteDesktopTypingTests: XCTestCase {
     func testPasteChordKeyMustSurviveLayoutAgreement() {
         // Forwarded as a scan code and translated by the guest, so it is subject to the same
         // ambiguity as the typing map: it must be a position both readings agree on, or nil.
-        let safe = RemoteDesktopKeyMapResolver.layoutSafeMap()
-        XCTAssertEqual(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(), safe["v"]?.keyCode)
+        let safe = RemoteDesktopKeyMapResolver.currentLayoutSafeMap()
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(map: safe), safe["v"]?.keyCode)
         if safe["v"] != nil {
-            XCTAssertEqual(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(), 9,
+            XCTAssertEqual(RemoteDesktopKeyMapResolver.layoutSafePasteKeyCode(map: safe), 9,
                            "on an agreeing Latin layout that is the ANSI position")
         }
     }

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -1,0 +1,146 @@
+import Carbon.HIToolbox
+import CoreGraphics
+@testable import FluidVoice_Debug
+import XCTest
+
+/// Covers the keycode-typing path used for remote-desktop targets, where clipboard
+/// redirection is unusable because the client only re-advertises its clipboard after a focus
+/// change.
+final class RemoteDesktopTypingTests: XCTestCase {
+    /// A deliberately small stand-in layout, so these tests do not depend on whatever keyboard
+    /// the machine running them happens to have selected.
+    private let asciiish: [Character: RemoteDesktopKeyStroke] = [
+        "a": .init(keyCode: 0, needsShift: false),
+        "A": .init(keyCode: 0, needsShift: true),
+        "b": .init(keyCode: 11, needsShift: false),
+        " ": .init(keyCode: 49, needsShift: false),
+        "'": .init(keyCode: 39, needsShift: false),
+        "\"": .init(keyCode: 39, needsShift: true),
+        "-": .init(keyCode: 27, needsShift: false),
+        ".": .init(keyCode: 47, needsShift: false),
+    ]
+
+    // MARK: - Transliteration
+
+    func testSmartPunctuationIsTransliteratedToASCII() {
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("it\u{2019}s"), "it's")
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("\u{201C}quoted\u{201D}"), "\"quoted\"")
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("a\u{2014}b"), "a--b")
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("a\u{2013}b"), "a-b")
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("wait\u{2026}"), "wait...")
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("a\u{00A0}b"), "a b")
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("\u{2022} item"), "- item")
+    }
+
+    func testTransliterationLeavesPlainTextUntouched() {
+        let plain = "Can you send me the quarterly report by Friday?"
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate(plain), plain)
+    }
+
+    func testTransliterationDoesNotInventReplacementsForRealNonASCII() {
+        // Accented letters and emoji have no unambiguous ASCII spelling, so they must survive
+        // untouched and be reported as unmappable rather than silently mangled.
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("caf\u{00E9}"), "caf\u{00E9}")
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.transliterate("hi \u{1F600}"), "hi \u{1F600}")
+    }
+
+    // MARK: - Stroke mapping
+
+    func testStrokesSpellTheTextAndCarryShiftWhereNeeded() throws {
+        let strokes = try XCTUnwrap(
+            TypingService.remoteDesktopKeyStrokes(for: "aAb", map: self.asciiish)
+        )
+        XCTAssertEqual(strokes.map(\.keyCode), [0, 0, 11])
+        XCTAssertEqual(strokes.map(\.needsShift), [false, true, false])
+    }
+
+    func testNewlinesAndTabsUseTheirOwnKeysRatherThanTheLayoutMap() throws {
+        let strokes = try XCTUnwrap(
+            TypingService.remoteDesktopKeyStrokes(for: "a\nb\tb\r", map: self.asciiish)
+        )
+        XCTAssertEqual(
+            strokes.map(\.keyCode),
+            [0, CGKeyCode(kVK_Return), 11, CGKeyCode(kVK_Tab), 11, CGKeyCode(kVK_Return)]
+        )
+        XCTAssertTrue(strokes.allSatisfy { !$0.needsShift })
+    }
+
+    func testMappingIsAllOrNothing() {
+        // A partially typed transcript is worse than none, so one unmappable character must
+        // abort the whole attempt and let the caller fall back.
+        XCTAssertNil(TypingService.remoteDesktopKeyStrokes(for: "caf\u{00E9}", map: self.asciiish))
+        XCTAssertNil(TypingService.remoteDesktopKeyStrokes(for: "a\u{1F600}b", map: self.asciiish))
+        XCTAssertNotNil(TypingService.remoteDesktopKeyStrokes(for: "ab a", map: self.asciiish))
+    }
+
+    func testEmptyTextMapsToNoStrokes() throws {
+        let strokes = try XCTUnwrap(TypingService.remoteDesktopKeyStrokes(for: "", map: self.asciiish))
+        XCTAssertTrue(strokes.isEmpty)
+    }
+
+    func testTransliteratedTextBecomesFullyTypeable() {
+        // The point of transliteration: text that would otherwise abort now types cleanly.
+        // Restricted to letters present in `asciiish` so this exercises transliteration
+        // rather than the toy fixture's coverage.
+        let raw = "ab\u{2019}a \u{201C}ba\u{201D}\u{2026}"
+        XCTAssertNil(TypingService.remoteDesktopKeyStrokes(for: raw, map: self.asciiish))
+        let normalized = RemoteDesktopKeyMapResolver.transliterate(raw)
+        XCTAssertNotNil(TypingService.remoteDesktopKeyStrokes(for: normalized, map: self.asciiish))
+    }
+
+    // MARK: - Unmappable reporting
+
+    func testUnmappableCharactersAreReportedOnceEachInOrder() {
+        let found = RemoteDesktopKeyMapResolver.unmappableCharacters(
+            in: "caf\u{00E9} \u{00E9}clair \u{1F600}",
+            map: self.asciiish
+        )
+        XCTAssertEqual(found, ["c", "f", "\u{00E9}", "l", "i", "r", "\u{1F600}"])
+    }
+
+    func testWhitespaceControlCharactersAreNotReportedAsUnmappable() {
+        XCTAssertTrue(
+            RemoteDesktopKeyMapResolver.unmappableCharacters(in: "a\nb\tb\r", map: self.asciiish).isEmpty
+        )
+    }
+
+    // MARK: - Layout resolution
+
+    func testResolverReturnsEmptyMapForMissingLayoutData() {
+        XCTAssertTrue(RemoteDesktopKeyMapResolver.resolve(layoutData: nil, keyboardType: 0).isEmpty)
+        XCTAssertTrue(RemoteDesktopKeyMapResolver.resolve(layoutData: Data(), keyboardType: 0).isEmpty)
+    }
+
+    func testLiveLayoutProducesATypeableASCIIRange() {
+        // Guards the UCKeyTranslate reverse scan against silently returning nothing.
+        let map = RemoteDesktopKeyMapResolver.current()
+        guard !map.isEmpty else {
+            return XCTFail("Expected a non-empty map for the active keyboard layout")
+        }
+        for character in "abcxyzABCXYZ0189 .,-'" {
+            XCTAssertNotNil(map[character], "Latin layouts must be able to type \(character)")
+        }
+        XCTAssertNil(map["\u{1F600}"], "No key press produces an emoji")
+    }
+
+    func testUnshiftedStrokeIsPreferredWhenBothReachTheSameCharacter() throws {
+        let map = RemoteDesktopKeyMapResolver.current()
+        guard let space = map[" "] else { throw XCTSkip("Active layout has no space mapping") }
+        XCTAssertFalse(space.needsShift, "Space must be typed without shift")
+    }
+
+    // MARK: - Per-character delay parsing
+
+    func testTypeDelayDefaultsAndClamps() {
+        XCTAssertEqual(
+            TypingService.remoteDesktopTypeDelayMicros(override: nil),
+            useconds_t(TypingService.remoteDesktopTypeDelayDefaultMs * 1000)
+        )
+        XCTAssertEqual(TypingService.remoteDesktopTypeDelayMicros(override: NSNumber(value: 5)), 5000)
+        XCTAssertEqual(TypingService.remoteDesktopTypeDelayMicros(override: NSNumber(value: 0)), 0)
+
+        let maximum = useconds_t(TypingService.remoteDesktopTypeDelayMaximumMs * 1000)
+        XCTAssertEqual(TypingService.remoteDesktopTypeDelayMicros(override: NSNumber(value: Int32.max)), maximum)
+        XCTAssertEqual(TypingService.remoteDesktopTypeDelayMicros(override: NSNumber(value: -5)), 0)
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -220,8 +220,8 @@ final class RemoteDesktopTypingTests: XCTestCase {
         }
     }
 
-    func testPasteChordFallsBackToAnsiOnlyForNonLatinLayouts() {
-        let ansiV = RemoteDesktopKeyMapResolver.ansiKeyMap["v"]!
+    func testPasteChordFallsBackToAnsiOnlyForNonLatinLayouts() throws {
+        let ansiV = try XCTUnwrap(RemoteDesktopKeyMapResolver.ansiKeyMap["v"])
 
         // A non-Latin layout has no `v` to disagree about: the guest's Latin sublayout puts it
         // where ANSI does, so the lossless paste stays available instead of inserting nothing.

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -179,6 +179,19 @@ final class RemoteDesktopTypingTests: XCTestCase {
         XCTAssertEqual(map[" "]?.needsShift, false)
     }
 
+    // MARK: - Paste chord position
+
+    func testPasteChordUsesTheGuestPositionForV() {
+        // The chord is forwarded to the guest as scan codes, so it must use the position 'v'
+        // occupies on the guest, not the local Command+V shortcut key. On a Dvorak local layout
+        // PasteKeyCodeResolver returns 47 while the ANSI position of 'v' is 9.
+        XCTAssertEqual(RemoteDesktopKeyMapResolver.ansiPasteKeyCode, 9)
+        XCTAssertEqual(
+            RemoteDesktopKeyMapResolver.ansiKeyMap["v"],
+            RemoteDesktopKeyStroke(keyCode: 9, needsShift: false)
+        )
+    }
+
     // MARK: - Caps Lock
 
     func testCapsLockInvertsShiftForLettersOnly() {

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -126,85 +126,90 @@ final class RemoteDesktopTypingTests: XCTestCase {
 
     // MARK: - Layout resolution
 
-    func testResolverReturnsEmptyMapForMissingLayoutData() {
-        XCTAssertTrue(RemoteDesktopKeyMapResolver.resolve(layoutData: nil, keyboardType: 0).isEmpty)
-        XCTAssertTrue(RemoteDesktopKeyMapResolver.resolve(layoutData: Data(), keyboardType: 0).isEmpty)
-    }
+    // MARK: - ANSI reference map
 
-    /// Reads an installed layout by identifier without enabling or switching any input source,
-    /// so these assertions do not depend on which keyboard the running machine has selected.
-    /// Same approach as `Tests/PasteKeyCodeResolverTests.swift`.
-    private func installedLayout(_ identifier: String) throws -> Data {
-        guard let sources = TISCreateInputSourceList(nil, true).takeRetainedValue() as? [TISInputSource] else {
-            throw XCTSkip("Unable to enumerate installed keyboard layouts")
-        }
-        let match = sources.first { source in
-            guard let pointer = TISGetInputSourceProperty(source, kTISPropertyInputSourceID) else { return false }
-            return Unmanaged<CFString>.fromOpaque(pointer).takeUnretainedValue() as String == identifier
-        }
-        guard let match,
-              let pointer = TISGetInputSourceProperty(match, kTISPropertyUnicodeKeyLayoutData)
-        else {
-            throw XCTSkip("Layout not installed: \(identifier)")
-        }
-        return Unmanaged<CFData>.fromOpaque(pointer).takeUnretainedValue() as Data
-    }
-
-    private func usMap() throws -> [Character: RemoteDesktopKeyStroke] {
-        RemoteDesktopKeyMapResolver.resolve(
-            layoutData: try self.installedLayout("com.apple.keylayout.US"),
-            keyboardType: UInt32(LMGetKbdType())
-        )
-    }
-
-    func testUSLayoutResolvesExpectedStrokes() throws {
-        let map = try self.usMap()
+    func testReferenceMapUsesStandardANSIPositions() {
+        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
         XCTAssertEqual(map["a"], RemoteDesktopKeyStroke(keyCode: 0, needsShift: false))
         XCTAssertEqual(map["A"], RemoteDesktopKeyStroke(keyCode: 0, needsShift: true))
+        XCTAssertEqual(map["v"], RemoteDesktopKeyStroke(keyCode: 9, needsShift: false))
         XCTAssertEqual(map["1"], RemoteDesktopKeyStroke(keyCode: 18, needsShift: false))
         XCTAssertEqual(map["!"], RemoteDesktopKeyStroke(keyCode: 18, needsShift: true))
-        XCTAssertEqual(map["v"], RemoteDesktopKeyStroke(keyCode: 9, needsShift: false))
-        XCTAssertEqual(map[" "], RemoteDesktopKeyStroke(keyCode: 49, needsShift: false))
+        // 5 and 6 sit at 23 and 22 respectively on ANSI, which is easy to transpose by hand.
+        XCTAssertEqual(map["5"], RemoteDesktopKeyStroke(keyCode: 23, needsShift: false))
+        XCTAssertEqual(map["6"], RemoteDesktopKeyStroke(keyCode: 22, needsShift: false))
+        XCTAssertEqual(map[" "], RemoteDesktopKeyStroke(keyCode: CGKeyCode(kVK_Space), needsShift: false))
     }
 
-    func testUSLayoutCoversPrintableASCIIAndNothingElse() throws {
-        let map = try self.usMap()
+    func testReferenceMapCoversPrintableASCIIExactly() {
+        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
         for scalar in UInt32(0x20)...UInt32(0x7E) {
             let character = Character(UnicodeScalar(scalar)!)
-            XCTAssertNotNil(map[character], "US layout must type U+\(String(scalar, radix: 16, uppercase: true))")
+            XCTAssertNotNil(
+                map[character],
+                "ANSI reference must type U+\(String(scalar, radix: 16, uppercase: true)) '\(character)'"
+            )
         }
-        XCTAssertNil(map["\u{1F600}"], "No key press produces an emoji")
-        XCTAssertNil(map["\u{00E9}"], "US layout cannot type a precomposed accented letter")
+        XCTAssertEqual(map.count, 0x7E - 0x20 + 1, "and nothing beyond printable ASCII")
     }
 
-    func testKeypadAndISOSectionKeysAreExcluded() throws {
-        let map = try self.usMap()
-        // '*' and '+' must come from Shift+8 and Shift+= rather than the keypad, which carries a
-        // different scan code class than a person typing the same glyph.
+    func testReferenceMapExcludesCharactersTheGuestWouldMistranslate() {
+        // Deliberately independent of the machine's active input source: the guest applies its
+        // own layout to the positions it receives, so a locally-typeable Cyrillic or accented
+        // character must not be offered - it would silently produce something else in the guest.
+        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
+        for absent in ["\u{00E9}", "\u{0439}", "\u{1F600}", "\u{20AC}", "\u{00A3}"] {
+            XCTAssertNil(map[Character(absent)], "\(absent) must fall to the lossless path")
+        }
+    }
+
+    func testReferenceMapNeverUsesKeypadOrISOSectionPositions() {
+        // Keypad codes carry a different scan-code class than a person typing the same glyph,
+        // and ANSI Windows maps the ISO section position to backslash.
+        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
+        XCTAssertFalse(map.values.contains { (65...92).contains($0.keyCode) })
+        XCTAssertFalse(map.values.contains { $0.keyCode == 10 })
         XCTAssertEqual(map["*"], RemoteDesktopKeyStroke(keyCode: 28, needsShift: true))
         XCTAssertEqual(map["+"], RemoteDesktopKeyStroke(keyCode: 24, needsShift: true))
-        XCTAssertFalse(map.values.contains { (65...92).contains($0.keyCode) }, "No keypad key codes")
-        XCTAssertFalse(map.values.contains { $0.keyCode == 10 }, "kVK_ISO_Section is excluded")
     }
 
-    func testDeadKeysAreNotOfferedAsDirectlyTypeable() throws {
-        // On US-International the quote and grave keys compose the next character instead of
-        // typing a glyph, so offering them would silently corrupt text.
-        let map = RemoteDesktopKeyMapResolver.resolve(
-            layoutData: try self.installedLayout("com.apple.keylayout.USInternational-PC"),
-            keyboardType: UInt32(LMGetKbdType())
-        )
-        guard !map.isEmpty else { throw XCTSkip("US-International layout unavailable") }
-        for dead in ["\"", "'", "`", "\u{02C6}", "\u{02DC}"] {
-            XCTAssertNil(map[Character(dead)], "Dead key \(dead) must not be typeable directly")
-        }
-        XCTAssertNotNil(map["a"], "Ordinary letters must still map")
-    }
-
-    func testUnshiftedStrokeIsPreferredWhenBothReachTheSameCharacter() throws {
-        let map = try self.usMap()
-        XCTAssertEqual(map[" "]?.needsShift, false)
+    func testReferenceMapPrefersUnshiftedWhereBothReachACharacter() {
+        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
         XCTAssertEqual(map["a"]?.needsShift, false)
+        XCTAssertEqual(map[" "]?.needsShift, false)
+    }
+
+    // MARK: - Caps Lock
+
+    func testCapsLockInvertsShiftForLettersOnly() {
+        // RDP synchronises lock state to the guest, so with Caps Lock on an unshifted 'a'
+        // position arrives as 'A'. Letters must invert; digits and punctuation must not.
+        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
+        let normalPlan = RemoteDesktopKeyMapResolver.plan(for: "aA1!", map: map, capsLockActive: false)
+        let lockedPlan = RemoteDesktopKeyMapResolver.plan(for: "aA1!", map: map, capsLockActive: true)
+        guard case let .strokes(normal) = normalPlan,
+              case let .strokes(withCaps) = lockedPlan
+        else { return XCTFail("expected both plans to produce strokes") }
+
+        XCTAssertEqual(normal.map(\.needsShift), [false, true, false, true])
+        XCTAssertEqual(
+            withCaps.map(\.needsShift),
+            [true, false, false, true],
+            "letters invert, digits and punctuation are unaffected"
+        )
+        XCTAssertEqual(
+            withCaps.map(\.keyCode),
+            normal.map(\.keyCode),
+            "Caps Lock changes shift only, never the key position"
+        )
+    }
+
+    func testCapsLockDoesNotAffectUnmappableReporting() {
+        let map = RemoteDesktopKeyMapResolver.ansiKeyMap
+        guard case let .unmappable(chars) = RemoteDesktopKeyMapResolver.plan(
+            for: "caf\u{00E9}", map: map, capsLockActive: true
+        ) else { return XCTFail("expected unmappable") }
+        XCTAssertEqual(chars, ["\u{00E9}"])
     }
 
     // MARK: - Per-character delay parsing

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -179,6 +179,33 @@ final class RemoteDesktopTypingTests: XCTestCase {
         XCTAssertEqual(map[" "]?.needsShift, false)
     }
 
+    // MARK: - Layout agreement
+
+    func testLayoutSafeMapKeepsOnlyPositionsBothReadingsAgreeOn() {
+        // A guest may mirror the local layout (RDP's default) or be plain ANSI. Only characters
+        // whose position is identical under both are safe; the rest must take the lossless path.
+        let ansi = RemoteDesktopKeyMapResolver.ansiKeyMap
+        let safe = RemoteDesktopKeyMapResolver.layoutSafeMap()
+
+        XCTAssertFalse(safe.isEmpty, "a Latin layout must retain a usable set")
+        for (character, stroke) in safe {
+            XCTAssertEqual(stroke, ansi[character], "a safe stroke must match the ANSI position")
+        }
+        XCTAssertLessThanOrEqual(safe.count, ansi.count, "agreement can only narrow the set")
+
+        let local = RemoteDesktopKeyMapResolver.localLayoutMap()
+        if local.isEmpty == false {
+            for (character, stroke) in safe {
+                XCTAssertEqual(stroke, local[character], "a safe stroke must match the local position too")
+            }
+        }
+    }
+
+    func testLocalLayoutMapIsEmptyForMissingData() {
+        XCTAssertTrue(RemoteDesktopKeyMapResolver.localLayoutMap(layoutData: nil, keyboardType: 0).isEmpty)
+        XCTAssertTrue(RemoteDesktopKeyMapResolver.localLayoutMap(layoutData: Data(), keyboardType: 0).isEmpty)
+    }
+
     // MARK: - Paste chord position
 
     func testPasteChordUsesTheGuestPositionForV() {

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -69,17 +69,19 @@ final class RemoteDesktopTypingTests: XCTestCase {
         XCTAssertEqual(strokes.map(\.needsShift), [false, true, false])
     }
 
-    func testNewlinesAndTabsUseTheirOwnKeysRatherThanTheLayoutMap() throws {
-        let strokes = try XCTUnwrap(
-            self.strokes("a\nb\tb\r")
-        )
-        XCTAssertEqual(
-            strokes.map(\.keyCode),
-            [0, CGKeyCode(kVK_Return), 11, CGKeyCode(kVK_Tab), 11, CGKeyCode(kVK_Return)]
-        )
-        // Newline is Shift+Return: a bare Return submits in most chat clients, so a
-        // multi-paragraph transcript typed with Return would send one partial message per line.
-        XCTAssertEqual(strokes.map(\.needsShift), [false, true, false, false, false, true])
+    func testReturnAndTabAreNeverTypedIntoARemoteSession() throws {
+        // Return commits and Tab moves focus. Every other key this path can press only inserts
+        // a character, so refusing these bounds the worst case to wrong text rather than an
+        // action taken inside the guest.
+        for activating in ["a\nb", "a\r\nb", "a\tb", "a\rb"] {
+            XCTAssertNil(
+                self.strokes(activating),
+                "\(activating.debugDescription) must not be typed"
+            )
+        }
+        XCTAssertEqual(self.unmappable("a\nb"), ["\n"])
+        XCTAssertEqual(self.unmappable("a\r\nb"), ["\r\n"])
+        XCTAssertEqual(self.unmappable("a\tb"), ["\t"])
     }
 
     func testMappingIsAllOrNothing() {
@@ -114,9 +116,12 @@ final class RemoteDesktopTypingTests: XCTestCase {
         XCTAssertEqual(found, ["c", "f", "\u{00E9}", "l", "i", "r", "\u{1F600}"])
     }
 
-    func testWhitespaceControlCharactersAreNotReportedAsUnmappable() {
-        XCTAssertNil(self.unmappable("a\nb\tb\r"), "Newlines and tabs have their own keys")
-        XCTAssertNil(self.unmappable("a\r\nb"), "CRLF is one grapheme cluster and must still map")
+    func testActivatingWhitespaceIsReportedAsUnmappable() {
+        XCTAssertEqual(
+            self.unmappable("a\nb\tb\r"),
+            ["\n", "\t", "\r"],
+            "Activating keys are reported so the caller falls back rather than pressing them"
+        )
     }
 
     // MARK: - Layout resolution
@@ -215,5 +220,19 @@ final class RemoteDesktopTypingTests: XCTestCase {
         let maximum = useconds_t(TypingService.remoteDesktopTypeDelayMaximumMs * 1000)
         XCTAssertEqual(TypingService.remoteDesktopTypeDelayMicros(override: NSNumber(value: Int32.max)), maximum)
         XCTAssertEqual(TypingService.remoteDesktopTypeDelayMicros(override: NSNumber(value: -5)), 0)
+    }
+    // MARK: - Warm-up parsing
+
+    func testWarmupDefaultsAndClamps() {
+        XCTAssertEqual(
+            TypingService.remoteDesktopWarmupMicros(override: nil),
+            useconds_t(TypingService.remoteDesktopWarmupDefaultMs * 1000)
+        )
+        XCTAssertEqual(TypingService.remoteDesktopWarmupMicros(override: NSNumber(value: 500)), 500_000)
+        XCTAssertEqual(TypingService.remoteDesktopWarmupMicros(override: NSNumber(value: 0)), 0)
+
+        let maximum = useconds_t(TypingService.remoteDesktopWarmupMaximumMs * 1000)
+        XCTAssertEqual(TypingService.remoteDesktopWarmupMicros(override: NSNumber(value: Int32.max)), maximum)
+        XCTAssertEqual(TypingService.remoteDesktopWarmupMicros(override: NSNumber(value: -1)), 0)
     }
 }

--- a/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
+++ b/Tests/FluidDictationIntegrationTests/RemoteDesktopTypingTests.swift
@@ -20,6 +20,21 @@ final class RemoteDesktopTypingTests: XCTestCase {
         ".": .init(keyCode: 47, needsShift: false),
     ]
 
+    /// `.strokes` payload, or nil when the plan reported unmappable characters.
+    private func strokes(_ text: String) -> [RemoteDesktopKeyStroke]? {
+        switch RemoteDesktopKeyMapResolver.plan(for: text, map: self.asciiish) {
+        case let .strokes(s): return s
+        case .unmappable: return nil
+        }
+    }
+
+    private func unmappable(_ text: String) -> [Character]? {
+        switch RemoteDesktopKeyMapResolver.plan(for: text, map: self.asciiish) {
+        case .strokes: return nil
+        case let .unmappable(c): return c
+        }
+    }
+
     // MARK: - Transliteration
 
     func testSmartPunctuationIsTransliteratedToASCII() {
@@ -48,7 +63,7 @@ final class RemoteDesktopTypingTests: XCTestCase {
 
     func testStrokesSpellTheTextAndCarryShiftWhereNeeded() throws {
         let strokes = try XCTUnwrap(
-            TypingService.remoteDesktopKeyStrokes(for: "aAb", map: self.asciiish)
+            self.strokes("aAb")
         )
         XCTAssertEqual(strokes.map(\.keyCode), [0, 0, 11])
         XCTAssertEqual(strokes.map(\.needsShift), [false, true, false])
@@ -56,25 +71,27 @@ final class RemoteDesktopTypingTests: XCTestCase {
 
     func testNewlinesAndTabsUseTheirOwnKeysRatherThanTheLayoutMap() throws {
         let strokes = try XCTUnwrap(
-            TypingService.remoteDesktopKeyStrokes(for: "a\nb\tb\r", map: self.asciiish)
+            self.strokes("a\nb\tb\r")
         )
         XCTAssertEqual(
             strokes.map(\.keyCode),
             [0, CGKeyCode(kVK_Return), 11, CGKeyCode(kVK_Tab), 11, CGKeyCode(kVK_Return)]
         )
-        XCTAssertTrue(strokes.allSatisfy { !$0.needsShift })
+        // Newline is Shift+Return: a bare Return submits in most chat clients, so a
+        // multi-paragraph transcript typed with Return would send one partial message per line.
+        XCTAssertEqual(strokes.map(\.needsShift), [false, true, false, false, false, true])
     }
 
     func testMappingIsAllOrNothing() {
         // A partially typed transcript is worse than none, so one unmappable character must
         // abort the whole attempt and let the caller fall back.
-        XCTAssertNil(TypingService.remoteDesktopKeyStrokes(for: "caf\u{00E9}", map: self.asciiish))
-        XCTAssertNil(TypingService.remoteDesktopKeyStrokes(for: "a\u{1F600}b", map: self.asciiish))
-        XCTAssertNotNil(TypingService.remoteDesktopKeyStrokes(for: "ab a", map: self.asciiish))
+        XCTAssertNil(self.strokes("caf\u{00E9}"))
+        XCTAssertNil(self.strokes("a\u{1F600}b"))
+        XCTAssertNotNil(self.strokes("ab a"))
     }
 
     func testEmptyTextMapsToNoStrokes() throws {
-        let strokes = try XCTUnwrap(TypingService.remoteDesktopKeyStrokes(for: "", map: self.asciiish))
+        let strokes = try XCTUnwrap(self.strokes(""))
         XCTAssertTrue(strokes.isEmpty)
     }
 
@@ -83,25 +100,23 @@ final class RemoteDesktopTypingTests: XCTestCase {
         // Restricted to letters present in `asciiish` so this exercises transliteration
         // rather than the toy fixture's coverage.
         let raw = "ab\u{2019}a \u{201C}ba\u{201D}\u{2026}"
-        XCTAssertNil(TypingService.remoteDesktopKeyStrokes(for: raw, map: self.asciiish))
+        XCTAssertNil(self.strokes(raw))
         let normalized = RemoteDesktopKeyMapResolver.transliterate(raw)
-        XCTAssertNotNil(TypingService.remoteDesktopKeyStrokes(for: normalized, map: self.asciiish))
+        XCTAssertNotNil(self.strokes(normalized))
     }
 
     // MARK: - Unmappable reporting
 
-    func testUnmappableCharactersAreReportedOnceEachInOrder() {
-        let found = RemoteDesktopKeyMapResolver.unmappableCharacters(
-            in: "caf\u{00E9} \u{00E9}clair \u{1F600}",
-            map: self.asciiish
-        )
+    func testUnmappableCharactersAreReportedOnceEachInOrder() throws {
+        // 'c', 'f', 'l', 'i' and 'r' are absent from the toy fixture on purpose - the point is
+        // first-occurrence order and de-duplication, not which letters a real layout has.
+        let found = try XCTUnwrap(self.unmappable("caf\u{00E9} \u{00E9}clair \u{1F600}"))
         XCTAssertEqual(found, ["c", "f", "\u{00E9}", "l", "i", "r", "\u{1F600}"])
     }
 
     func testWhitespaceControlCharactersAreNotReportedAsUnmappable() {
-        XCTAssertTrue(
-            RemoteDesktopKeyMapResolver.unmappableCharacters(in: "a\nb\tb\r", map: self.asciiish).isEmpty
-        )
+        XCTAssertNil(self.unmappable("a\nb\tb\r"), "Newlines and tabs have their own keys")
+        XCTAssertNil(self.unmappable("a\r\nb"), "CRLF is one grapheme cluster and must still map")
     }
 
     // MARK: - Layout resolution
@@ -111,22 +126,80 @@ final class RemoteDesktopTypingTests: XCTestCase {
         XCTAssertTrue(RemoteDesktopKeyMapResolver.resolve(layoutData: Data(), keyboardType: 0).isEmpty)
     }
 
-    func testLiveLayoutProducesATypeableASCIIRange() {
-        // Guards the UCKeyTranslate reverse scan against silently returning nothing.
-        let map = RemoteDesktopKeyMapResolver.current()
-        guard !map.isEmpty else {
-            return XCTFail("Expected a non-empty map for the active keyboard layout")
+    /// Reads an installed layout by identifier without enabling or switching any input source,
+    /// so these assertions do not depend on which keyboard the running machine has selected.
+    /// Same approach as `Tests/PasteKeyCodeResolverTests.swift`.
+    private func installedLayout(_ identifier: String) throws -> Data {
+        guard let sources = TISCreateInputSourceList(nil, true).takeRetainedValue() as? [TISInputSource] else {
+            throw XCTSkip("Unable to enumerate installed keyboard layouts")
         }
-        for character in "abcxyzABCXYZ0189 .,-'" {
-            XCTAssertNotNil(map[character], "Latin layouts must be able to type \(character)")
+        let match = sources.first { source in
+            guard let pointer = TISGetInputSourceProperty(source, kTISPropertyInputSourceID) else { return false }
+            return Unmanaged<CFString>.fromOpaque(pointer).takeUnretainedValue() as String == identifier
+        }
+        guard let match,
+              let pointer = TISGetInputSourceProperty(match, kTISPropertyUnicodeKeyLayoutData)
+        else {
+            throw XCTSkip("Layout not installed: \(identifier)")
+        }
+        return Unmanaged<CFData>.fromOpaque(pointer).takeUnretainedValue() as Data
+    }
+
+    private func usMap() throws -> [Character: RemoteDesktopKeyStroke] {
+        RemoteDesktopKeyMapResolver.resolve(
+            layoutData: try self.installedLayout("com.apple.keylayout.US"),
+            keyboardType: UInt32(LMGetKbdType())
+        )
+    }
+
+    func testUSLayoutResolvesExpectedStrokes() throws {
+        let map = try self.usMap()
+        XCTAssertEqual(map["a"], RemoteDesktopKeyStroke(keyCode: 0, needsShift: false))
+        XCTAssertEqual(map["A"], RemoteDesktopKeyStroke(keyCode: 0, needsShift: true))
+        XCTAssertEqual(map["1"], RemoteDesktopKeyStroke(keyCode: 18, needsShift: false))
+        XCTAssertEqual(map["!"], RemoteDesktopKeyStroke(keyCode: 18, needsShift: true))
+        XCTAssertEqual(map["v"], RemoteDesktopKeyStroke(keyCode: 9, needsShift: false))
+        XCTAssertEqual(map[" "], RemoteDesktopKeyStroke(keyCode: 49, needsShift: false))
+    }
+
+    func testUSLayoutCoversPrintableASCIIAndNothingElse() throws {
+        let map = try self.usMap()
+        for scalar in UInt32(0x20)...UInt32(0x7E) {
+            let character = Character(UnicodeScalar(scalar)!)
+            XCTAssertNotNil(map[character], "US layout must type U+\(String(scalar, radix: 16, uppercase: true))")
         }
         XCTAssertNil(map["\u{1F600}"], "No key press produces an emoji")
+        XCTAssertNil(map["\u{00E9}"], "US layout cannot type a precomposed accented letter")
+    }
+
+    func testKeypadAndISOSectionKeysAreExcluded() throws {
+        let map = try self.usMap()
+        // '*' and '+' must come from Shift+8 and Shift+= rather than the keypad, which carries a
+        // different scan code class than a person typing the same glyph.
+        XCTAssertEqual(map["*"], RemoteDesktopKeyStroke(keyCode: 28, needsShift: true))
+        XCTAssertEqual(map["+"], RemoteDesktopKeyStroke(keyCode: 24, needsShift: true))
+        XCTAssertFalse(map.values.contains { (65...92).contains($0.keyCode) }, "No keypad key codes")
+        XCTAssertFalse(map.values.contains { $0.keyCode == 10 }, "kVK_ISO_Section is excluded")
+    }
+
+    func testDeadKeysAreNotOfferedAsDirectlyTypeable() throws {
+        // On US-International the quote and grave keys compose the next character instead of
+        // typing a glyph, so offering them would silently corrupt text.
+        let map = RemoteDesktopKeyMapResolver.resolve(
+            layoutData: try self.installedLayout("com.apple.keylayout.USInternational-PC"),
+            keyboardType: UInt32(LMGetKbdType())
+        )
+        guard !map.isEmpty else { throw XCTSkip("US-International layout unavailable") }
+        for dead in ["\"", "'", "`", "\u{02C6}", "\u{02DC}"] {
+            XCTAssertNil(map[Character(dead)], "Dead key \(dead) must not be typeable directly")
+        }
+        XCTAssertNotNil(map["a"], "Ordinary letters must still map")
     }
 
     func testUnshiftedStrokeIsPreferredWhenBothReachTheSameCharacter() throws {
-        let map = RemoteDesktopKeyMapResolver.current()
-        guard let space = map[" "] else { throw XCTSkip("Active layout has no space mapping") }
-        XCTAssertFalse(space.needsShift, "Space must be typed without shift")
+        let map = try self.usMap()
+        XCTAssertEqual(map[" "]?.needsShift, false)
+        XCTAssertEqual(map["a"]?.needsShift, false)
     }
 
     // MARK: - Per-character delay parsing

--- a/Tests/PasteKeyCodeCacheLiveLayoutTests.swift
+++ b/Tests/PasteKeyCodeCacheLiveLayoutTests.swift
@@ -35,7 +35,7 @@ enum PasteKeyCodeCacheLiveLayoutTests {
         }
         guard TISEnableInputSource(dvorak) == noErr else { throw NSError(domain: "Enable failed", code: 2) }
         var refreshes = 0
-        let cache = PasteKeyCodeCache {
+        let cache = KeyboardLayoutSnapshotCache(initialValue: CGKeyCode(9)) {
             refreshes += 1
             return self.resolveV()
         }

--- a/Tests/PasteKeyCodeCacheRegressionTests.swift
+++ b/Tests/PasteKeyCodeCacheRegressionTests.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Carbon.HIToolbox
 
-// Standalone executable: compile with the production PasteKeyCodeCache.swift.
+// Standalone executable: compile with the production KeyboardLayoutSnapshotCache.swift.
 @main
 enum PasteKeyCodeCacheRegressionTests {
     static func main() {
@@ -9,7 +9,7 @@ enum PasteKeyCodeCacheRegressionTests {
         let name = Notification.Name("FluidVoice.PasteKeyCacheTest.\(UUID().uuidString)")
         var selectedKey: CGKeyCode = 9
         var lookups = 0
-        let cache = PasteKeyCodeCache(notificationName: name) {
+        let cache = KeyboardLayoutSnapshotCache(initialValue: CGKeyCode(9), notificationName: name) {
             precondition(Thread.isMainThread)
             lookups += 1
             return selectedKey
@@ -62,7 +62,7 @@ enum PasteKeyCodeCacheRegressionTests {
         precondition(finished.wait(timeout: .now() + 2) == .success, "Background reads must not wait for main")
         precondition(lookups == lookupsBeforeReads)
 
-        var released: PasteKeyCodeCache? = PasteKeyCodeCache(notificationName: name) { 9 }
+        var released: KeyboardLayoutSnapshotCache<CGKeyCode>? = KeyboardLayoutSnapshotCache(initialValue: CGKeyCode(9), notificationName: name) { 9 }
         released?.start()
         weak var weakCache = released
         released = nil

--- a/Tests/RemoteDesktopLayoutCacheRegressionTests.swift
+++ b/Tests/RemoteDesktopLayoutCacheRegressionTests.swift
@@ -86,8 +86,10 @@ enum RemoteDesktopLayoutCacheRegressionTests {
         // The agreement filter itself stays pure and testable without touching Carbon.
         precondition(RemoteDesktopKeyMapResolver.layoutSafeMap(local: [:]).isEmpty,
                      "no local layout means no agreement")
-        let ansiV = RemoteDesktopKeyMapResolver.ansiKeyMap["v"]
-        precondition(RemoteDesktopKeyMapResolver.layoutSafeMap(local: ["v": ansiV!])["v"] == ansiV,
+        guard let ansiV = RemoteDesktopKeyMapResolver.ansiKeyMap["v"] else {
+            fatalError("the ANSI table must define a position for v")
+        }
+        precondition(RemoteDesktopKeyMapResolver.layoutSafeMap(local: ["v": ansiV])["v"] == ansiV,
                      "an agreeing position survives the filter")
         precondition(RemoteDesktopKeyMapResolver.layoutSafeMap(local: ["v": stroke(47)])["v"] == nil,
                      "a disagreeing position is dropped")

--- a/Tests/RemoteDesktopLayoutCacheRegressionTests.swift
+++ b/Tests/RemoteDesktopLayoutCacheRegressionTests.swift
@@ -12,13 +12,17 @@ enum RemoteDesktopLayoutCacheRegressionTests {
         RemoteDesktopKeyStroke(keyCode: code, needsShift: false)
     }
 
+    static func snap(_ map: [Character: RemoteDesktopKeyStroke], paste: CGKeyCode? = 9) -> RemoteDesktopKeyMapResolver.Snapshot {
+        RemoteDesktopKeyMapResolver.Snapshot(typable: map, pasteKeyCode: paste)
+    }
+
     static func main() {
         precondition(Thread.isMainThread)
         let name = Notification.Name("FluidVoice.RemoteLayoutCacheTest.\(UUID().uuidString)")
-        var resolved: [Character: RemoteDesktopKeyStroke] = ["v": stroke(9)]
+        var resolved = snap(["v": stroke(9)])
         var lookups = 0
         let cache = KeyboardLayoutSnapshotCache(
-            initialValue: [Character: RemoteDesktopKeyStroke](),
+            initialValue: RemoteDesktopKeyMapResolver.Snapshot(),
             notificationName: name
         ) {
             precondition(Thread.isMainThread, "the layout must only ever be resolved on the main thread")
@@ -27,13 +31,14 @@ enum RemoteDesktopLayoutCacheRegressionTests {
         }
 
         // Fails closed before start(): an unstarted cache must not claim the layout agrees.
-        precondition(cache.snapshot().isEmpty, "an unstarted cache must offer nothing")
+        precondition(cache.snapshot().typable.isEmpty, "an unstarted cache must offer nothing")
+        precondition(cache.snapshot().pasteKeyCode == nil, "an unstarted cache must not offer a paste position")
         precondition(lookups == 0, "snapshot() must not resolve")
 
         cache.start()
         cache.start()
         precondition(lookups == 1, "Startup must resolve exactly once")
-        precondition(cache.snapshot()["v"] == stroke(9))
+        precondition(cache.snapshot().typable["v"] == stroke(9))
 
         // The typing path reads this per dictation, on a background queue, and must never
         // resolve the layout from there - that is the call that trapped inside HIToolbox.
@@ -42,7 +47,7 @@ enum RemoteDesktopLayoutCacheRegressionTests {
             group.enter()
             DispatchQueue.global(qos: .userInitiated).async {
                 precondition(!Thread.isMainThread)
-                precondition(cache.snapshot()["v"] == stroke(9))
+                precondition(cache.snapshot().typable["v"] == stroke(9))
                 group.leave()
             }
         }
@@ -59,7 +64,7 @@ enum RemoteDesktopLayoutCacheRegressionTests {
         RunLoop.current.run(until: Date().addingTimeInterval(0.02))
         precondition(lookups == 1, "Unrelated notifications must not refresh the cache")
 
-        func notifyAndWait(for map: [Character: RemoteDesktopKeyStroke], label: String) {
+        func notifyAndWait(for map: RemoteDesktopKeyMapResolver.Snapshot, label: String) {
             resolved = map
             DistributedNotificationCenter.default().postNotificationName(
                 name, object: nil, userInfo: nil, deliverImmediately: true
@@ -72,10 +77,10 @@ enum RemoteDesktopLayoutCacheRegressionTests {
         }
 
         // A layout switch narrows the agreed set; switching back restores it.
-        notifyAndWait(for: ["1": stroke(18)], label: "non-Latin layout")
-        notifyAndWait(for: ["v": stroke(9)], label: "back to Latin")
+        notifyAndWait(for: snap(["1": stroke(18)], paste: RemoteDesktopKeyMapResolver.ansiPasteKeyCode), label: "non-Latin layout")
+        notifyAndWait(for: snap(["v": stroke(9)]), label: "back to Latin")
         // Fail closed: an unreadable layout must empty the snapshot, not leave it stale.
-        notifyAndWait(for: [:], label: "unreadable layout")
+        notifyAndWait(for: snap([:], paste: nil), label: "unreadable layout")
         print("PASS remote-desktop layout cache: resolves on main only, \(lookups) lookups")
 
         // The agreement filter itself stays pure and testable without touching Carbon.

--- a/Tests/RemoteDesktopLayoutCacheRegressionTests.swift
+++ b/Tests/RemoteDesktopLayoutCacheRegressionTests.swift
@@ -1,0 +1,91 @@
+import AppKit
+import Carbon.HIToolbox
+
+// Standalone executable: compile with the production KeyboardLayoutSnapshotCache.swift and
+// RemoteDesktopKeyMap.swift.
+//
+// Pins the invariant that the Windows App crash violated: the remote-desktop typing path runs
+// on a background queue, so it must read a snapshot and must never resolve the layout itself.
+@main
+enum RemoteDesktopLayoutCacheRegressionTests {
+    static func stroke(_ code: CGKeyCode) -> RemoteDesktopKeyStroke {
+        RemoteDesktopKeyStroke(keyCode: code, needsShift: false)
+    }
+
+    static func main() {
+        precondition(Thread.isMainThread)
+        let name = Notification.Name("FluidVoice.RemoteLayoutCacheTest.\(UUID().uuidString)")
+        var resolved: [Character: RemoteDesktopKeyStroke] = ["v": stroke(9)]
+        var lookups = 0
+        let cache = KeyboardLayoutSnapshotCache(
+            initialValue: [Character: RemoteDesktopKeyStroke](),
+            notificationName: name
+        ) {
+            precondition(Thread.isMainThread, "the layout must only ever be resolved on the main thread")
+            lookups += 1
+            return resolved
+        }
+
+        // Fails closed before start(): an unstarted cache must not claim the layout agrees.
+        precondition(cache.snapshot().isEmpty, "an unstarted cache must offer nothing")
+        precondition(lookups == 0, "snapshot() must not resolve")
+
+        cache.start()
+        cache.start()
+        precondition(lookups == 1, "Startup must resolve exactly once")
+        precondition(cache.snapshot()["v"] == stroke(9))
+
+        // The typing path reads this per dictation, on a background queue, and must never
+        // resolve the layout from there - that is the call that trapped inside HIToolbox.
+        let group = DispatchGroup()
+        for _ in 0..<200 {
+            group.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                precondition(!Thread.isMainThread)
+                precondition(cache.snapshot()["v"] == stroke(9))
+                group.leave()
+            }
+        }
+        precondition(group.wait(timeout: .now() + 10) == .success, "background readers must not block")
+        precondition(lookups == 1, "Typing must not query the layout")
+
+        // Unrelated notifications must not refresh.
+        DistributedNotificationCenter.default().postNotificationName(
+            Notification.Name("FluidVoice.UnrelatedTest.\(UUID().uuidString)"),
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+        RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        precondition(lookups == 1, "Unrelated notifications must not refresh the cache")
+
+        func notifyAndWait(for map: [Character: RemoteDesktopKeyStroke], label: String) {
+            resolved = map
+            DistributedNotificationCenter.default().postNotificationName(
+                name, object: nil, userInfo: nil, deliverImmediately: true
+            )
+            let deadline = Date().addingTimeInterval(2)
+            while cache.snapshot() != map, Date() < deadline {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.005))
+            }
+            precondition(cache.snapshot() == map, "layout change must update the snapshot (\(label))")
+        }
+
+        // A layout switch narrows the agreed set; switching back restores it.
+        notifyAndWait(for: ["1": stroke(18)], label: "non-Latin layout")
+        notifyAndWait(for: ["v": stroke(9)], label: "back to Latin")
+        // Fail closed: an unreadable layout must empty the snapshot, not leave it stale.
+        notifyAndWait(for: [:], label: "unreadable layout")
+        print("PASS remote-desktop layout cache: resolves on main only, \(lookups) lookups")
+
+        // The agreement filter itself stays pure and testable without touching Carbon.
+        precondition(RemoteDesktopKeyMapResolver.layoutSafeMap(local: [:]).isEmpty,
+                     "no local layout means no agreement")
+        let ansiV = RemoteDesktopKeyMapResolver.ansiKeyMap["v"]
+        precondition(RemoteDesktopKeyMapResolver.layoutSafeMap(local: ["v": ansiV!])["v"] == ansiV,
+                     "an agreeing position survives the filter")
+        precondition(RemoteDesktopKeyMapResolver.layoutSafeMap(local: ["v": stroke(47)])["v"] == nil,
+                     "a disagreeing position is dropped")
+        print("PASS layoutSafeMap(local:) agreement filter")
+    }
+}

--- a/Tests/run_paste_key_cache_tests.sh
+++ b/Tests/run_paste_key_cache_tests.sh
@@ -10,7 +10,7 @@ export DEVELOPER_DIR="$task_developer_dir"
 task_repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 task_test_dir=$(mktemp -d /tmp/fluidvoice-paste-cache-tests.XXXXXX)
 xcrun swiftc -O \
-    "$task_repo_dir/Sources/Fluid/Services/PasteKeyCodeCache.swift" \
+    "$task_repo_dir/Sources/Fluid/Services/KeyboardLayoutSnapshotCache.swift" \
     "$task_repo_dir/Tests/PasteKeyCodeCacheRegressionTests.swift" \
     -o "$task_test_dir/paste-cache-tests"
 "$task_test_dir/paste-cache-tests"
@@ -19,9 +19,15 @@ xcrun swiftc -O \
     "$task_repo_dir/Tests/PasteKeyCodeResolverTests.swift" \
     -o "$task_test_dir/paste-resolver-tests"
 "$task_test_dir/paste-resolver-tests"
+xcrun swiftc -O \
+    "$task_repo_dir/Sources/Fluid/Services/KeyboardLayoutSnapshotCache.swift" \
+    "$task_repo_dir/Sources/Fluid/Services/RemoteDesktopKeyMap.swift" \
+    "$task_repo_dir/Tests/RemoteDesktopLayoutCacheRegressionTests.swift" \
+    -o "$task_test_dir/remote-layout-cache-tests"
+"$task_test_dir/remote-layout-cache-tests"
 if [ "${1:-}" = "--live" ]; then
     xcrun swiftc -O \
-        "$task_repo_dir/Sources/Fluid/Services/PasteKeyCodeCache.swift" \
+        "$task_repo_dir/Sources/Fluid/Services/KeyboardLayoutSnapshotCache.swift" \
         "$task_repo_dir/Sources/Fluid/Services/PasteKeyCodeResolver.swift" \
         "$task_repo_dir/Tests/PasteKeyCodeCacheLiveLayoutTests.swift" \
         -o "$task_test_dir/paste-live-tests"


### PR DESCRIPTION
## Description
Dictation never reached a remote-desktop session. Dictating into **Windows App** /
Microsoft Remote Desktop (`com.microsoft.rdc.macos`) produced the transcript in the overlay and
in History, but nothing landed in the remote window, in both text insertion modes.

Two independent causes, both measured against a live session rather than inferred:

**1. Clipboard redirection cannot be driven programmatically.** These clients only re-advertise
their clipboard to the guest after a *focus change*. Four pastes over 43 seconds, across four
distinct pasteboard writes 8 seconds apart, all delivered the **first** value; plain and
transient pasteboard items behaved identically and a 2.5 s settle changed nothing. Manual
copy/paste works only because copying means switching apps. So no settle delay can make a
paste-based approach reliable here, and forcing a real focus bounce visibly steals focus and
takes over a second to settle.

**2. The dictation hotkey leaves the guest in Windows menu mode.** An Option-based hotkey looks
to the guest like a *bare Alt tap* — the accompanying key is swallowed as the hotkey, so the
client forwards Alt down then Alt up with nothing between, and a bare Alt tap activates the
focused window's menu bar. The first character is then consumed as a menu accelerator, and when
it happens to match one it is worse than a lost character: `E` opened Notepad's Edit menu and
the rest of the text was consumed navigating it.

**The fix** routes this target to typing the transcript as real key presses, after resetting the
guest's keyboard state:

- Detect the target (mirrors the existing Ghostty per-app override in `TypingService`).
- Post a release for every modifier, then Escape to exit menu mode, then a short warm-up.
- Build a character → (key code, shift) map from the active layout via `UCKeyTranslate` and type
  real key presses. No clipboard is involved, so dictation into these targets no longer touches
  the user's clipboard at all.
- Transliterate smart punctuation first (curly quotes, em/en dashes, ellipsis, non-breaking
  spaces, bullets), since a curly apostrophe would otherwise turn "it's" into "its".
- Anything still unmappable (accented letters, emoji, CJK) aborts the attempt rather than
  emitting a prefix, and falls back to a lossless clipboard paste with the focus bounce.

Measured remedies for the menu-mode problem, with the hotkey's Alt tap reproduced
synthetically:

| Remedy | Result |
| --- | --- |
| none | leading character lost |
| Escape first | complete |
| second Alt tap | complete |
| 1200 ms wait only | leading character lost |
| modifier releases only | whole string consumed, Edit menu left open |

Escape rather than a second Alt tap: both work, but an Alt tap is a *toggle*, so if menu mode
were not active it would switch it on and cause the very bug it prevents. Escape only ever
exits. Waiting does not help, because this is a mode and not latency.

### Safety choices worth reviewing
- **Return and Tab are never typed.** Every other key this path can press (codes 0–50: letters,
  digits, punctuation) can only insert a character. Return *commits* and Tab *moves focus*, and
  the guest exposes no accessibility information through the client, so there is no way to
  confirm where keystrokes are landing. Text containing them goes to the lossless fallback.
- **All synthesized events are tagged** with `synthesizedEventUserData`. `GlobalHotkeyManager`
  taps `flagsChanged`, so an untagged synthetic modifier press would be matched as a
  modifier-only dictation shortcut and start a phantom recording on every dictation.
- **Modifier events are used exactly as `CGEvent` creates them.** A keyboard event for a
  modifier key code is *already* a `flagsChanged` carrying the device-side bit identifying which
  physical key it is; assigning `type` is a no-op and assigning `flags` discards that bit, which
  a client translating scan codes needs. Held-modifier flags are copied off the modifier event
  and inserted into the key events.
- **Dead keys are excluded** from the map. `kUCKeyTranslateNoDeadKeysMask` reports a dead key's
  standalone glyph, so on US-International and German layouts quote, grave and circumflex were
  offered as typeable when pressing them actually composes the next character.
- **Keypad key codes and `kVK_ISO_Section` are excluded.** The keypad was winning the map for
  `*` and `+`; ANSI Windows maps the ISO section position to backslash.
- **This target never falls through to the generic cascade.** Those paths post via `postToPid`,
  which this client ignores while the pipeline still reports success, and the clipboard ones
  would re-activate the target and hold the user's clipboard for five seconds to no effect.

### Scope and known limitations
- Only `com.microsoft.rdc.macos`. Citrix, VMware Horizon, Parallels and VNC are untouched.
- Non-Latin dictation is out of reach: in Scancode mode the guest applies its *own* layout to
  the key positions it receives, so that needs the client's Unicode keyboard mode, which is a
  client-side setting.
- The clipboard fallback path is exercised only by text this layout cannot type, and has not
  been verified against a live session.
- No new Settings UI. Three knobs exist as user defaults for field tuning without a rebuild:
  `RemoteDesktopTypeDelayMs` (16), `RemoteDesktopWarmupMs` (250),
  `RemoteDesktopClipboardSettleMs` (200).

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Related to discussion https://github.com/altic-dev/FluidVoice/discussions/563 and the earlier
attempt in https://github.com/altic-dev/FluidVoice/pull/562 (closed as stale).

That discussion's observation about dropped leading characters was correct, and this PR confirms
the cause. Its proposed mechanism could not have worked, though: it reused `postUnicodeChunks`,
so it stayed on `CGEvent(virtualKey: 0)` plus `keyboardSetUnicodeString`. A client in Scancode
mode forwards key *positions*, and Apple's own documentation notes that frameworks "may ignore
the Unicode string ... and do their own translation based on the virtual keycode" — so no typing
speed or warm-up would have made that path deliver text.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: 26.6.2 (Tahoe)
- [ ] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources Tests Package.swift`
- [ ] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: `xcodebuild test -project Fluid.xcodeproj -scheme Fluid -destination 'platform=macOS'` — **476 tests, 0 failures**

Manually verified end to end against a live Windows App session: dictation now types into the
remote window, first character included, with mixed case, digits and punctuation intact.

**SwiftLint and SwiftFormat were not run locally — neither is installed on this machine.** I
checked the configured rules by hand instead, including the opt-in ones. One real violation was
found and fixed that way: `discouraged_optional_collection` on a
`-> [RemoteDesktopKeyStroke]?` return type, which is now a `RemoteDesktopTypingPlan` sum type.
Body length was also checked — `TypingService`'s class body is roughly 1530 effective lines
against the 2000 warning. Please treat CI as the authority here.

## Screenshots / Video
Attach screenshots or a video for UI, UX, settings, onboarding, overlay, menu bar, or visual behavior changes.

- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
New unit tests cover the parts that are testable without a live remote session: the chord shape
and its flag fidelity, the hotkey-isolation tagging, the layout reverse map against a **fixed**
installed layout (read via `TISCreateInputSourceList` so the assertions do not depend on which
input source the running machine has selected), dead-key exclusion, transliteration,
all-or-nothing stroke planning, target resolution order, and the clamped user-default parsing.

Two notes for reviewers about test assertions that look like they could be stronger but cannot:
a nil-source `CGEvent` inherits the ambient combined-session modifier state, and
`.maskNonCoalesced` is set on a freshly created event in a standalone process but **not** inside
the XCTest host. Any assertion on an absolute flag value is therefore unstable by construction,
so the flag-fidelity guard is a superset comparison within a single chord, and the two places
where ambient state genuinely matters skip explicitly rather than assert.

The commit history is deliberately sequential and shows a clipboard approach being tried and
then disproved by measurement. Happy to squash it into a single commit if you would prefer that.
