### PR TITLE
Fix media pause and resume during dictation

### DIFF
--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -623,6 +623,8 @@ final class ASRService: ObservableObject {
 
     func shutdownForTermination() async {
         self.isTerminating = true
+        // Give media restoration the same quit window as audio cleanup.
+        MediaPlaybackService.shared.beginShutdown()
         let routeRecoveryShutdownStartedAt = Date().timeIntervalSince1970
         await self.cancelAudioRouteRecoveryAndWait()
         self.benchmarkLog(

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -519,6 +519,7 @@ final class ASRService: ObservableObject {
     private(set) var dictionaryTrainingAudioGeneration = 0
 
     @Published private(set) var isStarting: Bool = false // Guard against re-entrant start() calls
+    private var pendingMediaCaptureSessionID: Int?
     private var audioCaptureStartWaiters: [CheckedContinuation<Void, Never>] = []
     var isRunningOrStarting: Bool {
         self.isRunning || self.isStarting
@@ -665,6 +666,7 @@ final class ASRService: ObservableObject {
         self.isAsrReady = false
         self.isLoadingModel = false
         self.isDownloadingModel = false
+        await MediaPlaybackService.shared.shutdown()
     }
 
     /// The transcription provider, selected based on the unified SpeechModel setting.
@@ -1460,10 +1462,6 @@ final class ASRService: ObservableObject {
     private var isEngineTapInstalled = false
     private var isRecoveringAudioRoute = false
 
-    /// Tracks whether we paused system media for this recording session.
-    /// Used to resume playback only if we were the ones who paused it.
-    private var didPauseMediaForThisSession: Bool = false
-
     private var audioLevelSubject = PassthroughSubject<CGFloat, Never>()
     var audioLevelPublisher: AnyPublisher<CGFloat, Never> {
         self.audioLevelSubject.eraseToAnyPublisher()
@@ -2106,8 +2104,6 @@ final class ASRService: ObservableObject {
         // alive; startConfiguredAudioCapture reuses it for zero-stop first PCM.
         let handedOffMicrophonePreview = self.handOffMicrophonePreviewToCaptureStartIfNeeded()
 
-        // Reset media pause state for this session
-        self.didPauseMediaForThisSession = false
         self.audioEngineStandbyTask?.cancel()
         self.audioEngineStandbyTask = nil
         await self.waitForPendingAudioRouteRecoveryBeforeStart()
@@ -2139,6 +2135,15 @@ final class ASRService: ObservableObject {
         self.streamingHealthLastBufferCount = 0
         self.silentPCMRecoveryWatchdog = AudioCaptureIdlePolicy.SilentPCMRecoveryWatchdog()
         let captureSessionID = self.benchmarkSessionID
+        // Start media work alongside microphone startup; never await it on the
+        // capture path. Track only this start so cancelling a buffer-handoff wait
+        // cannot finish the previous session's still-running transcription.
+        self.pendingMediaCaptureSessionID = captureSessionID
+        defer { self.pendingMediaCaptureSessionID = nil }
+        MediaPlaybackService.shared.recordingStarted(
+            sessionID: captureSessionID,
+            enabled: SettingsStore.shared.pauseMediaDuringTranscription
+        )
         self.audioCaptureAttemptID &+= 1
         var readinessAttemptID = self.audioCaptureAttemptID
         self.audioCaptureReadinessGate.arm(
@@ -2359,23 +2364,6 @@ final class ASRService: ObservableObject {
             )
             onCaptureStarted?()
 
-            // Pause only after capture is live so media control cannot delay the
-            // first PCM packet. A quick stop while this await is in flight is
-            // handled explicitly below.
-            if SettingsStore.shared.pauseMediaDuringTranscription {
-                let didPause = await MediaPlaybackService.shared.pauseIfPlaying()
-                guard self.isRunning, self.isStoppingFinalTranscription == false else {
-                    if didPause {
-                        await MediaPlaybackService.shared.resumeIfWePaused(true)
-                    }
-                    return .started
-                }
-                self.didPauseMediaForThisSession = didPause
-                if didPause {
-                    DebugLogger.shared.info("🎵 Paused system media for transcription", source: "ASRService")
-                }
-            }
-
             // Direct capture already owns a required device-liveness listener
             // on its off-main lifecycle queue.
             if self.activeAudioCaptureBackend == .audioEngine,
@@ -2401,6 +2389,7 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.info("✅ START() completed successfully", source: "ASRService")
             return .started
         } catch {
+            MediaPlaybackService.shared.sessionFinished(sessionID: captureSessionID)
             await self.audioCaptureReadinessGate.cancel(
                 sessionID: captureSessionID,
                 attemptID: readinessAttemptID
@@ -2424,13 +2413,6 @@ final class ASRService: ObservableObject {
                 )
             } else {
                 DebugLogger.shared.error("Failed to start ASR session: \(error)", source: "ASRService")
-            }
-
-            // Resume media if we paused it before the failure
-            if self.didPauseMediaForThisSession {
-                await MediaPlaybackService.shared.resumeIfWePaused(true)
-                self.didPauseMediaForThisSession = false
-                DebugLogger.shared.info("🎵 Resumed system media after start failure", source: "ASRService")
             }
 
             guard wasCancelled == false else { return .failed }
@@ -2563,6 +2545,9 @@ final class ASRService: ObservableObject {
     func cancelPendingAudioCaptureStart(reason: String) async {
         guard self.isStarting, self.isRunning == false else { return }
         self.audioCaptureStartGeneration &+= 1
+        if let sessionID = self.pendingMediaCaptureSessionID {
+            MediaPlaybackService.shared.sessionFinished(sessionID: sessionID)
+        }
         // A start waiting for the previous session's PCM handoff must wake to
         // observe the generation change; the old stop keeps ownership of the gate.
         self.recordingBufferHandoffGate.releasePendingWaiters()
@@ -2723,6 +2708,8 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.warning("STOP() ignored - recording buffer handoff already active", source: "ASRService")
             return ""
         }
+        MediaPlaybackService.shared.recordingStopped(sessionID: stoppingSessionID)
+        defer { MediaPlaybackService.shared.sessionFinished(sessionID: stoppingSessionID) }
         self.isStoppingFinalTranscription = true
         var completedBufferHandoff = false
         defer {
@@ -2748,10 +2735,6 @@ final class ASRService: ObservableObject {
             completedBufferHandoff = true
             return ""
         }
-
-        // Capture media pause state before we reset it, for resuming at the end
-        let shouldResumeMedia = self.didPauseMediaForThisSession
-        self.didPauseMediaForThisSession = false // Reset for next session
 
         DebugLogger.shared.debug("📍 Preparing final transcription", source: "ASRService")
 
@@ -2813,7 +2796,6 @@ final class ASRService: ObservableObject {
             self.beginStreamingDrainRecovery(sessionID: stoppingSessionID, token: bufferHandoffToken)
             completedBufferHandoff = true // Recovery owns the PCM handoff until real work ends.
             self.lastStopOutcome = .failed
-            if shouldResumeMedia { await MediaPlaybackService.shared.resumeIfWePaused(true) }
             self.benchmarkLog("stop_end result=error reason=streaming_drain_timeout")
             return ""
         }
@@ -2847,10 +2829,6 @@ final class ASRService: ObservableObject {
                 "Final ASR result | provider=\(self.transcriptionProvider.name) | samples=0 | textChars=0 | confidence=nil | reason=no_audio",
                 source: "ASRService"
             )
-            if shouldResumeMedia {
-                await MediaPlaybackService.shared.resumeIfWePaused(true)
-                DebugLogger.shared.info("🎵 Resumed system media after empty audio", source: "ASRService")
-            }
             self.benchmarkLog("stop_end result=empty totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) reason=no_audio")
             return ""
         }
@@ -2878,10 +2856,6 @@ final class ASRService: ObservableObject {
                     "Final ASR result | provider=\(self.transcriptionProvider.name) | samples=\(pcm.count) | textChars=0 | confidence=nil | reason=short_silence",
                     source: "ASRService"
                 )
-                if shouldResumeMedia {
-                    await MediaPlaybackService.shared.resumeIfWePaused(true)
-                    DebugLogger.shared.info("🎵 Resumed system media after silent audio", source: "ASRService")
-                }
                 self.benchmarkLog(
                     "stop_end result=empty totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) reason=short_silence"
                 )
@@ -2926,11 +2900,6 @@ final class ASRService: ObservableObject {
             guard provider.isReady else {
                 DebugLogger.shared.error("Transcription provider is not ready", source: "ASRService")
                 self.lastStopOutcome = .failed
-                // Resume media playback if we paused it
-                if shouldResumeMedia {
-                    await MediaPlaybackService.shared.resumeIfWePaused(true)
-                    DebugLogger.shared.info("🎵 Resumed system media after provider not ready", source: "ASRService")
-                }
                 self.benchmarkLog("stop_end result=empty totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) reason=provider_not_ready")
                 return ""
             }
@@ -3034,12 +3003,6 @@ final class ASRService: ObservableObject {
                 )
             }
 
-            // Resume media playback if we paused it
-            if shouldResumeMedia {
-                await MediaPlaybackService.shared.resumeIfWePaused(true)
-                DebugLogger.shared.info("🎵 Resumed system media after transcription", source: "ASRService")
-            }
-
             self.lastStopOutcome = outputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? .empty
                 : .success
@@ -3067,12 +3030,6 @@ final class ASRService: ObservableObject {
             // Common errors like "audio too short" are expected during normal use
             // (e.g., accidental hotkey press) and would disrupt the user's workflow.
             // Errors are logged for debugging purposes.
-
-            // Resume media playback if we paused it
-            if shouldResumeMedia {
-                await MediaPlaybackService.shared.resumeIfWePaused(true)
-                DebugLogger.shared.info("🎵 Resumed system media after transcription failure", source: "ASRService")
-            }
 
             self.benchmarkLog("stop_end result=error totalMs=\(self.elapsedMilliseconds(since: stopStartedAt)) error=\(error.localizedDescription)")
             return ""
@@ -3285,6 +3242,8 @@ final class ASRService: ObservableObject {
         guard self.isRunning else { return }
         let stoppingSessionID = self.benchmarkSessionID
         guard let bufferHandoffToken = self.recordingBufferHandoffGate.begin() else { return }
+        MediaPlaybackService.shared.recordingStopped(sessionID: stoppingSessionID)
+        defer { MediaPlaybackService.shared.sessionFinished(sessionID: stoppingSessionID) }
         var completedBufferHandoff = false
         defer {
             if completedBufferHandoff == false {
@@ -3303,10 +3262,6 @@ final class ASRService: ObservableObject {
             completedBufferHandoff = true
             return
         }
-
-        // Capture media pause state before we reset it, for resuming at the end
-        let shouldResumeMedia = self.didPauseMediaForThisSession
-        self.didPauseMediaForThisSession = false // Reset for next session
 
         DebugLogger.shared.info("🛑 Stopping recording - releasing audio devices", source: "ASRService")
 
@@ -3330,7 +3285,6 @@ final class ASRService: ObservableObject {
         guard await self.drainActiveStreamingWork(sessionID: stoppingSessionID) else {
             self.beginStreamingDrainRecovery(sessionID: stoppingSessionID, token: bufferHandoffToken)
             completedBufferHandoff = true
-            if shouldResumeMedia { await MediaPlaybackService.shared.resumeIfWePaused(true) }
             return
         }
 
@@ -3346,12 +3300,6 @@ final class ASRService: ObservableObject {
         self.isProcessingChunk = false
         self.skipNextChunk = false
         self.refreshWordBoostStatus()
-
-        // Resume media playback if we paused it
-        if shouldResumeMedia {
-            await MediaPlaybackService.shared.resumeIfWePaused(true)
-            DebugLogger.shared.info("🎵 Resumed system media after stopping without transcription", source: "ASRService")
-        }
     }
 
     private func configureSession() throws {

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -138,7 +138,8 @@ final class MediaPlaybackService {
     private func resume(target: MediaPlaybackSnapshot) async {
         // Do not clear ownership until after the query: a new recording arriving
         // during it can inherit this verified pause without a play/pause burst.
-        guard let before = await self.query(context: "before_resume") else {
+        guard let before = await self.queryBeforeResume() else {
+            guard self.session == nil else { return }
             self.pausedTarget = nil
             self.log("resume_skipped reason=unknown_player")
             return
@@ -159,6 +160,20 @@ final class MediaPlaybackService {
         } else {
             self.backOff(context: "resume")
         }
+    }
+
+    private func queryBeforeResume() async -> MediaPlaybackSnapshot? {
+        // Retain confirmed ownership across brief metadata outages. Retry reads,
+        // never playback commands; give up after three bounded helper calls.
+        for attempt in 1...3 {
+            guard self.session == nil else { return nil }
+            if let snapshot = await self.query(context: "before_resume attempt=\(attempt)") {
+                return snapshot
+            }
+            guard self.session == nil else { return nil }
+            if attempt < 3 { await self.settle() }
+        }
+        return nil
     }
 
     private func verify(

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -113,7 +113,7 @@ final class MediaPlaybackService {
             self.log("pause_suppressed session=\(sessionID) reason=player_backoff")
             return
         }
-        guard let before = await self.query(context: "before_pause session=\(sessionID)") else { return }
+        guard let before = await self.queryBeforePause(sessionID: sessionID) else { return }
         guard self.canPause(sessionID) else {
             self.log("pause_skipped session=\(sessionID) reason=stale_recording")
             return
@@ -138,6 +138,18 @@ final class MediaPlaybackService {
         } else {
             self.backOff(context: "pause session=\(sessionID)")
         }
+    }
+
+    private func queryBeforePause(sessionID: Int) async -> MediaPlaybackSnapshot? {
+        for attempt in 1...3 {
+            guard self.canPause(sessionID) else { return nil }
+            if let snapshot = await self.query(context: "before_pause session=\(sessionID) attempt=\(attempt)") {
+                return snapshot
+            }
+            guard self.canPause(sessionID) else { return nil }
+            if attempt < 3 { await self.settle() }
+        }
+        return nil
     }
 
     private func resume(target: MediaPlaybackSnapshot) async {

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -1,244 +1,224 @@
 import Foundation
-#if arch(arm64)
-import MediaRemoteAdapter
-#endif
 
-#if arch(arm64)
-@MainActor
-protocol MediaPlaybackControlling {
-    func getTrackInfo(_ onReceive: @escaping (TrackInfo?) -> Void)
-    func pause()
-    func play()
-}
-
-extension MediaController: MediaPlaybackControlling {}
-#endif
-
-/// Service that wraps MediaRemoteAdapter's MediaController to provide
-/// controlled pause/resume functionality during transcription.
-///
-/// This service ensures we only pause media if it's currently playing,
-/// and only resume if we were the ones who paused it.
+/// One reconciler owns all media queries and commands. Recording events update
+/// intent synchronously; they never wait for media control or delay first PCM.
 @MainActor
 final class MediaPlaybackService {
-    #if arch(arm64)
-    typealias TimeoutScheduler = (
-        _ delay: TimeInterval,
-        _ action: @escaping @MainActor @Sendable () -> Void
-    ) -> Void
+    static let shared = MediaPlaybackService(transport: MediaPlaybackProcessTransport())
 
-    /// The pinned adapter's two-second deadline can occupy roughly 2.1 seconds
-    /// in run-loop slices. Leave additional time for process and callback delivery.
-    static let nowPlayingQueryTimeoutSeconds: TimeInterval = 2.5
-
-    private static let productionTimeoutScheduler: TimeoutScheduler = { delay, action in
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: action)
+    private struct Session {
+        let id: Int
+        var mayPause: Bool
     }
 
-    static let shared = MediaPlaybackService(
-        mediaController: MediaController(),
-        queryTimeoutSeconds: MediaPlaybackService.nowPlayingQueryTimeoutSeconds,
-        timeoutScheduler: MediaPlaybackService.productionTimeoutScheduler
-    )
+    private let transport: any MediaPlaybackTransport
+    private let settle: @Sendable () async -> Void
+    private let now: @Sendable () -> TimeInterval
+    private var session: Session?
+    private var revision: UInt64 = 0
+    private var attemptedSession: Int?
+    private var pausedTarget: MediaPlaybackSnapshot?
+    private var worker: Task<Void, Never>?
+    private var suspendedUntil: TimeInterval = 0
+    private var isShuttingDown = false
 
-    private let mediaController: any MediaPlaybackControlling
-    private let queryTimeoutSeconds: TimeInterval
-    private let timeoutScheduler: TimeoutScheduler
-
-    /// Creates an isolated service with injectable dependencies for deterministic tests.
     init(
-        mediaController: any MediaPlaybackControlling,
-        queryTimeoutSeconds: TimeInterval,
-        timeoutScheduler: @escaping TimeoutScheduler
+        transport: any MediaPlaybackTransport,
+        settle: @escaping @Sendable () async -> Void = {
+            try? await Task.sleep(nanoseconds: 150_000_000)
+        },
+        now: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
     ) {
-        self.mediaController = mediaController
-        self.queryTimeoutSeconds = queryTimeoutSeconds
-        self.timeoutScheduler = timeoutScheduler
+        self.transport = transport
+        self.settle = settle
+        self.now = now
     }
-    #else
-    static let shared = MediaPlaybackService()
 
-    private init() {}
-    #endif
+    func recordingStarted(sessionID: Int, enabled: Bool) {
+        guard !self.isShuttingDown else { return }
+        self.session = enabled ? Session(id: sessionID, mayPause: true) : nil
+        self.revision &+= 1
+        self.log("recording_started session=\(sessionID) enabled=\(enabled)")
+        self.wake()
+    }
 
-    // MARK: - Public API
+    /// Prevent a slow query from issuing pause after the hotkey is released.
+    /// A previously confirmed pause stays owned until transcription finishes.
+    func recordingStopped(sessionID: Int) {
+        guard self.session?.id == sessionID else { return }
+        self.session?.mayPause = false
+        self.revision &+= 1
+        self.log("recording_stopped session=\(sessionID)")
+        self.wake()
+    }
 
-    #if arch(arm64)
-    /// Pauses system media playback if something is currently playing.
-    ///
-    /// - Returns: `true` if a pause request was issued, `false` if nothing was playing or
-    ///   if we couldn't determine playback state. The media adapter does not acknowledge
-    ///   command completion.
-    ///
-    /// - Note: Uses a local one-shot gate to protect against `MediaRemoteAdapter`
-    ///   firing the `getTrackInfo` callback more than once, which would otherwise
-    ///   crash with `EXC_BREAKPOINT` (SIGTRAP) due to double-resume of a
-    ///   `CheckedContinuation`.
-    func pauseIfPlaying() async -> Bool {
-        return await withCheckedContinuation { continuation in
-            let queryStartedAt = DispatchTime.now().uptimeNanoseconds
-            let resumeLock = NSLock()
-            var didResume = false
+    /// An older transcription finishing cannot resume a newer recording's media.
+    func sessionFinished(sessionID: Int) {
+        guard self.session?.id == sessionID else { return }
+        self.session = nil
+        self.revision &+= 1
+        self.log("session_finished session=\(sessionID)")
+        self.wake()
+    }
 
-            @MainActor
-            func elapsedMilliseconds() -> UInt64 {
-                (DispatchTime.now().uptimeNanoseconds - queryStartedAt) / 1_000_000
+    func shutdown() async {
+        self.isShuttingDown = true
+        self.session = nil
+        self.revision &+= 1
+        self.wake()
+        await self.waitUntilSettled()
+    }
+
+    /// Also used by deterministic tests; no continuous observer or polling task.
+    func waitUntilSettled() async {
+        while let worker = self.worker {
+            await worker.value
+        }
+    }
+
+    private func wake() {
+        guard self.worker == nil else { return }
+        self.worker = Task { await self.reconcile() }
+    }
+
+    private func reconcile() async {
+        while true {
+            let observedRevision = self.revision
+            if let session = self.session {
+                if session.mayPause, self.attemptedSession != session.id {
+                    self.attemptedSession = session.id
+                    await self.pause(sessionID: session.id)
+                }
+            } else if let target = self.pausedTarget {
+                await self.resume(target: target)
             }
-
-            @discardableResult
-            @MainActor
-            func resumeOnce(
-                _ value: Bool,
-                logDuplicate: Bool = true,
-                beforeResume: () -> Void = {}
-            ) -> Bool {
-                var shouldResume = false
-
-                resumeLock.lock()
-                if !didResume {
-                    didResume = true
-                    shouldResume = true
-                }
-                resumeLock.unlock()
-
-                guard shouldResume else {
-                    if logDuplicate {
-                        DebugLogger.shared.warning(
-                            """
-                            MediaPlaybackService: Suppressed late or duplicate media callback \
-                            (elapsedMs: \(elapsedMilliseconds()))
-                            """,
-                            source: "MediaPlaybackService"
-                        )
-                    }
-                    return false
-                }
-
-                beforeResume()
-                continuation.resume(returning: value)
-                return true
-            }
-
-            self.timeoutScheduler(self.queryTimeoutSeconds) {
-                if resumeOnce(false, logDuplicate: false) {
-                    DebugLogger.shared.warning(
-                        """
-                        MediaPlaybackService: Now Playing query timed out; leaving playback unchanged \
-                        (elapsedMs: \(elapsedMilliseconds()))
-                        """,
-                        source: "MediaPlaybackService"
-                    )
-                }
-            }
-
-            self.mediaController.getTrackInfo { [weak self] trackInfo in
-                guard let self = self else {
-                    DebugLogger.shared.warning(
-                        """
-                        MediaPlaybackService: Service released before query completed \
-                        (elapsedMs: \(elapsedMilliseconds()))
-                        """,
-                        source: "MediaPlaybackService"
-                    )
-                    resumeOnce(false)
-                    return
-                }
-
-                // If no track info is available, nothing is playing
-                guard let trackInfo = trackInfo else {
-                    DebugLogger.shared.debug(
-                        """
-                        MediaPlaybackService: No track info available, nothing to pause \
-                        (elapsedMs: \(elapsedMilliseconds()))
-                        """,
-                        source: "MediaPlaybackService"
-                    )
-                    resumeOnce(false)
-                    return
-                }
-
-                // Determine if media is currently playing
-                // Use isPlaying if available, otherwise check playbackRate
-                let isPlaying: Bool
-                if let playing = trackInfo.payload.isPlaying {
-                    isPlaying = playing
-                } else {
-                    // playbackRate of 1.0 typically means playing, 0.0 means paused
-                    isPlaying = (trackInfo.payload.playbackRate ?? 0.0) > 0.0
-                }
-
-                // Log what we found
-                DebugLogger.shared.debug(
-                    """
-                    MediaPlaybackService: Track info received
-                    - App: \(trackInfo.payload.applicationName ?? "Unknown")
-                    - Bundle: \(trackInfo.payload.bundleIdentifier ?? "Unknown")
-                    - Title: \(trackInfo.payload.title ?? "Unknown")
-                    - isPlaying: \(trackInfo.payload.isPlaying?.description ?? "nil")
-                    - playbackRate: \(trackInfo.payload.playbackRate?.description ?? "nil")
-                    - Determined playing: \(isPlaying)
-                    - elapsedMs: \(elapsedMilliseconds())
-                    """,
-                    source: "MediaPlaybackService"
-                )
-
-                if isPlaying {
-                    resumeOnce(true) {
-                        DebugLogger.shared.info(
-                            """
-                            MediaPlaybackService: Media is playing, sending pause command \
-                            (elapsedMs: \(elapsedMilliseconds()))
-                            """,
-                            source: "MediaPlaybackService"
-                        )
-                        self.mediaController.pause()
-                    }
-                } else {
-                    DebugLogger.shared.debug(
-                        """
-                        MediaPlaybackService: Media is not playing, no action needed \
-                        (elapsedMs: \(elapsedMilliseconds()))
-                        """,
-                        source: "MediaPlaybackService"
-                    )
-                    resumeOnce(false)
-                }
+            guard observedRevision != self.revision else {
+                self.worker = nil
+                return
             }
         }
     }
 
-    /// Resumes media playback only if we were the ones who paused it.
-    ///
-    /// - Parameter wePaused: `true` if `pauseIfPlaying()` returned `true` for this session.
-    func resumeIfWePaused(_ wePaused: Bool) async {
-        guard wePaused else {
-            DebugLogger.shared.debug(
-                "MediaPlaybackService: We didn't pause media, not resuming",
-                source: "MediaPlaybackService"
-            )
+    private func canPause(_ sessionID: Int) -> Bool {
+        self.session?.id == sessionID && self.session?.mayPause == true
+    }
+
+    private func pause(sessionID: Int) async {
+        guard self.now() >= self.suspendedUntil else {
+            self.log("pause_suppressed session=\(sessionID) reason=player_backoff")
             return
         }
-
-        DebugLogger.shared.info(
-            "MediaPlaybackService: Resuming media playback (we paused it)",
-            source: "MediaPlaybackService"
-        )
-
-        // Use explicit play() command - never toggle
-        self.mediaController.play()
+        guard let before = await self.query(context: "before_pause session=\(sessionID)") else { return }
+        guard self.canPause(sessionID) else {
+            self.log("pause_skipped session=\(sessionID) reason=stale_recording")
+            return
+        }
+        if let owned = self.pausedTarget, owned.matches(before), before.isPlaying == false {
+            self.log("pause_retained session=\(sessionID) reason=already_owned")
+            return
+        }
+        // A player change or manual playback invalidates our previous ownership.
+        self.pausedTarget = nil
+        guard before.isPlaying == true else {
+            self.log("pause_skipped session=\(sessionID) reason=not_known_playing")
+            return
+        }
+        let result = await self.transport.send(.pause)
+        self.logCommand(.pause, result: result, sessionID: sessionID)
+        // Even a timed-out helper might have sent its command before exiting.
+        // Observe state before deciding whether we own a pause to restore.
+        if let paused = await self.verify(target: before, playing: false, context: "pause session=\(sessionID)") {
+            self.pausedTarget = paused
+            self.log("pause_verified session=\(sessionID)")
+        } else {
+            self.backOff(context: "pause session=\(sessionID)")
+        }
     }
-    #else
-    // Intel Mac stub - media control not available
-    func pauseIfPlaying() async -> Bool {
-        DebugLogger.shared.debug(
-            "MediaPlaybackService: Not available on Intel Macs",
-            source: "MediaPlaybackService"
-        )
-        return false
+
+    private func resume(target: MediaPlaybackSnapshot) async {
+        // Do not clear ownership until after the query: a new recording arriving
+        // during it can inherit this verified pause without a play/pause burst.
+        guard let before = await self.query(context: "before_resume") else {
+            self.pausedTarget = nil
+            self.log("resume_skipped reason=unknown_player")
+            return
+        }
+        guard self.session == nil else {
+            self.log("resume_skipped reason=new_recording")
+            return
+        }
+        self.pausedTarget = nil
+        guard target.matches(before), before.isPlaying == false else {
+            self.log("resume_skipped reason=player_item_or_state_changed")
+            return
+        }
+        let result = await self.transport.send(.play)
+        self.logCommand(.play, result: result, sessionID: nil)
+        if await self.verify(target: before, playing: true, context: "resume") != nil {
+            self.log("resume_verified")
+        } else {
+            self.backOff(context: "resume")
+        }
     }
 
-    func resumeIfWePaused(_ wePaused: Bool) async {
-        // No-op on Intel
+    private func verify(
+        target: MediaPlaybackSnapshot, playing: Bool, context: String
+    ) async -> MediaPlaybackSnapshot? {
+        // Read at most twice; never retry a playback command blindly. This checks
+        // reported state, not rendered video: Netflix can disagree with its UI.
+        for attempt in 1...2 {
+            await self.settle()
+            guard let observed = await self.query(context: "verify_\(context) attempt=\(attempt)") else {
+                continue
+            }
+            guard target.matches(observed) else {
+                self.log("verification_failed context=\(context) reason=player_or_item_changed")
+                return nil
+            }
+            if observed.isPlaying == playing { return observed }
+        }
+        self.log("verification_failed context=\(context) reason=state_not_confirmed")
+        return nil
     }
-    #endif
+
+    private func query(context: String) async -> MediaPlaybackSnapshot? {
+        let started = self.now()
+        let result = await self.transport.query()
+        let elapsed = Int((self.now() - started) * 1000)
+        switch result {
+        case let .snapshot(snapshot):
+            self.log(
+                "query context=\(context) elapsedMs=\(elapsed) " +
+                    "bundle=\(snapshot.bundleIdentifier) pid=\(snapshot.processID) " +
+                    "playing=\(snapshot.isPlaying.map(String.init) ?? "unknown") " +
+                    "hasTitle=\(snapshot.title != nil)"
+            )
+            return snapshot
+        case let .unavailable(reason):
+            self.log("query_unavailable context=\(context) elapsedMs=\(elapsed) reason=\(reason)")
+            return nil
+        }
+    }
+
+    private func backOff(context: String) {
+        // A finite cooldown limits damage from hotkey spam against an unresponsive
+        // player. The next recording after the cooldown performs a fresh query.
+        self.suspendedUntil = self.now() + 10
+        self.log("commands_suspended context=\(context) seconds=10")
+    }
+
+    private func logCommand(
+        _ command: MediaPlaybackCommand, result: MediaPlaybackCommandResult, sessionID: Int?
+    ) {
+        let status: String
+        switch result {
+        case .helperCompleted: status = "helper_completed_player_unconfirmed"
+        case let .failed(reason): status = "failed:\(reason)"
+        }
+        self.log("command=\(command.rawValue) session=\(sessionID.map(String.init) ?? "none") result=\(status)")
+    }
+
+    private func log(_ message: String) {
+        DebugLogger.shared.info("MEDIA_CONTROL \(message)", source: "MediaPlaybackService")
+    }
 }

--- a/Sources/Fluid/Services/MediaPlaybackService.swift
+++ b/Sources/Fluid/Services/MediaPlaybackService.swift
@@ -61,11 +61,16 @@ final class MediaPlaybackService {
         self.wake()
     }
 
-    func shutdown() async {
+    func beginShutdown() {
+        guard !self.isShuttingDown else { return }
         self.isShuttingDown = true
         self.session = nil
         self.revision &+= 1
         self.wake()
+    }
+
+    func shutdown() async {
+        self.beginShutdown()
         await self.waitUntilSettled()
     }
 
@@ -136,29 +141,38 @@ final class MediaPlaybackService {
     }
 
     private func resume(target: MediaPlaybackSnapshot) async {
-        // Do not clear ownership until after the query: a new recording arriving
-        // during it can inherit this verified pause without a play/pause burst.
-        guard let before = await self.queryBeforeResume() else {
+        // Retry a command only after fresh metadata confirms the same paused item.
+        // Retain ownership while a new recording may inherit the pause.
+        for attempt in 1...2 {
+            guard let before = await self.queryBeforeResume() else {
+                if self.session == nil { self.pausedTarget = nil }
+                self.log("resume_skipped reason=unknown_player")
+                return
+            }
+            guard self.session == nil else {
+                self.log("resume_skipped reason=new_recording")
+                return
+            }
+            guard target.matches(before), before.isPlaying == false else {
+                self.pausedTarget = nil
+                self.log("resume_skipped reason=player_item_or_state_changed")
+                return
+            }
+            let result = await self.transport.send(.play)
+            self.logCommand(.play, result: result, sessionID: nil)
+            if await self.verify(target: before, playing: true, context: "resume") != nil {
+                self.pausedTarget = nil
+                self.log("resume_verified")
+                return
+            }
             guard self.session == nil else { return }
-            self.pausedTarget = nil
-            self.log("resume_skipped reason=unknown_player")
-            return
-        }
-        guard self.session == nil else {
-            self.log("resume_skipped reason=new_recording")
-            return
-        }
-        self.pausedTarget = nil
-        guard target.matches(before), before.isPlaying == false else {
-            self.log("resume_skipped reason=player_item_or_state_changed")
-            return
-        }
-        let result = await self.transport.send(.play)
-        self.logCommand(.play, result: result, sessionID: nil)
-        if await self.verify(target: before, playing: true, context: "resume") != nil {
-            self.log("resume_verified")
-        } else {
-            self.backOff(context: "resume")
+            // Quit is best-effort within the app's overall termination deadline.
+            // Do not add another command cycle while shutdown is in progress.
+            if self.isShuttingDown || attempt == 2 {
+                self.pausedTarget = nil
+                self.backOff(context: "resume")
+                return
+            }
         }
     }
 
@@ -171,6 +185,7 @@ final class MediaPlaybackService {
                 return snapshot
             }
             guard self.session == nil else { return nil }
+            if self.isShuttingDown { return nil }
             if attempt < 3 { await self.settle() }
         }
         return nil
@@ -182,6 +197,7 @@ final class MediaPlaybackService {
         // Read at most twice; never retry a playback command blindly. This checks
         // reported state, not rendered video: Netflix can disagree with its UI.
         for attempt in 1...2 {
+            if attempt > 1, self.isShuttingDown { break }
             await self.settle()
             guard let observed = await self.query(context: "verify_\(context) attempt=\(attempt)") else {
                 continue

--- a/Sources/Fluid/Services/MediaPlaybackTransport.swift
+++ b/Sources/Fluid/Services/MediaPlaybackTransport.swift
@@ -134,7 +134,7 @@ nonisolated struct MediaHelperResult: Sendable {
 
 /// Private process plumbing; never runs on the main actor.
 nonisolated enum MediaHelperProcess {
-    static func run(arguments: [String], timeout: TimeInterval = 3.5) -> MediaHelperResult {
+    static func run(arguments: [String], timeout: TimeInterval = 1.0) -> MediaHelperResult {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/perl")
         process.arguments = arguments

--- a/Sources/Fluid/Services/MediaPlaybackTransport.swift
+++ b/Sources/Fluid/Services/MediaPlaybackTransport.swift
@@ -1,0 +1,242 @@
+import Foundation
+#if arch(arm64)
+import MediaRemoteAdapter
+#endif
+
+nonisolated struct MediaPlaybackSnapshot: Equatable, Sendable {
+    let bundleIdentifier: String
+    let processID: Int32
+    let title: String?
+    let isPlaying: Bool?
+
+    // Safari exposes its WebKit media process, not a tab ID. This comparison
+    // can reject a changed player/item, but cannot prove exact-tab identity.
+    func matches(_ other: Self) -> Bool {
+        self.bundleIdentifier == other.bundleIdentifier &&
+            self.processID == other.processID && self.title == other.title
+    }
+}
+
+nonisolated enum MediaPlaybackQueryResult: Sendable {
+    case snapshot(MediaPlaybackSnapshot)
+    case unavailable(String)
+}
+
+nonisolated enum MediaPlaybackCommand: String, Sendable {
+    case pause
+    case play
+}
+
+nonisolated enum MediaPlaybackCommandResult: Sendable {
+    /// The helper exited successfully. This is NOT acknowledgement from the player.
+    case helperCompleted
+    case failed(String)
+}
+
+nonisolated protocol MediaPlaybackTransport: Sendable {
+    nonisolated func query() async -> MediaPlaybackQueryResult
+    nonisolated func send(_ command: MediaPlaybackCommand) async -> MediaPlaybackCommandResult
+}
+
+/// Uses the existing bundled bridge, but owns its process completion and output.
+/// A serial queue plus a hard process deadline prevents overlapping commands,
+/// unbounded helpers, and the adapter's exit-versus-output callback race.
+final nonisolated class MediaPlaybackProcessTransport: MediaPlaybackTransport, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "media.playback.transport", qos: .utility)
+
+    func query() async -> MediaPlaybackQueryResult {
+        let result = await self.invoke("get")
+        guard result.failure == nil else { return .unavailable(result.failure ?? "helper_failed") }
+        return Self.decode(result.output)
+    }
+
+    func send(_ command: MediaPlaybackCommand) async -> MediaPlaybackCommandResult {
+        let result = await self.invoke(command.rawValue)
+        if let failure = result.failure { return .failed(failure) }
+        return .helperCompleted
+    }
+
+    static func decode(_ output: Data) -> MediaPlaybackQueryResult {
+        guard let text = String(data: output, encoding: .utf8) else {
+            return .unavailable("invalid_utf8")
+        }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .unavailable("empty_output") }
+        guard trimmed != "NIL", trimmed != "null" else { return .unavailable("no_media_reported") }
+        guard let object = try? JSONSerialization.jsonObject(with: output) as? [String: Any],
+              let payload = object["payload"] as? [String: Any]
+        else { return .unavailable("invalid_payload") }
+        let processID: Int32?
+        if let value = payload["PID"] as? String {
+            processID = Int32(value)
+        } else {
+            processID = (payload["PID"] as? NSNumber)?.int32Value
+        }
+        guard let bundle = payload["bundleIdentifier"] as? String, !bundle.isEmpty,
+              let processID, processID > 0
+        else { return .unavailable("missing_player_identity") }
+        let playing: Bool?
+        if let value = payload["isPlaying"] as? Bool {
+            playing = value
+        } else if let rate = payload["playbackRate"] as? Double {
+            playing = rate > 0
+        } else {
+            playing = nil
+        }
+        return .snapshot(MediaPlaybackSnapshot(
+            bundleIdentifier: bundle,
+            processID: processID,
+            title: payload["title"] as? String,
+            isPlaying: playing
+        ))
+    }
+
+    private func invoke(_ command: String) async -> MediaHelperResult {
+        await withCheckedContinuation { continuation in
+            self.queue.async {
+                continuation.resume(returning: self.run(command))
+            }
+        }
+    }
+
+    private func run(_ command: String) -> MediaHelperResult {
+        #if arch(arm64)
+        let framework = Bundle(for: MediaController.self)
+        guard let library = framework.executablePath,
+              let resourceURL = Bundle.main.url(
+                  forResource: "MediaRemoteAdapter_MediaRemoteAdapter", withExtension: "bundle"
+              ),
+              let resources = Bundle(url: resourceURL),
+              let script = resources.path(forResource: "run", ofType: "pl")
+        else { return MediaHelperResult(output: Data(), failure: "bridge_resources_missing") }
+
+        // Run the shipped script unchanged. For commands, keep its run loop alive
+        // through one bounded query before exiting, as the original upstream does.
+        // The returned state is not used as command acknowledgement.
+        let wrapper = """
+        my $script = shift @ARGV;
+        my $command = $ARGV[1];
+        do $script;
+        die $@ if $@;
+        main::get() if $command eq 'pause' || $command eq 'play';
+        """
+        return MediaHelperProcess.run(arguments: ["-e", wrapper, script, library, command])
+        #else
+        return MediaHelperResult(output: Data(), failure: "unsupported_architecture")
+        #endif
+    }
+}
+
+nonisolated struct MediaHelperResult: Sendable {
+    let output: Data
+    let failure: String?
+}
+
+/// Private process plumbing; never runs on the main actor.
+nonisolated enum MediaHelperProcess {
+    static func run(arguments: [String], timeout: TimeInterval = 3.5) -> MediaHelperResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/perl")
+        process.arguments = arguments
+        let output = Pipe()
+        let errors = Pipe()
+        let outputBuffer = MediaHelperBuffer(limit: 4 * 1024 * 1024)
+        let errorBuffer = MediaHelperBuffer(limit: 4096)
+        process.standardOutput = output
+        process.standardError = errors
+        output.fileHandleForReading.readabilityHandler = { handle in outputBuffer.drain(handle) }
+        errors.fileHandleForReading.readabilityHandler = { handle in errorBuffer.drain(handle) }
+        defer {
+            output.fileHandleForReading.readabilityHandler = nil
+            errors.fileHandleForReading.readabilityHandler = nil
+            try? output.fileHandleForReading.close()
+            try? errors.fileHandleForReading.close()
+        }
+        do {
+            try process.run()
+        } catch {
+            return MediaHelperResult(output: Data(), failure: "launch_failed:\(error.localizedDescription)")
+        }
+        let deadline = MediaHelperDeadline(process: process)
+        let timeoutWork = DispatchWorkItem { deadline.expire() }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: timeoutWork)
+        process.waitUntilExit()
+        let timedOut = deadline.finish()
+        timeoutWork.cancel()
+        output.fileHandleForReading.readabilityHandler = nil
+        errors.fileHandleForReading.readabilityHandler = nil
+        let data = outputBuffer.finish(output.fileHandleForReading)
+        let stderr = errorBuffer.finish(errors.fileHandleForReading)
+        if timedOut { return MediaHelperResult(output: data, failure: "helper_timeout") }
+        if process.terminationStatus != 0 {
+            let message = (String(bytes: stderr.prefix(512), encoding: .utf8) ?? "invalid_utf8")
+                .replacingOccurrences(of: "\n", with: " ")
+            return MediaHelperResult(output: data, failure: "helper_exit_\(process.terminationStatus):\(message)")
+        }
+        if outputBuffer.overflowed { return MediaHelperResult(output: Data(), failure: "output_limit") }
+        return MediaHelperResult(output: data, failure: nil)
+    }
+}
+
+private final nonisolated class MediaHelperDeadline: @unchecked Sendable {
+    private let lock = NSLock()
+    private let process: Process
+    private var finished = false
+    private var expired = false
+
+    init(process: Process) { self.process = process }
+
+    func expire() {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard !self.finished, self.process.isRunning else { return }
+        self.expired = true
+        // This is our own one-shot Perl child, with no user state to flush.
+        kill(self.process.processIdentifier, SIGKILL)
+    }
+
+    func finish() -> Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.finished = true
+        return self.expired
+    }
+}
+
+private final nonisolated class MediaHelperBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private let limit: Int
+    private var data = Data()
+    private var didOverflow = false
+
+    init(limit: Int) { self.limit = limit }
+
+    var overflowed: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.didOverflow
+    }
+
+    func drain(_ handle: FileHandle) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        let chunk = handle.availableData
+        if chunk.isEmpty { handle.readabilityHandler = nil }
+        self.append(chunk)
+    }
+
+    func finish(_ handle: FileHandle) -> Data {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        while let chunk = try? handle.read(upToCount: 16_384), !chunk.isEmpty {
+            self.append(chunk)
+        }
+        return self.data
+    }
+
+    private func append(_ chunk: Data) {
+        let remaining = self.limit - self.data.count
+        if chunk.count > remaining { self.didOverflow = true }
+        self.data.append(chunk.prefix(remaining))
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
+++ b/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
@@ -1,215 +1,397 @@
 @testable import FluidVoice_Debug
 import Foundation
-#if arch(arm64)
-import MediaRemoteAdapter
-#endif
 import XCTest
 
-#if arch(arm64)
 @MainActor
 final class MediaPlaybackServiceTests: XCTestCase {
-    func testPlayingCallbackBeforeTimeoutRequestsPause() async throws {
-        let (service, controller, scheduler) = self.makeService()
-        let pauseTask = Task { await service.pauseIfPlaying() }
-
-        await controller.waitUntilQueryRegistered()
-        XCTAssertEqual(scheduler.scheduledDelays, [2.5])
-        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
-
-        let didPause = await pauseTask.value
-        XCTAssertTrue(didPause)
-        XCTAssertEqual(controller.pauseCallCount, 1)
-
-        scheduler.advance(by: 2.5)
-        XCTAssertEqual(controller.pauseCallCount, 1)
+    func testVerifiedPauseAndResumeAreOrdered() async {
+        let transport = FakeMediaPlaybackTransport([self.state(true), self.state(false), self.state(false), self.state(true)])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.recordingStopped(sessionID: 1)
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let maxInFlight = await transport.maximumInFlight
+        XCTAssertEqual(commands, [.pause, .play])
+        XCTAssertEqual(maxInFlight, 1)
     }
 
-    func testCallbackAfterFormerOneSecondBoundaryStillRequestsPause() async throws {
-        let (service, controller, scheduler) = self.makeService()
-        let pauseTask = Task { await service.pauseIfPlaying() }
-
-        await controller.waitUntilQueryRegistered()
-        XCTAssertEqual(scheduler.scheduledDelays, [MediaPlaybackService.nowPlayingQueryTimeoutSeconds])
-        XCTAssertGreaterThan(MediaPlaybackService.nowPlayingQueryTimeoutSeconds, 2)
-
-        scheduler.advance(by: 1.1)
-        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
-
-        let didPause = await pauseTask.value
-        XCTAssertTrue(didPause)
-        XCTAssertEqual(controller.pauseCallCount, 1)
-
-        scheduler.advance(by: 1.4)
-        XCTAssertEqual(controller.pauseCallCount, 1)
-    }
-
-    func testTimeoutThenLatePlayingCallbackNeverPauses() async throws {
-        let (service, controller, scheduler) = self.makeService()
-        let pauseTask = Task { await service.pauseIfPlaying() }
-
-        await controller.waitUntilQueryRegistered()
-        scheduler.advance(by: 2.5)
-
-        let didPause = await pauseTask.value
-        XCTAssertFalse(didPause)
-        XCTAssertEqual(controller.pauseCallCount, 0)
-
-        controller.complete(with: try self.makeTrackInfo(isPlaying: true, playbackRate: 1))
-        XCTAssertEqual(controller.pauseCallCount, 0)
-    }
-
-    func testDuplicatePlayingCallbacksIssueOnePause() async throws {
-        let (service, controller, _) = self.makeService()
-        let pauseTask = Task { await service.pauseIfPlaying() }
-        let playingTrack = try self.makeTrackInfo(isPlaying: true, playbackRate: 1)
-
-        await controller.waitUntilQueryRegistered()
-        controller.complete(with: playingTrack, retainingCallback: true)
-        controller.complete(with: playingTrack)
-
-        let didPause = await pauseTask.value
-        XCTAssertTrue(didPause)
-        XCTAssertEqual(controller.pauseCallCount, 1)
-    }
-
-    func testPlaybackStateResolutionDoesNotPauseFalseCasesAndUsesRateFallback() async throws {
-        let nilResult = await self.pauseResult(for: nil)
-        XCTAssertFalse(nilResult.didPause)
-        XCTAssertEqual(nilResult.pauseCallCount, 0)
-
-        let explicitlyPaused = await self.pauseResult(
-            for: try self.makeTrackInfo(isPlaying: false, playbackRate: 1)
-        )
-        XCTAssertFalse(explicitlyPaused.didPause)
-        XCTAssertEqual(explicitlyPaused.pauseCallCount, 0)
-
-        let zeroRate = await self.pauseResult(
-            for: try self.makeTrackInfo(isPlaying: nil, playbackRate: 0)
-        )
-        XCTAssertFalse(zeroRate.didPause)
-        XCTAssertEqual(zeroRate.pauseCallCount, 0)
-
-        let positiveRate = await self.pauseResult(
-            for: try self.makeTrackInfo(isPlaying: nil, playbackRate: 1)
-        )
-        XCTAssertTrue(positiveRate.didPause)
-        XCTAssertEqual(positiveRate.pauseCallCount, 1)
-    }
-
-    func testResumeOnlyPlaysWhenPauseOwnershipIsTrue() async {
-        let (service, controller, _) = self.makeService()
-
-        await service.resumeIfWePaused(false)
-        XCTAssertEqual(controller.playCallCount, 0)
-
-        await service.resumeIfWePaused(true)
-        XCTAssertEqual(controller.playCallCount, 1)
-    }
-
-    private func makeService() -> (
-        service: MediaPlaybackService,
-        controller: FakeMediaPlaybackController,
-        scheduler: ManualTimeoutScheduler
-    ) {
-        let controller = FakeMediaPlaybackController()
-        let scheduler = ManualTimeoutScheduler()
-        let service = MediaPlaybackService(
-            mediaController: controller,
-            queryTimeoutSeconds: MediaPlaybackService.nowPlayingQueryTimeoutSeconds,
-            timeoutScheduler: scheduler.schedule
-        )
-        return (service, controller, scheduler)
-    }
-
-    private func pauseResult(for trackInfo: TrackInfo?) async -> (
-        didPause: Bool,
-        pauseCallCount: Int
-    ) {
-        let (service, controller, _) = self.makeService()
-        let pauseTask = Task { await service.pauseIfPlaying() }
-
-        await controller.waitUntilQueryRegistered()
-        controller.complete(with: trackInfo)
-
-        return (await pauseTask.value, controller.pauseCallCount)
-    }
-
-    private func makeTrackInfo(isPlaying: Bool?, playbackRate: Double?) throws -> TrackInfo {
-        var payload: [String: Any] = [:]
-        if let isPlaying {
-            payload["isPlaying"] = isPlaying
+    func testUnavailableOrPausedMediaNeverStartsPlayback() async {
+        for result in [MediaPlaybackQueryResult.unavailable("no_media"), self.state(false), self.state(nil)] {
+            let transport = FakeMediaPlaybackTransport([result])
+            let service = self.service(transport)
+            service.recordingStarted(sessionID: 1, enabled: true)
+            await service.waitUntilSettled()
+            service.sessionFinished(sessionID: 1)
+            await service.waitUntilSettled()
+            let commands = await transport.commands
+            XCTAssertTrue(commands.isEmpty)
         }
-        if let playbackRate {
-            payload["playbackRate"] = playbackRate
+    }
+
+    func testDisabledSettingDoesNoMediaIO() async {
+        let transport = FakeMediaPlaybackTransport([])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: false)
+        await service.waitUntilSettled()
+        let count = await transport.queryCount
+        XCTAssertEqual(count, 0)
+    }
+
+    func testStopDuringQueryPreventsLatePause() async {
+        let transport = FakeMediaPlaybackTransport([])
+        await transport.holdQuery(1)
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await transport.waitForQuery(1)
+        service.recordingStopped(sessionID: 1)
+        await transport.releaseQuery(self.state(true))
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertTrue(commands.isEmpty)
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+    }
+
+    func testFailedStartDuringQueryNeverPauses() async {
+        let transport = FakeMediaPlaybackTransport([])
+        await transport.holdQuery(1)
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await transport.waitForQuery(1)
+        service.sessionFinished(sessionID: 1)
+        await transport.releaseQuery(self.state(true))
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertTrue(commands.isEmpty)
+    }
+
+    func testFailedStartDuringPauseRestoresPlaybackOnce() async {
+        let transport = FakeMediaPlaybackTransport([self.state(true), self.state(false), self.state(false), self.state(true)])
+        await transport.holdCommand(1)
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await transport.waitForCommand(1)
+        service.sessionFinished(sessionID: 1)
+        service.sessionFinished(sessionID: 1)
+        await transport.releaseCommand(.helperCompleted)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let maxInFlight = await transport.maximumInFlight
+        XCTAssertEqual(commands, [.pause, .play])
+        XCTAssertEqual(maxInFlight, 1)
+    }
+
+    func testNewRecordingSupersedesPendingQueryAndOldFinish() async {
+        let transport = FakeMediaPlaybackTransport([self.state(true), self.state(false)])
+        await transport.holdQuery(1)
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await transport.waitForQuery(1)
+        service.recordingStarted(sessionID: 2, enabled: true)
+        service.sessionFinished(sessionID: 1)
+        await transport.releaseQuery(self.state(true))
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let count = await transport.queryCount
+        XCTAssertEqual(commands, [.pause])
+        XCTAssertEqual(count, 3)
+    }
+
+    func testStopDuringPauseWaitsForConfirmationBeforeResume() async {
+        let transport = FakeMediaPlaybackTransport([self.state(true), self.state(false), self.state(false), self.state(true)])
+        await transport.holdCommand(1)
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await transport.waitForCommand(1)
+        service.recordingStopped(sessionID: 1)
+        service.sessionFinished(sessionID: 1)
+        let pendingCommands = await transport.commands
+        XCTAssertEqual(pendingCommands, [.pause])
+        await transport.releaseCommand(.helperCompleted)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let maxInFlight = await transport.maximumInFlight
+        XCTAssertEqual(commands, [.pause, .play])
+        XCTAssertEqual(maxInFlight, 1)
+    }
+
+    func testNewRecordingDuringResumeQueryRetainsPause() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), self.state(false), self.state(false), self.state(true),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        await transport.holdQuery(3)
+        service.sessionFinished(sessionID: 1)
+        await transport.waitForQuery(3)
+        service.recordingStarted(sessionID: 2, enabled: true)
+        await transport.releaseQuery(self.state(false))
+        await service.waitUntilSettled()
+        let beforeFinish = await transport.commands
+        XCTAssertEqual(beforeFinish, [.pause])
+        service.sessionFinished(sessionID: 1)
+        service.sessionFinished(sessionID: 2)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play])
+    }
+
+    func testUnconfirmedPauseDoesNotResumeOrSpamCommands() async {
+        let transport = FakeMediaPlaybackTransport([self.state(true), self.state(true), self.state(true)])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        for id in 2...10 {
+            service.recordingStarted(sessionID: id, enabled: true)
+            await service.waitUntilSettled()
+            service.sessionFinished(sessionID: id)
         }
-        let data = try JSONSerialization.data(withJSONObject: ["payload": payload])
-        return try JSONDecoder().decode(TrackInfo.self, from: data)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let count = await transport.queryCount
+        XCTAssertEqual(commands, [.pause])
+        XCTAssertEqual(count, 3)
+    }
+
+    func testNewRecordingDuringPlayWaitsBeforePausingAgain() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), self.state(false), self.state(true), self.state(true), self.state(false),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        await transport.holdCommand(2)
+        service.sessionFinished(sessionID: 1)
+        await transport.waitForCommand(2)
+        service.recordingStarted(sessionID: 2, enabled: true)
+        service.sessionFinished(sessionID: 1)
+        await transport.releaseCommand(.helperCompleted)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let maxInFlight = await transport.maximumInFlight
+        XCTAssertEqual(commands, [.pause, .play, .pause])
+        XCTAssertEqual(maxInFlight, 1)
+    }
+
+    func testPauseRemainsOwnedUntilTranscriptionFinishes() async {
+        let transport = FakeMediaPlaybackTransport([self.state(true), self.state(false), self.state(false), self.state(true)])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.recordingStopped(sessionID: 1)
+        await service.waitUntilSettled()
+        let beforeFinish = await transport.commands
+        XCTAssertEqual(beforeFinish, [.pause])
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play])
+    }
+
+    func testCooldownHasBoundedExit() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(true), self.state(true), self.state(true), self.state(false),
+        ])
+        let clock = MediaTestClock()
+        let service = MediaPlaybackService(transport: transport, settle: {}, now: { clock.value })
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        clock.advance(11)
+        service.recordingStarted(sessionID: 2, enabled: true)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .pause])
+    }
+
+    func testChangedPlayerOrItemAndManualPlayAreNotResumed() async {
+        for changed in [self.state(false, pid: 2), self.state(false, title: "Other"), self.state(true)] {
+            let transport = FakeMediaPlaybackTransport([self.state(true), self.state(false), changed])
+            let service = self.service(transport)
+            service.recordingStarted(sessionID: 1, enabled: true)
+            await service.waitUntilSettled()
+            service.sessionFinished(sessionID: 1)
+            await service.waitUntilSettled()
+            let commands = await transport.commands
+            XCTAssertEqual(commands, [.pause])
+        }
+    }
+
+    func testUnknownVerificationNeverClaimsOwnership() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), .unavailable("timeout"), .unavailable("empty_output"),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause])
+    }
+
+    func testCommandTimeoutStillChecksForAppliedPause() async {
+        let transport = FakeMediaPlaybackTransport([self.state(true), self.state(false), self.state(false), self.state(true)])
+        await transport.holdCommand(1)
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await transport.waitForCommand(1)
+        await transport.releaseCommand(.failed("helper_timeout"))
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play])
+    }
+
+    func testShutdownRestoresConfirmedPauseAndRejectsNewStarts() async {
+        let transport = FakeMediaPlaybackTransport([self.state(true), self.state(false), self.state(false), self.state(true)])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        await service.shutdown()
+        service.recordingStarted(sessionID: 2, enabled: true)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play])
+    }
+
+    func testRawQueryFailuresAreDistinct() {
+        for (text, reason) in [("", "empty_output"), ("NIL\n", "no_media_reported"), ("{", "invalid_payload")] {
+            guard case let .unavailable(actual) = MediaPlaybackProcessTransport.decode(Data(text.utf8)) else {
+                return XCTFail("Expected unavailable: \(reason)")
+            }
+            XCTAssertEqual(actual, reason)
+        }
+    }
+
+    func testRawQueryAcceptsMissingTitleAndDoesNotOverrideExplicitPause() {
+        let text = #"{"payload":{"PID":"42","bundleIdentifier":"com.apple.WebKit.GPU","isPlaying":false,"playbackRate":1}}"#
+        guard case let .snapshot(snapshot) = MediaPlaybackProcessTransport.decode(Data(text.utf8)) else {
+            return XCTFail("Expected player state")
+        }
+        XCTAssertEqual(snapshot.processID, 42)
+        XCTAssertNil(snapshot.title)
+        XCTAssertEqual(snapshot.isPlaying, false)
+    }
+
+    func testProcessDrainsBothPipesBeforeCompletion() async {
+        let result = await Task.detached {
+            MediaHelperProcess.run(arguments: ["-e", "print 'x' x 200000; print STDERR 'y' x 200000;"])
+        }.value
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.output.count, 200_000)
+    }
+
+    func testProcessTimeoutTerminatesHelper() async {
+        let result = await Task.detached {
+            MediaHelperProcess.run(arguments: ["-e", "sleep 10;"], timeout: 0.1)
+        }.value
+        XCTAssertEqual(result.failure, "helper_timeout")
+    }
+
+    func testProcessOutputIsBounded() async {
+        let result = await Task.detached {
+            MediaHelperProcess.run(arguments: ["-e", "print 'x' x 5000000;"])
+        }.value
+        XCTAssertEqual(result.failure, "output_limit")
+        XCTAssertTrue(result.output.isEmpty)
+    }
+
+    private func service(_ transport: FakeMediaPlaybackTransport) -> MediaPlaybackService {
+        MediaPlaybackService(transport: transport, settle: {}, now: { 0 })
+    }
+
+    private func state(_ playing: Bool?, pid: Int32 = 1, title: String = "Netflix") -> MediaPlaybackQueryResult {
+        .snapshot(MediaPlaybackSnapshot(bundleIdentifier: "com.apple.WebKit.GPU", processID: pid, title: title, isPlaying: playing))
     }
 }
 
-@MainActor
-private final class FakeMediaPlaybackController: MediaPlaybackControlling {
-    private var callback: ((TrackInfo?) -> Void)?
-    private var registrationWaiters: [CheckedContinuation<Void, Never>] = []
-    private(set) var pauseCallCount = 0
-    private(set) var playCallCount = 0
+private actor FakeMediaPlaybackTransport: MediaPlaybackTransport {
+    private var results: [MediaPlaybackQueryResult]
+    private var heldQueryIndex: Int?
+    private var heldCommandIndex: Int?
+    private var queryContinuation: CheckedContinuation<MediaPlaybackQueryResult, Never>?
+    private var commandContinuation: CheckedContinuation<MediaPlaybackCommandResult, Never>?
+    private var queryWaiter: (Int, CheckedContinuation<Void, Never>)?
+    private var commandWaiter: (Int, CheckedContinuation<Void, Never>)?
+    private var inFlight = 0
+    private(set) var maximumInFlight = 0
+    private(set) var queryCount = 0
+    private(set) var commands: [MediaPlaybackCommand] = []
 
-    func getTrackInfo(_ onReceive: @escaping (TrackInfo?) -> Void) {
-        self.callback = onReceive
-        let waiters = self.registrationWaiters
-        self.registrationWaiters.removeAll()
-        waiters.forEach { $0.resume() }
-    }
+    init(_ results: [MediaPlaybackQueryResult]) { self.results = results }
 
-    func pause() {
-        self.pauseCallCount += 1
-    }
-
-    func play() {
-        self.playCallCount += 1
-    }
-
-    func waitUntilQueryRegistered() async {
-        guard self.callback == nil else { return }
-        await withCheckedContinuation { continuation in
-            self.registrationWaiters.append(continuation)
+    func query() async -> MediaPlaybackQueryResult {
+        self.inFlight += 1
+        self.maximumInFlight = max(self.maximumInFlight, self.inFlight)
+        defer { self.inFlight -= 1 }
+        self.queryCount += 1
+        if let (count, continuation) = self.queryWaiter, self.queryCount >= count {
+            self.queryWaiter = nil
+            continuation.resume()
         }
+        if self.queryCount == self.heldQueryIndex {
+            return await withCheckedContinuation { self.queryContinuation = $0 }
+        }
+        return self.results.isEmpty ? .unavailable("exhausted") : self.results.removeFirst()
     }
 
-    func complete(with trackInfo: TrackInfo?, retainingCallback: Bool = false) {
-        let callback = self.callback
-        if !retainingCallback {
-            self.callback = nil
+    func send(_ command: MediaPlaybackCommand) async -> MediaPlaybackCommandResult {
+        self.inFlight += 1
+        self.maximumInFlight = max(self.maximumInFlight, self.inFlight)
+        defer { self.inFlight -= 1 }
+        self.commands.append(command)
+        if let (count, continuation) = self.commandWaiter, self.commands.count >= count {
+            self.commandWaiter = nil
+            continuation.resume()
         }
-        callback?(trackInfo)
+        if self.commands.count == self.heldCommandIndex {
+            return await withCheckedContinuation { self.commandContinuation = $0 }
+        }
+        return .helperCompleted
+    }
+
+    func holdQuery(_ index: Int) { self.heldQueryIndex = index }
+    func holdCommand(_ index: Int) { self.heldCommandIndex = index }
+    func releaseQuery(_ result: MediaPlaybackQueryResult) {
+        self.queryContinuation?.resume(returning: result)
+        self.queryContinuation = nil
+    }
+
+    func releaseCommand(_ result: MediaPlaybackCommandResult) {
+        self.commandContinuation?.resume(returning: result)
+        self.commandContinuation = nil
+    }
+
+    func waitForQuery(_ count: Int) async {
+        guard self.queryCount < count else { return }
+        await withCheckedContinuation { self.queryWaiter = (count, $0) }
+    }
+
+    func waitForCommand(_ count: Int) async {
+        guard self.commands.count < count else { return }
+        await withCheckedContinuation { self.commandWaiter = (count, $0) }
     }
 }
 
-@MainActor
-private final class ManualTimeoutScheduler {
-    private struct ScheduledAction {
-        let deadline: TimeInterval
-        let action: @MainActor @Sendable () -> Void
+private final nonisolated class MediaTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var time: TimeInterval = 0
+
+    var value: TimeInterval {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.time
     }
 
-    private var currentTime: TimeInterval = 0
-    private var scheduledActions: [ScheduledAction] = []
-
-    var scheduledDelays: [TimeInterval] {
-        self.scheduledActions.map(\.deadline)
-    }
-
-    func schedule(after delay: TimeInterval, action: @escaping @MainActor @Sendable () -> Void) {
-        self.scheduledActions.append(
-            ScheduledAction(deadline: self.currentTime + delay, action: action)
-        )
-    }
-
-    func advance(by interval: TimeInterval) {
-        self.currentTime += interval
-        let readyActions = self.scheduledActions.filter { $0.deadline <= self.currentTime }
-        self.scheduledActions.removeAll { $0.deadline <= self.currentTime }
-        readyActions.forEach { $0.action() }
+    func advance(_ seconds: TimeInterval) {
+        self.lock.lock()
+        self.time += seconds
+        self.lock.unlock()
     }
 }
-#endif

--- a/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
+++ b/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
@@ -140,6 +140,103 @@ final class MediaPlaybackServiceTests: XCTestCase {
         XCTAssertEqual(commands, [.pause, .play])
     }
 
+    func testFailedPlayRetriesOnlyAfterConfirmingSamePausedPlayer() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), self.state(false), self.state(false), self.state(false),
+            self.state(false), self.state(true),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play, .play])
+    }
+
+    func testFailedPlayDoesNotRetryForChangedPlayer() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), self.state(false), self.state(false), self.state(false),
+            self.state(false, pid: 2),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play])
+    }
+
+    func testFailedPlayRetryIsBounded() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), self.state(false), self.state(false), self.state(false),
+            self.state(false), self.state(false), self.state(false),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play, .play])
+    }
+
+    func testShutdownDuringPauseUsesOneVerificationPerCommand() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), self.state(false), self.state(false),
+        ])
+        await transport.holdCommand(1)
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await transport.waitForCommand(1)
+        service.beginShutdown()
+        service.beginShutdown()
+        service.recordingStarted(sessionID: 2, enabled: true)
+        await transport.releaseCommand(.helperCompleted)
+        await service.shutdown()
+        let commands = await transport.commands
+        let count = await transport.queryCount
+        XCTAssertEqual(commands, [.pause, .play])
+        XCTAssertEqual(count, 4)
+    }
+
+    func testNewRecordingDuringFailedPlayRetainsPause() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), self.state(false), self.state(false), self.state(false),
+            self.state(false), self.state(false), self.state(true),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        await transport.holdCommand(2)
+        service.sessionFinished(sessionID: 1)
+        await transport.waitForCommand(2)
+        service.recordingStarted(sessionID: 2, enabled: true)
+        await transport.releaseCommand(.failed("timeout"))
+        await service.waitUntilSettled()
+        let beforeFinish = await transport.commands
+        XCTAssertEqual(beforeFinish, [.pause, .play])
+        service.sessionFinished(sessionID: 2)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play, .play])
+    }
+
+    func testShutdownDoesNotRetryUnavailableQuery() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), .unavailable("temporary"),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        await service.shutdown()
+        let commands = await transport.commands
+        let count = await transport.queryCount
+        XCTAssertEqual(commands, [.pause])
+        XCTAssertEqual(count, 3)
+    }
+
     func testTransientResumeQueryFailureRetriesBeforePlaying() async {
         let transport = FakeMediaPlaybackTransport([
             self.state(true), self.state(false), .unavailable("temporary"), self.state(false), self.state(true),
@@ -348,6 +445,15 @@ final class MediaPlaybackServiceTests: XCTestCase {
         }.value
         XCTAssertNil(result.failure)
         XCTAssertEqual(result.output.count, 200_000)
+    }
+
+    func testDefaultProcessTimeoutIsOneSecond() async {
+        let started = ProcessInfo.processInfo.systemUptime
+        let result = await Task.detached {
+            MediaHelperProcess.run(arguments: ["-e", "sleep 10"])
+        }.value
+        XCTAssertEqual(result.failure, "helper_timeout")
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - started, 2.0)
     }
 
     func testProcessTimeoutTerminatesHelper() async {

--- a/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
+++ b/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
@@ -140,6 +140,69 @@ final class MediaPlaybackServiceTests: XCTestCase {
         XCTAssertEqual(commands, [.pause, .play])
     }
 
+    func testTransientResumeQueryFailureRetriesBeforePlaying() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), .unavailable("temporary"), self.state(false), self.state(true),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play])
+    }
+
+    func testResumeQueryFailureStopsAfterBoundedRetries() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), .unavailable("temporary"),
+            .unavailable("temporary"), .unavailable("temporary"),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let count = await transport.queryCount
+        XCTAssertEqual(commands, [.pause])
+        XCTAssertEqual(count, 5)
+    }
+
+    func testResumeRetryDoesNotPlayChangedItem() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), .unavailable("temporary"), self.state(false, title: "Other"),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        service.sessionFinished(sessionID: 1)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause])
+    }
+
+    func testNewRecordingDuringUnavailableResumeQueryRetainsPause() async {
+        let transport = FakeMediaPlaybackTransport([
+            self.state(true), self.state(false), self.state(false), self.state(false), self.state(true),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        await transport.holdQuery(3)
+        service.sessionFinished(sessionID: 1)
+        await transport.waitForQuery(3)
+        service.recordingStarted(sessionID: 2, enabled: true)
+        await transport.releaseQuery(.unavailable("temporary"))
+        await service.waitUntilSettled()
+        let beforeFinish = await transport.commands
+        XCTAssertEqual(beforeFinish, [.pause])
+        service.sessionFinished(sessionID: 2)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause, .play])
+    }
+
     func testUnconfirmedPauseDoesNotResumeOrSpamCommands() async {
         let transport = FakeMediaPlaybackTransport([self.state(true), self.state(true), self.state(true)])
         let service = self.service(transport)

--- a/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
+++ b/Tests/FluidDictationIntegrationTests/MediaPlaybackServiceTests.swift
@@ -31,6 +31,45 @@ final class MediaPlaybackServiceTests: XCTestCase {
         }
     }
 
+    func testInitialQueryRetriesTransientFailure() async {
+        let transport = FakeMediaPlaybackTransport([
+            .unavailable("temporary"), self.state(true), self.state(false),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        XCTAssertEqual(commands, [.pause])
+    }
+
+    func testInitialQueryRetriesAreBounded() async {
+        let transport = FakeMediaPlaybackTransport([
+            .unavailable("temporary"), .unavailable("temporary"), .unavailable("temporary"),
+        ])
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let count = await transport.queryCount
+        XCTAssertTrue(commands.isEmpty)
+        XCTAssertEqual(count, 3)
+    }
+
+    func testReleasedRecordingDoesNotRetryUnavailableInitialQuery() async {
+        let transport = FakeMediaPlaybackTransport([])
+        await transport.holdQuery(1)
+        let service = self.service(transport)
+        service.recordingStarted(sessionID: 1, enabled: true)
+        await transport.waitForQuery(1)
+        service.recordingStopped(sessionID: 1)
+        await transport.releaseQuery(.unavailable("temporary"))
+        await service.waitUntilSettled()
+        let commands = await transport.commands
+        let count = await transport.queryCount
+        XCTAssertTrue(commands.isEmpty)
+        XCTAssertEqual(count, 1)
+    }
+
     func testDisabledSettingDoesNoMediaIO() async {
         let transport = FakeMediaPlaybackTransport([])
         let service = self.service(transport)


### PR DESCRIPTION
## Description
Rapid dictation starts and stops could issue overlapping media commands and leave Safari/Netflix playback out of sync. Serialize playback work, verify reported player state, and ignore stale recording sessions before restoring playback.

Start the pause request alongside microphone startup and keep all media queries and commands off the transcription wait path. Failed or cancelled starts release their playback session promptly.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Follow-up to #955; targets its enhancements branch so this PR contains only playback changes.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac
- [x] Tested on macOS version: macOS 27 beta
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources Tests Package.swift`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: 36 focused playback XCTest tests passed in an Apple Development-signed harness using the production service and transport sources.

Private FI incremental build passed and the installed app signature was verified. Manual Safari/Netflix dictation checks confirmed working pause/resume and the earlier pause behavior.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes
The full app-hosted XCTest launch stalled in dyld before tests began on this beta OS; the focused harness was used instead. Intel runtime is untested; the existing unsupported-architecture behavior is retained.

Player metadata verification cannot prove rendered video state or exact Safari tab identity. Commands are never blindly retried; unconfirmed transitions trigger a bounded cooldown. Each helper has a one-second timeout. Resume gets one command retry only after fresh same-player paused-state verification. Quit starts media recovery alongside audio cleanup and suppresses additional recovery cycles. Captured output is bounded, with no continuous polling.
