### PR TITLE
feat(overlay): low-memory chip above the transcription area

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		0B05F11E000000000000A002 /* SupportedFileExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */; };
 		803000000000000000000003 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 803000000000000000000004 /* MediaRemoteAdapter */; };
 		B51800000000000000000002 /* SpokenSendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51800000000000000000001 /* SpokenSendTests.swift */; };
+		B51800000000000000000004 /* SystemMemoryPressureMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51800000000000000000003 /* SystemMemoryPressureMonitorTests.swift */; };
 		B51900000000000000000002 /* PrivateAIProviderPromptFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51900000000000000000001 /* PrivateAIProviderPromptFormatTests.swift */; };
 		C0DE63700000000000000002 /* WhisperLanguageSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE63700000000000000001 /* WhisperLanguageSelectionTests.swift */; };
 		7CDB0A2F2F3C4D5600FB7CAD /* dictation_fixture.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7CDB0A2B2F3C4D5600FB7CAD /* dictation_fixture.wav */; };
@@ -73,6 +74,7 @@
 		C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineRetirementDrainTests.swift; sourceTree = "<group>"; };
 		DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectAudioReliabilityTests.swift; sourceTree = "<group>"; };
 		B51800000000000000000001 /* SpokenSendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpokenSendTests.swift; sourceTree = "<group>"; };
+		B51800000000000000000003 /* SystemMemoryPressureMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMemoryPressureMonitorTests.swift; sourceTree = "<group>"; };
 		B51900000000000000000001 /* PrivateAIProviderPromptFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateAIProviderPromptFormatTests.swift; sourceTree = "<group>"; };
 		B52000000000000000000001 /* PrivateAIDictationTokenBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateAIDictationTokenBudgetTests.swift; sourceTree = "<group>"; };
 		C0DE63700000000000000001 /* WhisperLanguageSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperLanguageSelectionTests.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */,
 				803000000000000000000001 /* MediaPlaybackServiceTests.swift */,
 				B51800000000000000000001 /* SpokenSendTests.swift */,
+				B51800000000000000000003 /* SystemMemoryPressureMonitorTests.swift */,
 				B51900000000000000000001 /* PrivateAIProviderPromptFormatTests.swift */,
 				B52000000000000000000001 /* PrivateAIDictationTokenBudgetTests.swift */,
 				C0DE63700000000000000001 /* WhisperLanguageSelectionTests.swift */,
@@ -345,6 +348,7 @@
 				7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */,
 				803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */,
 				B51800000000000000000002 /* SpokenSendTests.swift in Sources */,
+				B51800000000000000000004 /* SystemMemoryPressureMonitorTests.swift in Sources */,
 				B51900000000000000000002 /* PrivateAIProviderPromptFormatTests.swift in Sources */,
 				C0DE63700000000000000002 /* WhisperLanguageSelectionTests.swift in Sources */,
 				0B05F11E000000000000A002 /* SupportedFileExtensionsTests.swift in Sources */,

--- a/Sources/Fluid/ContentView.swift
+++ b/Sources/Fluid/ContentView.swift
@@ -2693,7 +2693,8 @@ struct ContentView: View {
             DebugLogger.shared.info(
                 "Dictation AI post-processing finished in \(postProcessingLatencyMs)ms "
                     + "provider=\(postProcessingProviderName) model=\(postProcessingModelName) "
-                    + "inputChars=\(postProcessingInputChars) fallback=\(aiFallbackReason != nil)",
+                    + "inputChars=\(postProcessingInputChars) fallback=\(aiFallbackReason != nil) "
+                    + SystemMemoryPressureMonitor.diagnosticsSummary(),
                 source: "ContentView"
             )
             // Clear transient status text before leaving processing state to avoid

--- a/Sources/Fluid/Persistence/BackupService.swift
+++ b/Sources/Fluid/Persistence/BackupService.swift
@@ -91,6 +91,7 @@ struct SettingsBackupPayload: Codable, Equatable {
     let audioHistoryBudgetGB: Double?
     let notifyAIProcessingFailures: Bool?
     let showMicrophoneChangeAlerts: Bool?
+    let showSystemLoadAlerts: Bool?
     let weekendsDontBreakStreak: Bool
     let fillerWords: [String]
     let removeFillerWordsEnabled: Bool

--- a/Sources/Fluid/Persistence/SettingsStore.swift
+++ b/Sources/Fluid/Persistence/SettingsStore.swift
@@ -3247,6 +3247,18 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Whether the dictation overlay shows a chip when the Mac is low on memory.
+    var showSystemLoadAlerts: Bool {
+        get {
+            let value = self.defaults.object(forKey: Keys.showSystemLoadAlerts)
+            return value as? Bool ?? true
+        }
+        set {
+            objectWillChange.send()
+            self.defaults.set(newValue, forKey: Keys.showSystemLoadAlerts)
+        }
+    }
+
     func makeBackupPayload() -> SettingsBackupPayload {
         SettingsBackupPayload(
             selectedProviderID: self.selectedProviderID,
@@ -3324,6 +3336,7 @@ final class SettingsStore: ObservableObject {
             audioHistoryBudgetGB: self.audioHistoryBudgetGB,
             notifyAIProcessingFailures: self.notifyAIProcessingFailures,
             showMicrophoneChangeAlerts: self.showMicrophoneChangeAlerts,
+            showSystemLoadAlerts: self.showSystemLoadAlerts,
             weekendsDontBreakStreak: self.weekendsDontBreakStreak,
             fillerWords: self.fillerWords,
             removeFillerWordsEnabled: self.removeFillerWordsEnabled,
@@ -3488,6 +3501,9 @@ final class SettingsStore: ObservableObject {
         }
         if let showMicrophoneChangeAlerts = payload.showMicrophoneChangeAlerts {
             self.showMicrophoneChangeAlerts = showMicrophoneChangeAlerts
+        }
+        if let showSystemLoadAlerts = payload.showSystemLoadAlerts {
+            self.showSystemLoadAlerts = showSystemLoadAlerts
         }
         self.weekendsDontBreakStreak = payload.weekendsDontBreakStreak
         self.fillerWords = payload.fillerWords
@@ -5435,6 +5451,7 @@ private extension SettingsStore {
         // Keep the original persisted key so existing installs migrate in place.
         static let microphoneSelectionMigrationVersion = "AppOnlyMicrophoneSelectionMigrationVersion"
         static let showMicrophoneChangeAlerts = "ShowMicrophoneChangeAlerts"
+        static let showSystemLoadAlerts = "ShowSystemLoadAlerts"
         static let visualizerNoiseThreshold = "VisualizerNoiseThreshold"
         static let launchAtStartup = "LaunchAtStartup"
         static let showInDock = "ShowInDock"

--- a/Sources/Fluid/Services/AppServices.swift
+++ b/Sources/Fluid/Services/AppServices.swift
@@ -38,6 +38,8 @@ final class AppServices: ObservableObject {
         guard !self.isUIReady else { return }
         DebugLogger.shared.info("🚦 UI Ready signal received - services can now initialize", source: "AppServices")
         self.isUIReady = true
+        // Cheap (one sysctl per 10 s) and needed by the overlay, so it starts with the UI.
+        SystemMemoryPressureMonitor.shared.start()
     }
 
     // MARK: - Lazy Services

--- a/Sources/Fluid/Services/SystemMemoryPressureMonitor.swift
+++ b/Sources/Fluid/Services/SystemMemoryPressureMonitor.swift
@@ -1,0 +1,89 @@
+//
+//  SystemMemoryPressureMonitor.swift
+//  Fluid
+//
+//  Tells the dictation overlay when the Mac is low on memory. Everything Fluid
+//  runs lives in unified memory; when other apps fill RAM, macOS evicts the idle
+//  model pages and the next request pays to bring them back.
+//
+//  Signal: `kern.memorystatus_level`, the percent of RAM that is neither wired
+//  nor compressed (Activity Monitor's pressure graph is 100 minus this).
+//  The kernel's own warn/critical level is deliberately not used: it was observed
+//  stuck at "warn" for minutes with 94% available (tasks/memory-pressure-toast.md).
+//
+
+import Combine
+import Foundation
+
+/// Pure hysteresis over available-memory samples. Unit tested.
+nonisolated struct MemoryPressureEvaluator {
+    var enterPercent = 50
+    var exitPercent = 60
+    private(set) var lowStreak = 0
+    private(set) var isConstrained = false
+
+    mutating func observe(availablePercent percent: Int) {
+        if percent <= self.enterPercent {
+            self.lowStreak += 1
+        } else if percent >= self.exitPercent {
+            self.lowStreak = 0
+        }
+        // Two consecutive low samples to enter; stay until memory rises to `exitPercent`.
+        self.isConstrained = self.lowStreak >= 2 || (self.isConstrained && percent < self.exitPercent)
+    }
+}
+
+@MainActor
+final class SystemMemoryPressureMonitor: ObservableObject {
+    static let shared = SystemMemoryPressureMonitor()
+
+    @Published private(set) var isConstrained = false
+
+    private var evaluator = MemoryPressureEvaluator()
+    private var source: DispatchSourceMemoryPressure?
+    private var timer: Timer?
+
+    /// One sysctl per 10 s, plus an extra sample on kernel pressure events. Idempotent.
+    func start() {
+        guard self.source == nil else { return }
+        // `FLUID_MEMORY_ADVISORY_THRESHOLD=99` shows the chip on any Mac for manual testing.
+        if let raw = ProcessInfo.processInfo.environment["FLUID_MEMORY_ADVISORY_THRESHOLD"],
+           let enter = Int(raw), (1...100).contains(enter)
+        {
+            self.evaluator.enterPercent = enter
+            self.evaluator.exitPercent = min(enter + 10, 100)
+        }
+
+        let source = DispatchSource.makeMemoryPressureSource(eventMask: [.normal, .warning, .critical], queue: .main)
+        source.setEventHandler { [weak self] in self?.refresh() }
+        source.activate()
+        self.source = source
+
+        self.timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+        self.timer?.tolerance = 5
+        self.refresh()
+    }
+
+    private func refresh() {
+        guard let percent = Self.readAvailableMemoryPercent() else { return }
+        let was = self.evaluator.isConstrained
+        self.evaluator.observe(availablePercent: percent)
+        guard self.evaluator.isConstrained != was else { return }
+        self.isConstrained = self.evaluator.isConstrained
+        DebugLogger.shared.info("Memory constrained=\(self.isConstrained) available=\(percent)%", source: "SystemMemory")
+    }
+
+    /// For diagnostics log lines, read fresh from the kernel.
+    nonisolated static func diagnosticsSummary() -> String {
+        "sysAvailMem=\(Self.readAvailableMemoryPercent().map { "\($0)%" } ?? "?")"
+    }
+
+    /// `kern.memorystatus_level`: percent of RAM that is neither wired nor compressed.
+    nonisolated static func readAvailableMemoryPercent() -> Int? {
+        var value: UInt32 = 0
+        var size = MemoryLayout<UInt32>.size
+        return sysctlbyname("kern.memorystatus_level", &value, &size, nil, 0) == 0 ? Int(min(value, 100)) : nil
+    }
+}

--- a/Sources/Fluid/Services/SystemMemoryPressureMonitor.swift
+++ b/Sources/Fluid/Services/SystemMemoryPressureMonitor.swift
@@ -25,7 +25,9 @@ nonisolated struct MemoryPressureEvaluator {
     mutating func observe(availablePercent percent: Int) {
         if percent <= self.enterPercent {
             self.lowStreak += 1
-        } else if percent >= self.exitPercent {
+        } else if !self.isConstrained || percent >= self.exitPercent {
+            // Any non-low sample breaks the streak; while constrained, the band below
+            // `exitPercent` keeps it so the chip does not flicker.
             self.lowStreak = 0
         }
         // Two consecutive low samples to enter; stay until memory rises to `exitPercent`.
@@ -77,7 +79,7 @@ final class SystemMemoryPressureMonitor: ObservableObject {
 
     /// For diagnostics log lines, read fresh from the kernel.
     nonisolated static func diagnosticsSummary() -> String {
-        "sysAvailMem=\(Self.readAvailableMemoryPercent().map { "\($0)%" } ?? "?")"
+        "sysAvailMem=\(self.readAvailableMemoryPercent().map { "\($0)%" } ?? "?")"
     }
 
     /// `kern.memorystatus_level`: percent of RAM that is neither wired nor compressed.

--- a/Sources/Fluid/UI/SettingsSearch.swift
+++ b/Sources/Fluid/UI/SettingsSearch.swift
@@ -43,6 +43,7 @@ enum SettingsSearchTarget: Hashable {
     case notifications
     case aiEnhancementFailures
     case microphoneChanges
+    case systemLoadAlerts
 
     case audio
     case inputDevicePriority
@@ -99,7 +100,7 @@ enum SettingsSearchTarget: Hashable {
              .textFormatting:
             return .dictation
 
-        case .notifications, .aiEnhancementFailures, .microphoneChanges:
+        case .notifications, .aiEnhancementFailures, .microphoneChanges, .systemLoadAlerts:
             return .notifications
 
         case .audio, .inputDevicePriority, .outputDevice:
@@ -292,6 +293,11 @@ enum SettingsSearchIndex {
             target: .microphoneChanges,
             title: "Microphone Changes",
             terms: ["mic device lost changed alert notification"]
+        ),
+        .init(
+            target: .systemLoadAlerts,
+            title: "Low Memory Warnings",
+            terms: ["memory pressure ram slow performance system load chip overlay"]
         ),
 
         .init(target: .audio, title: "Audio", terms: ["sound devices microphone speaker"]),

--- a/Sources/Fluid/UI/SettingsView.swift
+++ b/Sources/Fluid/UI/SettingsView.swift
@@ -1138,6 +1138,18 @@ struct SettingsView: View {
                                 )
                             )
                             .settingsSearchTarget(.microphoneChanges)
+
+                            Divider().opacity(0.2)
+
+                            self.optionToggleRow(
+                                title: "Low Memory Warnings",
+                                description: "Show a chip in the dictation overlay when your Mac is low on memory and cleanup may be slower.",
+                                isOn: Binding(
+                                    get: { self.settings.showSystemLoadAlerts },
+                                    set: { self.settings.showSystemLoadAlerts = $0 }
+                                )
+                            )
+                            .settingsSearchTarget(.systemLoadAlerts)
                         }
                     }
                     .padding(16)

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -2075,6 +2075,7 @@ struct BottomOverlayView: View {
     @ObservedObject private var appServices = AppServices.shared
     @ObservedObject private var activeAppMonitor = ActiveAppMonitor.shared
     @ObservedObject private var historyStore = TranscriptionHistoryStore.shared
+    @ObservedObject private var memoryPressure = SystemMemoryPressureMonitor.shared
     @ObservedObject private var settings = SettingsStore.shared
     @Environment(\.theme) private var theme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -2449,9 +2450,14 @@ struct BottomOverlayView: View {
             (self.settings.enableStreamingPreview || self.contentState.isAIProcessingFailureVisible)
     }
 
+    private var showsSystemLoadChip: Bool {
+        self.settings.showSystemLoadAlerts && self.memoryPressure.isConstrained
+    }
+
     private var overlayFrameHeight: CGFloat? {
-        guard self.layout.usesFixedCanvas else { return nil }
-        return self.shouldReservePreviewArea ? self.layout.overlayHeight : nil
+        guard self.layout.usesFixedCanvas, self.shouldReservePreviewArea else { return nil }
+        let chipRow = SystemLoadChip.height(for: self.layout.transFontSize) + self.layout.vPadding / 2
+        return self.layout.overlayHeight + (self.showsSystemLoadChip ? chipRow : 0)
     }
 
     private var previewMaxWidth: CGFloat {
@@ -3106,6 +3112,12 @@ struct BottomOverlayView: View {
             }
 
             VStack(spacing: self.layout.vPadding / 2) {
+                if self.showsSystemLoadChip {
+                    SystemLoadChip(fontSize: self.layout.transFontSize)
+                        .frame(maxWidth: self.previewMaxWidth, alignment: .leading)
+                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                }
+
                 if self.shouldReservePreviewArea {
                     if self.layout.usesFixedCanvas {
                         // Transcription text area (fixed-height in large mode)
@@ -3397,6 +3409,9 @@ struct BottomOverlayView: View {
         .onChange(of: self.settings.enableStreamingPreview) { _, _ in
             self.dynamicPreviewResizeBucket = self.previewResizeBucket(for: self.currentPreviewSizingText)
             self.frozenDynamicPreviewHeight = nil
+            BottomOverlayWindowController.shared.refreshSizeForContent()
+        }
+        .onChange(of: self.showsSystemLoadChip) { _, _ in
             BottomOverlayWindowController.shared.refreshSizeForContent()
         }
         .onChange(of: self.contentState.cachedPreviewText) { _, _ in

--- a/Sources/Fluid/Views/BottomOverlayView.swift
+++ b/Sources/Fluid/Views/BottomOverlayView.swift
@@ -2451,7 +2451,8 @@ struct BottomOverlayView: View {
     }
 
     private var showsSystemLoadChip: Bool {
-        self.settings.showSystemLoadAlerts && self.memoryPressure.isConstrained
+        // The 100 pt pill has no room for a readable chip.
+        self.layout.showsPreview && self.settings.showSystemLoadAlerts && self.memoryPressure.isConstrained
     }
 
     private var overlayFrameHeight: CGFloat? {

--- a/Sources/Fluid/Views/NotchContentViews.swift
+++ b/Sources/Fluid/Views/NotchContentViews.swift
@@ -499,6 +499,7 @@ struct NotchExpandedView: View {
     @ObservedObject private var contentState = NotchContentState.shared
     @ObservedObject private var settings = SettingsStore.shared
     @ObservedObject private var activeAppMonitor = ActiveAppMonitor.shared
+    @ObservedObject private var memoryPressure = SystemMemoryPressureMonitor.shared
     @Environment(\.theme) private var theme
     @State private var isHoveringPromptChip = false
     @State private var isHoveringPromptMenu = false
@@ -1016,6 +1017,12 @@ struct NotchExpandedView: View {
             .animation(.easeOut(duration: 0.14), value: self.contentState.spokenSendIndicatorState)
 
             self.promptHoverMenuRow
+
+            if self.settings.showSystemLoadAlerts, self.memoryPressure.isConstrained {
+                SystemLoadChip(fontSize: 10)
+                    .frame(width: self.previewMaxWidth, alignment: .leading)
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+            }
 
             if self.contentState.isAIProcessingFailureVisible && !self.contentState.isProcessing {
                 HStack(spacing: 6) {

--- a/Sources/Fluid/Views/SystemLoadChip.swift
+++ b/Sources/Fluid/Views/SystemLoadChip.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct SystemLoadChip: View {
     let fontSize: CGFloat
 
-    static func height(for fontSize: CGFloat) -> CGFloat { fontSize + 10 }
+    static func height(for fontSize: CGFloat) -> CGFloat {
+        fontSize + 10
+    }
 
     var body: some View {
         Label("Mac is low on memory · cleanup may be slower", systemImage: "memorychip")

--- a/Sources/Fluid/Views/SystemLoadChip.swift
+++ b/Sources/Fluid/Views/SystemLoadChip.swift
@@ -1,0 +1,25 @@
+//
+//  SystemLoadChip.swift
+//  Fluid
+//
+//  Capsule shown above the live-transcription area while the Mac is low on memory.
+//
+
+import SwiftUI
+
+struct SystemLoadChip: View {
+    let fontSize: CGFloat
+
+    static func height(for fontSize: CGFloat) -> CGFloat { fontSize + 10 }
+
+    var body: some View {
+        Label("Mac is low on memory · cleanup may be slower", systemImage: "memorychip")
+            .font(.system(size: self.fontSize - 1, weight: .semibold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.85)
+            .foregroundStyle(Color.orange.opacity(0.95))
+            .padding(.horizontal, 8)
+            .frame(height: Self.height(for: self.fontSize))
+            .background(Capsule().fill(Color.orange.opacity(0.14)))
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/SystemMemoryPressureMonitorTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SystemMemoryPressureMonitorTests.swift
@@ -18,12 +18,13 @@ final class MemoryPressureEvaluatorTests: XCTestCase {
         XCTAssertFalse(self.run([48]))
         XCTAssertFalse(self.run([48, 70, 49]))
         XCTAssertTrue(self.run([48, 46]))
-        // 55 sits inside the band: neither counts nor resets.
-        XCTAssertTrue(self.run([48, 55, 49]))
+        // An in-band sample breaks the streak while not yet constrained.
+        XCTAssertFalse(self.run([48, 55, 49]))
     }
 
     func testClearsOnlyAtExitThreshold() {
         XCTAssertTrue(self.run([48, 46, 59]))
+        XCTAssertTrue(self.run([48, 46, 55, 55]))
         XCTAssertFalse(self.run([48, 46, 60]))
     }
 }

--- a/Tests/FluidDictationIntegrationTests/SystemMemoryPressureMonitorTests.swift
+++ b/Tests/FluidDictationIntegrationTests/SystemMemoryPressureMonitorTests.swift
@@ -1,0 +1,50 @@
+@testable import FluidVoice_Debug
+import XCTest
+
+final class MemoryPressureEvaluatorTests: XCTestCase {
+    private func run(_ samples: [Int]) -> Bool {
+        var evaluator = MemoryPressureEvaluator()
+        for percent in samples {
+            evaluator.observe(availablePercent: percent)
+        }
+        return evaluator.isConstrained
+    }
+
+    func testHealthyMachineStaysClear() {
+        XCTAssertFalse(self.run([94, 75, 51]))
+    }
+
+    func testNeedsTwoConsecutiveLowSamples() {
+        XCTAssertFalse(self.run([48]))
+        XCTAssertFalse(self.run([48, 70, 49]))
+        XCTAssertTrue(self.run([48, 46]))
+        // 55 sits inside the band: neither counts nor resets.
+        XCTAssertTrue(self.run([48, 55, 49]))
+    }
+
+    func testClearsOnlyAtExitThreshold() {
+        XCTAssertTrue(self.run([48, 46, 59]))
+        XCTAssertFalse(self.run([48, 46, 60]))
+    }
+}
+
+@MainActor
+final class SystemMemoryPressureMonitorTests: XCTestCase {
+    func testKernelReadSucceedsOnThisMac() throws {
+        let percent = try XCTUnwrap(SystemMemoryPressureMonitor.readAvailableMemoryPercent())
+        XCTAssertTrue((0...100).contains(percent))
+        XCTAssertTrue(SystemMemoryPressureMonitor.diagnosticsSummary().hasPrefix("sysAvailMem="))
+    }
+
+    func testSettingDefaultsOnAndRoundTripsThroughBackup() {
+        let key = "ShowSystemLoadAlerts"
+        let defaults = UserDefaults.standard
+        let previous = defaults.object(forKey: key)
+        defer { previous.map { defaults.set($0, forKey: key) } ?? defaults.removeObject(forKey: key) }
+
+        defaults.removeObject(forKey: key)
+        XCTAssertTrue(SettingsStore.shared.showSystemLoadAlerts)
+        SettingsStore.shared.showSystemLoadAlerts = false
+        XCTAssertEqual(SettingsStore.shared.makeBackupPayload().showSystemLoadAlerts, false)
+    }
+}


### PR DESCRIPTION
## Description
Fluid runs its speech and Fluid Intelligence models fully on-device. When other apps fill RAM, macOS evicts the idle model pages and the next request pays to bring them back. Users experience this as Fluid "being slow" with no hint that the machine is the cause (one reporter in #925 saw it at 54% memory pressure on a 36 GB M4 Max).

This PR adds a small chip above the live transcription text, in both the bottom pill and the notch, while the Mac is low on memory:

> Mac is low on memory · cleanup may be slower

- `SystemMemoryPressureMonitor` polls `kern.memorystatus_level` (percent of RAM neither wired nor compressed, i.e. 100 minus Activity Monitor's pressure graph) every 10 s and on kernel pressure events. Constrained at ≤ 50% for two consecutive samples, clears at ≥ 60%. One unprivileged sysctl per sample.
- Chip is static and orange; the bottom pill's fixed canvas grows by one row while it is visible. Not shown on the 100 pt pill size.
- Settings → Notifications → **Low Memory Warnings** toggle, default on, included in backup/restore and settings search.
- The "Dictation AI post-processing finished" log line now carries `sysAvailMem=NN%` for triaging slow-cleanup reports.

The kernel's own warn/critical pressure level was tried first and dropped: on macOS 27.0 it stayed at WARN for minutes while 94% of memory was available. A real WARN implies < 50% available, so the percentage tier fires within 20 s anyway; the dispatch pressure source is kept only as a "sample now" nudge.

## Type of Change
- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Relates to #925 (surfaces the cause of slow cleanup; does not make cleanup faster).

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac (M3 Max, 128 GB)
- [x] Tested on macOS version: 27.0 (26A5388g)
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources Tests Package.swift` (only pre-existing `legacy_swiftui_aspect_ratio` findings on untouched lines)
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: `MemoryPressureEvaluatorTests` + `SystemMemoryPressureMonitorTests`, 5/5 pass
- Live: `FLUID_MEMORY_ADVISORY_THRESHOLD=99` lowers the trigger so the chip shows on any Mac; the Debug build trips within 10 s of launch, logged under `[SystemMemory]`.
- Real pressure: `sudo memory_pressure -l warn` drops the percentage below 50 and the chip appears within ~20 s, clearing above 60%.

## Screenshots / Video
_Screenshot of the chip in the bottom overlay to be attached._

- [ ] No UI/visual changes; screenshots/video are not applicable.

## Notes
Deliberately minimal: no dismiss button (the settings toggle is the persistent opt-out for Macs that sit at low memory permanently), no thermal or CPU-load tiers. Both can be layered onto the same monitor if reports call for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SorCyrzUUgCFzTH52DgnqZ
