### PR TITLE
Fix microphone recovery after audio device changes

### DIFF
--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		F1BD00000000000000000002 /* StripThinkingTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BD00000000000000000001 /* StripThinkingTagsTests.swift */; };
 		C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */; };
 		DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */; };
+		DA7200020000000000000002 /* AudioHardwareRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7200010000000000000001 /* AudioHardwareRecoveryTests.swift */; };
 		7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */; };
 		803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803000000000000000000001 /* MediaPlaybackServiceTests.swift */; };
 		0B05F11E000000000000A002 /* SupportedFileExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B05F11E000000000000A001 /* SupportedFileExtensionsTests.swift */; };
@@ -73,6 +74,7 @@
 		F1BD00000000000000000001 /* StripThinkingTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripThinkingTagsTests.swift; sourceTree = "<group>"; };
 		C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineRetirementDrainTests.swift; sourceTree = "<group>"; };
 		DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectAudioReliabilityTests.swift; sourceTree = "<group>"; };
+		DA7200010000000000000001 /* AudioHardwareRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioHardwareRecoveryTests.swift; sourceTree = "<group>"; };
 		B51800000000000000000001 /* SpokenSendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpokenSendTests.swift; sourceTree = "<group>"; };
 		B51900000000000000000001 /* PrivateAIProviderPromptFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateAIProviderPromptFormatTests.swift; sourceTree = "<group>"; };
 		B52000000000000000000001 /* PrivateAIDictationTokenBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateAIDictationTokenBudgetTests.swift; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 				F1BD00000000000000000001 /* StripThinkingTagsTests.swift */,
 				C0DE63600000000000000001 /* AudioEngineRetirementDrainTests.swift */,
 				DA7100010000000000000001 /* DirectAudioReliabilityTests.swift */,
+				DA7200010000000000000001 /* AudioHardwareRecoveryTests.swift */,
 				7CFA1D0B2F500000C0DEF002 /* TypingServiceTransientPasteboardTests.swift */,
 				803000000000000000000001 /* MediaPlaybackServiceTests.swift */,
 				B51800000000000000000001 /* SpokenSendTests.swift */,
@@ -345,6 +348,7 @@
 				F1BD00000000000000000002 /* StripThinkingTagsTests.swift in Sources */,
 				C0DE63600000000000000002 /* AudioEngineRetirementDrainTests.swift in Sources */,
 				DA7100020000000000000002 /* DirectAudioReliabilityTests.swift in Sources */,
+				DA7200020000000000000002 /* AudioHardwareRecoveryTests.swift in Sources */,
 				7CFA1D0B2F500000C0DEF001 /* TypingServiceTransientPasteboardTests.swift in Sources */,
 				803000000000000000000002 /* MediaPlaybackServiceTests.swift in Sources */,
 				B51800000000000000000002 /* SpokenSendTests.swift in Sources */,

--- a/Fluid.xcodeproj/project.pbxproj
+++ b/Fluid.xcodeproj/project.pbxproj
@@ -505,7 +505,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = V4J43B279J;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_CODE_COVERAGE = NO;
@@ -533,7 +533,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = "1.6.10-beta.1";
+				MARKETING_VERSION = "1.6.10-beta.2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.FluidApp.app.debug;
 				PRODUCT_NAME = "FluidVoice Debug";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -560,7 +560,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = V4J43B279J;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_CODE_COVERAGE = NO;
@@ -588,7 +588,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = "1.6.10-beta.1";
+				MARKETING_VERSION = "1.6.10-beta.2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.FluidApp.app;
 				PRODUCT_NAME = FluidVoice;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Info.plist
+++ b/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.10-beta.1</string>
+	<string>1.6.10-beta.2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -1346,10 +1346,15 @@ final class ASRService: ObservableObject {
     /// cancellation handler also covers cancellation before queue admission.
     private func startCancellableAudioCapture(
         excluding excludedInputUIDs: Set<String>,
-        forcingInputUID: String?
+        forcingInputUID: String?,
+        onInputSnapshotRead: @escaping @MainActor (Int) -> Void
     ) async throws {
         let task = Task {
-            try await self.startConfiguredAudioCapture(excluding: excludedInputUIDs, forcingInputUID: forcingInputUID)
+            try await self.startConfiguredAudioCapture(
+                excluding: excludedInputUIDs,
+                forcingInputUID: forcingInputUID,
+                onInputSnapshotRead: onInputSnapshotRead
+            )
         }
         self.pendingAudioCaptureBackendStart = task
         defer { self.pendingAudioCaptureBackendStart = nil }
@@ -1362,7 +1367,8 @@ final class ASRService: ObservableObject {
 
     private func startConfiguredAudioCapture(
         excluding excludedInputUIDs: Set<String> = [],
-        forcingInputUID: String? = nil
+        forcingInputUID: String? = nil,
+        onInputSnapshotRead: @MainActor (Int) -> Void = { _ in }
     ) async throws {
         let startGeneration = self.audioCaptureStartGeneration
         let previousAttemptIdentity = self.audioStartAttemptInputUID.map {
@@ -1393,6 +1399,7 @@ final class ASRService: ObservableObject {
                 try self.checkCaptureStartGeneration(startGeneration)
                 let allDevices = deviceSnapshot.devices
                 let availableInputs = allDevices.filter(\.hasInput)
+                onInputSnapshotRead(availableInputs.count)
                 let selectedInput: AudioDevice.Device?
                 if let forcingInputUID {
                     selectedInput = availableInputs.first { $0.uid == forcingInputUID }
@@ -2282,10 +2289,8 @@ final class ASRService: ObservableObject {
         self.isDictionaryTrainingCaptureActive = false
 
         do {
-            let maximumStartAttempts =
-                SettingsStore.shared.experimentalDirectAudioCaptureEnabled
-                    ? max(self.cachedInputDeviceIDsByUID.count, 1) + 1
-                    : 1
+            var maximumStartAttempts = 1
+            var hasReadInputSnapshot = false
             var startAttempt = 1
             var fallbackAttempt = 1
             var failedInputUIDs = Set<String>()
@@ -2298,7 +2303,14 @@ final class ASRService: ObservableObject {
                 do {
                     try await self.startCancellableAudioCapture(
                         excluding: failedInputUIDs,
-                        forcingInputUID: forcedInputUID
+                        forcingInputUID: forcedInputUID,
+                        onInputSnapshotRead: { inputCount in
+                            guard hasReadInputSnapshot == false else { return }
+                            // Freeze a bounded budget from the same fresh snapshot
+                            // that selected the first input, including one retry.
+                            hasReadInputSnapshot = true
+                            maximumStartAttempts = max(inputCount, 1) + 1
+                        }
                     )
                 } catch {
                     try self.checkCaptureStartGeneration(startGeneration)
@@ -4180,8 +4192,8 @@ final class ASRService: ObservableObject {
 
         do {
             guard hardwareAvailable else { throw BoundedAudioHardwareQueue.Failure.recovering }
-            let maximumStartAttempts = SettingsStore.shared.experimentalDirectAudioCaptureEnabled
-                ? max(self.cachedInputDeviceIDsByUID.count, 1) + 1 : 1
+            var maximumStartAttempts = 1
+            var hasReadInputSnapshot = false
             var failedInputUIDs = Set<String>()
             var immediatelyRetriedInputUID: String?
             var completedAttempts = 0
@@ -4202,7 +4214,14 @@ final class ASRService: ObservableObject {
                 )
 
                 do {
-                    try await self.startConfiguredAudioCapture(excluding: failedInputUIDs)
+                    try await self.startConfiguredAudioCapture(
+                        excluding: failedInputUIDs,
+                        onInputSnapshotRead: { inputCount in
+                            guard hasReadInputSnapshot == false else { return }
+                            hasReadInputSnapshot = true
+                            maximumStartAttempts = max(inputCount, 1) + 1
+                        }
+                    )
                 } catch {
                     guard error is BoundedAudioHardwareQueue.Failure == false,
                           error is CancellationError == false

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -528,6 +528,7 @@ final class ASRService: ObservableObject {
     private let audioCaptureReadinessGate = AudioCaptureReadinessGate()
     private let firstPCMTimeoutNanoseconds: UInt64 = 2_000_000_000
     private var audioCaptureStartGeneration: UInt64 = 0
+    private var pendingAudioCaptureBackendStart: Task<Void, Error>?
     private var audioCaptureAttemptID: UInt64 = 0
     private var isTerminating = false
     private var hasCompletedFirstTranscription: Bool = false // Track if model has warmed up with first transcription
@@ -543,6 +544,65 @@ final class ASRService: ObservableObject {
     @Published var errorTitle: String = "Error"
     @Published var errorMessage: String = ""
     @Published var showError: Bool = false
+
+    #if DEBUG
+    /// Exercise the real recovery coordinator with fake hardware, without
+    /// initializing a model, recording a physical microphone, or changing defaults.
+    var recoveryPacketHandlerForTesting: DirectCoreAudioPacketHandler {
+        let pipeline = self.audioCapturePipeline
+        return { samples, frames, rate, hostTime, sampleTime in
+            pipeline.handle(
+                samples: samples,
+                frameCount: frames,
+                sampleRate: rate,
+                inputHostTime: hostTime,
+                inputSampleTime: sampleTime
+            )
+        }
+    }
+
+    func configureAudioRouteRecoveryForTesting(
+        controller: DirectCoreAudioLifecycleController,
+        devices: [AudioDevice.Device],
+        initialSamples: [Float]
+    ) {
+        precondition(self.isRunning == false && self.isStarting == false)
+        self.directAudioLifecycleController = controller
+        self.cacheCurrentDeviceList(devices)
+        self.benchmarkSessionID = 987_654
+        self.audioCaptureStartGeneration &+= 1
+        self.audioCaptureAttemptID &+= 1
+        self.activeAudioCaptureBackend = .directCoreAudio
+        self.audioBuffer.append(initialSamples)
+        self.audioCapturePipeline.setRecordingEnabled(
+            true, sessionID: self.benchmarkSessionID, attemptID: self.audioCaptureAttemptID
+        )
+        self.isRunning = true
+    }
+
+    func triggerAudioRouteRecoveryForTesting() {
+        self.scheduleAudioRouteRecovery(
+            reason: "injected input change", requiresIdlePrewarm: true, reconcilesInputSelection: true
+        )
+    }
+
+    var audioRouteRecoveryStateForTesting: (pending: Bool, recovering: Bool, acceptingPCM: Bool, samples: [Float]) {
+        (
+            self.pendingAudioRouteRecovery != nil,
+            self.isRecoveringAudioRoute,
+            self.audioCapturePipeline.isRecordingEnabledForTesting,
+            self.audioBuffer.getAll()
+        )
+    }
+
+    func finishAudioRouteRecoveryTest() async {
+        await self.cancelAudioRouteRecoveryAndWait()
+        self.isRunning = false
+        self.audioCapturePipeline.setRecordingEnabled(false)
+        await self.directAudioLifecycleController.shutdown(reason: "test_complete")
+        self.audioBuffer.clear()
+    }
+    #endif
 
     /// Returns a user-friendly status message for model loading state
     var modelStatusMessage: String {
@@ -625,14 +685,14 @@ final class ASRService: ObservableObject {
         self.isTerminating = true
         // Give media restoration the same quit window as audio cleanup.
         MediaPlaybackService.shared.beginShutdown()
+        if self.isStarting, self.isRunning == false {
+            await self.cancelPendingAudioCaptureStart(reason: "app_termination")
+        }
         let routeRecoveryShutdownStartedAt = Date().timeIntervalSince1970
         await self.cancelAudioRouteRecoveryAndWait()
         self.benchmarkLog(
             "route_recovery_shutdown elapsedMs=\(self.elapsedMilliseconds(since: routeRecoveryShutdownStartedAt))"
         )
-        if self.isStarting, self.isRunning == false {
-            await self.cancelPendingAudioCaptureStart(reason: "app_termination")
-        }
         if self.isRunning {
             await self.stopWithoutTranscription()
         }
@@ -1260,10 +1320,29 @@ final class ASRService: ObservableObject {
         return snapshot
     }
 
+    /// Bridge the app's Cancel action to the actual backend task. The task's
+    /// cancellation handler also covers cancellation before queue admission.
+    private func startCancellableAudioCapture(
+        excluding excludedInputUIDs: Set<String>,
+        forcingInputUID: String?
+    ) async throws {
+        let task = Task {
+            try await self.startConfiguredAudioCapture(excluding: excludedInputUIDs, forcingInputUID: forcingInputUID)
+        }
+        self.pendingAudioCaptureBackendStart = task
+        defer { self.pendingAudioCaptureBackendStart = nil }
+        try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
     private func startConfiguredAudioCapture(
         excluding excludedInputUIDs: Set<String> = [],
         forcingInputUID: String? = nil
     ) async throws {
+        let startGeneration = self.audioCaptureStartGeneration
         let previousAttemptIdentity = self.audioStartAttemptInputUID.map {
             AudioCaptureIdlePolicy.CaptureAttemptIdentity(
                 uid: $0,
@@ -1282,14 +1361,10 @@ final class ASRService: ObservableObject {
             // release.
             await self.audioEngineRetirementDrain.waitForScheduledReleases()
             do {
-                let deviceSnapshot = await Task.detached(priority: .userInitiated) {
-                    let allDevices = AudioDevice.listAllDevices()
-                    return (
-                        allDevices: allDevices,
-                        defaultInputUID: AudioDevice.getDefaultInputDevice(from: allDevices)?.uid
-                    )
-                }.value
-                let allDevices = deviceSnapshot.allDevices
+                try self.checkCaptureStartGeneration(startGeneration)
+                let deviceSnapshot = try await self.directAudioLifecycleController.readCaptureDeviceSnapshot()
+                try self.checkCaptureStartGeneration(startGeneration)
+                let allDevices = deviceSnapshot.devices
                 let availableInputs = allDevices.filter(\.hasInput)
                 let selectedInput: AudioDevice.Device?
                 if let forcingInputUID {
@@ -1326,10 +1401,17 @@ final class ASRService: ObservableObject {
                 self.audioStartAttemptInputName = attemptIdentity.name
                 self.audioStartAttemptIsBluetooth = attemptIdentity.isBluetooth
                 self.audioStartAttemptIsInternalMicrophone = attemptIdentity.isInternalMicrophone
+                if self.directAudioLifecycleController.isRecoveringHardware {
+                    guard await self.directAudioLifecycleController.waitForPendingHardwareRetirement() else {
+                        throw CancellationError()
+                    }
+                    try self.checkCaptureStartGeneration(startGeneration)
+                }
                 let device = try await self.directAudioLifecycleController.resolveDevice(
                     selection: selection,
                     reason: "recording_start"
                 )
+                try self.checkCaptureStartGeneration(startGeneration)
                 self.audioStartAttemptInputUID = device.uid
                 self.audioStartAttemptInputName = device.name
                 self.audioStartAttemptIsBluetooth = device.isBluetooth
@@ -1343,7 +1425,7 @@ final class ASRService: ObservableObject {
                     deviceName: device.name,
                     reason: "recording_start"
                 )
-                try Task.checkCancellation()
+                try self.checkCaptureStartGeneration(startGeneration)
                 self.activeAudioCaptureBackend = .directCoreAudio
                 let callbackDurationMilliseconds =
                     Double(snapshot.bufferFrameSize ?? 0) /
@@ -1370,6 +1452,13 @@ final class ASRService: ObservableObject {
         try await self.startAVAudioEngineCapture()
     }
 
+    private func checkCaptureStartGeneration(_ generation: UInt64) throws {
+        try Task.checkCancellation()
+        guard generation == self.audioCaptureStartGeneration, self.isTerminating == false else {
+            throw CancellationError()
+        }
+    }
+
     private func startAVAudioEngineCapture() async throws {
         await self.audioEngineRetirementDrain.waitForScheduledReleases()
         self.benchmarkLog("audio_backend kind=av_audio_engine reason=faster_recording_start_disabled")
@@ -1387,7 +1476,8 @@ final class ASRService: ObservableObject {
         case .directCoreAudio:
             let report = await self.directAudioLifecycleController.stop(
                 retainPrepared: retainDirectPreparedCapture,
-                reason: reason
+                reason: reason,
+                recoveringRoute: self.isRecoveringAudioRoute
             )
             if report.status != noErr {
                 DebugLogger.shared.warning(
@@ -2185,7 +2275,7 @@ final class ASRService: ObservableObject {
             while true {
                 let routeGenerationAtStart = self.audioRouteRecoveryGeneration
                 do {
-                    try await self.startConfiguredAudioCapture(
+                    try await self.startCancellableAudioCapture(
                         excluding: failedInputUIDs,
                         forcingInputUID: forcedInputUID
                     )
@@ -2547,6 +2637,9 @@ final class ASRService: ObservableObject {
     func cancelPendingAudioCaptureStart(reason: String) async {
         guard self.isStarting, self.isRunning == false else { return }
         self.audioCaptureStartGeneration &+= 1
+        self.pendingAudioCaptureBackendStart?.cancel()
+        self.audioCapturePipeline.setRecordingEnabled(false)
+        self.directAudioLifecycleController.cancelPendingStartup()
         if let sessionID = self.pendingMediaCaptureSessionID {
             MediaPlaybackService.shared.sessionFinished(sessionID: sessionID)
         }
@@ -3238,6 +3331,10 @@ final class ASRService: ObservableObject {
     }
 
     func stopWithoutTranscription() async {
+        await self.stopWithoutTranscription(finishingRecovery: false)
+    }
+
+    private func stopWithoutTranscription(finishingRecovery: Bool) async {
         if self.isStarting, self.isRunning == false {
             await self.cancelPendingAudioCaptureStart(reason: "stop_without_transcription")
         }
@@ -3258,7 +3355,9 @@ final class ASRService: ObservableObject {
             self.isDictionaryTrainingCaptureActive = false
         }
 
-        await self.cancelAudioRouteRecoveryAndWait()
+        if finishingRecovery == false {
+            await self.cancelAudioRouteRecoveryAndWait()
+        }
         guard self.isRunning, self.benchmarkSessionID == stoppingSessionID else {
             self.recordingBufferHandoffGate.complete(bufferHandoffToken)
             completedBufferHandoff = true
@@ -3919,6 +4018,14 @@ final class ASRService: ObservableObject {
             self.finishAudioRouteRecovery(request)
         }
 
+        let hardwareAvailable = await self.directAudioLifecycleController.waitForHardwareAvailability()
+        guard request.generation == self.audioRouteRecoveryGeneration,
+              Task.isCancelled == false, self.isTerminating == false else { return }
+        guard hardwareAvailable else {
+            await self.finishAudioRouteRecoveryFailure(request, error: BoundedAudioHardwareQueue.Failure.recovering)
+            return
+        }
+
         if request.reconcilesInputSelection,
            await self.reconcileInputSelectionAfterTopologySettles(request) == false
         {
@@ -3951,16 +4058,29 @@ final class ASRService: ObservableObject {
     private func reconcileInputSelectionAfterTopologySettles(
         _ request: AudioRouteRecoveryRequest
     ) async -> Bool {
-        let snapshot = await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let devices = AudioDevice.listInputDevicesRefreshingLiveness()
-                let defaultInputUID = AudioDevice.getDefaultInputDevice()?.uid
-                continuation.resume(returning: (devices, defaultInputUID))
+        var resolvedSnapshot: DirectCoreAudioLifecycleController.DeviceSnapshot?
+        var queryError: Error = BoundedAudioHardwareQueue.Failure.recovering
+        // One bounded retry covers transient HAL queries without leaving a
+        // recording paused after its recovery request has been consumed.
+        for _ in 0..<2 {
+            let available = await self.directAudioLifecycleController.waitForDeviceQueryAvailability()
+            guard request.generation == self.audioRouteRecoveryGeneration,
+                  Task.isCancelled == false, self.isTerminating == false else { return false }
+            guard available else { break }
+            do {
+                resolvedSnapshot = try await self.directAudioLifecycleController.readDeviceSnapshot(refreshLiveness: true)
+                break
+            } catch {
+                queryError = error
             }
         }
         guard request.generation == self.audioRouteRecoveryGeneration,
-              Task.isCancelled == false
-        else { return false }
+              Task.isCancelled == false, self.isTerminating == false else { return false }
+        guard let devices = resolvedSnapshot else {
+            await self.finishAudioRouteRecoveryFailure(request, error: queryError)
+            return false
+        }
+        let snapshot = (devices.devices, devices.defaultInputUID)
 
         let currentUIDs = Set(snapshot.0.map(\.uid))
         guard currentUIDs == self.cachedDeviceUIDs else {
@@ -3995,7 +4115,8 @@ final class ASRService: ObservableObject {
             reconcilesInputSelection: request.reconcilesInputSelection
         )
         await self.directAudioLifecycleController.invalidate(
-            reason: "idle_route_change:\(request.reason)"
+            reason: "idle_route_change:\(request.reason)",
+            recoveringRoute: true
         )
         await self.retireAudioEngineAndWait(reason: "idle_route_change:\(request.reason)")
 
@@ -4027,18 +4148,19 @@ final class ASRService: ObservableObject {
             reason: "active_route_recovery"
         )
         await self.retireAudioEngineAndWait(reason: "audio_route_recovery")
-
-        guard request.generation == self.audioRouteRecoveryGeneration, Task.isCancelled == false else { return }
+        let hardwareAvailable = await self.directAudioLifecycleController.waitForHardwareAvailability()
+        guard request.generation == self.audioRouteRecoveryGeneration,
+              Task.isCancelled == false, self.isTerminating == false else { return }
 
         do {
-            let maximumAttempts = SettingsStore.shared.experimentalDirectAudioCaptureEnabled
-                ? max(AudioDevice.listInputDevices().count, 1) + 1
-                : 1
+            guard hardwareAvailable else { throw BoundedAudioHardwareQueue.Failure.recovering }
+            let maximumStartAttempts = SettingsStore.shared.experimentalDirectAudioCaptureEnabled
+                ? max(self.cachedInputDeviceIDsByUID.count, 1) + 1 : 1
             var failedInputUIDs = Set<String>()
             var immediatelyRetriedInputUID: String?
             var completedAttempts = 0
 
-            while completedAttempts < maximumAttempts {
+            while completedAttempts < maximumStartAttempts {
                 completedAttempts += 1
                 self.audioCaptureAttemptID &+= 1
                 let readinessAttemptID = self.audioCaptureAttemptID
@@ -4056,6 +4178,9 @@ final class ASRService: ObservableObject {
                 do {
                     try await self.startConfiguredAudioCapture(excluding: failedInputUIDs)
                 } catch {
+                    guard error is BoundedAudioHardwareQueue.Failure == false,
+                          error is CancellationError == false
+                    else { throw error }
                     if let failedUID = self.audioStartAttemptInputUID {
                         let retrySameInput = immediatelyRetriedInputUID == nil
                         if retrySameInput {
@@ -4065,7 +4190,7 @@ final class ASRService: ObservableObject {
                             failedInputUIDs.insert(failedUID)
                         }
                     }
-                    guard completedAttempts < maximumAttempts else { throw error }
+                    guard completedAttempts < maximumStartAttempts else { throw error }
                     self.audioCapturePipeline.setRecordingEnabled(false)
                     await self.stopActiveAudioCapture(
                         retainDirectPreparedCapture: false,
@@ -4134,7 +4259,7 @@ final class ASRService: ObservableObject {
                         failedInputUIDs.insert(failedUID)
                     }
                 }
-                guard completedAttempts < maximumAttempts else {
+                guard completedAttempts < maximumStartAttempts else {
                     throw NSError(
                         domain: "ASRService",
                         code: -3,
@@ -4156,25 +4281,41 @@ final class ASRService: ObservableObject {
                 userInfo: [NSLocalizedDescriptionKey: "No replacement microphone is available."]
             )
         } catch {
-            guard request.generation == self.audioRouteRecoveryGeneration, Task.isCancelled == false else { return }
-            self.audioCapturePipeline.setRecordingEnabled(false)
-            await self.stopActiveAudioCapture(
-                retainDirectPreparedCapture: false,
-                reason: "active_route_recovery_failed"
-            )
-            DebugLogger.shared.error("Audio route recovery failed: \(error)", source: "ASRService")
-            AppServices.shared.microphonePreferenceCoordinator.markActiveSelectionUnavailable()
+            await self.finishAudioRouteRecoveryFailure(request, error: error)
+        }
+    }
 
-            // Avoid asking stopWithoutTranscription() to await the recovery task
-            // that is currently executing this catch block.
-            self.audioRouteRecoveryTask = nil
-            await self.stopWithoutTranscription()
-            NotificationCenter.default.post(
-                name: NSNotification.Name("ASRServiceDeviceDisconnected"),
-                object: nil,
-                userInfo: ["errorMessage": "Recording stopped because the audio device changed."]
+    private func finishAudioRouteRecoveryFailure(_ request: AudioRouteRecoveryRequest, error: Error) async {
+        guard request.generation == self.audioRouteRecoveryGeneration,
+              Task.isCancelled == false, self.isTerminating == false else { return }
+        DebugLogger.shared.error("Audio route recovery failed: \(error)", source: "ASRService")
+        AppServices.shared.microphonePreferenceCoordinator.markActiveSelectionUnavailable()
+        let failedSessionID = self.benchmarkSessionID
+        var expectedStartGeneration = self.audioCaptureStartGeneration
+        let wasCapturing = self.isRunning || self.isStarting
+        if self.isRunning {
+            // This task keeps recovery ownership until its defer runs. User Stop
+            // may cancel and await it, but it must never await itself here.
+            await self.stopWithoutTranscription(finishingRecovery: true)
+        } else if self.isStarting {
+            // Startup may itself be awaiting this recovery. Invalidate it without
+            // awaiting its completion, so it can unwind after this task returns.
+            self.audioCaptureStartGeneration &+= 1
+            expectedStartGeneration = self.audioCaptureStartGeneration
+            self.audioCapturePipeline.setRecordingEnabled(false)
+            self.directAudioLifecycleController.cancelPendingStartup()
+            self.recordingBufferHandoffGate.releasePendingWaiters()
+            await self.audioCaptureReadinessGate.cancel(
+                sessionID: failedSessionID, attemptID: self.audioCaptureAttemptID
             )
         }
+        guard wasCapturing, self.benchmarkSessionID == failedSessionID,
+              self.audioCaptureStartGeneration == expectedStartGeneration,
+              request.generation == self.audioRouteRecoveryGeneration,
+              Task.isCancelled == false, self.isTerminating == false else { return }
+        self.errorTitle = "Recording Stopped"
+        self.errorMessage = "The microphone could not recover after the audio device changed. \(error.localizedDescription)"
+        self.showError = true
     }
 
     private func handleDirectCaptureFormatInvalidation(
@@ -5982,6 +6123,10 @@ private final nonisolated class AudioCapturePipeline: @unchecked Sendable {
         defer { self.lock.unlock() }
         return self.levelMonitoringEnabled
     }
+
+    #if DEBUG
+    var isRecordingEnabledForTesting: Bool { self.lock.withLock { self.recordingEnabled } }
+    #endif
 
     func setLevelMonitoringEnabled(_ enabled: Bool) {
         self.lock.lock()

--- a/Sources/Fluid/Services/ASRService.swift
+++ b/Sources/Fluid/Services/ASRService.swift
@@ -529,6 +529,7 @@ final class ASRService: ObservableObject {
     private let firstPCMTimeoutNanoseconds: UInt64 = 2_000_000_000
     private var audioCaptureStartGeneration: UInt64 = 0
     private var pendingAudioCaptureBackendStart: Task<Void, Error>?
+    private var mediaPlaybackService = MediaPlaybackService.shared
     private var audioCaptureAttemptID: UInt64 = 0
     private var isTerminating = false
     private var hasCompletedFirstTranscription: Bool = false // Track if model has warmed up with first transcription
@@ -544,6 +545,14 @@ final class ASRService: ObservableObject {
     @Published var errorTitle: String = "Error"
     @Published var errorMessage: String = ""
     @Published var showError: Bool = false
+    let audioCaptureFailurePresented = PassthroughSubject<Void, Never>()
+
+    private func presentAudioCaptureFailure(title: String, message: String) {
+        self.errorTitle = title
+        self.errorMessage = message
+        self.showError = true
+        self.audioCaptureFailurePresented.send()
+    }
 
     #if DEBUG
     /// Exercise the real recovery coordinator with fake hardware, without
@@ -584,6 +593,19 @@ final class ASRService: ObservableObject {
         self.scheduleAudioRouteRecovery(
             reason: "injected input change", requiresIdlePrewarm: true, reconcilesInputSelection: true
         )
+    }
+
+    func useMediaPlaybackForTesting(_ service: MediaPlaybackService) {
+        self.mediaPlaybackService = service
+    }
+
+    func failAudioRouteRecoveryForTesting(stale: Bool = false) async {
+        await self.finishAudioRouteRecoveryFailure(AudioRouteRecoveryRequest(
+            generation: stale ? self.audioRouteRecoveryGeneration &- 1 : self.audioRouteRecoveryGeneration,
+            reason: "injected recovery failure",
+            requiresIdlePrewarm: true,
+            reconcilesInputSelection: false
+        ), error: BoundedAudioHardwareQueue.Failure.recovering)
     }
 
     var audioRouteRecoveryStateForTesting: (pending: Bool, recovering: Bool, acceptingPCM: Bool, samples: [Float]) {
@@ -684,7 +706,7 @@ final class ASRService: ObservableObject {
     func shutdownForTermination() async {
         self.isTerminating = true
         // Give media restoration the same quit window as audio cleanup.
-        MediaPlaybackService.shared.beginShutdown()
+        self.mediaPlaybackService.beginShutdown()
         if self.isStarting, self.isRunning == false {
             await self.cancelPendingAudioCaptureStart(reason: "app_termination")
         }
@@ -728,7 +750,7 @@ final class ASRService: ObservableObject {
         self.isAsrReady = false
         self.isLoadingModel = false
         self.isDownloadingModel = false
-        await MediaPlaybackService.shared.shutdown()
+        await self.mediaPlaybackService.shutdown()
     }
 
     /// The transcription provider, selected based on the unified SpeechModel setting.
@@ -1362,6 +1384,11 @@ final class ASRService: ObservableObject {
             await self.audioEngineRetirementDrain.waitForScheduledReleases()
             do {
                 try self.checkCaptureStartGeneration(startGeneration)
+                if self.directAudioLifecycleController.isRecoveringHardware {
+                    let available = await self.directAudioLifecycleController.waitForPendingHardwareRetirement()
+                    try self.checkCaptureStartGeneration(startGeneration)
+                    guard available else { throw BoundedAudioHardwareQueue.Failure.recovering }
+                }
                 let deviceSnapshot = try await self.directAudioLifecycleController.readCaptureDeviceSnapshot()
                 try self.checkCaptureStartGeneration(startGeneration)
                 let allDevices = deviceSnapshot.devices
@@ -1401,12 +1428,6 @@ final class ASRService: ObservableObject {
                 self.audioStartAttemptInputName = attemptIdentity.name
                 self.audioStartAttemptIsBluetooth = attemptIdentity.isBluetooth
                 self.audioStartAttemptIsInternalMicrophone = attemptIdentity.isInternalMicrophone
-                if self.directAudioLifecycleController.isRecoveringHardware {
-                    guard await self.directAudioLifecycleController.waitForPendingHardwareRetirement() else {
-                        throw CancellationError()
-                    }
-                    try self.checkCaptureStartGeneration(startGeneration)
-                }
                 let device = try await self.directAudioLifecycleController.resolveDevice(
                     selection: selection,
                     reason: "recording_start"
@@ -2232,7 +2253,7 @@ final class ASRService: ObservableObject {
         // cannot finish the previous session's still-running transcription.
         self.pendingMediaCaptureSessionID = captureSessionID
         defer { self.pendingMediaCaptureSessionID = nil }
-        MediaPlaybackService.shared.recordingStarted(
+        self.mediaPlaybackService.recordingStarted(
             sessionID: captureSessionID,
             enabled: SettingsStore.shared.pauseMediaDuringTranscription
         )
@@ -2263,7 +2284,7 @@ final class ASRService: ObservableObject {
         do {
             let maximumStartAttempts =
                 SettingsStore.shared.experimentalDirectAudioCaptureEnabled
-                    ? max(AudioDevice.listInputDevices().count, 1) + 1
+                    ? max(self.cachedInputDeviceIDsByUID.count, 1) + 1
                     : 1
             var startAttempt = 1
             var fallbackAttempt = 1
@@ -2280,6 +2301,11 @@ final class ASRService: ObservableObject {
                         forcingInputUID: forcedInputUID
                     )
                 } catch {
+                    try self.checkCaptureStartGeneration(startGeneration)
+                    guard error is BoundedAudioHardwareQueue.Failure == false,
+                          error is CancellationError == false,
+                          self.directAudioLifecycleController.isRecoveringHardware == false
+                    else { throw error }
                     guard let failedUID = self.audioStartAttemptInputUID else { throw error }
                     let now = ProcessInfo.processInfo.systemUptime
                     let retryBluetoothInput = bluetoothStabilization.shouldRetry(
@@ -2481,7 +2507,7 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.info("✅ START() completed successfully", source: "ASRService")
             return .started
         } catch {
-            MediaPlaybackService.shared.sessionFinished(sessionID: captureSessionID)
+            self.mediaPlaybackService.sessionFinished(sessionID: captureSessionID)
             await self.audioCaptureReadinessGate.cancel(
                 sessionID: captureSessionID,
                 attemptID: readinessAttemptID
@@ -2531,15 +2557,9 @@ final class ASRService: ObservableObject {
                 errorMessage = "Failed to start audio recording: \(error.localizedDescription)"
             }
 
-            self.errorTitle = noUsableMicrophone ? "Microphone Unavailable" : "Recording Error"
-            self.errorMessage = errorMessage
-            self.showError = true
-
-            // Post notification for UI to display
-            NotificationCenter.default.post(
-                name: NSNotification.Name("ASRServiceStartFailed"),
-                object: nil,
-                userInfo: ["errorMessage": errorMessage]
+            self.presentAudioCaptureFailure(
+                title: noUsableMicrophone ? "Microphone Unavailable" : "Recording Error",
+                message: errorMessage
             )
             return .failed
         }
@@ -2634,18 +2654,24 @@ final class ASRService: ObservableObject {
         )
     }
 
-    func cancelPendingAudioCaptureStart(reason: String) async {
-        guard self.isStarting, self.isRunning == false else { return }
+    /// Recovery can be awaited by startup, so it must interrupt without waiting
+    /// for startup to finish. Keep task cancellation and media release together.
+    private func interruptPendingAudioCaptureStart() {
         self.audioCaptureStartGeneration &+= 1
         self.pendingAudioCaptureBackendStart?.cancel()
         self.audioCapturePipeline.setRecordingEnabled(false)
         self.directAudioLifecycleController.cancelPendingStartup()
         if let sessionID = self.pendingMediaCaptureSessionID {
-            MediaPlaybackService.shared.sessionFinished(sessionID: sessionID)
+            self.mediaPlaybackService.sessionFinished(sessionID: sessionID)
         }
         // A start waiting for the previous session's PCM handoff must wake to
         // observe the generation change; the old stop keeps ownership of the gate.
         self.recordingBufferHandoffGate.releasePendingWaiters()
+    }
+
+    func cancelPendingAudioCaptureStart(reason: String) async {
+        guard self.isStarting, self.isRunning == false else { return }
+        self.interruptPendingAudioCaptureStart()
         let cancelledSessionID = self.benchmarkSessionID
         self.benchmarkLog(
             "capture_start_cancel reason=\(reason) session=\(cancelledSessionID) " +
@@ -2803,8 +2829,8 @@ final class ASRService: ObservableObject {
             DebugLogger.shared.warning("STOP() ignored - recording buffer handoff already active", source: "ASRService")
             return ""
         }
-        MediaPlaybackService.shared.recordingStopped(sessionID: stoppingSessionID)
-        defer { MediaPlaybackService.shared.sessionFinished(sessionID: stoppingSessionID) }
+        self.mediaPlaybackService.recordingStopped(sessionID: stoppingSessionID)
+        defer { self.mediaPlaybackService.sessionFinished(sessionID: stoppingSessionID) }
         self.isStoppingFinalTranscription = true
         var completedBufferHandoff = false
         defer {
@@ -3341,8 +3367,8 @@ final class ASRService: ObservableObject {
         guard self.isRunning else { return }
         let stoppingSessionID = self.benchmarkSessionID
         guard let bufferHandoffToken = self.recordingBufferHandoffGate.begin() else { return }
-        MediaPlaybackService.shared.recordingStopped(sessionID: stoppingSessionID)
-        defer { MediaPlaybackService.shared.sessionFinished(sessionID: stoppingSessionID) }
+        self.mediaPlaybackService.recordingStopped(sessionID: stoppingSessionID)
+        defer { self.mediaPlaybackService.sessionFinished(sessionID: stoppingSessionID) }
         var completedBufferHandoff = false
         defer {
             if completedBufferHandoff == false {
@@ -4300,11 +4326,8 @@ final class ASRService: ObservableObject {
         } else if self.isStarting {
             // Startup may itself be awaiting this recovery. Invalidate it without
             // awaiting its completion, so it can unwind after this task returns.
-            self.audioCaptureStartGeneration &+= 1
+            self.interruptPendingAudioCaptureStart()
             expectedStartGeneration = self.audioCaptureStartGeneration
-            self.audioCapturePipeline.setRecordingEnabled(false)
-            self.directAudioLifecycleController.cancelPendingStartup()
-            self.recordingBufferHandoffGate.releasePendingWaiters()
             await self.audioCaptureReadinessGate.cancel(
                 sessionID: failedSessionID, attemptID: self.audioCaptureAttemptID
             )
@@ -4313,9 +4336,10 @@ final class ASRService: ObservableObject {
               self.audioCaptureStartGeneration == expectedStartGeneration,
               request.generation == self.audioRouteRecoveryGeneration,
               Task.isCancelled == false, self.isTerminating == false else { return }
-        self.errorTitle = "Recording Stopped"
-        self.errorMessage = "The microphone could not recover after the audio device changed. \(error.localizedDescription)"
-        self.showError = true
+        self.presentAudioCaptureFailure(
+            title: "Recording Stopped",
+            message: "The microphone could not recover after the audio device changed. \(error.localizedDescription)"
+        )
     }
 
     private func handleDirectCaptureFormatInvalidation(
@@ -4515,6 +4539,7 @@ final class ASRService: ObservableObject {
 
     private var deviceListListenerInstalled = false
     private var deviceListListenerToken: AudioObjectPropertyListenerBlock?
+    private let deviceListListenerQueue = DispatchQueue(label: "com.fluidvoice.audio.topology-notifications", qos: .userInitiated)
     private var monitoredDeviceID: AudioObjectID?
     private var monitoredDeviceIsAliveListenerToken: AudioObjectPropertyListenerBlock?
 
@@ -4529,16 +4554,17 @@ final class ASRService: ObservableObject {
             mElement: kAudioObjectPropertyElementMain
         )
 
-        let token: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            // Defer to next runloop pass — CoreAudio may hold an internal lock during
-            // this callback, and our handler makes synchronous CoreAudio queries that
-            // would deadlock waiting for the same lock.
+        let controller = self.directAudioLifecycleController
+        let token: AudioObjectPropertyListenerBlock = { [weak self, weak controller] _, _ in
+            // Mark freshness immediately, even if the UI is busy. This only
+            // updates an in-memory revision; HAL queries remain outside callbacks.
+            controller?.noteHardwareTopologyChanged()
             DispatchQueue.main.async { self?.handleDeviceListChanged() }
         }
         let status = AudioObjectAddPropertyListenerBlock(
             AudioObjectID(kAudioObjectSystemObject),
             &address,
-            DispatchQueue.main,
+            self.deviceListListenerQueue,
             token
         )
 

--- a/Sources/Fluid/Services/BoundedAudioHardwareQueue.swift
+++ b/Sources/Fluid/Services/BoundedAudioHardwareQueue.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+/// Cancellation releases callers, never the native operation's memory or queue.
+/// Healthy startup has no deadline. Recovery queries and teardown can explicitly
+/// bound their caller wait without aborting or freeing a native call.
+/// Interrupted hardware must finish serialized cleanup before another operation
+/// can be admitted. In particular, cancellation must not launch a second IOProc.
+final nonisolated class BoundedAudioHardwareQueue: @unchecked Sendable {
+    enum Failure: LocalizedError {
+        case timedOut
+        case recovering
+        case cleanupFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .timedOut, .recovering:
+                "The microphone is not responding. Try again shortly. If it remains unavailable, quit and reopen FluidVoice."
+            case .cleanupFailed:
+                "The microphone could not be reset safely. Quit and reopen FluidVoice before recording again."
+            }
+        }
+    }
+
+    private final class Cancellation: @unchecked Sendable {
+        private let lock = NSLock()
+        private var cancelled = false
+
+        var isCancelled: Bool { self.lock.withLock { self.cancelled } }
+
+        func cancel() { self.lock.withLock { self.cancelled = true } }
+    }
+
+    private struct Pending {
+        let fail: @Sendable (Error) -> Void
+        let timer: DispatchWorkItem?
+        let recover: @Sendable () -> Bool
+    }
+
+    private struct AvailabilityWaiter {
+        let continuation: CheckedContinuation<Bool, Never>
+        let timer: DispatchWorkItem?
+    }
+
+    let queue: DispatchQueue
+    private let timeout: TimeInterval?
+    private let lock = NSLock()
+    private var pending: [UUID: Pending] = [:]
+    private var recovering = false
+    private var cleanupFailed = false
+    private var availabilityWaiters: [UUID: AvailabilityWaiter] = [:]
+
+    init(queue: DispatchQueue, timeout: TimeInterval? = nil) {
+        self.queue = queue
+        self.timeout = timeout
+    }
+
+    var isAvailable: Bool {
+        self.lock.withLock { self.recovering == false && self.cleanupFailed == false }
+    }
+
+    func checkAvailable() throws {
+        try self.lock.withLock {
+            if self.cleanupFailed { throw Failure.cleanupFailed }
+            if self.recovering { throw Failure.recovering }
+        }
+    }
+
+    /// Only the serialized owner can establish that an earlier cleanup failure
+    /// is now safe (for example, after a matching device-removal notification).
+    /// A running native operation must still complete its own recovery first.
+    @discardableResult
+    func clearFailureAfterSerializedRecovery() -> Bool {
+        dispatchPrecondition(condition: .onQueue(self.queue))
+        let cleared = self.lock.withLock {
+            guard self.recovering == false, self.cleanupFailed else { return false }
+            self.cleanupFailed = false
+            return true
+        }
+        if cleared { self.resumeAvailabilityWaitersIfReady() }
+        return cleared
+    }
+
+    /// Wait for serialized cleanup without starting another hardware operation.
+    /// Cancellation removes only this waiter; it must not interrupt the cleanup.
+    func waitUntilAvailable(timeout: TimeInterval? = nil) async -> Bool {
+        let id = UUID()
+        let cancellation = Cancellation()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                self.lock.lock()
+                if cancellation.isCancelled {
+                    self.lock.unlock()
+                    continuation.resume(returning: false)
+                    return
+                }
+                if self.recovering == false, self.cleanupFailed == false {
+                    self.lock.unlock()
+                    continuation.resume(returning: true)
+                    return
+                }
+                let timer = timeout.map { _ in DispatchWorkItem { [weak self] in self?.finishAvailabilityWaiter(id) } }
+                self.availabilityWaiters[id] = AvailabilityWaiter(continuation: continuation, timer: timer)
+                self.lock.unlock()
+                if let timeout, let timer {
+                    DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout, execute: timer)
+                }
+            }
+        } onCancel: {
+            cancellation.cancel()
+            self.finishAvailabilityWaiter(id)
+        }
+    }
+
+    private func finishAvailabilityWaiter(_ id: UUID) {
+        guard let waiter = self.lock.withLock({ self.availabilityWaiters.removeValue(forKey: id) }) else { return }
+        waiter.timer?.cancel()
+        waiter.continuation.resume(returning: false)
+    }
+
+    private func resumeAvailabilityWaitersIfReady() {
+        let waiters = self.lock.withLock {
+            guard self.recovering == false, self.cleanupFailed == false else { return [AvailabilityWaiter]() }
+            let waiters = Array(self.availabilityWaiters.values)
+            self.availabilityWaiters.removeAll(keepingCapacity: false)
+            return waiters
+        }
+        for waiter in waiters {
+            waiter.timer?.cancel()
+            waiter.continuation.resume(returning: true)
+        }
+    }
+
+    func run<Value: Sendable>(
+        cancellable: Bool = true,
+        timeout: TimeInterval? = nil,
+        recover: @escaping @Sendable () -> Bool,
+        operation: @escaping @Sendable () throws -> Value
+    ) async throws -> Value {
+        let id = UUID()
+        let cancellation = Cancellation()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.lock.lock()
+                if cancellation.isCancelled || self.recovering || self.cleanupFailed {
+                    let error: Error = cancellation.isCancelled
+                        ? CancellationError()
+                        : (self.cleanupFailed ? Failure.cleanupFailed : Failure.recovering)
+                    self.lock.unlock()
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let deadline = timeout ?? self.timeout
+                let timer = deadline.map { _ in DispatchWorkItem { [weak self] in
+                    self?.interrupt(requestID: id, error: Failure.timedOut)
+                } }
+                self.pending[id] = Pending(
+                    fail: { continuation.resume(throwing: $0) },
+                    timer: timer,
+                    recover: recover
+                )
+                // Enqueue under the admission lock so interruption cannot put
+                // cleanup ahead of an admitted native operation.
+                self.queue.async {
+                    guard self.lock.withLock({ self.pending[id] != nil }) else { return }
+                    let result = Result { try operation() }
+                    self.lock.lock()
+                    let request = self.pending.removeValue(forKey: id)
+                    self.lock.unlock()
+                    guard let request else { return } // Already cancelled/timed out.
+                    request.timer?.cancel()
+                    continuation.resume(with: result)
+                }
+                if let deadline, let timer {
+                    DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                        deadline: .now() + deadline,
+                        execute: timer
+                    )
+                }
+                self.lock.unlock()
+            }
+        } onCancel: {
+            guard cancellable else { return }
+            cancellation.cancel()
+            self.interrupt(requestID: id, error: CancellationError())
+        }
+    }
+
+    /// Used when the UI cancels a recording without cancelling its Swift task.
+    /// No work is created when startup has already finished.
+    func cancelPendingOperations() {
+        self.interrupt(requestID: nil, error: CancellationError())
+    }
+
+    private func interrupt(requestID: UUID?, error: Error) {
+        self.lock.lock()
+        guard self.recovering == false,
+              let request = requestID.flatMap({ self.pending[$0] }) ??
+              (requestID == nil ? self.pending.values.first : nil)
+        else {
+            self.lock.unlock()
+            return
+        }
+        self.recovering = true
+        let requests = Array(self.pending.values)
+        self.pending.removeAll(keepingCapacity: false)
+        // The native call may still be running. Never stop/free its resources
+        // from this thread, and do not allocate replacement hardware meanwhile.
+        let recover = request.recover
+        self.queue.async {
+            let recovered = recover()
+            self.lock.withLock {
+                self.cleanupFailed = recovered == false
+                self.recovering = false
+            }
+            if recovered { self.resumeAvailabilityWaitersIfReady() }
+        }
+        self.lock.unlock()
+        for request in requests {
+            request.timer?.cancel()
+            request.fail(error)
+        }
+    }
+}

--- a/Sources/Fluid/Services/BoundedAudioHardwareQueue.swift
+++ b/Sources/Fluid/Services/BoundedAudioHardwareQueue.swift
@@ -10,10 +10,11 @@ final nonisolated class BoundedAudioHardwareQueue: @unchecked Sendable {
         case timedOut
         case recovering
         case cleanupFailed
+        case deviceStopped
 
         var errorDescription: String? {
             switch self {
-            case .timedOut, .recovering:
+            case .timedOut, .recovering, .deviceStopped:
                 "The microphone is not responding. Try again shortly. If it remains unavailable, quit and reopen FluidVoice."
             case .cleanupFailed:
                 "The microphone could not be reset safely. Quit and reopen FluidVoice before recording again."
@@ -189,6 +190,12 @@ final nonisolated class BoundedAudioHardwareQueue: @unchecked Sendable {
     /// No work is created when startup has already finished.
     func cancelPendingOperations() {
         self.interrupt(requestID: nil, error: CancellationError())
+    }
+
+    /// A device notification can establish failure before a native call returns.
+    /// The caller is released, but cleanup still waits behind the native owner.
+    func failPendingOperationsAfterDeviceStopped() {
+        self.interrupt(requestID: nil, error: Failure.deviceStopped)
     }
 
     private func interrupt(requestID: UUID?, error: Error) {

--- a/Sources/Fluid/Services/DirectCoreAudioInput.swift
+++ b/Sources/Fluid/Services/DirectCoreAudioInput.swift
@@ -671,9 +671,16 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
     private let recoveryTimeout: TimeInterval
     private let hardwareOperations: BoundedAudioHardwareQueue
     private let deviceQueries: BoundedAudioHardwareQueue
+    private let captureDeviceQueries: BoundedAudioHardwareQueue
     private var shutdownRequested = false
+    // A display can change HAL topology without changing the selected input's
+    // ID or format. Refresh stopped capture on the next Start, not mid-recording.
+    private var hardwareTopologyRevision: UInt64 = 0 // snapshotLock
+    private var lastStartedTopologyRevision: UInt64 = 0 // lifecycleQueue
     private let stoppedHardwareLock = NSLock()
     private var stoppedHardwareGenerations: Set<UInt64> = []
+    private var lastReportedAbnormalStopGeneration: UInt64?
+    private var pendingFormatInvalidationGenerations: Set<UInt64> = []
     private var storedSnapshot = Snapshot(
         phase: .empty,
         generation: 0,
@@ -720,6 +727,10 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         self.deviceQueries = BoundedAudioHardwareQueue(
             queue: DispatchQueue(label: "com.fluidvoice.audio.device-snapshot", qos: .userInitiated),
             timeout: operationTimeout ?? 5
+        )
+        self.captureDeviceQueries = BoundedAudioHardwareQueue(
+            queue: DispatchQueue(label: "com.fluidvoice.audio.capture-device-snapshot", qos: .userInitiated),
+            timeout: operationTimeout
         )
         self.packetHandler = packetHandler
         self.inputFactory = inputFactory
@@ -778,11 +789,22 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
     }
 
     func waitForPendingHardwareRetirement() async -> Bool {
-        await self.hardwareOperations.waitUntilAvailable()
+        await self.hardwareOperations.waitUntilAvailable(timeout: self.recoveryTimeout)
     }
 
     func cancelPendingStartup() {
         self.hardwareOperations.cancelPendingOperations()
+        self.captureDeviceQueries.cancelPendingOperations()
+    }
+
+    /// No HAL calls or capture mutations in the device-list notification path.
+    /// Multiple events collapse into one fresh setup at the next stopped start.
+    func noteHardwareTopologyChanged() {
+        let revision = self.snapshotLock.withLock {
+            self.hardwareTopologyRevision &+= 1
+            return self.hardwareTopologyRevision
+        }
+        Self.log("Direct capture topology changed revision=\(revision); next stopped start requires fresh input", level: .info)
     }
 
     struct DeviceSnapshot: Sendable {
@@ -790,11 +812,16 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         let defaultInputUID: String?
     }
 
-    /// Ordinary capture retains independent discovery with no recovery deadline.
+    /// Cancellation releases the caller even if HAL discovery is blocked. This
+    /// queue is independent of recovery queries and never stops running capture.
     func readCaptureDeviceSnapshot() async throws -> DeviceSnapshot {
-        try await Task.detached(priority: .userInitiated) {
-            try self.deviceSnapshotReader(false)
-        }.value
+        try await self.captureDeviceQueries.run(recover: { true }) {
+            let startedAt = ProcessInfo.processInfo.systemUptime
+            Self.log("Direct capture startup device query begin", level: .debug)
+            let snapshot = try self.deviceSnapshotReader(false)
+            Self.log("Direct capture startup device query end elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))", level: .debug)
+            return snapshot
+        }
     }
 
     func readDeviceSnapshot(refreshLiveness: Bool = false) async throws -> DeviceSnapshot {
@@ -890,6 +917,18 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                 else {
                     throw Self.error("Direct Core Audio lifecycle is shut down.")
                 }
+                let topologyRevision = self.snapshotLock.withLock { self.hardwareTopologyRevision }
+                if let input = self.input, input.isRunning == false,
+                   topologyRevision != self.lastStartedTopologyRevision
+                {
+                    // A prewarm made during device churn can still have a stale
+                    // IOProc despite an unchanged fingerprint. Rebuild once on
+                    // actual demand, after the user has finished connecting it.
+                    let status = self.invalidateLocked(reason: "topology_changed_before_start")
+                    guard status == noErr, self.isPoisoned == false else {
+                        throw BoundedAudioHardwareQueue.Failure.cleanupFailed
+                    }
+                }
                 var prepared = try self.prepareLocked(
                     deviceID: deviceID,
                     deviceName: deviceName,
@@ -935,12 +974,16 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                         input: validatedInput,
                         fingerprint: validatedInput.formatFingerprint
                     )
+                    self.lastStartedTopologyRevision = topologyRevision
                     Self.log(
                         "Direct capture start reused running input generation=\(self.generation) " +
                             "device='\(deviceName)'",
                         level: .debug
                     )
                     return self.snapshot
+                }
+                guard topologyRevision == self.snapshotLock.withLock({ self.hardwareTopologyRevision }) else {
+                    throw Self.error("Audio hardware changed while preparing the microphone. Retry with fresh capture state.")
                 }
                 self.publishSnapshot(
                     phase: .starting,
@@ -955,9 +998,13 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                     level: .info
                 )
                 try self.hardwareOperations.checkAvailable()
+                Self.log("Direct capture native start enter generation=\(self.generation) device=\(deviceID)", level: .info)
                 try validatedInput.start()
+                Self.log("Direct capture native start return generation=\(self.generation) elapsedMs=\(Self.elapsedMilliseconds(since: startStartedAt))", level: .info)
                 try self.hardwareOperations.checkAvailable()
+                Self.log("Direct capture post-start validation begin generation=\(self.generation)", level: .debug)
                 let fingerprintAfterStart = try self.fingerprintReader(deviceID)
+                Self.log("Direct capture post-start validation end generation=\(self.generation)", level: .debug)
                 try self.hardwareOperations.checkAvailable()
                 guard fingerprintAfterStart == validatedInput.formatFingerprint,
                       validatedInput.openPacketGateIfClean()
@@ -972,6 +1019,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                     input: validatedInput,
                     fingerprint: validatedInput.formatFingerprint
                 )
+                self.lastStartedTopologyRevision = topologyRevision
                 Self.log(
                     "Direct capture start end generation=\(self.generation) " +
                         "elapsedMs=\(Self.elapsedMilliseconds(since: startStartedAt)) " +
@@ -1366,7 +1414,6 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
             return
         }
 
-        let invalidationHandler = self.onFormatInvalidated
         let block = Self.makeDevicePropertyListener(objectID: objectID) { [weak self, weak input] objectID in
             let deviceIsAlive =
                 name == "device_is_alive"
@@ -1375,9 +1422,6 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
             let hardwareIsKnownStopped = Self.hardwareIsKnownStopped(
                 reason: name, deviceIsAlive: deviceIsAlive
             )
-            if hardwareIsKnownStopped {
-                self?.recordStoppedHardwareNotification(generation: generation)
-            }
             if name == "device_is_alive" {
                 Self.log(
                     "Direct capture liveness notification generation=\(generation) " +
@@ -1387,21 +1431,12 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                     level: hardwareIsKnownStopped ? .warning : .info
                 )
             }
-            input?.markFormatDirty()
-            invalidationHandler(
-                FormatInvalidation(
-                    generation: generation,
-                    deviceID: input?.deviceID ?? kAudioObjectUnknown,
-                    reason: name,
-                    wasRunning: input?.isRunning ?? false
-                )
+            self?.handleFormatNotification(
+                generation: generation,
+                reason: name,
+                input: input,
+                hardwareIsKnownStopped: hardwareIsKnownStopped
             )
-            self?.lifecycleQueue.async { [weak self] in
-                self?.handleFormatInvalidationLocked(
-                    generation: generation,
-                    reason: name
-                )
-            }
         }
         let status = AudioObjectAddPropertyListenerBlock(
             objectID,
@@ -1426,6 +1461,52 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         self.listenerRegistrations.append(
             ListenerRegistration(objectID: objectID, address: address, block: block)
         )
+    }
+
+    private func handleFormatNotification(
+        generation: UInt64,
+        reason: String,
+        input: (any DirectCoreAudioInputControlling)?,
+        hardwareIsKnownStopped: Bool
+    ) {
+        let snapshot = self.snapshotLock.withLock { self.storedSnapshot }
+        guard generation == snapshot.generation else { return }
+        let action = self.stoppedHardwareLock.withLock {
+            if hardwareIsKnownStopped { self.stoppedHardwareGenerations.insert(generation) }
+            let report = reason != "io_stopped_abnormally" || self.lastReportedAbnormalStopGeneration != generation
+            if reason == "io_stopped_abnormally" { self.lastReportedAbnormalStopGeneration = generation }
+            let enqueue = self.pendingFormatInvalidationGenerations.insert(generation).inserted
+            return (report, enqueue)
+        }
+        input?.markFormatDirty()
+        if hardwareIsKnownStopped {
+            self.snapshotLock.withLock {
+                // Recheck under the publication lock: a late callback must not
+                // interrupt a replacement generation admitted in the meantime.
+                if self.storedSnapshot.generation == generation,
+                   self.storedSnapshot.phase == .starting || self.storedSnapshot.phase == .preparing
+                {
+                    self.hardwareOperations.failPendingOperationsAfterDeviceStopped()
+                }
+            }
+        }
+        if action.0 {
+            self.onFormatInvalidated(FormatInvalidation(
+                generation: generation,
+                deviceID: input?.deviceID ?? snapshot.deviceID ?? kAudioObjectUnknown,
+                reason: reason,
+                wasRunning: input?.isRunning ?? false
+            ))
+        }
+        if action.1 {
+            self.lifecycleQueue.async { [weak self] in
+                guard let self else { return }
+                self.handleFormatInvalidationLocked(generation: generation, reason: reason)
+                self.stoppedHardwareLock.withLock {
+                    _ = self.pendingFormatInvalidationGenerations.remove(generation)
+                }
+            }
+        }
     }
 
     private func handleFormatInvalidationLocked(generation: UInt64, reason: String) {
@@ -1519,6 +1600,12 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
     }
 
     #if DEBUG
+    func simulateAbnormalStopNotificationForTesting(generation: UInt64) {
+        self.handleFormatNotification(
+            generation: generation, reason: "io_stopped_abnormally", input: nil, hardwareIsKnownStopped: true
+        )
+    }
+
     func simulateStoppedHardwareNotificationForTesting(
         generation: UInt64,
         reason: String

--- a/Sources/Fluid/Services/DirectCoreAudioInput.swift
+++ b/Sources/Fluid/Services/DirectCoreAudioInput.swift
@@ -676,6 +676,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
     // A display can change HAL topology without changing the selected input's
     // ID or format. Refresh stopped capture on the next Start, not mid-recording.
     private var hardwareTopologyRevision: UInt64 = 0 // snapshotLock
+    private var topologyRecoveryCheckPending = false // snapshotLock
     private var lastStartedTopologyRevision: UInt64 = 0 // lifecycleQueue
     private let stoppedHardwareLock = NSLock()
     private var stoppedHardwareGenerations: Set<UInt64> = []
@@ -694,6 +695,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
     private let packetHandler: PacketHandler
     private let inputFactory: InputFactory
     private let deviceSnapshotReader: @Sendable (Bool) throws -> DeviceSnapshot
+    private let deviceLivenessReader: @Sendable (AudioObjectID) -> Bool?
     private let deviceResolver: @Sendable (DirectCoreAudioDeviceSelection) throws -> AudioDevice.Device?
     private let fingerprintReader: FingerprintReader
     private let onFormatInvalidated: @Sendable (FormatInvalidation) -> Void
@@ -707,6 +709,12 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
     private var isShutDown = false
     private var isPoisoned = false
     private var inputDeviceName: String?
+    private struct FailedHardware: Equatable {
+        let generation: UInt64
+        let deviceID: AudioObjectID
+    }
+
+    private var failedHardware: FailedHardware?
 
     init(
         packetHandler: @escaping PacketHandler,
@@ -719,6 +727,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         installsHardwareListeners: Bool = true,
         operationTimeout: TimeInterval? = nil,
         deviceSnapshotReader: @escaping @Sendable (Bool) throws -> DeviceSnapshot = DirectCoreAudioLifecycleController.queryDeviceSnapshot,
+        deviceLivenessReader: @escaping @Sendable (AudioObjectID) -> Bool? = DirectCoreAudioLifecycleController.readDeviceLiveness,
         deviceResolver: @escaping @Sendable (DirectCoreAudioDeviceSelection) throws -> AudioDevice.Device? = DirectCoreAudioLifecycleController.resolveSelectedDevice,
         onFormatInvalidated: @escaping @Sendable (FormatInvalidation) -> Void
     ) {
@@ -736,6 +745,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         self.inputFactory = inputFactory
         self.fingerprintReader = fingerprintReader
         self.deviceSnapshotReader = deviceSnapshotReader
+        self.deviceLivenessReader = deviceLivenessReader
         self.deviceResolver = deviceResolver
         self.installsHardwareListeners = installsHardwareListeners
         self.onFormatInvalidated = onFormatInvalidated
@@ -805,6 +815,63 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
             return self.hardwareTopologyRevision
         }
         Self.log("Direct capture topology changed revision=\(revision); next stopped start requires fresh input", level: .info)
+        self.scheduleFailedHardwareCheck()
+    }
+
+    private func scheduleFailedHardwareCheck() {
+        let enqueue = self.snapshotLock.withLock {
+            guard self.shutdownRequested == false, self.topologyRecoveryCheckPending == false else { return false }
+            self.topologyRecoveryCheckPending = true
+            return true
+        }
+        if enqueue {
+            // Queue behind native work and its cleanup. A topology callback must
+            // never clear failure while that work still owns capture resources.
+            // Coalesce bursts here; ordinary capture startup is never delayed.
+            self.lifecycleQueue.asyncAfter(deadline: .now() + 0.05) { [weak self] in self?.checkFailedHardwareLocked() }
+        }
+    }
+
+    private func checkFailedHardwareLocked() {
+        let revision = self.snapshotLock.withLock { self.hardwareTopologyRevision }
+        guard self.isShutDown == false,
+              self.snapshotLock.withLock({ self.shutdownRequested == false }),
+              self.isPoisoned, let failedHardware = self.failedHardware
+        else {
+            self.snapshotLock.withLock { self.topologyRecoveryCheckPending = false }
+            return
+        }
+        Task { [weak self, deviceQueries, deviceLivenessReader] in
+            // Unknown, failed, or timed-out queries cannot authorize replacement.
+            // Keep HAL queries off both the notification and lifecycle queues.
+            let isAlive = try? await deviceQueries.run(recover: { true }) {
+                deviceLivenessReader(failedHardware.deviceID)
+            }
+            self?.lifecycleQueue.async { [weak self] in
+                guard let self else { return }
+                defer {
+                    // An event can arrive even while this completion is being
+                    // handled. Release ownership only after applying its result,
+                    // then recheck any newer revision instead of losing it.
+                    let changedAgain = self.snapshotLock.withLock {
+                        self.topologyRecoveryCheckPending = false
+                        return revision != self.hardwareTopologyRevision
+                    }
+                    if changedAgain { self.scheduleFailedHardwareCheck() }
+                }
+                guard self.isShutDown == false,
+                      self.snapshotLock.withLock({ self.shutdownRequested == false && revision == self.hardwareTopologyRevision }),
+                      self.failedHardware == failedHardware,
+                      self.generation == failedHardware.generation,
+                      isAlive == false
+                else { return }
+                self.recordStoppedHardwareNotification(generation: failedHardware.generation)
+                self.handleFormatInvalidationLocked(
+                    generation: failedHardware.generation,
+                    reason: "device_list_confirmed_stopped"
+                )
+            }
+        }
     }
 
     struct DeviceSnapshot: Sendable {
@@ -974,7 +1041,8 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                         input: validatedInput,
                         fingerprint: validatedInput.formatFingerprint
                     )
-                    self.lastStartedTopologyRevision = topologyRevision
+                    // Reusing preview does not refresh its native setup. Keep
+                    // the pending revision so the next stopped start rebuilds.
                     Self.log(
                         "Direct capture start reused running input generation=\(self.generation) " +
                             "device='\(deviceName)'",
@@ -1303,6 +1371,12 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                 )
             } else {
                 self.isPoisoned = true
+                if let input {
+                    self.failedHardware = FailedHardware(generation: self.generation, deviceID: input.deviceID)
+                    // Covers removal while listeners were being detached, before
+                    // cleanup had published its failure to the hardware queue.
+                    self.scheduleFailedHardwareCheck()
+                }
                 Self.log(
                     "Direct capture teardown failed generation=\(self.generation) " +
                         "status=\(status); lifecycle poisoned and callback context quarantined",
@@ -1521,6 +1595,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
             if hardwareIsKnownStopped {
                 let wasPoisoned = self.isPoisoned
                 self.isPoisoned = false
+                self.failedHardware = nil
                 let clearedQueueFailure = self.hardwareOperations.clearFailureAfterSerializedRecovery()
                 if wasPoisoned || clearedQueueFailure {
                     let shuttingDown = self.isShutDown || self.snapshotLock.withLock { self.shutdownRequested }
@@ -1600,6 +1675,10 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
     }
 
     #if DEBUG
+    var isTopologyRecoveryCheckPendingForTesting: Bool {
+        self.snapshotLock.withLock { self.topologyRecoveryCheckPending }
+    }
+
     func simulateAbnormalStopNotificationForTesting(generation: UInt64) {
         self.handleFormatNotification(
             generation: generation, reason: "io_stopped_abnormally", input: nil, hardwareIsKnownStopped: true

--- a/Sources/Fluid/Services/DirectCoreAudioInput.swift
+++ b/Sources/Fluid/Services/DirectCoreAudioInput.swift
@@ -668,6 +668,10 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         qos: .userInitiated
     )
     private let snapshotLock = NSLock()
+    private let recoveryTimeout: TimeInterval
+    private let hardwareOperations: BoundedAudioHardwareQueue
+    private let deviceQueries: BoundedAudioHardwareQueue
+    private var shutdownRequested = false
     private let stoppedHardwareLock = NSLock()
     private var stoppedHardwareGenerations: Set<UInt64> = []
     private var storedSnapshot = Snapshot(
@@ -682,6 +686,8 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
 
     private let packetHandler: PacketHandler
     private let inputFactory: InputFactory
+    private let deviceSnapshotReader: @Sendable (Bool) throws -> DeviceSnapshot
+    private let deviceResolver: @Sendable (DirectCoreAudioDeviceSelection) throws -> AudioDevice.Device?
     private let fingerprintReader: FingerprintReader
     private let onFormatInvalidated: @Sendable (FormatInvalidation) -> Void
     private let installsHardwareListeners: Bool
@@ -704,11 +710,22 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
             try DirectCoreAudioFormatFingerprint.read(deviceID: $0)
         },
         installsHardwareListeners: Bool = true,
+        operationTimeout: TimeInterval? = nil,
+        deviceSnapshotReader: @escaping @Sendable (Bool) throws -> DeviceSnapshot = DirectCoreAudioLifecycleController.queryDeviceSnapshot,
+        deviceResolver: @escaping @Sendable (DirectCoreAudioDeviceSelection) throws -> AudioDevice.Device? = DirectCoreAudioLifecycleController.resolveSelectedDevice,
         onFormatInvalidated: @escaping @Sendable (FormatInvalidation) -> Void
     ) {
+        self.recoveryTimeout = operationTimeout ?? 5
+        self.hardwareOperations = BoundedAudioHardwareQueue(queue: self.lifecycleQueue, timeout: operationTimeout)
+        self.deviceQueries = BoundedAudioHardwareQueue(
+            queue: DispatchQueue(label: "com.fluidvoice.audio.device-snapshot", qos: .userInitiated),
+            timeout: operationTimeout ?? 5
+        )
         self.packetHandler = packetHandler
         self.inputFactory = inputFactory
         self.fingerprintReader = fingerprintReader
+        self.deviceSnapshotReader = deviceSnapshotReader
+        self.deviceResolver = deviceResolver
         self.installsHardwareListeners = installsHardwareListeners
         self.onFormatInvalidated = onFormatInvalidated
     }
@@ -735,50 +752,119 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
     }
 
     var snapshot: Snapshot {
-        self.snapshotLock.lock()
-        defer { self.snapshotLock.unlock() }
-        return self.storedSnapshot
+        var snapshot = self.snapshotLock.withLock { self.storedSnapshot }
+        if self.hardwareOperations.isAvailable == false {
+            snapshot = Snapshot(
+                phase: .failed,
+                generation: snapshot.generation,
+                deviceID: snapshot.deviceID,
+                deviceName: snapshot.deviceName,
+                sampleRate: snapshot.sampleRate,
+                bufferFrameSize: snapshot.bufferFrameSize,
+                fingerprint: snapshot.fingerprint
+            )
+        }
+        return snapshot
+    }
+
+    var isRecoveringHardware: Bool { self.hardwareOperations.isAvailable == false }
+
+    func waitForHardwareAvailability() async -> Bool {
+        await self.hardwareOperations.waitUntilAvailable(timeout: self.recoveryTimeout)
+    }
+
+    func waitForDeviceQueryAvailability() async -> Bool {
+        await self.deviceQueries.waitUntilAvailable(timeout: self.recoveryTimeout)
+    }
+
+    func waitForPendingHardwareRetirement() async -> Bool {
+        await self.hardwareOperations.waitUntilAvailable()
+    }
+
+    func cancelPendingStartup() {
+        self.hardwareOperations.cancelPendingOperations()
+    }
+
+    struct DeviceSnapshot: Sendable {
+        let devices: [AudioDevice.Device]
+        let defaultInputUID: String?
+    }
+
+    /// Ordinary capture retains independent discovery with no recovery deadline.
+    func readCaptureDeviceSnapshot() async throws -> DeviceSnapshot {
+        try await Task.detached(priority: .userInitiated) {
+            try self.deviceSnapshotReader(false)
+        }.value
+    }
+
+    func readDeviceSnapshot(refreshLiveness: Bool = false) async throws -> DeviceSnapshot {
+        // Only route recovery uses this bounded queue. Its cancellation cannot
+        // interrupt ordinary startup discovery or an already recording input.
+        try await self.deviceQueries.run(recover: { true }) {
+            try self.deviceSnapshotReader(refreshLiveness)
+        }
+    }
+
+    private static func queryDeviceSnapshot(refreshLiveness: Bool) -> DeviceSnapshot {
+        let devices = refreshLiveness
+            ? AudioDevice.listInputDevicesRefreshingLiveness()
+            : AudioDevice.listAllDevices()
+        return DeviceSnapshot(
+            devices: devices,
+            defaultInputUID: AudioDevice.getDefaultInputDevice(from: devices)?.uid
+        )
+    }
+
+    private func performHardwareOperation<Value: Sendable>(
+        cancellable: Bool = true,
+        timeout: TimeInterval? = nil,
+        _ operation: @escaping @Sendable () throws -> Value
+    ) async throws -> Value {
+        try await self.hardwareOperations.run(cancellable: cancellable, timeout: timeout, recover: { [self] in
+            let status = self.invalidateLocked(reason: "interrupted_hardware_operation")
+            if self.snapshotLock.withLock({ self.shutdownRequested }) {
+                self.isShutDown = true
+                self.publishSnapshot(phase: .shutDown, input: nil, fingerprint: nil)
+            }
+            Self.log("Direct capture interrupted operation drained status=\(status)", level: .info)
+            return status == noErr && self.isPoisoned == false
+        }) {
+            try self.hardwareOperations.checkAvailable()
+            return try operation()
+        }
     }
 
     func resolveDevice(
         selection: DirectCoreAudioDeviceSelection,
         reason: String
     ) async throws -> AudioDevice.Device {
-        try await withCheckedThrowingContinuation { continuation in
-            self.lifecycleQueue.async {
-                let startedAt = ProcessInfo.processInfo.systemUptime
-                let device: AudioDevice.Device?
-                switch selection {
-                case .systemDefault:
-                    device = AudioDevice.getDefaultInputDevice()
-                        .flatMap { AudioDevice.isInputDeviceUsable($0) ? $0 : nil }
-                case let .preferredUID(uid):
-                    if let preferredDevice = AudioDevice.getInputDevice(byUID: uid),
-                       AudioDevice.isInputDeviceUsable(preferredDevice)
-                    {
-                        device = preferredDevice
-                    } else {
-                        // Let ASRService retry the next app-priority device. Falling back
-                        // here would silently bypass the user's order during a HAL race.
-                        device = nil
-                    }
-                }
-                guard let device else {
-                    continuation.resume(
-                        throwing: Self.error(
-                            "No input device is available for \(selection)."
-                        )
-                    )
-                    return
-                }
-                Self.log(
-                    "Direct capture device resolved off-main reason=\(reason) " +
-                        "device='\(device.name)' id=\(device.id) " +
-                        "elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))",
-                    level: .info
-                )
-                continuation.resume(returning: device)
+        try await self.performHardwareOperation {
+            let startedAt = ProcessInfo.processInfo.systemUptime
+            let device = try self.deviceResolver(selection)
+            guard let device else {
+                throw Self.error("No input device is available for \(selection).")
             }
+            Self.log(
+                "Direct capture device resolved off-main reason=\(reason) " +
+                    "device='\(device.name)' id=\(device.id) " +
+                    "elapsedMs=\(Self.elapsedMilliseconds(since: startedAt))",
+                level: .info
+            )
+            return device
+        }
+    }
+
+    private static func resolveSelectedDevice(_ selection: DirectCoreAudioDeviceSelection) -> AudioDevice.Device? {
+        switch selection {
+        case .systemDefault:
+            return AudioDevice.getDefaultInputDevice()
+                .flatMap { AudioDevice.isInputDeviceUsable($0) ? $0 : nil }
+        case let .preferredUID(uid):
+            // Keep fallback in ASRService so it always follows the app's priority.
+            guard let device = AudioDevice.getInputDevice(byUID: uid),
+                  AudioDevice.isInputDeviceUsable(device)
+            else { return nil }
+            return device
         }
     }
 
@@ -787,20 +873,8 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         deviceName: String,
         reason: String
     ) async throws -> Snapshot {
-        try await withCheckedThrowingContinuation { continuation in
-            self.lifecycleQueue.async {
-                do {
-                    try continuation.resume(
-                        returning: self.prepareLocked(
-                            deviceID: deviceID,
-                            deviceName: deviceName,
-                            reason: reason
-                        )
-                    )
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
+        try await self.performHardwareOperation {
+            try self.prepareLocked(deviceID: deviceID, deviceName: deviceName, reason: reason)
         }
     }
 
@@ -809,83 +883,50 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         deviceName: String,
         reason: String
     ) async throws -> Snapshot {
-        try await withCheckedThrowingContinuation { continuation in
-            self.lifecycleQueue.async {
-                do {
-                    guard self.isShutDown == false else {
-                        throw Self.error("Direct Core Audio lifecycle is shut down.")
-                    }
-                    var prepared = try self.prepareLocked(
+        try await self.performHardwareOperation {
+            do {
+                guard self.isShutDown == false,
+                      self.snapshotLock.withLock({ self.shutdownRequested == false })
+                else {
+                    throw Self.error("Direct Core Audio lifecycle is shut down.")
+                }
+                var prepared = try self.prepareLocked(
+                    deviceID: deviceID,
+                    deviceName: deviceName,
+                    reason: reason
+                )
+                guard let input = self.input else {
+                    throw Self.error("Direct Core Audio input was not prepared.")
+                }
+
+                let validationStartedAt = ProcessInfo.processInfo.systemUptime
+                let currentFingerprint = try self.fingerprintReader(deviceID)
+                if currentFingerprint != input.formatFingerprint {
+                    Self.log(
+                        "Direct capture fingerprint changed before start; rebuilding " +
+                            "generation=\(prepared.generation) old={\(input.formatFingerprint.logDescription)} " +
+                            "new={\(currentFingerprint.logDescription)}",
+                        level: .warning
+                    )
+                    self.invalidateLocked(reason: "pre_start_fingerprint_changed")
+                    prepared = try self.prepareLocked(
                         deviceID: deviceID,
                         deviceName: deviceName,
-                        reason: reason
+                        reason: "pre_start_fingerprint_changed"
                     )
-                    guard let input = self.input else {
-                        throw Self.error("Direct Core Audio input was not prepared.")
-                    }
+                }
 
-                    let validationStartedAt = ProcessInfo.processInfo.systemUptime
-                    let currentFingerprint = try self.fingerprintReader(deviceID)
-                    if currentFingerprint != input.formatFingerprint {
-                        Self.log(
-                            "Direct capture fingerprint changed before start; rebuilding " +
-                                "generation=\(prepared.generation) old={\(input.formatFingerprint.logDescription)} " +
-                                "new={\(currentFingerprint.logDescription)}",
-                            level: .warning
-                        )
-                        self.invalidateLocked(reason: "pre_start_fingerprint_changed")
-                        prepared = try self.prepareLocked(
-                            deviceID: deviceID,
-                            deviceName: deviceName,
-                            reason: "pre_start_fingerprint_changed"
-                        )
-                    }
-
-                    guard let validatedInput = self.input else {
-                        throw Self.error("Direct Core Audio input disappeared before start.")
-                    }
-                    if validatedInput.isRunning {
-                        let runningFingerprint = try self.fingerprintReader(deviceID)
-                        guard runningFingerprint == validatedInput.formatFingerprint,
-                              validatedInput.openPacketGateIfClean()
-                        else {
-                            throw Self.error(
-                                "Direct Core Audio format changed while reusing running input generation " +
-                                    "\(self.generation)."
-                            )
-                        }
-                        self.publishSnapshot(
-                            phase: .running,
-                            input: validatedInput,
-                            fingerprint: validatedInput.formatFingerprint
-                        )
-                        Self.log(
-                            "Direct capture start reused running input generation=\(self.generation) " +
-                                "device='\(deviceName)'",
-                            level: .debug
-                        )
-                        continuation.resume(returning: self.snapshot)
-                        return
-                    }
-                    self.publishSnapshot(
-                        phase: .starting,
-                        input: validatedInput,
-                        fingerprint: validatedInput.formatFingerprint
-                    )
-                    let startStartedAt = ProcessInfo.processInfo.systemUptime
-                    Self.log(
-                        "Direct capture start begin generation=\(self.generation) " +
-                            "device='\(deviceName)' validationMs=" +
-                            "\(Self.elapsedMilliseconds(since: validationStartedAt))",
-                        level: .info
-                    )
-                    try validatedInput.start()
-                    let fingerprintAfterStart = try self.fingerprintReader(deviceID)
-                    guard fingerprintAfterStart == validatedInput.formatFingerprint,
+                guard let validatedInput = self.input else {
+                    throw Self.error("Direct Core Audio input disappeared before start.")
+                }
+                if validatedInput.isRunning {
+                    let runningFingerprint = try self.fingerprintReader(deviceID)
+                    try self.hardwareOperations.checkAvailable()
+                    guard runningFingerprint == validatedInput.formatFingerprint,
                           validatedInput.openPacketGateIfClean()
                     else {
                         throw Self.error(
-                            "Direct Core Audio format changed while starting generation " +
+                            "Direct Core Audio format changed while reusing running input generation " +
                                 "\(self.generation)."
                         )
                     }
@@ -895,37 +936,70 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                         fingerprint: validatedInput.formatFingerprint
                     )
                     Self.log(
-                        "Direct capture start end generation=\(self.generation) " +
-                            "elapsedMs=\(Self.elapsedMilliseconds(since: startStartedAt)) " +
-                            "fingerprint={\(validatedInput.formatFingerprint.logDescription)}",
-                        level: .info
+                        "Direct capture start reused running input generation=\(self.generation) " +
+                            "device='\(deviceName)'",
+                        level: .debug
                     )
-                    continuation.resume(returning: self.snapshot)
-                } catch {
-                    self.publishSnapshot(
-                        phase: .failed,
-                        input: self.input,
-                        fingerprint: self.input?.formatFingerprint
-                    )
-                    self.invalidateLocked(reason: "start_failed")
-                    continuation.resume(throwing: error)
+                    return self.snapshot
                 }
+                self.publishSnapshot(
+                    phase: .starting,
+                    input: validatedInput,
+                    fingerprint: validatedInput.formatFingerprint
+                )
+                let startStartedAt = ProcessInfo.processInfo.systemUptime
+                Self.log(
+                    "Direct capture start begin generation=\(self.generation) " +
+                        "device='\(deviceName)' validationMs=" +
+                        "\(Self.elapsedMilliseconds(since: validationStartedAt))",
+                    level: .info
+                )
+                try self.hardwareOperations.checkAvailable()
+                try validatedInput.start()
+                try self.hardwareOperations.checkAvailable()
+                let fingerprintAfterStart = try self.fingerprintReader(deviceID)
+                try self.hardwareOperations.checkAvailable()
+                guard fingerprintAfterStart == validatedInput.formatFingerprint,
+                      validatedInput.openPacketGateIfClean()
+                else {
+                    throw Self.error(
+                        "Direct Core Audio format changed while starting generation " +
+                            "\(self.generation)."
+                    )
+                }
+                self.publishSnapshot(
+                    phase: .running,
+                    input: validatedInput,
+                    fingerprint: validatedInput.formatFingerprint
+                )
+                Self.log(
+                    "Direct capture start end generation=\(self.generation) " +
+                        "elapsedMs=\(Self.elapsedMilliseconds(since: startStartedAt)) " +
+                        "fingerprint={\(validatedInput.formatFingerprint.logDescription)}",
+                    level: .info
+                )
+                return self.snapshot
+            } catch {
+                self.publishSnapshot(
+                    phase: .failed,
+                    input: self.input,
+                    fingerprint: self.input?.formatFingerprint
+                )
+                self.invalidateLocked(reason: "start_failed")
+                throw error
             }
         }
     }
 
-    func stop(retainPrepared: Bool, reason: String) async -> StopReport {
-        await withCheckedContinuation { continuation in
-            self.lifecycleQueue.async {
+    func stop(retainPrepared: Bool, reason: String, recoveringRoute: Bool = false) async -> StopReport {
+        do {
+            return try await self.performHardwareOperation(cancellable: false, timeout: recoveringRoute ? self.recoveryTimeout : nil) {
                 guard let input = self.input else {
-                    continuation.resume(
-                        returning: StopReport(
-                            status: noErr,
-                            droppedPackets: 0,
-                            retainedPreparedCapture: false
-                        )
+                    return StopReport(
+                        status: noErr,
+                        droppedPackets: 0,
+                        retainedPreparedCapture: false
                     )
-                    return
                 }
 
                 let startedAt = ProcessInfo.processInfo.systemUptime
@@ -965,38 +1039,31 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                         "retained=\(retainPrepared && self.input != nil)",
                     level: .info
                 )
-                continuation.resume(
-                    returning: StopReport(
-                        status: status,
-                        droppedPackets: droppedPackets,
-                        retainedPreparedCapture: retainPrepared && self.input != nil
-                    )
+                return StopReport(
+                    status: status,
+                    droppedPackets: droppedPackets,
+                    retainedPreparedCapture: retainPrepared && self.input != nil
                 )
             }
+        } catch {
+            Self.log("Direct capture stop interrupted reason=\(reason): \(error.localizedDescription)", level: .warning)
+            return StopReport(status: kAudioHardwareUnspecifiedError, droppedPackets: 0, retainedPreparedCapture: false)
         }
     }
 
-    func invalidate(reason: String) async {
-        await withCheckedContinuation { continuation in
-            self.lifecycleQueue.async {
-                _ = self.invalidateLocked(reason: reason)
-                continuation.resume()
-            }
+    func invalidate(reason: String, recoveringRoute: Bool = false) async {
+        _ = try? await self.performHardwareOperation(cancellable: false, timeout: recoveringRoute ? self.recoveryTimeout : nil) {
+            self.invalidateLocked(reason: reason)
         }
     }
 
     func shutdown(reason: String) async {
-        await withCheckedContinuation { continuation in
-            self.lifecycleQueue.async {
-                guard self.isShutDown == false else {
-                    continuation.resume()
-                    return
-                }
-                self.isShutDown = true
-                _ = self.invalidateLocked(reason: reason)
-                self.publishSnapshot(phase: .shutDown, input: nil, fingerprint: nil)
-                continuation.resume()
-            }
+        self.snapshotLock.withLock { self.shutdownRequested = true }
+        _ = try? await self.performHardwareOperation(cancellable: false, timeout: self.recoveryTimeout) {
+            guard self.isShutDown == false else { return }
+            self.isShutDown = true
+            _ = self.invalidateLocked(reason: reason)
+            self.publishSnapshot(phase: .shutDown, input: nil, fingerprint: nil)
         }
     }
 
@@ -1005,7 +1072,10 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         deviceName: String,
         reason: String
     ) throws -> Snapshot {
-        guard self.isShutDown == false else {
+        try self.hardwareOperations.checkAvailable()
+        guard self.isShutDown == false,
+              self.snapshotLock.withLock({ self.shutdownRequested == false })
+        else {
             throw Self.error("Direct Core Audio lifecycle is shut down.")
         }
         guard self.isPoisoned == false else {
@@ -1015,6 +1085,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         }
 
         let currentFingerprint = try self.fingerprintReader(deviceID)
+        try self.hardwareOperations.checkAvailable()
         if let input = self.input,
            input.deviceID == deviceID,
            input.formatFingerprint == currentFingerprint
@@ -1064,9 +1135,11 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
 
         let gate = DirectCoreAudioPacketGate()
         let downstreamHandler = self.packetHandler
+        let hardwareOperations = self.hardwareOperations
         let input: any DirectCoreAudioInputControlling
         do {
             input = try self.inputFactory(deviceID) { samples, frameCount, sampleRate, inputHostTime, inputSampleTime in
+                guard hardwareOperations.isAvailable else { return }
                 gate.withAcceptedPacket {
                     downstreamHandler(
                         samples,
@@ -1093,6 +1166,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         self.input = input
         self.packetGate = gate
         do {
+            try self.hardwareOperations.checkAvailable()
             if self.installsHardwareListeners {
                 try self.installFormatListenersLocked(
                     fingerprint: input.formatFingerprint,
@@ -1101,6 +1175,7 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
                 )
             }
             let fingerprintAfterListeners = try self.fingerprintReader(deviceID)
+            try self.hardwareOperations.checkAvailable()
             guard fingerprintAfterListeners == input.formatFingerprint else {
                 throw Self.error(
                     "Direct Core Audio format changed while installing listeners."
@@ -1292,22 +1367,21 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         }
 
         let invalidationHandler = self.onFormatInvalidated
-        let block: AudioObjectPropertyListenerBlock = { [weak self, weak input] listenerObjectID, _ in
+        let block = Self.makeDevicePropertyListener(objectID: objectID) { [weak self, weak input] objectID in
             let deviceIsAlive =
                 name == "device_is_alive"
-                    ? Self.readDeviceLiveness(objectID: listenerObjectID)
+                    ? Self.readDeviceLiveness(objectID: objectID)
                     : nil
-            let hardwareIsKnownStopped =
-                name == "audio_service_restarted" ||
-                name == "io_stopped_abnormally" ||
-                (name == "device_is_alive" && deviceIsAlive != true)
+            let hardwareIsKnownStopped = Self.hardwareIsKnownStopped(
+                reason: name, deviceIsAlive: deviceIsAlive
+            )
             if hardwareIsKnownStopped {
                 self?.recordStoppedHardwareNotification(generation: generation)
             }
             if name == "device_is_alive" {
                 Self.log(
                     "Direct capture liveness notification generation=\(generation) " +
-                        "device=\(listenerObjectID) " +
+                        "device=\(objectID) " +
                         "alive=\(deviceIsAlive.map(String.init) ?? "unreadable") " +
                         "knownStopped=\(hardwareIsKnownStopped)",
                     level: hardwareIsKnownStopped ? .warning : .info
@@ -1363,14 +1437,19 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
         let hardwareIsKnownStopped =
             self.consumeStoppedHardwareNotification(generation: generation)
         guard let input = self.input else {
-            if hardwareIsKnownStopped, self.isPoisoned {
+            if hardwareIsKnownStopped {
+                let wasPoisoned = self.isPoisoned
                 self.isPoisoned = false
-                self.publishSnapshot(phase: .empty, input: nil, fingerprint: nil)
-                Self.log(
-                    "Direct capture cleared teardown poison generation=\(generation) " +
-                        "after delayed \(reason) notification",
-                    level: .warning
-                )
+                let clearedQueueFailure = self.hardwareOperations.clearFailureAfterSerializedRecovery()
+                if wasPoisoned || clearedQueueFailure {
+                    let shuttingDown = self.isShutDown || self.snapshotLock.withLock { self.shutdownRequested }
+                    self.publishSnapshot(phase: shuttingDown ? .shutDown : .empty, input: nil, fingerprint: nil)
+                    Self.log(
+                        "Direct capture cleared teardown failure generation=\(generation) " +
+                            "after delayed \(reason) notification queueRecovered=\(clearedQueueFailure)",
+                        level: .warning
+                    )
+                }
             }
             return
         }
@@ -1386,6 +1465,20 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
             reason: "format_listener:\(reason)",
             allowStoppedHardwareReplacement: hardwareIsKnownStopped
         )
+    }
+
+    /// The block API supplies an address count, unlike the C proc API which
+    /// also supplies an object ID. Always use the ID from registration.
+    static func makeDevicePropertyListener(
+        objectID: AudioObjectID,
+        handler: @escaping @Sendable (AudioObjectID) -> Void
+    ) -> AudioObjectPropertyListenerBlock {
+        { _, _ in handler(objectID) }
+    }
+
+    static func hardwareIsKnownStopped(reason: String, deviceIsAlive: Bool?) -> Bool {
+        reason == "audio_service_restarted" || reason == "io_stopped_abnormally" ||
+            (reason == "device_is_alive" && deviceIsAlive == false)
     }
 
     private func recordStoppedHardwareNotification(generation: UInt64) {
@@ -1416,6 +1509,9 @@ final nonisolated class DirectCoreAudioLifecycleController: @unchecked Sendable 
             &size,
             &isAlive
         )
+        // An object removed from HAL is gone; other unreadable results are
+        // unknown and must not authorize replacement after failed teardown.
+        if status == kAudioHardwareBadDeviceError || status == kAudioHardwareBadObjectError { return false }
         guard status == noErr, size == UInt32(MemoryLayout<UInt32>.size) else {
             return nil
         }

--- a/Sources/Fluid/Services/MenuBarManager.swift
+++ b/Sources/Fluid/Services/MenuBarManager.swift
@@ -89,6 +89,17 @@ final class MenuBarManager: NSObject, ObservableObject, NSMenuDelegate {
         guard self.configuredASRIdentifier != identifier else { return }
         self.configuredASRIdentifier = identifier
         self.asrService = asrService
+        asrService.audioCaptureFailurePresented
+            .sink { [weak self, weak asrService] in
+                guard let self, let asrService,
+                      self.asrService === asrService,
+                      asrService.showError, asrService.isRunning == false
+                else { return }
+                // The recording error must also be visible when the user only
+                // uses the menu bar and has closed the main window.
+                self.openMainWindow()
+            }
+            .store(in: &self.cancellables)
         if SettingsStore.shared.overlayPosition == .bottom {
             DispatchQueue.main.async {
                 guard SettingsStore.shared.overlayPosition == .bottom else { return }

--- a/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
@@ -414,15 +414,13 @@ final class MonitorTopologyRecoveryTests: XCTestCase {
         try await waitForEvent(input, "query")
         let began = ProcessInfo.processInfo.systemUptime
         query.cancel()
-        do { _ = try await query.value; XCTFail("Cancelled discovery must fail") }
-        catch { XCTAssertTrue(error is CancellationError) }
+        do { _ = try await query.value; XCTFail("Cancelled discovery must fail") } catch { XCTAssertTrue(error is CancellationError) }
         XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.2)
         input.emit()
         XCTAssertEqual(input.count("delivered"), 1)
         XCTAssertEqual(input.count("invalidate"), 0)
         XCTAssertFalse(controller.isRecoveringHardware)
-        do { _ = try await controller.readCaptureDeviceSnapshot(); XCTFail("Do not pile up blocked queries") }
-        catch { XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure) }
+        do { _ = try await controller.readCaptureDeviceSnapshot(); XCTFail("Do not pile up blocked queries") } catch { XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure) }
         XCTAssertEqual(input.count("query"), 1)
         input.release.signal()
         await controller.shutdown(reason: "test_complete")
@@ -461,8 +459,7 @@ final class MonitorTopologyRecoveryTests: XCTestCase {
         for _ in 0..<100 {
             controller.simulateAbnormalStopNotificationForTesting(generation: generation)
         }
-        do { _ = try await starting.value; XCTFail("Known failed startup must release its caller") }
-        catch { XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure) }
+        do { _ = try await starting.value; XCTFail("Known failed startup must release its caller") } catch { XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure) }
         XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.2)
         XCTAssertEqual(input.count("notification"), 1)
         XCTAssertEqual(input.count("invalidate"), 0, "Native startup still owns the resources")
@@ -612,15 +609,25 @@ private final nonisolated class RecoveryInput: DirectCoreAudioInputControlling, 
 
     var formatFingerprint: DirectCoreAudioFormatFingerprint {
         DirectCoreAudioFormatFingerprint(
-            deviceID: self.deviceID, streamID: self.deviceID + 1,
+            deviceID: self.deviceID,
+            streamID: self.deviceID + 1,
             virtualFormat: DirectCoreAudioStreamFormatFingerprint(AudioStreamBasicDescription(
-                mSampleRate: 48_000, mFormatID: kAudioFormatLinearPCM,
+                mSampleRate: 48_000,
+                mFormatID: kAudioFormatLinearPCM,
                 mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
-                mBytesPerPacket: 4, mFramesPerPacket: 1, mBytesPerFrame: 4,
-                mChannelsPerFrame: 1, mBitsPerChannel: 32, mReserved: 0
+                mBytesPerPacket: 4,
+                mFramesPerPacket: 1,
+                mBytesPerFrame: 4,
+                mChannelsPerFrame: 1,
+                mBitsPerChannel: 32,
+                mReserved: 0
             )),
-            physicalFormat: nil, inputBufferChannels: [1], nominalSampleRate: 48_000,
-            bufferFrameSize: 512, variableBufferFrameSizeMaximum: nil, dataSourceID: nil
+            physicalFormat: nil,
+            inputBufferChannels: [1],
+            nominalSampleRate: 48_000,
+            bufferFrameSize: 512,
+            variableBufferFrameSizeMaximum: nil,
+            dataSourceID: nil
         )
     }
 
@@ -669,7 +676,10 @@ private final nonisolated class RecoveryInput: DirectCoreAudioInputControlling, 
     func emit() {
         let handler = self.lock.withLock { self.handler }
         let samples = [Float](repeating: 0.5, count: 48)
-        samples.withUnsafeBufferPointer { handler?($0.baseAddress!, $0.count, 48_000, 0, 0) }
+        samples.withUnsafeBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            handler?(baseAddress, buffer.count, 48_000, 0, 0)
+        }
     }
 }
 
@@ -1064,7 +1074,15 @@ private func withASRRecoveryFixture(
     // discovery cannot masquerade as a recovery-induced preference change.
     let query = DirectCoreAudioLifecycleController(packetHandler: { _, _, _, _, _ in }, onFormatInvalidated: { _ in })
     let liveInputs = try await query.readDeviceSnapshot().devices.filter(\.hasInput)
-    let fixture = ASRRecoveryFixture(queryDelay: queryDelay, queryFailures: queryFailures, liveInputs: liveInputs, externalStopDelay: externalStopDelay, operationTimeout: operationTimeout, firstQueryDelay: firstQueryDelay, builtInStartDelay: builtInStartDelay)
+    let fixture = ASRRecoveryFixture(
+        queryDelay: queryDelay,
+        queryFailures: queryFailures,
+        liveInputs: liveInputs,
+        externalStopDelay: externalStopDelay,
+        operationTimeout: operationTimeout,
+        firstQueryDelay: firstQueryDelay,
+        builtInStartDelay: builtInStartDelay
+    )
     defer { fixture.restoreSettings() }
     do {
         try await fixture.start()

--- a/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
@@ -856,6 +856,68 @@ private final nonisolated class RecoveryInput: DirectCoreAudioInputControlling, 
 #if canImport(FluidVoice_Debug)
 final class AudioRouteRecoveryIntegrationTests: XCTestCase {
     @MainActor
+    func testStartupTriesNewMicrophoneMissingFromDeviceCache() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            fixture.hardware.enableNewFallback()
+            let outcome = await fixture.service.start(forDictionaryTraining: true)
+            XCTAssertEqual(outcome, .started)
+            XCTAssertTrue(fixture.service.isRunning)
+            XCTAssertEqual(fixture.controller.snapshot.deviceID, 300)
+            XCTAssertEqual(fixture.hardware.resolutionAttempts, [100, 100, 300])
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 300), 1)
+            fixture.assertSettingsPreserved()
+            await fixture.service.stopWithoutTranscription()
+        }
+    }
+
+    @MainActor
+    func testActiveRecoveryTriesNewMicrophoneMissingFromDeviceCache() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0) { fixture in
+            fixture.hardware.enableNewFallback()
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            try await fixture.waitForRecoveryAttempt()
+            XCTAssertEqual(fixture.controller.snapshot.deviceID, 300)
+            XCTAssertEqual(fixture.hardware.resolutionAttempts, [100, 100, 300])
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 300), 1)
+            fixture.assertSessionPreserved()
+        }
+    }
+
+    @MainActor
+    func testFreshSnapshotBudgetStopsAfterAllStartupInputsFail() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            fixture.hardware.enableNewFallback(fails: true)
+            let outcome = await fixture.service.start(forDictionaryTraining: true)
+            XCTAssertEqual(outcome, .failed)
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.isStarting)
+            XCTAssertTrue(fixture.service.showError)
+            XCTAssertEqual(fixture.hardware.resolutionAttempts, [100, 100, 300])
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 300), 0)
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testFreshSnapshotBudgetStopsAfterAllRecoveryInputsFail() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0) { fixture in
+            fixture.hardware.enableNewFallback(fails: true)
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            try await fixture.waitForRecoveryAttempt()
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.audioRouteRecoveryStateForTesting.acceptingPCM)
+            XCTAssertTrue(fixture.service.showError)
+            XCTAssertEqual(fixture.hardware.resolutionAttempts, [100, 100, 300])
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 300), 0)
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
     func testFailedRecoveryCancelsWaitingRetryAndResumesMediaBeforeNativeCleanup() async throws {
         try await withASRRecoveryFixture(queryDelay: 0, builtInStartDelay: 0.8) { fixture in
             await fixture.service.stopWithoutTranscription()
@@ -1315,13 +1377,8 @@ private final class ASRRecoveryFixture {
             fingerprintReader: { RecoveryInput(deviceID: $0).formatFingerprint },
             installsHardwareListeners: false,
             operationTimeout: operationTimeout,
-            deviceSnapshotReader: { _ in try hardware.snapshot() },
-            deviceResolver: { selection in
-                switch selection {
-                case .systemDefault: hardware.builtIn
-                case let .preferredUID(uid): uid == hardware.builtIn.uid ? hardware.builtIn : nil
-                }
-            },
+            deviceSnapshotReader: { refreshLiveness in try hardware.snapshot(refreshLiveness: refreshLiveness) },
+            deviceResolver: { try hardware.resolve($0) },
             onFormatInvalidated: { _ in }
         )
     }
@@ -1332,6 +1389,15 @@ private final class ASRRecoveryFixture {
             controller: self.controller, devices: [self.hardware.builtIn], initialSamples: self.prefix
         )
         self.service.partialTranscription = "words already captured"
+    }
+
+    func waitForRecoveryAttempt() async throws {
+        for _ in 0..<1500 {
+            let state = self.service.audioRouteRecoveryStateForTesting
+            if state.pending == false, state.recovering == false { return }
+            try await Task.sleep(nanoseconds: 2_000_000)
+        }
+        XCTFail("Recovery retry budget did not finish")
     }
 
     func waitForBuiltInStartCount(_ count: Int) async throws {
@@ -1389,6 +1455,34 @@ private actor RecoveryMediaTransport: MediaPlaybackTransport {
 }
 
 private final nonisolated class ASRRecoveryHardware: @unchecked Sendable {
+    private let newFallback = AudioDevice.Device(id: 300, uid: "recovery-test-new", name: "New microphone", hasInput: true, hasOutput: false)
+    private var newFallbackEnabled = false
+    private var newFallbackFails = false
+    private var resolutions: [AudioObjectID] = []
+
+    var resolutionAttempts: [AudioObjectID] { self.lock.withLock { self.resolutions } }
+
+    func enableNewFallback(fails: Bool = false) {
+        self.lock.withLock { self.newFallbackEnabled = true; self.newFallbackFails = fails }
+    }
+
+    func resolve(_ selection: DirectCoreAudioDeviceSelection) throws -> AudioDevice.Device? {
+        try self.lock.withLock {
+            let device: AudioDevice.Device?
+            switch selection {
+            case .systemDefault: device = self.builtIn
+            case let .preferredUID(uid):
+                device = uid == self.builtIn.uid ? self.builtIn : (uid == self.newFallback.uid ? self.newFallback : nil)
+            }
+            guard let device else { return nil }
+            self.resolutions.append(device.id)
+            if self.newFallbackEnabled, device.id == 100 || self.newFallbackFails {
+                throw NSError(domain: "InjectedMicrophoneStartFailure", code: 1)
+            }
+            return device
+        }
+    }
+
     let builtIn = AudioDevice.Device(id: 100, uid: "recovery-test-built-in", name: "Test Built-in", hasInput: true, hasOutput: false)
     private let lock = NSLock()
     private let queryDelay: TimeInterval
@@ -1419,7 +1513,7 @@ private final nonisolated class ASRRecoveryHardware: @unchecked Sendable {
         return input
     }
 
-    func snapshot() throws -> DirectCoreAudioLifecycleController.DeviceSnapshot {
+    func snapshot(refreshLiveness: Bool) throws -> DirectCoreAudioLifecycleController.DeviceSnapshot {
         let fail = self.lock.withLock {
             self.queries += 1
             let fail = self.queryFailures > 0
@@ -1429,7 +1523,12 @@ private final nonisolated class ASRRecoveryHardware: @unchecked Sendable {
         let delay = self.lock.withLock { self.queries == 1 ? (self.firstQueryDelay ?? self.queryDelay) : self.queryDelay }
         Thread.sleep(forTimeInterval: delay)
         if fail { throw NSError(domain: "InjectedDeviceScan", code: 1) }
-        return .init(devices: [self.builtIn], defaultInputUID: self.builtIn.uid)
+        // The event cache/reconciliation still knows one input; the newer
+        // capture-selection snapshot already contains the connected fallback.
+        let inputs = self.lock.withLock {
+            self.newFallbackEnabled && refreshLiveness == false ? [self.builtIn, self.newFallback] : [self.builtIn]
+        }
+        return .init(devices: inputs, defaultInputUID: self.builtIn.uid)
     }
 }
 #endif

--- a/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
@@ -1,0 +1,1139 @@
+import CoreAudio
+#if canImport(FluidVoice_Debug)
+@testable import FluidVoice_Debug
+#else
+@testable import AudioRecoveryTestSupport
+#endif
+import Foundation
+import XCTest
+
+final class AudioHardwareRecoveryTests: XCTestCase {
+    func testUnreadableLivenessDoesNotAuthorizeUnsafeReplacement() {
+        XCTAssertFalse(DirectCoreAudioLifecycleController.hardwareIsKnownStopped(reason: "device_is_alive", deviceIsAlive: nil))
+        XCTAssertFalse(DirectCoreAudioLifecycleController.hardwareIsKnownStopped(reason: "device_is_alive", deviceIsAlive: true))
+        XCTAssertTrue(DirectCoreAudioLifecycleController.hardwareIsKnownStopped(reason: "device_is_alive", deviceIsAlive: false))
+        XCTAssertTrue(DirectCoreAudioLifecycleController.hardwareIsKnownStopped(reason: "io_stopped_abnormally", deviceIsAlive: nil))
+        XCTAssertFalse(DirectCoreAudioLifecycleController.hardwareIsKnownStopped(reason: "nominal_sample_rate", deviceIsAlive: nil))
+    }
+
+    func testRecoveryQueryCancellationCannotFailOrdinaryStartupDiscovery() async throws {
+        let input = RecoveryInput(block: "recovery_query")
+        defer { input.release.signal() }
+        let controller = DirectCoreAudioLifecycleController(
+            packetHandler: { _, _, _, _, _ in },
+            inputFactory: { _, _ in input },
+            fingerprintReader: { _ in input.formatFingerprint },
+            installsHardwareListeners: false,
+            deviceSnapshotReader: { refreshLiveness in
+                if refreshLiveness { input.perform("recovery_query") }
+                return .init(devices: [], defaultInputUID: nil)
+            },
+            onFormatInvalidated: { _ in }
+        )
+        let recoveryQuery = Task { try await controller.readDeviceSnapshot(refreshLiveness: true) }
+        try await waitForEvent(input, "recovery_query")
+        recoveryQuery.cancel()
+        _ = try? await recoveryQuery.value
+        let began = ProcessInfo.processInfo.systemUptime
+        _ = try await controller.readCaptureDeviceSnapshot()
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.2)
+        XCTAssertFalse(controller.isRecoveringHardware)
+        XCTAssertEqual(input.count("start"), 0)
+        input.release.signal()
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testRestartWaitCanBeCancelledWithoutTouchingBlockedNativeCall() async throws {
+        let input = RecoveryInput(block: "start")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input, timeout: nil)
+        let starting = Task { try await controller.start(deviceID: 144, deviceName: "Test", reason: "cancel") }
+        try await waitForEvent(input, "start")
+        controller.cancelPendingStartup()
+        _ = try? await starting.value
+        let waiting = Task { await controller.waitForPendingHardwareRetirement() }
+        waiting.cancel()
+        let available = await waiting.value
+        XCTAssertFalse(available)
+        XCTAssertEqual(input.count("start"), 1)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "safe_restart")
+        XCTAssertEqual(input.count("start"), 2)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testAvailabilityWaitersResumeOnlyAfterCleanupAndCancellationStaysLocal() async throws {
+        let input = RecoveryInput(block: "start")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input, timeout: 1)
+        let initiallyAvailable = await controller.waitForHardwareAvailability()
+        XCTAssertTrue(initiallyAvailable)
+        let starting = Task { try await controller.start(deviceID: 144, deviceName: "Test", reason: "waiters") }
+        try await waitForEvent(input, "start")
+        starting.cancel()
+        _ = try? await starting.value
+        let waiters = (0..<40).map { _ in Task { await controller.waitForHardwareAvailability() } }
+        for waiter in waiters.prefix(20) {
+            waiter.cancel()
+        }
+        for waiter in waiters.prefix(20) {
+            let available = await waiter.value
+            XCTAssertFalse(available)
+        }
+        XCTAssertTrue(controller.isRecoveringHardware)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        input.release.signal()
+        for waiter in waiters.suffix(20) {
+            let available = await waiter.value
+            XCTAssertTrue(available)
+        }
+        XCTAssertFalse(controller.isRecoveringHardware)
+        XCTAssertEqual(input.count("start"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testAvailabilityWaitEndsWhenCleanupNeverBecomesSafe() async throws {
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input)
+        _ = try? await controller.start(deviceID: 144, deviceName: "Test", reason: "unresolved_cleanup")
+        input.release.signal()
+        let began = ProcessInfo.processInfo.systemUptime
+        let available = await controller.waitForHardwareAvailability()
+        XCTAssertFalse(available)
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.5)
+        XCTAssertEqual(input.count("start"), 1)
+        XCTAssertTrue(controller.isRecoveringHardware)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testBlockedStartTimesOutAndDropsLatePacketsUntilCleanupCompletes() async throws {
+        let input = RecoveryInput(block: "start")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input)
+        let began = ProcessInfo.processInfo.systemUptime
+        do {
+            _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "timeout")
+            XCTFail("Blocked startup must time out")
+        } catch {
+            XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure)
+        }
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 1)
+        XCTAssertTrue(controller.isRecoveringHardware)
+        XCTAssertEqual(controller.snapshot.phase, .failed)
+        XCTAssertEqual(input.count("start"), 1)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 0)
+        do {
+            _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "retry_while_blocked")
+            XCTFail("A second native start must not overlap the blocked one")
+        } catch {}
+        XCTAssertEqual(input.count("start"), 1)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        XCTAssertEqual(input.count("open"), 0, "A timed-out start must never open its packet gate")
+        XCTAssertGreaterThan(input.count("invalidate"), 0)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 0, "Retired packets remain rejected after recovery")
+        let retried = try await controller.start(deviceID: 144, deviceName: "Test", reason: "retry_after_cleanup")
+        XCTAssertEqual(retried.phase, .running)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testPostStartFingerprintTimeoutNeverOpensPacketGate() async throws {
+        let input = RecoveryInput(block: "post_start_fingerprint")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input)
+        do {
+            _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "blocked_post_start_query")
+            XCTFail("Post-start hardware validation must time out")
+        } catch {
+            XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure)
+        }
+        XCTAssertEqual(input.count("start"), 1)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 0)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        XCTAssertEqual(input.count("open"), 0)
+        XCTAssertFalse(input.isRunning)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testDeviceQueryTimeoutDoesNotStopRecordingOrDropItsAudio() async throws {
+        let input = RecoveryInput(block: "query")
+        defer { input.release.signal() }
+        let controller = DirectCoreAudioLifecycleController(
+            packetHandler: { _, _, _, _, _ in input.record("delivered") },
+            inputFactory: { _, handler in input.setHandler(handler); return input },
+            fingerprintReader: { _ in input.formatFingerprint },
+            installsHardwareListeners: false,
+            operationTimeout: 0.08,
+            deviceSnapshotReader: { _ in
+                input.perform("query")
+                return .init(devices: [], defaultInputUID: nil)
+            },
+            onFormatInvalidated: { _ in }
+        )
+        _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "recording")
+        do {
+            _ = try await controller.readDeviceSnapshot()
+            XCTFail("Device enumeration must time out")
+        } catch {
+            XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure)
+        }
+        XCTAssertEqual(controller.snapshot.phase, .running)
+        XCTAssertFalse(controller.isRecoveringHardware)
+        XCTAssertEqual(input.count("stop"), 0)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 1)
+        input.release.signal()
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testExplicitCancellationAndShutdownReturnBeforeNativeStartDoes() async throws {
+        let input = RecoveryInput(block: "start")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input, timeout: 1)
+        let starting = Task {
+            try await controller.start(deviceID: 144, deviceName: "Test", reason: "cancel")
+        }
+        try await waitForEvent(input, "start")
+        controller.cancelPendingStartup()
+        let began = ProcessInfo.processInfo.systemUptime
+        do {
+            _ = try await starting.value
+            XCTFail("Cancelled startup must not report success")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        await controller.shutdown(reason: "quit_while_starting")
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.5)
+        XCTAssertEqual(input.count("invalidate"), 0, "Do not tear down a native call concurrently")
+        input.release.signal()
+        try await waitForRecovery(controller)
+        XCTAssertEqual(controller.snapshot.phase, .shutDown)
+        XCTAssertEqual(input.count("open"), 0)
+        do {
+            _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "after_quit")
+            XCTFail("Late completion must not undo shutdown")
+        } catch {}
+        XCTAssertEqual(input.count("start"), 1)
+    }
+
+    func testTaskCancellationWakesCallerAndPreservesSerializedCleanup() async throws {
+        let input = RecoveryInput(block: "start")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input, timeout: 1)
+        let starting = Task {
+            try await controller.start(deviceID: 144, deviceName: "Test", reason: "task_cancel")
+        }
+        try await waitForEvent(input, "start")
+        starting.cancel()
+        do {
+            _ = try await starting.value
+            XCTFail("Task cancellation must wake the caller")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(input.count("invalidate"), 0)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        XCTAssertGreaterThan(input.count("invalidate"), 0)
+        XCTAssertEqual(input.count("open"), 0)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testBlockedPreparationIsAlsoBoundedAndLateInputIsDestroyed() async throws {
+        let input = RecoveryInput(block: "prepare")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input)
+        do {
+            _ = try await controller.prepare(deviceID: 144, deviceName: "Test", reason: "blocked_prepare")
+            XCTFail("Preparation must also have a deadline")
+        } catch {
+            XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure)
+        }
+        XCTAssertEqual(input.count("start"), 0)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        XCTAssertGreaterThan(input.count("invalidate"), 0)
+        XCTAssertEqual(input.count("start"), 0)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testBlockedStopReturnsFailureWithoutStartingReplacementHardware() async throws {
+        let input = RecoveryInput(block: "stop")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input)
+        _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "before_stop")
+        let result = await controller.stop(retainPrepared: true, reason: "blocked_stop")
+        XCTAssertNotEqual(result.status, noErr)
+        XCTAssertFalse(result.retainedPreparedCapture)
+        XCTAssertTrue(controller.isRecoveringHardware)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 0)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        XCTAssertEqual(input.count("start"), 1)
+        XCTAssertFalse(controller.snapshot.isPrepared)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testFailedCleanupKeepsHardwareUnavailable() async throws {
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input)
+        _ = try? await controller.start(deviceID: 144, deviceName: "Test", reason: "timeout")
+        input.release.signal()
+        try await waitForEvent(input, "invalidate")
+        // A query must fail promptly even if cleanup cannot safely release the IOProc.
+        do {
+            _ = try await controller.prepare(deviceID: 144, deviceName: "Test", reason: "unsafe_retry")
+            XCTFail("Failed teardown must not create replacement hardware")
+        } catch {}
+        XCTAssertTrue(controller.isRecoveringHardware)
+        XCTAssertEqual(input.count("prepare"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testCancelledQueuedStartNeverCallsHardwareLater() async throws {
+        let input = RecoveryInput(block: "prepare")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input, timeout: 1)
+        let preparing = Task {
+            try await controller.prepare(deviceID: 144, deviceName: "Test", reason: "prewarm")
+        }
+        try await waitForEvent(input, "prepare")
+        let starting = Task {
+            try await controller.start(deviceID: 144, deviceName: "Test", reason: "queued_start")
+        }
+        starting.cancel()
+        _ = try? await starting.value
+        input.release.signal()
+        _ = try? await preparing.value
+        try await waitForRecovery(controller)
+        XCTAssertEqual(input.count("start"), 0)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testPropertyListenerUsesRegisteredDeviceRatherThanAddressCount() {
+        let input = RecoveryInput()
+        let listener = DirectCoreAudioLifecycleController.makeDevicePropertyListener(objectID: 144) { objectID in
+            input.record("device_\(objectID)")
+        }
+        var addresses = [
+            AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyDeviceIsAlive, mScope: kAudioObjectPropertyScopeGlobal, mElement: kAudioObjectPropertyElementMain),
+            AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyStreams, mScope: kAudioObjectPropertyScopeInput, mElement: kAudioObjectPropertyElementMain),
+        ]
+        addresses.withUnsafeMutableBufferPointer { buffer in
+            guard let base = buffer.baseAddress else { return }
+            listener(1, base)
+            listener(2, base)
+        }
+        XCTAssertEqual(input.count("device_144"), 2)
+        XCTAssertEqual(input.count("device_1"), 0)
+        XCTAssertEqual(input.count("device_2"), 0)
+    }
+}
+
+/// This same class is also run against the original controller for comparison.
+final class NormalAudioCaptureCompatibilityTests: XCTestCase {
+    func testHealthySlowNativeStartsAtFiveAndTenSecondsSucceed() async throws {
+        for delay in [5.2, 10.0] {
+            let input = RecoveryInput(delays: ["start": delay])
+            let controller = makeDefaultRecoveryController(input)
+            let started = try await controller.start(deviceID: 144, deviceName: "Test", reason: "healthy_slow")
+            XCTAssertEqual(started.phase, .running)
+            XCTAssertEqual(input.count("open"), 1)
+            XCTAssertEqual(input.count("invalidate"), 0)
+            input.emit()
+            XCTAssertEqual(input.count("delivered"), 1)
+            await controller.shutdown(reason: "test_complete")
+        }
+    }
+
+    func testHealthySlowPostStartFingerprintStillSucceeds() async throws {
+        let input = RecoveryInput(delays: ["post_start_fingerprint": 5.2])
+        let controller = makeDefaultRecoveryController(input)
+        let started = try await controller.start(deviceID: 144, deviceName: "Test", reason: "healthy_slow_fingerprint")
+        XCTAssertEqual(started.phase, .running)
+        XCTAssertEqual(input.count("open"), 1)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testHealthySlowStopStillRetainsPreparedInput() async throws {
+        let input = RecoveryInput(delays: ["stop": 5.2])
+        let controller = makeDefaultRecoveryController(input)
+        _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "before_slow_stop")
+        let stopped = await controller.stop(retainPrepared: true, reason: "normal_slow_stop")
+        XCTAssertEqual(stopped.status, noErr)
+        XCTAssertTrue(stopped.retainedPreparedCapture)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testFiftyHealthyPreparedStartStopCyclesRetainOneInput() async throws {
+        let input = RecoveryInput()
+        let controller = makeDefaultRecoveryController(input)
+        _ = try await controller.prepare(deviceID: 144, deviceName: "Test", reason: "prewarm")
+        for cycle in 1...50 {
+            let started = try await controller.start(deviceID: 144, deviceName: "Test", reason: "normal_start")
+            XCTAssertEqual(started.phase, .running)
+            input.emit()
+            XCTAssertEqual(input.count("delivered"), cycle)
+            let stopped = await controller.stop(retainPrepared: true, reason: "normal_stop")
+            XCTAssertEqual(stopped.status, noErr)
+            XCTAssertTrue(stopped.retainedPreparedCapture)
+            XCTAssertFalse(input.isRunning)
+        }
+        XCTAssertEqual(input.count("prepare"), 1)
+        XCTAssertEqual(input.count("start"), 50)
+        XCTAssertEqual(input.count("stop"), 50)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        await controller.shutdown(reason: "test_complete")
+    }
+}
+
+private func makeDefaultRecoveryController(_ input: RecoveryInput) -> DirectCoreAudioLifecycleController {
+    DirectCoreAudioLifecycleController(
+        packetHandler: { _, _, _, _, _ in input.record("delivered") },
+        inputFactory: { _, handler in input.perform("prepare"); input.setHandler(handler); return input },
+        fingerprintReader: { _ in
+            if input.isRunning { input.perform("post_start_fingerprint") }
+            return input.formatFingerprint
+        },
+        installsHardwareListeners: false,
+        onFormatInvalidated: { _ in }
+    )
+}
+
+private func makeRecoveryController(_ input: RecoveryInput, timeout: TimeInterval? = 0.08) -> DirectCoreAudioLifecycleController {
+    DirectCoreAudioLifecycleController(
+        packetHandler: { _, _, _, _, _ in input.record("delivered") },
+        inputFactory: { _, handler in
+            input.perform("prepare")
+            input.setHandler(handler)
+            return input
+        },
+        fingerprintReader: { _ in
+            if input.isRunning { input.perform("post_start_fingerprint") }
+            return input.formatFingerprint
+        },
+        installsHardwareListeners: false,
+        operationTimeout: timeout,
+        onFormatInvalidated: { _ in }
+    )
+}
+
+private func waitForRecovery(_ controller: DirectCoreAudioLifecycleController) async throws {
+    for _ in 0..<1000 {
+        if controller.isRecoveringHardware == false { return }
+        try await Task.sleep(nanoseconds: 1_000_000)
+    }
+    XCTFail("Serialized recovery did not finish after releasing native hardware")
+}
+
+private func waitForEvent(_ input: RecoveryInput, _ event: String) async throws {
+    for _ in 0..<1000 {
+        if input.count(event) > 0 { return }
+        try await Task.sleep(nanoseconds: 1_000_000)
+    }
+    XCTFail("Native operation did not enter: \(event)")
+}
+
+private final nonisolated class RecoveryInput: DirectCoreAudioInputControlling, @unchecked Sendable {
+    let deviceID: AudioObjectID
+    let sampleRate: Double = 48_000
+    let hardwareBufferFrameSize: UInt32 = 512
+    let release = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private let blockedOperation: String?
+    private let cleanupFails: Bool
+    private let delays: [String: TimeInterval]
+    private let automaticPCM: Bool
+    private var events: [String: Int] = [:]
+    private var running = false
+    private var handler: DirectCoreAudioPacketHandler?
+
+    init(deviceID: AudioObjectID = 144, block: String? = nil, cleanupFails: Bool = false, delays: [String: TimeInterval] = [:], automaticPCM: Bool = false) {
+        self.deviceID = deviceID
+        self.blockedOperation = block
+        self.cleanupFails = cleanupFails
+        self.delays = delays
+        self.automaticPCM = automaticPCM
+    }
+
+    var formatFingerprint: DirectCoreAudioFormatFingerprint {
+        DirectCoreAudioFormatFingerprint(
+            deviceID: self.deviceID, streamID: self.deviceID + 1,
+            virtualFormat: DirectCoreAudioStreamFormatFingerprint(AudioStreamBasicDescription(
+                mSampleRate: 48_000, mFormatID: kAudioFormatLinearPCM,
+                mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+                mBytesPerPacket: 4, mFramesPerPacket: 1, mBytesPerFrame: 4,
+                mChannelsPerFrame: 1, mBitsPerChannel: 32, mReserved: 0
+            )),
+            physicalFormat: nil, inputBufferChannels: [1], nominalSampleRate: 48_000,
+            bufferFrameSize: 512, variableBufferFrameSizeMaximum: nil, dataSourceID: nil
+        )
+    }
+
+    var isRunning: Bool { self.lock.withLock { self.running } }
+    var droppedPacketCount: UInt64 { 0 }
+    func count(_ event: String) -> Int { self.lock.withLock { self.events[event, default: 0] } }
+    func record(_ event: String) { self.lock.withLock { self.events[event, default: 0] += 1 } }
+    func setHandler(_ handler: @escaping DirectCoreAudioPacketHandler) { self.lock.withLock { self.handler = handler } }
+
+    func perform(_ event: String) {
+        let count = self.lock.withLock {
+            self.events[event, default: 0] += 1
+            return self.events[event, default: 0]
+        }
+        if event == self.blockedOperation, count == 1 {
+            // A broken watchdog fails the timing assertions without hanging the test runner.
+            _ = self.release.wait(timeout: .now() + 3)
+        }
+        if let delay = self.delays[event] { Thread.sleep(forTimeInterval: delay) }
+    }
+
+    func start() throws {
+        self.perform("start")
+        self.lock.withLock { self.running = true }
+    }
+
+    func stop() -> OSStatus {
+        self.perform("stop")
+        self.lock.withLock { self.running = false }
+        return noErr
+    }
+
+    func invalidate() -> OSStatus {
+        self.perform("invalidate")
+        self.lock.withLock { self.running = false }
+        return self.cleanupFails ? kAudioHardwareUnspecifiedError : noErr
+    }
+
+    func markFormatDirty() {}
+    func openPacketGateIfClean() -> Bool {
+        self.record("open")
+        if self.automaticPCM { self.emit() }
+        return true
+    }
+
+    func emit() {
+        let handler = self.lock.withLock { self.handler }
+        let samples = [Float](repeating: 0.5, count: 48)
+        samples.withUnsafeBufferPointer { handler?($0.baseAddress!, $0.count, 48_000, 0, 0) }
+    }
+}
+
+#if canImport(FluidVoice_Debug)
+final class AudioRouteRecoveryIntegrationTests: XCTestCase {
+    @MainActor
+    func testCancellingCallerTaskCancelsNativeStartupAndStaysQuiet() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, builtInStartDelay: 0.15) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            let starting = Task { await fixture.service.start(forDictionaryTraining: true) }
+            try await fixture.waitForBuiltInStartCount(1)
+            starting.cancel()
+            let outcome = await starting.value
+            XCTAssertEqual(outcome, .failed)
+            try await Task.sleep(nanoseconds: 250_000_000)
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.isStarting)
+            XCTAssertFalse(fixture.service.showError)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 1)
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testTwentyEarlyCancelsNeverStartRecordingAfterCancelReturns() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, builtInStartDelay: 0.01) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            for _ in 0..<20 {
+                let starting = Task { await fixture.service.start(forDictionaryTraining: true) }
+                for _ in 0..<1000 {
+                    if fixture.service.isStarting { break }
+                    await Task.yield()
+                }
+                XCTAssertTrue(fixture.service.isStarting)
+                await fixture.service.stopWithoutTranscription()
+                _ = await starting.value
+                let startsAtCancel = fixture.hardware.startCount(deviceID: 100)
+                try await Task.sleep(nanoseconds: 20_000_000)
+                XCTAssertFalse(fixture.service.isRunning)
+                XCTAssertFalse(fixture.service.isStarting)
+                XCTAssertFalse(fixture.service.showError)
+                XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), startsAtCancel)
+            }
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testTwentyOrdinaryStartsAndStopsKeepRecoveryIdle() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            for _ in 0..<20 {
+                let outcome = await fixture.service.start(forDictionaryTraining: true)
+                XCTAssertEqual(outcome, .started)
+                XCTAssertTrue(fixture.service.isRunning)
+                XCTAssertFalse(fixture.service.audioRouteRecoveryStateForTesting.pending)
+                var stoppedCallbacks = 0
+                _ = await fixture.service.stop(onCaptureStopped: { stoppedCallbacks += 1 }, forDictionaryTraining: true)
+                XCTAssertEqual(stoppedCallbacks, 1)
+                XCTAssertFalse(fixture.service.isRunning)
+                XCTAssertFalse(fixture.service.isStarting)
+                XCTAssertFalse(fixture.service.showError)
+                fixture.assertSettingsPreserved()
+            }
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 20)
+        }
+    }
+
+    @MainActor
+    func testOrdinarySlowStartBeyondFiveSecondsStillReachesFirstPCM() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, builtInStartDelay: 5.2) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            let outcome = await fixture.service.start(forDictionaryTraining: true)
+            XCTAssertEqual(outcome, .started)
+            XCTAssertTrue(fixture.service.isRunning)
+            XCTAssertTrue(fixture.service.audioRouteRecoveryStateForTesting.acceptingPCM)
+            XCTAssertFalse(fixture.service.showError)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 1)
+            fixture.assertSettingsPreserved()
+            await fixture.service.stopWithoutTranscription()
+        }
+    }
+
+    @MainActor
+    func testCancelThenImmediateRestartWaitsForSafeCleanupAndSucceeds() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, builtInStartDelay: 0.65) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            let first = Task { await fixture.service.start(forDictionaryTraining: true) }
+            try await fixture.waitForBuiltInStartCount(1)
+            let began = ProcessInfo.processInfo.systemUptime
+            await fixture.service.stopWithoutTranscription()
+            XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.3)
+            let firstResult = await first.value
+            XCTAssertEqual(firstResult, .failed)
+            let secondResult = await fixture.service.start(forDictionaryTraining: true)
+            XCTAssertEqual(secondResult, .started)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 2)
+            XCTAssertFalse(fixture.service.showError)
+            fixture.assertSettingsPreserved()
+            await fixture.service.stopWithoutTranscription()
+        }
+    }
+
+    @MainActor
+    func testCancellingImmediateRestartWaitDoesNotStartLater() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, builtInStartDelay: 0.65) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            let first = Task { await fixture.service.start(forDictionaryTraining: true) }
+            try await fixture.waitForBuiltInStartCount(1)
+            await fixture.service.stopWithoutTranscription()
+            _ = await first.value
+            let second = Task { await fixture.service.start(forDictionaryTraining: true) }
+            try await Task.sleep(nanoseconds: 30_000_000)
+            XCTAssertTrue(fixture.service.isStarting)
+            let began = ProcessInfo.processInfo.systemUptime
+            await fixture.service.stopWithoutTranscription()
+            XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.3)
+            let secondResult = await second.value
+            XCTAssertEqual(secondResult, .failed)
+            try await Task.sleep(nanoseconds: 800_000_000)
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.isStarting)
+            XCTAssertFalse(fixture.service.showError)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 1)
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testDelayedScanRecoversWithoutChangingRecordedAudioOrSettings() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0.12) { fixture in
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            try await fixture.waitForBuiltInRecovery()
+            fixture.assertSessionPreserved()
+        }
+    }
+
+    @MainActor
+    func testTransientScanFailureRetriesWithoutAbandoningRecording() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0.12, queryFailures: 1) { fixture in
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            try await fixture.waitForBuiltInRecovery()
+            fixture.assertSessionPreserved()
+            XCTAssertGreaterThanOrEqual(fixture.hardware.queryCount, 2)
+        }
+    }
+
+    @MainActor
+    func testCancelDuringDelayedScanNeverRestartsAfterQueryCompletes() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0.65) { fixture in
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            for _ in 0..<500 {
+                if fixture.hardware.queryCount > 0 { break }
+                try await Task.sleep(nanoseconds: 2_000_000)
+            }
+            XCTAssertGreaterThan(fixture.hardware.queryCount, 0)
+            await fixture.service.stopWithoutTranscription()
+            try await Task.sleep(nanoseconds: 800_000_000)
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.audioRouteRecoveryStateForTesting.pending)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 0)
+            XCTAssertEqual(fixture.service.audioRouteRecoveryStateForTesting.samples, [])
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testTimedOutScanWaitsForQueryCleanupThenRetriesSuccessfully() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, operationTimeout: 0.4, firstQueryDelay: 0.6) { fixture in
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            try await fixture.waitForBuiltInRecovery()
+            fixture.assertSessionPreserved()
+            XCTAssertGreaterThanOrEqual(fixture.hardware.queryCount, 2)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 1)
+            XCTAssertFalse(fixture.service.showError)
+        }
+    }
+
+    @MainActor
+    func testRepeatedScanFailureStopsWithErrorInsteadOfRemainingSilentlyPaused() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0.02, queryFailures: 100) { fixture in
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            for _ in 0..<1500 {
+                if fixture.service.showError { break }
+                try await Task.sleep(nanoseconds: 2_000_000)
+            }
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.audioRouteRecoveryStateForTesting.pending)
+            XCTAssertFalse(fixture.service.audioRouteRecoveryStateForTesting.acceptingPCM)
+            XCTAssertTrue(fixture.service.showError)
+            XCTAssertEqual(fixture.hardware.queryCount, 2)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 0)
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testEventDuringDelayedCleanupAutomaticallyRecoversAfterCleanup() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, externalStopDelay: 0.9, operationTimeout: 0.4) { fixture in
+            _ = await fixture.controller.stop(retainPrepared: false, reason: "injected_delayed_cleanup")
+            XCTAssertTrue(fixture.controller.isRecoveringHardware)
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            try await fixture.waitForBuiltInRecovery()
+            fixture.assertSessionPreserved()
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 1)
+        }
+    }
+
+    @MainActor
+    func testCancelDuringCleanupWaitNeverStartsReplacement() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, externalStopDelay: 0.85, operationTimeout: 0.4) { fixture in
+            _ = await fixture.controller.stop(retainPrepared: false, reason: "injected_delayed_cleanup")
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            try await Task.sleep(nanoseconds: 330_000_000)
+            await fixture.service.stopWithoutTranscription()
+            try await Task.sleep(nanoseconds: 700_000_000)
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.audioRouteRecoveryStateForTesting.pending)
+            XCTAssertFalse(fixture.service.showError)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 0)
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testNewEventDuringDelayedScanRetainsLatestRecoveryOnly() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0.18) { fixture in
+            fixture.service.triggerAudioRouteRecoveryForTesting()
+            for _ in 0..<500 {
+                if fixture.hardware.queryCount > 0 { break }
+                try await Task.sleep(nanoseconds: 2_000_000)
+            }
+            for _ in 0..<20 {
+                fixture.service.triggerAudioRouteRecoveryForTesting()
+            }
+            try await fixture.waitForBuiltInRecovery()
+            fixture.assertSessionPreserved()
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 1)
+            XCTAssertFalse(fixture.service.showError)
+        }
+    }
+
+    @MainActor
+    func testHealthyCaptureWithoutRouteChangeDoesNoRecoveryWork() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0) { fixture in
+            try await Task.sleep(nanoseconds: 400_000_000)
+            XCTAssertEqual(fixture.hardware.queryCount, 0)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 200), 1)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 0)
+            XCTAssertEqual(fixture.controller.snapshot.phase, .running)
+            XCTAssertTrue(fixture.service.audioRouteRecoveryStateForTesting.acceptingPCM)
+            fixture.assertSessionPreserved()
+        }
+    }
+}
+
+@MainActor
+private func withASRRecoveryFixture(
+    queryDelay: TimeInterval,
+    queryFailures: Int = 0,
+    externalStopDelay: TimeInterval = 0,
+    operationTimeout: TimeInterval? = nil,
+    firstQueryDelay: TimeInterval? = nil,
+    builtInStartDelay: TimeInterval = 0,
+    _ body: (ASRRecoveryFixture) async throws -> Void
+) async throws {
+    // The hosted app also performs its normal startup device reconciliation.
+    // Seed those existing inputs below the fake pair so that unrelated startup
+    // discovery cannot masquerade as a recovery-induced preference change.
+    let query = DirectCoreAudioLifecycleController(packetHandler: { _, _, _, _, _ in }, onFormatInvalidated: { _ in })
+    let liveInputs = try await query.readDeviceSnapshot().devices.filter(\.hasInput)
+    let fixture = ASRRecoveryFixture(queryDelay: queryDelay, queryFailures: queryFailures, liveInputs: liveInputs, externalStopDelay: externalStopDelay, operationTimeout: operationTimeout, firstQueryDelay: firstQueryDelay, builtInStartDelay: builtInStartDelay)
+    defer { fixture.restoreSettings() }
+    do {
+        try await fixture.start()
+        try await body(fixture)
+    } catch {
+        await fixture.service.finishAudioRouteRecoveryTest()
+        throw error
+    }
+    await fixture.service.finishAudioRouteRecoveryTest()
+}
+
+@MainActor
+private final class ASRRecoveryFixture {
+    let service: ASRService
+    let controller: DirectCoreAudioLifecycleController
+    let hardware: ASRRecoveryHardware
+    private let restore: () -> Void
+    private let outputUID: String?
+    private let modelID: String
+    private let providerID: String
+    private let expectedPriority: [String]
+    private let prefix: [Float] = [0.125, 0.25, 0.375]
+
+    init(queryDelay: TimeInterval, queryFailures: Int, liveInputs: [AudioDevice.Device], externalStopDelay: TimeInterval, operationTimeout: TimeInterval?, firstQueryDelay: TimeInterval?, builtInStartDelay: TimeInterval) {
+        let settings = SettingsStore.shared
+        let priority = settings.microphonePriority
+        let preferred = settings.preferredInputDeviceUID
+        let suppressed = settings.suppressedMicrophoneUIDs
+        let version = settings.microphoneSelectionMigrationVersion
+        let alerts = settings.showMicrophoneChangeAlerts
+        let pauseMedia = settings.pauseMediaDuringTranscription
+        self.restore = {
+            settings.microphonePriority = priority
+            settings.preferredInputDeviceUID = preferred
+            settings.suppressedMicrophoneUIDs = suppressed
+            settings.microphoneSelectionMigrationVersion = version
+            settings.showMicrophoneChangeAlerts = alerts
+            settings.pauseMediaDuringTranscription = pauseMedia
+        }
+        settings.microphoneSelectionMigrationVersion = 4
+        settings.microphonePriority = [
+            .init(uid: "recovery-test-external", name: "Test External"),
+            .init(uid: "recovery-test-built-in", name: "Test Built-in"),
+        ] + liveInputs.map { .init(uid: $0.uid, name: $0.name) }
+        settings.preferredInputDeviceUID = "recovery-test-external"
+        settings.suppressedMicrophoneUIDs = []
+        settings.showMicrophoneChangeAlerts = false
+        settings.pauseMediaDuringTranscription = false
+        self.expectedPriority = settings.microphonePriority.map(\.uid)
+        self.outputUID = settings.preferredOutputDeviceUID
+        self.modelID = settings.selectedSpeechModel.rawValue
+        self.providerID = settings.selectedProviderID
+        let service = ASRService()
+        self.service = service
+        let hardware = ASRRecoveryHardware(queryDelay: queryDelay, queryFailures: queryFailures, externalStopDelay: externalStopDelay, firstQueryDelay: firstQueryDelay, builtInStartDelay: builtInStartDelay)
+        self.hardware = hardware
+        self.controller = DirectCoreAudioLifecycleController(
+            packetHandler: service.recoveryPacketHandlerForTesting,
+            inputFactory: { id, handler in hardware.makeInput(id, handler: handler) },
+            fingerprintReader: { RecoveryInput(deviceID: $0).formatFingerprint },
+            installsHardwareListeners: false,
+            operationTimeout: operationTimeout,
+            deviceSnapshotReader: { _ in try hardware.snapshot() },
+            deviceResolver: { selection in
+                switch selection {
+                case .systemDefault: hardware.builtIn
+                case let .preferredUID(uid): uid == hardware.builtIn.uid ? hardware.builtIn : nil
+                }
+            },
+            onFormatInvalidated: { _ in }
+        )
+    }
+
+    func start() async throws {
+        _ = try await self.controller.start(deviceID: 200, deviceName: "Test External", reason: "test_existing_capture")
+        self.service.configureAudioRouteRecoveryForTesting(
+            controller: self.controller, devices: [self.hardware.builtIn], initialSamples: self.prefix
+        )
+        self.service.partialTranscription = "words already captured"
+    }
+
+    func waitForBuiltInStartCount(_ count: Int) async throws {
+        for _ in 0..<1000 {
+            if self.hardware.startCount(deviceID: 100) >= count { return }
+            try await Task.sleep(nanoseconds: 2_000_000)
+        }
+        XCTFail("Expected built-in native start count \(count)")
+    }
+
+    func waitForBuiltInRecovery() async throws {
+        for _ in 0..<1500 {
+            let state = self.service.audioRouteRecoveryStateForTesting
+            if self.controller.snapshot.deviceID == 100, self.controller.snapshot.phase == .running,
+               state.pending == false, state.recovering == false
+            { return }
+            try await Task.sleep(nanoseconds: 2_000_000)
+        }
+        let state = self.service.audioRouteRecoveryStateForTesting
+        XCTFail("Recovery did not finish: running=\(self.service.isRunning) acceptingPCM=\(state.acceptingPCM) pending=\(state.pending) phase=\(self.controller.snapshot.phase)")
+    }
+
+    func assertSessionPreserved() {
+        XCTAssertTrue(self.service.isRunning)
+        XCTAssertTrue(self.service.audioRouteRecoveryStateForTesting.acceptingPCM)
+        XCTAssertEqual(Array(self.service.audioRouteRecoveryStateForTesting.samples.prefix(self.prefix.count)), self.prefix)
+        XCTAssertEqual(self.service.partialTranscription, "words already captured")
+        self.assertSettingsPreserved()
+    }
+
+    func assertSettingsPreserved() {
+        XCTAssertEqual(SettingsStore.shared.microphonePriority.map(\.uid), self.expectedPriority)
+        XCTAssertEqual(SettingsStore.shared.preferredInputDeviceUID, "recovery-test-external")
+        XCTAssertEqual(SettingsStore.shared.preferredOutputDeviceUID, self.outputUID)
+        XCTAssertEqual(SettingsStore.shared.selectedSpeechModel.rawValue, self.modelID)
+        XCTAssertEqual(SettingsStore.shared.selectedProviderID, self.providerID)
+    }
+
+    func restoreSettings() { self.restore() }
+}
+
+private final nonisolated class ASRRecoveryHardware: @unchecked Sendable {
+    let builtIn = AudioDevice.Device(id: 100, uid: "recovery-test-built-in", name: "Test Built-in", hasInput: true, hasOutput: false)
+    private let lock = NSLock()
+    private let queryDelay: TimeInterval
+    private let builtInStartDelay: TimeInterval
+    private let externalStopDelay: TimeInterval
+    private let firstQueryDelay: TimeInterval?
+    private var queryFailures: Int
+    private var queries = 0
+    private var inputs: [RecoveryInput] = []
+
+    init(queryDelay: TimeInterval, queryFailures: Int, externalStopDelay: TimeInterval, firstQueryDelay: TimeInterval?, builtInStartDelay: TimeInterval) {
+        self.builtInStartDelay = builtInStartDelay
+        self.firstQueryDelay = firstQueryDelay
+        self.externalStopDelay = externalStopDelay
+        self.queryDelay = queryDelay
+        self.queryFailures = queryFailures
+    }
+
+    var queryCount: Int { self.lock.withLock { self.queries } }
+    func startCount(deviceID: AudioObjectID) -> Int {
+        self.lock.withLock { self.inputs.filter { $0.deviceID == deviceID }.reduce(0) { $0 + $1.count("start") } }
+    }
+
+    func makeInput(_ id: AudioObjectID, handler: @escaping DirectCoreAudioPacketHandler) -> RecoveryInput {
+        let input = RecoveryInput(deviceID: id, delays: id == 200 ? ["stop": self.externalStopDelay] : ["start": self.builtInStartDelay], automaticPCM: true)
+        input.setHandler(handler)
+        self.lock.withLock { self.inputs.append(input) }
+        return input
+    }
+
+    func snapshot() throws -> DirectCoreAudioLifecycleController.DeviceSnapshot {
+        let fail = self.lock.withLock {
+            self.queries += 1
+            let fail = self.queryFailures > 0
+            self.queryFailures = max(0, self.queryFailures - 1)
+            return fail
+        }
+        let delay = self.lock.withLock { self.queries == 1 ? (self.firstQueryDelay ?? self.queryDelay) : self.queryDelay }
+        Thread.sleep(forTimeInterval: delay)
+        if fail { throw NSError(domain: "InjectedDeviceScan", code: 1) }
+        return .init(devices: [self.builtIn], defaultInputUID: self.builtIn.uid)
+    }
+}
+#endif
+
+/// Injected timing and device changes; these tests never open a physical mic.
+final class AudioHardwareAdversarialTests: XCTestCase {
+    func testFortyDelayedExternalToBuiltInSwitchesRejectOldDeviceEventsAndPCM() async throws {
+        let fleet = RecoveryFleet()
+        let controller = fleet.makeController()
+        for cycle in 0..<40 {
+            let externalID = AudioObjectID(200 + cycle)
+            let external = try await controller.start(deviceID: externalID, deviceName: "External", reason: "adversarial_external")
+            let oldInput = try XCTUnwrap(fleet.latest)
+            oldInput.emit()
+            await controller.simulateStoppedHardwareNotificationForTesting(generation: external.generation, reason: "device_is_alive")
+            let replacement = try await controller.start(deviceID: 100, deviceName: "Built-in", reason: "adversarial_fallback")
+            XCTAssertEqual(replacement.deviceID, 100)
+            XCTAssertEqual(replacement.phase, .running)
+            let delivered = fleet.deliveryCount
+            oldInput.emit()
+            // Delayed/duplicate unplug notifications must not retire the new mic.
+            for _ in 0..<4 {
+                await controller.simulateStoppedHardwareNotificationForTesting(generation: external.generation, reason: "device_is_alive")
+            }
+            XCTAssertEqual(fleet.deliveryCount, delivered)
+            XCTAssertEqual(controller.snapshot.generation, replacement.generation)
+            XCTAssertEqual(controller.snapshot.phase, .running)
+            try XCTUnwrap(fleet.latest).emit()
+            XCTAssertEqual(fleet.deliveryCount, delivered + 1)
+            XCTAssertEqual(fleet.runningCount, 1)
+        }
+        await controller.shutdown(reason: "test_complete")
+        XCTAssertEqual(fleet.runningCount, 0)
+    }
+
+    func testThirtyCancelledDelayedStartsRemainRetryableAfterCleanup() async throws {
+        for _ in 0..<30 {
+            let input = RecoveryInput(block: "start", delays: ["invalidate": 0.006])
+            let controller = makeRecoveryController(input, timeout: 1)
+            let start = Task { try await controller.start(deviceID: 144, deviceName: "External", reason: "cancel_race") }
+            try await waitForEvent(input, "start")
+            start.cancel()
+            _ = await start.result
+            XCTAssertTrue(controller.isRecoveringHardware)
+            input.emit()
+            XCTAssertEqual(input.count("delivered"), 0)
+            input.release.signal()
+            try await waitForRecovery(controller)
+            XCTAssertEqual(input.count("open"), 0)
+            let retry = try await controller.start(deviceID: 144, deviceName: "Built-in", reason: "after_cancel_cleanup")
+            XCTAssertEqual(retry.phase, .running)
+            await controller.shutdown(reason: "test_complete")
+            XCTAssertFalse(input.isRunning)
+        }
+    }
+
+    func testDelayedCleanupRejectsReplacementUntilOldInputIsRetired() async throws {
+        let input = RecoveryInput(block: "invalidate")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input, timeout: 0.08)
+        _ = try await controller.start(deviceID: 144, deviceName: "External", reason: "before_unplug")
+        await controller.invalidate(reason: "unplug")
+        XCTAssertTrue(controller.isRecoveringHardware)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 0)
+        do {
+            _ = try await controller.start(deviceID: 144, deviceName: "Built-in", reason: "during_cleanup")
+            XCTFail("Replacement must not overlap unresolved native cleanup")
+        } catch {}
+        XCTAssertEqual(input.count("start"), 1)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        _ = try await controller.start(deviceID: 144, deviceName: "Built-in", reason: "after_cleanup")
+        XCTAssertEqual(input.count("start"), 2)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testEightyDeadlineRacesNeverDeliverAudioAfterFailedStartup() async throws {
+        var successes = 0
+        var failures = 0
+        for iteration in 0..<80 {
+            let delays: [TimeInterval] = [0.002, 0.009, 0.01, 0.012, 0.02]
+            let input = RecoveryInput(delays: ["start": delays[iteration % delays.count]])
+            let controller = makeRecoveryController(input, timeout: 0.01)
+            do {
+                _ = try await controller.start(deviceID: 144, deviceName: "Delayed", reason: "deadline_race")
+                successes += 1
+                input.emit()
+                XCTAssertEqual(input.count("delivered"), 1)
+            } catch {
+                failures += 1
+                input.emit()
+                XCTAssertEqual(input.count("delivered"), 0)
+                try await waitForRecovery(controller)
+                input.emit()
+                XCTAssertEqual(input.count("delivered"), 0)
+            }
+            await controller.shutdown(reason: "test_complete")
+        }
+        XCTAssertGreaterThan(successes, 0)
+        XCTAssertGreaterThan(failures, 0)
+        print("ADVERSARIAL deadline races: successes=\(successes) failures=\(failures)")
+    }
+
+    func testLateDeviceGoneNotificationRestoresReplacementAfterTimedOutFailedCleanup() async throws {
+        // Desired behavior. This deliberately exposes any permanent timeout latch
+        // that disagrees with the existing safe late-device-removal recovery path.
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input)
+        do {
+            _ = try await controller.start(deviceID: 144, deviceName: "Removed", reason: "timeout_then_removed")
+            XCTFail("Injected blocked start must time out")
+        } catch {}
+        let generation = controller.snapshot.generation
+        input.release.signal()
+        // Wait for the actual cleanup-failed gate, not just entry into invalidate().
+        // Sending removal before cleanup finishes takes a different, healthy path.
+        var cleanupFinished = false
+        for _ in 0..<1000 {
+            do {
+                _ = try await controller.prepare(deviceID: 144, deviceName: "Probe", reason: "wait_for_failed_cleanup")
+            } catch BoundedAudioHardwareQueue.Failure.cleanupFailed {
+                cleanupFinished = true
+                break
+            } catch {}
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTAssertTrue(cleanupFinished)
+        await controller.simulateStoppedHardwareNotificationForTesting(generation: generation &- 1, reason: "device_is_alive")
+        XCTAssertTrue(controller.isRecoveringHardware, "An old device notification must not clear the current failed generation")
+        await controller.simulateStoppedHardwareNotificationForTesting(generation: generation, reason: "device_is_alive")
+        XCTAssertFalse(controller.isRecoveringHardware, "Known-stopped old hardware must not leave the timeout gate permanently unavailable")
+        do {
+            _ = try await controller.prepare(deviceID: 144, deviceName: "Replacement", reason: "late_removal_recovery")
+        } catch {
+            XCTFail("Safe replacement is still rejected after late device removal: \(error)")
+        }
+        await controller.shutdown(reason: "test_complete")
+    }
+}
+
+private final nonisolated class RecoveryFleet: @unchecked Sendable {
+    private let lock = NSLock()
+    private var inputs: [RecoveryInput] = []
+    private var delivered = 0
+
+    var latest: RecoveryInput? { self.lock.withLock { self.inputs.last } }
+    var deliveryCount: Int { self.lock.withLock { self.delivered } }
+    var runningCount: Int { self.lock.withLock { self.inputs.filter(\.isRunning).count } }
+
+    func makeController() -> DirectCoreAudioLifecycleController {
+        DirectCoreAudioLifecycleController(
+            packetHandler: { [self] _, _, _, _, _ in self.lock.withLock { self.delivered += 1 } },
+            inputFactory: { [self] deviceID, handler in
+                let input = RecoveryInput(deviceID: deviceID, delays: ["start": 0.001, "invalidate": 0.001])
+                input.setHandler(handler)
+                self.lock.withLock { self.inputs.append(input) }
+                return input
+            },
+            fingerprintReader: { RecoveryInput(deviceID: $0).formatFingerprint },
+            installsHardwareListeners: false,
+            operationTimeout: 1,
+            onFormatInvalidated: { _ in }
+        )
+    }
+}

--- a/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
@@ -342,6 +342,146 @@ final class AudioHardwareRecoveryTests: XCTestCase {
     }
 }
 
+final class MonitorTopologyRecoveryTests: XCTestCase {
+    func testDisplayTopologyChangeRefreshesUnchangedPreparedInputOnlyOnce() async throws {
+        let input = RecoveryInput()
+        let controller = makeDefaultRecoveryController(input)
+        let old = try await controller.prepare(deviceID: 144, deviceName: "Test", reason: "before_display")
+        for _ in 0..<100 {
+            controller.noteHardwareTopologyChanged()
+        }
+        // Even a prewarm during topology churn is refreshed at actual demand.
+        _ = try await controller.prepare(deviceID: 144, deviceName: "Test", reason: "idle_prewarm")
+        XCTAssertEqual(input.count("invalidate"), 0)
+        let fresh = try await controller.start(deviceID: 144, deviceName: "Test", reason: "after_display")
+        XCTAssertGreaterThan(fresh.generation, old.generation)
+        XCTAssertEqual(input.count("prepare"), 2)
+        XCTAssertEqual(input.count("invalidate"), 1)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 1)
+        _ = await controller.stop(retainPrepared: true, reason: "stop")
+        let reused = try await controller.start(deviceID: 144, deviceName: "Test", reason: "ordinary_next_start")
+        XCTAssertEqual(reused.generation, fresh.generation)
+        XCTAssertEqual(input.count("prepare"), 2)
+        XCTAssertEqual(input.count("invalidate"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testDisplayChangeDoesNotInterruptRunningAudioButRefreshesAfterStop() async throws {
+        let input = RecoveryInput()
+        let controller = makeDefaultRecoveryController(input)
+        let running = try await controller.start(deviceID: 144, deviceName: "Test", reason: "running")
+        controller.noteHardwareTopologyChanged()
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 1)
+        XCTAssertEqual(input.count("stop"), 0)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        XCTAssertEqual(controller.snapshot.phase, .running)
+        _ = await controller.stop(retainPrepared: true, reason: "user_stop")
+        let fresh = try await controller.start(deviceID: 144, deviceName: "Test", reason: "next_start")
+        XCTAssertGreaterThan(fresh.generation, running.generation)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testRunningPreviewHandoffDoesNotDiscardOpeningAudioAfterDisplayChange() async throws {
+        let input = RecoveryInput()
+        let controller = makeDefaultRecoveryController(input)
+        let preview = try await controller.start(deviceID: 144, deviceName: "Test", reason: "preview")
+        controller.noteHardwareTopologyChanged()
+        let handoff = try await controller.start(deviceID: 144, deviceName: "Test", reason: "handoff")
+        input.emit()
+        XCTAssertEqual(handoff.generation, preview.generation)
+        XCTAssertEqual(input.count("start"), 1)
+        XCTAssertEqual(input.count("stop"), 0)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        XCTAssertEqual(input.count("delivered"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testCancelledStartupDiscoveryReturnsWhileHALIsBlockedAndLeavesCaptureAlone() async throws {
+        let input = RecoveryInput(block: "query")
+        defer { input.release.signal() }
+        let controller = DirectCoreAudioLifecycleController(
+            packetHandler: { _, _, _, _, _ in input.record("delivered") },
+            inputFactory: { _, handler in input.setHandler(handler); return input },
+            fingerprintReader: { _ in input.formatFingerprint },
+            installsHardwareListeners: false,
+            deviceSnapshotReader: { _ in input.perform("query"); return .init(devices: [], defaultInputUID: nil) },
+            onFormatInvalidated: { _ in }
+        )
+        _ = try await controller.start(deviceID: 144, deviceName: "Test", reason: "existing_capture")
+        let query = Task { try await controller.readCaptureDeviceSnapshot() }
+        try await waitForEvent(input, "query")
+        let began = ProcessInfo.processInfo.systemUptime
+        query.cancel()
+        do { _ = try await query.value; XCTFail("Cancelled discovery must fail") }
+        catch { XCTAssertTrue(error is CancellationError) }
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.2)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 1)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        XCTAssertFalse(controller.isRecoveringHardware)
+        do { _ = try await controller.readCaptureDeviceSnapshot(); XCTFail("Do not pile up blocked queries") }
+        catch { XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure) }
+        XCTAssertEqual(input.count("query"), 1)
+        input.release.signal()
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testFailedHardwareRetirementWaitHasDeadlineWithoutStartingReplacement() async throws {
+        let input = RecoveryInput(block: "start")
+        defer { input.release.signal() }
+        let controller = makeRecoveryController(input, timeout: 0.08)
+        _ = try? await controller.start(deviceID: 144, deviceName: "Test", reason: "blocked")
+        let began = ProcessInfo.processInfo.systemUptime
+        let available = await controller.waitForPendingHardwareRetirement()
+        XCTAssertFalse(available)
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.5)
+        XCTAssertEqual(input.count("start"), 1)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testAbnormalStopReleasesBlockedStartOnceAndRejectsLateGenerationEvents() async throws {
+        let input = RecoveryInput(block: "start")
+        defer { input.release.signal() }
+        let controller = DirectCoreAudioLifecycleController(
+            packetHandler: { _, _, _, _, _ in input.record("delivered") },
+            inputFactory: { _, handler in input.setHandler(handler); return input },
+            fingerprintReader: { _ in input.formatFingerprint },
+            installsHardwareListeners: false,
+            onFormatInvalidated: { _ in input.record("notification") }
+        )
+        let starting = Task { try await controller.start(deviceID: 144, deviceName: "Test", reason: "blocked") }
+        try await waitForEvent(input, "start")
+        let generation = controller.snapshot.generation
+        let began = ProcessInfo.processInfo.systemUptime
+        for _ in 0..<100 {
+            controller.simulateAbnormalStopNotificationForTesting(generation: generation)
+        }
+        do { _ = try await starting.value; XCTFail("Known failed startup must release its caller") }
+        catch { XCTAssertTrue(error is BoundedAudioHardwareQueue.Failure) }
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - began, 0.2)
+        XCTAssertEqual(input.count("notification"), 1)
+        XCTAssertEqual(input.count("invalidate"), 0, "Native startup still owns the resources")
+        XCTAssertEqual(input.count("open"), 0)
+        _ = try? await controller.start(deviceID: 144, deviceName: "Test", reason: "unsafe_retry")
+        XCTAssertEqual(input.count("start"), 1)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        let fresh = try await controller.start(deviceID: 144, deviceName: "Test", reason: "safe_retry")
+        XCTAssertGreaterThan(fresh.generation, generation)
+        controller.simulateAbnormalStopNotificationForTesting(generation: generation)
+        XCTAssertEqual(input.count("notification"), 1)
+        XCTAssertEqual(controller.snapshot.phase, .running)
+        input.emit()
+        XCTAssertEqual(input.count("delivered"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+}
+
 /// This same class is also run against the original controller for comparison.
 final class NormalAudioCaptureCompatibilityTests: XCTestCase {
     func testHealthySlowNativeStartsAtFiveAndTenSecondsSucceed() async throws {
@@ -535,6 +675,123 @@ private final nonisolated class RecoveryInput: DirectCoreAudioInputControlling, 
 
 #if canImport(FluidVoice_Debug)
 final class AudioRouteRecoveryIntegrationTests: XCTestCase {
+    @MainActor
+    func testFailedRecoveryCancelsWaitingRetryAndResumesMediaBeforeNativeCleanup() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0, builtInStartDelay: 0.8) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            let first = Task { await fixture.service.start(forDictionaryTraining: true) }
+            try await fixture.waitForBuiltInStartCount(1)
+            await fixture.service.cancelPendingAudioCaptureStart(reason: "injected_user_cancel")
+            let firstOutcome = await first.value
+            XCTAssertEqual(firstOutcome, .failed)
+            XCTAssertTrue(fixture.controller.isRecoveringHardware)
+
+            let transport = RecoveryMediaTransport()
+            let media = MediaPlaybackService(transport: transport, settle: {})
+            fixture.service.useMediaPlaybackForTesting(media)
+            SettingsStore.shared.pauseMediaDuringTranscription = true
+            let retry = Task { await fixture.service.start(forDictionaryTraining: true) }
+            for _ in 0..<200 {
+                if await transport.commands == [.pause] { break }
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            await media.waitUntilSettled()
+            let paused = await transport.commands
+            XCTAssertEqual(paused, [.pause])
+            XCTAssertTrue(fixture.service.isStarting)
+            var failurePresentations = 0
+            let observation = fixture.service.audioCaptureFailurePresented.sink {
+                failurePresentations += 1
+                XCTAssertTrue(fixture.service.showError)
+                XCTAssertEqual(fixture.service.errorTitle, "Recording Stopped")
+            }
+            defer { observation.cancel() }
+            let began = ProcessInfo.processInfo.systemUptime
+            await fixture.service.failAudioRouteRecoveryForTesting()
+            let retryOutcome = await retry.value
+            await media.waitUntilSettled()
+            let elapsed = ProcessInfo.processInfo.systemUptime - began
+            print("MONITOR_RECOVERY_TEST failed_recovery_release_ms=\(elapsed * 1000)")
+            XCTAssertLessThan(elapsed, 0.2)
+            XCTAssertEqual(retryOutcome, .failed)
+            XCTAssertFalse(fixture.service.isStarting)
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertTrue(fixture.service.showError)
+            XCTAssertEqual(failurePresentations, 1)
+            XCTAssertTrue(fixture.controller.isRecoveringHardware)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 1)
+            let resumed = await transport.commands
+            XCTAssertEqual(resumed, [.pause, .play])
+            try await waitForRecovery(fixture.controller)
+            let afterDrain = await transport.commands
+            XCTAssertEqual(afterDrain, [.pause, .play], "Late cleanup must not change playback or restart recording")
+            XCTAssertFalse(fixture.service.isRunning)
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testStaleRecoveryFailureCannotStopNewRecordingOrResumeItsMedia() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            let transport = RecoveryMediaTransport()
+            let media = MediaPlaybackService(transport: transport, settle: {})
+            fixture.service.useMediaPlaybackForTesting(media)
+            SettingsStore.shared.pauseMediaDuringTranscription = true
+            let outcome = await fixture.service.start(forDictionaryTraining: true)
+            XCTAssertEqual(outcome, .started)
+            await media.waitUntilSettled()
+            var failurePresentations = 0
+            let observation = fixture.service.audioCaptureFailurePresented.sink { failurePresentations += 1 }
+            defer { observation.cancel() }
+            await fixture.service.failAudioRouteRecoveryForTesting(stale: true)
+            await media.waitUntilSettled()
+            XCTAssertTrue(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.showError)
+            XCTAssertEqual(failurePresentations, 0)
+            let commands = await transport.commands
+            XCTAssertEqual(commands, [.pause])
+            await fixture.service.stopWithoutTranscription()
+            await media.waitUntilSettled()
+            let stopped = await transport.commands
+            XCTAssertEqual(stopped, [.pause, .play])
+            fixture.assertSettingsPreserved()
+        }
+    }
+
+    @MainActor
+    func testCancelDuringSlowStartupDiscoveryKeepsMainThreadResponsive() async throws {
+        try await withASRRecoveryFixture(queryDelay: 0.6) { fixture in
+            await fixture.service.stopWithoutTranscription()
+            fixture.service.micStatus = .authorized
+            var failurePresentations = 0
+            let observation = fixture.service.audioCaptureFailurePresented.sink { failurePresentations += 1 }
+            defer { observation.cancel() }
+            let starting = Task { await fixture.service.start(forDictionaryTraining: true) }
+            for _ in 0..<200 {
+                if fixture.hardware.queryCount > 0 { break }
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            XCTAssertEqual(fixture.hardware.queryCount, 1)
+            let began = ProcessInfo.processInfo.systemUptime
+            await fixture.service.cancelPendingAudioCaptureStart(reason: "cancel_during_device_query")
+            let outcome = await starting.value
+            let elapsed = ProcessInfo.processInfo.systemUptime - began
+            print("MONITOR_RECOVERY_TEST cancelled_discovery_release_ms=\(elapsed * 1000)")
+            XCTAssertLessThan(elapsed, 0.2)
+            XCTAssertEqual(outcome, .failed)
+            XCTAssertFalse(fixture.service.isStarting)
+            XCTAssertFalse(fixture.service.isRunning)
+            XCTAssertFalse(fixture.service.showError)
+            XCTAssertEqual(failurePresentations, 0)
+            try await Task.sleep(nanoseconds: 650_000_000)
+            XCTAssertEqual(fixture.hardware.startCount(deviceID: 100), 0)
+            fixture.assertSettingsPreserved()
+        }
+    }
+
     @MainActor
     func testCancellingCallerTaskCancelsNativeStartupAndStaysQuiet() async throws {
         try await withASRRecoveryFixture(queryDelay: 0, builtInStartDelay: 0.15) { fixture in
@@ -926,6 +1183,21 @@ private final class ASRRecoveryFixture {
     }
 
     func restoreSettings() { self.restore() }
+}
+
+private actor RecoveryMediaTransport: MediaPlaybackTransport {
+    private var playing = true
+    private(set) var commands: [MediaPlaybackCommand] = []
+
+    func query() async -> MediaPlaybackQueryResult {
+        .snapshot(MediaPlaybackSnapshot(bundleIdentifier: "test.player", processID: 1, title: "Test item", isPlaying: self.playing))
+    }
+
+    func send(_ command: MediaPlaybackCommand) async -> MediaPlaybackCommandResult {
+        self.commands.append(command)
+        self.playing = command == .play
+        return .helperCompleted
+    }
 }
 
 private final nonisolated class ASRRecoveryHardware: @unchecked Sendable {

--- a/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
+++ b/Tests/FluidDictationIntegrationTests/AudioHardwareRecoveryTests.swift
@@ -343,6 +343,166 @@ final class AudioHardwareRecoveryTests: XCTestCase {
 }
 
 final class MonitorTopologyRecoveryTests: XCTestCase {
+    func testHealthyTopologyChangeDoesNotQueryLivenessOrInterruptCapture() async throws {
+        let input = RecoveryInput()
+        let probe = FailedDeviceLivenessProbe()
+        let controller = makeRecoveryController(input, timeout: nil, deviceLivenessReader: { probe.read($0) })
+        _ = try await controller.start(deviceID: 144, deviceName: "Healthy", reason: "recording")
+        for _ in 0..<100 { controller.noteHardwareTopologyChanged() }
+        try await waitForTopologyCheck(controller)
+        input.emit()
+        XCTAssertTrue(probe.deviceIDs.isEmpty)
+        XCTAssertEqual(controller.snapshot.phase, .running)
+        XCTAssertEqual(input.count("stop"), 0)
+        XCTAssertEqual(input.count("invalidate"), 0)
+        XCTAssertEqual(input.count("delivered"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testGlobalTopologyRemovalClearsFailedCleanupAndAllowsNextRecording() async throws {
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        let probe = FailedDeviceLivenessProbe()
+        let controller = makeRecoveryController(input, deviceLivenessReader: { probe.read($0) })
+        defer { input.release.signal() }
+        _ = try? await controller.start(deviceID: 144, deviceName: "Removed", reason: "failed_start")
+        input.release.signal()
+        try await waitForFailedCleanup(controller)
+        try await waitForTopologyCheck(controller)
+        XCTAssertTrue(controller.isRecoveringHardware)
+        XCTAssertEqual(probe.deviceIDs, [144])
+
+        // This is the actual entry point used by the global HAL device-list
+        // listener, after invalidate() has removed all per-device listeners.
+        probe.setAlive(false)
+        controller.noteHardwareTopologyChanged()
+        try await waitForTopologyCheck(controller)
+        XCTAssertFalse(controller.isRecoveringHardware)
+        let replacement = try await controller.start(deviceID: 144, deviceName: "Replacement", reason: "next_recording")
+        input.emit()
+        XCTAssertEqual(replacement.phase, .running)
+        XCTAssertEqual(input.count("delivered"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testUnrelatedTopologyAndUnknownLivenessKeepFailedCleanupBlocked() async throws {
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        let probe = FailedDeviceLivenessProbe()
+        let controller = makeRecoveryController(input, deviceLivenessReader: { probe.read($0) })
+        defer { input.release.signal() }
+        _ = try? await controller.start(deviceID: 144, deviceName: "Still connected", reason: "failed_start")
+        input.release.signal()
+        try await waitForFailedCleanup(controller)
+        try await waitForTopologyCheck(controller)
+        for alive in [true, nil] as [Bool?] {
+            probe.setAlive(alive)
+            for _ in 0..<100 { controller.noteHardwareTopologyChanged() }
+            try await waitForTopologyCheck(controller)
+            XCTAssertTrue(controller.isRecoveringHardware)
+            XCTAssertEqual(input.count("prepare"), 1)
+            XCTAssertEqual(input.count("delivered"), 0)
+        }
+        XCTAssertTrue(probe.deviceIDs.allSatisfy { $0 == 144 })
+        XCTAssertLessThan(probe.deviceIDs.count, 10, "Coalesce event bursts instead of querying once per notification")
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testRemovalDuringBlockedNativeWorkWaitsForItsCleanup() async throws {
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        let probe = FailedDeviceLivenessProbe(alive: false)
+        let controller = makeRecoveryController(input, deviceLivenessReader: { probe.read($0) })
+        defer { input.release.signal() }
+        _ = try? await controller.start(deviceID: 144, deviceName: "Removed", reason: "failed_start")
+        for _ in 0..<100 { controller.noteHardwareTopologyChanged() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertTrue(controller.isRecoveringHardware)
+        XCTAssertTrue(probe.deviceIDs.isEmpty, "Do not check or unlock while native startup owns capture")
+        XCTAssertEqual(input.count("invalidate"), 0)
+        XCTAssertEqual(input.count("prepare"), 1)
+        input.release.signal()
+        try await waitForRecovery(controller)
+        XCTAssertEqual(input.count("invalidate"), 1)
+        XCTAssertEqual(probe.deviceIDs, [144])
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testRemovalDuringLivenessQueryRechecksTheLatestTopology() async throws {
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        let probe = FailedDeviceLivenessProbe()
+        let controller = makeRecoveryController(input, timeout: 1, deviceLivenessReader: { probe.read($0) })
+        defer { input.release.signal(); probe.release.signal() }
+        let starting = Task { try await controller.start(deviceID: 144, deviceName: "Old", reason: "old_start") }
+        try await waitForEvent(input, "start")
+        starting.cancel()
+        _ = try? await starting.value
+        input.release.signal()
+        try await waitForFailedCleanup(controller)
+        try await waitForTopologyCheck(controller)
+        probe.blockNextRead(alive: true)
+        controller.noteHardwareTopologyChanged()
+        try await probe.waitForReadCount(2)
+        probe.setAlive(false)
+        controller.noteHardwareTopologyChanged()
+        probe.release.signal()
+        try await waitForRecovery(controller)
+        try await waitForTopologyCheck(controller)
+        XCTAssertEqual(probe.deviceIDs.count, 3, "Recheck after the in-flight query returns an older snapshot")
+        XCTAssertEqual(controller.snapshot.phase, .empty)
+        XCTAssertEqual(input.count("prepare"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testLateLivenessResultCannotClearOrStopNewCapture() async throws {
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        let probe = FailedDeviceLivenessProbe()
+        let controller = makeRecoveryController(input, timeout: 1, deviceLivenessReader: { probe.read($0) })
+        defer { input.release.signal(); probe.release.signal() }
+        let starting = Task { try await controller.start(deviceID: 144, deviceName: "Old", reason: "old_start") }
+        try await waitForEvent(input, "start")
+        starting.cancel()
+        _ = try? await starting.value
+        input.release.signal()
+        try await waitForFailedCleanup(controller)
+        try await waitForTopologyCheck(controller)
+        let oldGeneration = controller.snapshot.generation
+        probe.blockNextRead(alive: false)
+        controller.noteHardwareTopologyChanged()
+        try await probe.waitForReadCount(2)
+        // A valid per-device signal wins the race and admits a new generation.
+        await controller.simulateStoppedHardwareNotificationForTesting(generation: oldGeneration, reason: "device_is_alive")
+        let replacement = try await controller.start(deviceID: 144, deviceName: "New", reason: "replacement")
+        probe.release.signal()
+        try await waitForTopologyCheck(controller)
+        input.emit()
+        XCTAssertGreaterThan(replacement.generation, oldGeneration)
+        XCTAssertEqual(controller.snapshot.phase, .running)
+        XCTAssertEqual(input.count("invalidate"), 1)
+        XCTAssertEqual(input.count("delivered"), 1)
+        await controller.shutdown(reason: "test_complete")
+    }
+
+    func testBlockedTopologyQueryDoesNotUnlockAndShutdownCannotBeReversed() async throws {
+        let input = RecoveryInput(block: "start", cleanupFails: true)
+        let probe = FailedDeviceLivenessProbe()
+        let controller = makeRecoveryController(input, deviceLivenessReader: { probe.read($0) })
+        defer { input.release.signal(); probe.release.signal() }
+        _ = try? await controller.start(deviceID: 144, deviceName: "Old", reason: "failed_start")
+        input.release.signal()
+        try await waitForFailedCleanup(controller)
+        try await waitForTopologyCheck(controller)
+        probe.blockNextRead(alive: false)
+        controller.noteHardwareTopologyChanged()
+        try await probe.waitForReadCount(2)
+        try await waitForTopologyCheck(controller)
+        XCTAssertTrue(controller.isRecoveringHardware, "Timed-out liveness is unknown, not proof of removal")
+        await controller.shutdown(reason: "test_complete")
+        probe.release.signal()
+        controller.noteHardwareTopologyChanged()
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertTrue(controller.isRecoveringHardware)
+        XCTAssertEqual(input.count("prepare"), 1)
+        XCTAssertEqual(input.count("delivered"), 0)
+    }
+
     func testDisplayTopologyChangeRefreshesUnchangedPreparedInputOnlyOnce() async throws {
         let input = RecoveryInput()
         let controller = makeDefaultRecoveryController(input)
@@ -395,6 +555,11 @@ final class MonitorTopologyRecoveryTests: XCTestCase {
         XCTAssertEqual(input.count("stop"), 0)
         XCTAssertEqual(input.count("invalidate"), 0)
         XCTAssertEqual(input.count("delivered"), 1)
+        _ = await controller.stop(retainPrepared: true, reason: "handoff_recording_stopped")
+        let next = try await controller.start(deviceID: 144, deviceName: "Test", reason: "after_handoff")
+        XCTAssertGreaterThan(next.generation, handoff.generation, "Handoff must preserve the pending topology rebuild")
+        XCTAssertEqual(input.count("invalidate"), 1)
+        XCTAssertEqual(input.count("start"), 2)
         await controller.shutdown(reason: "test_complete")
     }
 
@@ -551,7 +716,11 @@ private func makeDefaultRecoveryController(_ input: RecoveryInput) -> DirectCore
     )
 }
 
-private func makeRecoveryController(_ input: RecoveryInput, timeout: TimeInterval? = 0.08) -> DirectCoreAudioLifecycleController {
+private func makeRecoveryController(
+    _ input: RecoveryInput,
+    timeout: TimeInterval? = 0.08,
+    deviceLivenessReader: @escaping @Sendable (AudioObjectID) -> Bool? = { _ in true }
+) -> DirectCoreAudioLifecycleController {
     DirectCoreAudioLifecycleController(
         packetHandler: { _, _, _, _, _ in input.record("delivered") },
         inputFactory: { _, handler in
@@ -565,6 +734,7 @@ private func makeRecoveryController(_ input: RecoveryInput, timeout: TimeInterva
         },
         installsHardwareListeners: false,
         operationTimeout: timeout,
+        deviceLivenessReader: deviceLivenessReader,
         onFormatInvalidated: { _ in }
     )
 }
@@ -1426,4 +1596,58 @@ private final nonisolated class RecoveryFleet: @unchecked Sendable {
             onFormatInvalidated: { _ in }
         )
     }
+}
+
+private final nonisolated class FailedDeviceLivenessProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var alive: Bool?
+    private var shouldBlock = false
+    private var ids: [AudioObjectID] = []
+    let release = DispatchSemaphore(value: 0)
+
+    init(alive: Bool? = true) { self.alive = alive }
+    var deviceIDs: [AudioObjectID] { self.lock.withLock { self.ids } }
+    func setAlive(_ alive: Bool?) { self.lock.withLock { self.alive = alive } }
+    func blockNextRead(alive: Bool?) {
+        self.lock.withLock { self.alive = alive; self.shouldBlock = true }
+    }
+
+    func read(_ id: AudioObjectID) -> Bool? {
+        let state = self.lock.withLock {
+            self.ids.append(id)
+            let state = (self.alive, self.shouldBlock)
+            self.shouldBlock = false
+            return state
+        }
+        if state.1 { _ = self.release.wait(timeout: .now() + 3) }
+        return state.0
+    }
+
+    func waitForReadCount(_ count: Int) async throws {
+        for _ in 0..<1000 {
+            if self.deviceIDs.count >= count { return }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("Failed-device liveness query did not run")
+    }
+}
+
+private func waitForTopologyCheck(_ controller: DirectCoreAudioLifecycleController) async throws {
+    for _ in 0..<1000 {
+        if controller.isTopologyRecoveryCheckPendingForTesting == false { return }
+        try await Task.sleep(nanoseconds: 1_000_000)
+    }
+    XCTFail("Topology recovery did not finish within its bounded query window")
+}
+
+private func waitForFailedCleanup(_ controller: DirectCoreAudioLifecycleController) async throws {
+    for _ in 0..<1000 {
+        do {
+            _ = try await controller.prepare(deviceID: 144, deviceName: "Probe", reason: "wait_for_failed_cleanup")
+        } catch BoundedAudioHardwareQueue.Failure.cleanupFailed {
+            return
+        } catch {}
+        try await Task.sleep(nanoseconds: 1_000_000)
+    }
+    XCTFail("Serialized cleanup did not publish its failed state")
 }

--- a/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
+++ b/Tests/FluidDictationIntegrationTests/DirectAudioReliabilityTests.swift
@@ -1173,6 +1173,7 @@ final class DirectAudioReliabilityTests: XCTestCase {
             inputFactory: { _, _ in input },
             fingerprintReader: { _ in fingerprint },
             installsHardwareListeners: false,
+            deviceLivenessReader: { _ in true },
             onFormatInvalidated: { _ in }
         )
         _ = try await controller.start(
@@ -1222,6 +1223,7 @@ final class DirectAudioReliabilityTests: XCTestCase {
                 try fingerprintReader.read()
             },
             installsHardwareListeners: false,
+            deviceLivenessReader: { _ in true },
             onFormatInvalidated: { _ in }
         )
 


### PR DESCRIPTION
<!--
PRs that do not follow this template will be blocked by the PR Policy check.
If the missing information is not fixed after 48 hours, the PR may be closed.
-->

## Description
Rebuild microphone setup after audio-device changes and fix cancellation and playback restoration when recording recovery fails.

## Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Chore
- [ ] 📝 Documentation update

## Related Issue or Discussion
Stacked on #955.

## Testing
- [ ] Tested on Intel Mac
- [x] Tested on Apple Silicon Mac (automated tests)
- [x] Tested on macOS version: 27.0
- [x] Ran linter locally: `swiftlint --strict --config .swiftlint.yml Sources Tests Package.swift`
- [x] Ran formatter locally: `swiftformat --config .swiftformat Sources`
- [x] Ran tests locally: 188 signed tests and 37 controller ThreadSanitizer tests passed.

## Screenshots / Video
- [x] No UI/visual changes; screenshots/video are not applicable.

## Notes


